### PR TITLE
Refactor content shape & live integrations; add SmartTikTokLink and normalize pages

### DIFF
--- a/src/app/api/admin/live/route.ts
+++ b/src/app/api/admin/live/route.ts
@@ -16,7 +16,7 @@ const KEYS = {
   url: "stream:url",
 };
 
-const DEFAULT_URL = "https://www.tiktok.com/@six.bit/live";
+const DEFAULT_URL = "https://www.tiktok.com/@six.bit";
 
 function getRedis(): Redis | null {
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -43,7 +43,7 @@ function isWithinBroadcastWindow(): boolean {
 
   if (weekday !== "Fri") return false;
   const t = hour * 60 + minute;
-  return t >= 18 * 60 + 30 && t < 23 * 60 + 30;
+  return t >= 18 * 60 + 40 && t < 23 * 60;
 }
 
 // ---- GET: Read status (public) ----

--- a/src/app/database/[slug]/page.tsx
+++ b/src/app/database/[slug]/page.tsx
@@ -108,7 +108,13 @@ export default async function EntityPage({
             <div className="border border-accent/20 bg-surface p-2 crt-frame">
               <div className="relative aspect-[4/5] overflow-hidden crt-scanlines crt-vignette crt-flicker">
                 <Image
-                  src={getEntryImage(entry)}
+                  src={getEntryImage({
+                    id: entry.slug,
+                    image: entry.image,
+                    clearance: (entry as { clearance?: string }).clearance || "PUBLIC",
+                    category: entry.category,
+                    status: entry.status,
+                  })}
                   alt={entry.title}
                   fill
                   className="object-cover crt-tint"

--- a/src/app/database/[slug]/page.tsx
+++ b/src/app/database/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { databasePage } from "@/content";
+import { databasePage, externalLinks } from "@/content";
 import { PageHero, SectionDot } from "@/components/LiveEffects";
 import { getEntryImage } from "@/lib/placeholder";
 import Image from "next/image";
@@ -6,14 +6,18 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-function slugify(name: string) {
-  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+function resolveExternal(href: string): string {
+  if (href.startsWith("EXTERNAL:")) {
+    const key = href.replace("EXTERNAL:", "") as keyof typeof externalLinks;
+    return externalLinks[key] ?? href;
+  }
+  return href;
 }
 
 // Generate static paths for all entries
 export function generateStaticParams() {
-  return databasePage.entries.map((entry) => ({
-    slug: slugify(entry.name),
+  return databasePage.dossiers.map((entry) => ({
+    slug: entry.slug,
   }));
 }
 
@@ -24,14 +28,14 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const entry = databasePage.entries.find((e) => slugify(e.name) === slug);
+  const entry = databasePage.dossiers.find((e) => e.slug === slug);
   if (!entry) return { title: "Not Found — BARCODE Network" };
 
   return {
-    title: `${entry.name} — BARCODE Network Database`,
+    title: `${entry.title} — BARCODE Network Database`,
     description: entry.summary,
     openGraph: {
-      title: `${entry.name} — BARCODE Network Database`,
+      title: `${entry.title} — BARCODE Network Database`,
       description: entry.summary,
     },
   };
@@ -64,7 +68,7 @@ export default async function EntityPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const entry = databasePage.entries.find((e) => slugify(e.name) === slug);
+  const entry = databasePage.dossiers.find((e) => e.slug === slug);
 
   if (!entry) notFound();
 
@@ -88,8 +92,8 @@ export default async function EntityPage({
           {/* Header info */}
           <div className="mb-10">
             <PageHero
-              label={`// DOSSIER: ${entry.id}`}
-              heading={entry.name}
+              label={`// DOSSIER: ${entry.slug.toUpperCase()}`}
+              heading={entry.title}
               description=""
             />
             {/* Quick meta badges */}
@@ -97,14 +101,14 @@ export default async function EntityPage({
               <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${statusColors[entry.status] || "text-muted"}`}>
                 {entry.status}
               </span>
-              <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${clearanceColors[entry.clearance] || "text-muted"}`}>
-                {entry.clearance}
+              <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${clearanceColors[(entry as { clearance?: string }).clearance || ""] || "text-muted"}`}>
+                {(entry as { clearance?: string }).clearance || "PUBLIC"}
               </span>
               <span className="text-xs uppercase tracking-widest px-2 py-1 border border-border text-muted">
                 {entry.category}
               </span>
             </div>
-            <p className="text-sm text-muted/60 mt-4">{entry.role}</p>
+            <p className="text-sm text-muted/60 mt-4">{(entry as { role?: string }).role || "N/A"}</p>
           </div>
 
           {/* Portrait / Placeholder */}
@@ -112,17 +116,23 @@ export default async function EntityPage({
             <div className="border border-accent/20 bg-surface p-2 crt-frame">
               <div className="relative aspect-[4/5] overflow-hidden crt-scanlines crt-vignette crt-flicker">
                 <Image
-                  src={getEntryImage(entry)}
-                  alt={entry.name}
+                  src={getEntryImage({
+                    id: entry.slug,
+                    image: entry.image,
+                    clearance: (entry as { clearance?: string }).clearance || "PUBLIC",
+                    category: entry.category,
+                    status: entry.status,
+                  })}
+                  alt={entry.title}
                   fill
                   className="object-cover crt-tint"
                   unoptimized
                 />
               </div>
               <div className="mt-2 flex items-center justify-between px-1">
-                <span className="text-xs font-mono text-muted/50">{entry.id}</span>
-                <span className={`text-xs font-mono ${clearanceColors[entry.clearance] || "text-muted/50"}`}>
-                  {entry.clearance}
+                <span className="text-xs font-mono text-muted/50">{entry.slug.toUpperCase()}</span>
+                <span className={`text-xs font-mono ${clearanceColors[(entry as { clearance?: string }).clearance || ""] || "text-muted/50"}`}>
+                  {(entry as { clearance?: string }).clearance || "PUBLIC"}
                 </span>
               </div>
             </div>
@@ -145,13 +155,13 @@ export default async function EntityPage({
               </div>
 
               <div className="space-y-4">
-                <InfoRow label="Designation" value={entry.id} />
-                <InfoRow label="Name" value={entry.name} accent />
+                <InfoRow label="Designation" value={entry.slug.toUpperCase()} />
+                <InfoRow label="Name" value={entry.title} accent />
                 <InfoRow label="Category" value={entry.category} />
                 <InfoRow label="Status" value={entry.status} colorClass={statusColors[entry.status]} />
-                <InfoRow label="Clearance" value={entry.clearance} colorClass={clearanceColors[entry.clearance]} />
-                <InfoRow label="Role" value={entry.role} />
-                <InfoRow label="Origin" value={entry.origin} colorClass={originColors[entry.origin]} />
+                <InfoRow label="Clearance" value={(entry as { clearance?: string }).clearance || "PUBLIC"} colorClass={clearanceColors[(entry as { clearance?: string }).clearance || ""]} />
+                <InfoRow label="Role" value={(entry as { role?: string }).role || "N/A"} />
+                <InfoRow label="Origin" value={(entry as { origin?: string }).origin || "UNVERIFIED"} colorClass={originColors[(entry as { origin?: string }).origin || ""]} />
                 <div className="flex items-center justify-between border-b border-border/50 pb-2">
                   <span className="text-xs uppercase tracking-[0.3em] text-muted">
                     Tags
@@ -173,12 +183,12 @@ export default async function EntityPage({
                       Link
                     </span>
                     <a
-                      href={entry.link}
+                      href={resolveExternal(entry.link)}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-sm text-accent hover:text-accent-dim transition-colors truncate max-w-[60%] text-right"
                     >
-                      {entry.link.replace(/^https?:\/\/(www\.)?/, "").split("/")[0]} →
+                      {resolveExternal(entry.link).replace(/^https?:\/\/(www\.)?/, "").split("/")[0]} →
                     </a>
                   </div>
                 )}
@@ -312,10 +322,10 @@ export default async function EntityPage({
               &gt; BARCODE_NETWORK // DOSSIER QUERY
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              <p>&gt; SELECT * FROM network_dossiers WHERE id = &apos;{entry.id}&apos;</p>
-              <p>&gt; RECORD FOUND: {entry.name}</p>
-              <p>&gt; STATUS: {entry.status} // CLEARANCE: {entry.clearance}</p>
-              <p>&gt; CATEGORY: {entry.category} // ORIGIN: {entry.origin}</p>
+              <p>&gt; SELECT * FROM network_dossiers WHERE id = &apos;{entry.slug.toUpperCase()}&apos;</p>
+              <p>&gt; RECORD FOUND: {entry.title}</p>
+              <p>&gt; STATUS: {entry.status} {"//"} CLEARANCE: {(entry as { clearance?: string }).clearance || "PUBLIC"}</p>
+              <p>&gt; CATEGORY: {entry.category} {"//"} ORIGIN: {(entry as { origin?: string }).origin || "UNVERIFIED"}</p>
               <p className="text-accent mt-3">
                 &gt; DOSSIER LOADED<span className="cursor-blink">_</span>
               </p>

--- a/src/app/database/[slug]/page.tsx
+++ b/src/app/database/[slug]/page.tsx
@@ -6,14 +6,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-function slugify(name: string) {
-  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-}
-
 // Generate static paths for all entries
 export function generateStaticParams() {
-  return databasePage.entries.map((entry) => ({
-    slug: slugify(entry.name),
+  return databasePage.dossiers.map((entry) => ({
+    slug: entry.slug,
   }));
 }
 
@@ -24,14 +20,14 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const entry = databasePage.entries.find((e) => slugify(e.name) === slug);
+  const entry = databasePage.dossiers.find((e) => e.slug === slug);
   if (!entry) return { title: "Not Found — BARCODE Network" };
 
   return {
-    title: `${entry.name} — BARCODE Network Database`,
+    title: `${entry.title} — BARCODE Network Database`,
     description: entry.summary,
     openGraph: {
-      title: `${entry.name} — BARCODE Network Database`,
+      title: `${entry.title} — BARCODE Network Database`,
       description: entry.summary,
     },
   };
@@ -64,7 +60,7 @@ export default async function EntityPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const entry = databasePage.entries.find((e) => slugify(e.name) === slug);
+  const entry = databasePage.dossiers.find((e) => e.slug === slug);
 
   if (!entry) notFound();
 
@@ -88,8 +84,8 @@ export default async function EntityPage({
           {/* Header info */}
           <div className="mb-10">
             <PageHero
-              label={`// DOSSIER: ${entry.id}`}
-              heading={entry.name}
+              label={`// DOSSIER: ${entry.slug.toUpperCase()}`}
+              heading={entry.title}
               description=""
             />
             {/* Quick meta badges */}
@@ -97,14 +93,14 @@ export default async function EntityPage({
               <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${statusColors[entry.status] || "text-muted"}`}>
                 {entry.status}
               </span>
-              <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${clearanceColors[entry.clearance] || "text-muted"}`}>
-                {entry.clearance}
+              <span className={`text-xs uppercase tracking-widest px-2 py-1 border border-current/20 ${clearanceColors[(entry as { clearance?: string }).clearance || ""] || "text-muted"}`}>
+                {(entry as { clearance?: string }).clearance || "PUBLIC"}
               </span>
               <span className="text-xs uppercase tracking-widest px-2 py-1 border border-border text-muted">
                 {entry.category}
               </span>
             </div>
-            <p className="text-sm text-muted/60 mt-4">{entry.role}</p>
+            <p className="text-sm text-muted/60 mt-4">{(entry as { role?: string }).role || "N/A"}</p>
           </div>
 
           {/* Portrait / Placeholder */}
@@ -113,16 +109,16 @@ export default async function EntityPage({
               <div className="relative aspect-[4/5] overflow-hidden crt-scanlines crt-vignette crt-flicker">
                 <Image
                   src={getEntryImage(entry)}
-                  alt={entry.name}
+                  alt={entry.title}
                   fill
                   className="object-cover crt-tint"
                   unoptimized
                 />
               </div>
               <div className="mt-2 flex items-center justify-between px-1">
-                <span className="text-xs font-mono text-muted/50">{entry.id}</span>
-                <span className={`text-xs font-mono ${clearanceColors[entry.clearance] || "text-muted/50"}`}>
-                  {entry.clearance}
+                <span className="text-xs font-mono text-muted/50">{entry.slug.toUpperCase()}</span>
+                <span className={`text-xs font-mono ${clearanceColors[(entry as { clearance?: string }).clearance || ""] || "text-muted/50"}`}>
+                  {(entry as { clearance?: string }).clearance || "PUBLIC"}
                 </span>
               </div>
             </div>
@@ -145,13 +141,13 @@ export default async function EntityPage({
               </div>
 
               <div className="space-y-4">
-                <InfoRow label="Designation" value={entry.id} />
-                <InfoRow label="Name" value={entry.name} accent />
+                <InfoRow label="Designation" value={entry.slug.toUpperCase()} />
+                <InfoRow label="Name" value={entry.title} accent />
                 <InfoRow label="Category" value={entry.category} />
                 <InfoRow label="Status" value={entry.status} colorClass={statusColors[entry.status]} />
-                <InfoRow label="Clearance" value={entry.clearance} colorClass={clearanceColors[entry.clearance]} />
-                <InfoRow label="Role" value={entry.role} />
-                <InfoRow label="Origin" value={entry.origin} colorClass={originColors[entry.origin]} />
+                <InfoRow label="Clearance" value={(entry as { clearance?: string }).clearance || "PUBLIC"} colorClass={clearanceColors[(entry as { clearance?: string }).clearance || ""]} />
+                <InfoRow label="Role" value={(entry as { role?: string }).role || "N/A"} />
+                <InfoRow label="Origin" value={(entry as { origin?: string }).origin || "UNVERIFIED"} colorClass={originColors[(entry as { origin?: string }).origin || ""]} />
                 <div className="flex items-center justify-between border-b border-border/50 pb-2">
                   <span className="text-xs uppercase tracking-[0.3em] text-muted">
                     Tags
@@ -312,10 +308,10 @@ export default async function EntityPage({
               &gt; BARCODE_NETWORK // DOSSIER QUERY
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              <p>&gt; SELECT * FROM network_dossiers WHERE id = &apos;{entry.id}&apos;</p>
-              <p>&gt; RECORD FOUND: {entry.name}</p>
-              <p>&gt; STATUS: {entry.status} // CLEARANCE: {entry.clearance}</p>
-              <p>&gt; CATEGORY: {entry.category} // ORIGIN: {entry.origin}</p>
+              <p>&gt; SELECT * FROM network_dossiers WHERE id = &apos;{entry.slug.toUpperCase()}&apos;</p>
+              <p>&gt; RECORD FOUND: {entry.title}</p>
+              <p>&gt; STATUS: {entry.status} {"//"} CLEARANCE: {(entry as { clearance?: string }).clearance || "PUBLIC"}</p>
+              <p>&gt; CATEGORY: {entry.category} {"//"} ORIGIN: {(entry as { origin?: string }).origin || "UNVERIFIED"}</p>
               <p className="text-accent mt-3">
                 &gt; DOSSIER LOADED<span className="cursor-blink">_</span>
               </p>

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -14,7 +14,19 @@ export const metadata: Metadata = {
   },
 };
 
-const databaseEntries = databasePage.entries;
+const databaseEntries = databasePage.dossiers.map((entry) => ({
+  id: entry.slug.toUpperCase(),
+  name: entry.title,
+  image: entry.image,
+  category: entry.category,
+  status: entry.status,
+  clearance: "PUBLIC",
+  role: entry.category,
+  origin: "UNVERIFIED",
+  summary: entry.summary,
+  tags: entry.tags,
+  notes: entry.notes,
+}));
 
 export default function DatabasePage() {
   return (
@@ -24,7 +36,7 @@ export default function DatabasePage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 sm:py-24">
           <PageHero
             label={databasePage.hero.label}
-            heading={databasePage.hero.heading}
+            heading={`${databasePage.hero.heading1} ${databasePage.hero.heading2}`}
             description={databasePage.hero.description}
           />
         </div>
@@ -70,9 +82,9 @@ export default function DatabasePage() {
               &gt; BARCODE_NETWORK // DATABASE QUERY
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              {databasePage.terminalQuery.map((line, i) => (
-                <p key={i}>&gt; {line}</p>
-              ))}
+	              {(databasePage as { terminalQuery?: string[] }).terminalQuery?.map((line, i) => (
+	                <p key={i}>&gt; {line}</p>
+	              )) || null}
               <p className="text-accent mt-3">
                 &gt; {databaseEntries.filter((e) => e.status === "ACTIVE").length} RECORDS FOUND
                 <span className="cursor-blink">_</span>

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -14,7 +14,36 @@ export const metadata: Metadata = {
   },
 };
 
-const databaseEntries = databasePage.entries;
+const VALID_CATEGORIES = new Set(["Entity", "Personnel", "Sponsor", "Interface", "Production"] as const);
+const VALID_STATUSES = new Set(["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"] as const);
+const VALID_CLEARANCE = new Set(["PUBLIC", "INTERNAL", "RESTRICTED"] as const);
+
+function normalizeCategory(category: string): "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production" {
+  return VALID_CATEGORIES.has(category as never) ? (category as "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production") : "Interface";
+}
+
+function normalizeStatus(status: string): "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN" {
+  return VALID_STATUSES.has(status as never) ? (status as "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN") : "UNKNOWN";
+}
+
+function normalizeClearance(clearance: string | undefined): "PUBLIC" | "INTERNAL" | "RESTRICTED" {
+  if (!clearance) return "PUBLIC";
+  return VALID_CLEARANCE.has(clearance as never) ? (clearance as "PUBLIC" | "INTERNAL" | "RESTRICTED") : "PUBLIC";
+}
+
+const databaseEntries = databasePage.dossiers.map((entry) => ({
+  id: entry.slug.toUpperCase(),
+  name: entry.title,
+  image: entry.image,
+  category: normalizeCategory(entry.category),
+  status: normalizeStatus(entry.status),
+  clearance: normalizeClearance((entry as { clearance?: string }).clearance),
+  role: entry.category || "N/A",
+  origin: "UNVERIFIED" as const,
+  summary: entry.summary,
+  tags: entry.tags,
+  notes: entry.notes,
+}));
 
 export default function DatabasePage() {
   return (
@@ -24,7 +53,7 @@ export default function DatabasePage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 sm:py-24">
           <PageHero
             label={databasePage.hero.label}
-            heading={databasePage.hero.heading}
+            heading={`${databasePage.hero.heading1} ${databasePage.hero.heading2}`}
             description={databasePage.hero.description}
           />
         </div>
@@ -70,9 +99,9 @@ export default function DatabasePage() {
               &gt; BARCODE_NETWORK // DATABASE QUERY
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              {databasePage.terminalQuery.map((line, i) => (
-                <p key={i}>&gt; {line}</p>
-              ))}
+	              {(databasePage as { terminalQuery?: string[] }).terminalQuery?.map((line, i) => (
+	                <p key={i}>&gt; {line}</p>
+	              )) || null}
               <p className="text-accent mt-3">
                 &gt; {databaseEntries.filter((e) => e.status === "ACTIVE").length} RECORDS FOUND
                 <span className="cursor-blink">_</span>

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
 
 const VALID_CATEGORIES = new Set(["Entity", "Personnel", "Sponsor", "Interface", "Production"] as const);
 const VALID_STATUSES = new Set(["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"] as const);
+const VALID_CLEARANCE = new Set(["PUBLIC", "INTERNAL", "RESTRICTED"] as const);
 
 function normalizeCategory(category: string): "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production" {
   return VALID_CATEGORIES.has(category as never) ? (category as "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production") : "Interface";
@@ -25,13 +26,18 @@ function normalizeStatus(status: string): "ACTIVE" | "INACTIVE" | "ARCHIVED" | "
   return VALID_STATUSES.has(status as never) ? (status as "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN") : "UNKNOWN";
 }
 
+function normalizeClearance(clearance: string | undefined): "PUBLIC" | "INTERNAL" | "RESTRICTED" {
+  if (!clearance) return "PUBLIC";
+  return VALID_CLEARANCE.has(clearance as never) ? (clearance as "PUBLIC" | "INTERNAL" | "RESTRICTED") : "PUBLIC";
+}
+
 const databaseEntries = databasePage.dossiers.map((entry) => ({
   id: entry.slug.toUpperCase(),
   name: entry.title,
   image: entry.image,
   category: normalizeCategory(entry.category),
   status: normalizeStatus(entry.status),
-  clearance: "PUBLIC" as const,
+  clearance: normalizeClearance((entry as { clearance?: string }).clearance),
   role: entry.category || "N/A",
   origin: "UNVERIFIED" as const,
   summary: entry.summary,

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -14,15 +14,26 @@ export const metadata: Metadata = {
   },
 };
 
+const VALID_CATEGORIES = new Set(["Entity", "Personnel", "Sponsor", "Interface", "Production"] as const);
+const VALID_STATUSES = new Set(["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"] as const);
+
+function normalizeCategory(category: string): "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production" {
+  return VALID_CATEGORIES.has(category as never) ? (category as "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production") : "Interface";
+}
+
+function normalizeStatus(status: string): "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN" {
+  return VALID_STATUSES.has(status as never) ? (status as "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN") : "UNKNOWN";
+}
+
 const databaseEntries = databasePage.dossiers.map((entry) => ({
   id: entry.slug.toUpperCase(),
   name: entry.title,
   image: entry.image,
-  category: entry.category,
-  status: entry.status,
-  clearance: "PUBLIC",
-  role: entry.category,
-  origin: "UNVERIFIED",
+  category: normalizeCategory(entry.category),
+  status: normalizeStatus(entry.status),
+  clearance: "PUBLIC" as const,
+  role: entry.category || "N/A",
+  origin: "UNVERIFIED" as const,
   summary: entry.summary,
   tags: entry.tags,
   notes: entry.notes,

--- a/src/app/merch/page.tsx
+++ b/src/app/merch/page.tsx
@@ -21,107 +21,23 @@ export default function MerchPage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 sm:py-24">
           <PageHero
             label={merchPage.hero.label}
-            heading={merchPage.hero.heading}
+            heading={`${merchPage.hero.heading1} ${merchPage.hero.heading2}`}
             description={merchPage.hero.description}
           />
         </div>
       </section>
 
-      {/* Products — 1st Wave */}
-      <section className="border-b border-border">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="flex items-center justify-between mb-8">
-            <div className="flex items-center gap-3">
-              <SectionDot />
-              <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-                1st Wave — Supply Drop
-              </h2>
-            </div>
-            <a
-              href={merchPage.storeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-accent/60 hover:text-accent uppercase tracking-widest transition-colors"
-            >
-              View Store →
-            </a>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {merchPage.products.map((product) => (
-              <a
-                key={product.name}
-                href={product.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group border border-border bg-surface hover:border-accent/40 p-6 transition-all"
-              >
-                <span className="text-xs text-accent/50 uppercase tracking-[0.3em]">
-                  {product.tag}
-                </span>
-                <h3 className="text-sm font-bold text-foreground mt-2 mb-3 group-hover:text-accent transition-colors leading-snug">
-                  {product.name}
-                </h3>
-                <div className="flex items-center gap-2">
-                  <span className="text-lg font-bold text-accent">
-                    {product.price}
-                  </span>
-                  <span className="text-xs text-muted line-through">
-                    {product.originalPrice}
-                  </span>
-                </div>
-                <span className="block mt-3 text-xs text-muted/40 uppercase tracking-wider group-hover:text-accent/60 transition-colors">
-                  Get it →
-                </span>
-              </a>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Book — OBSERVER NOT FOUND */}
       <section className="border-b border-border noise-bg">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 py-16">
           <div className="flex items-center gap-3 mb-8">
             <SectionDot />
             <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-              Publication
+              Supply Status
             </h2>
           </div>
-
-          <a
-            href={merchPage.book.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group block border border-border bg-surface hover:border-accent/40 p-8 transition-all max-w-3xl"
-          >
-            <span className="text-xs text-accent/50 uppercase tracking-[0.3em]">
-              {merchPage.book.tag}
-            </span>
-            <h3 className="text-2xl sm:text-3xl font-bold text-foreground mt-3 mb-2 group-hover:text-accent transition-colors tracking-wider">
-              {merchPage.book.title}
-            </h3>
-            <p className="text-xs text-muted uppercase tracking-widest mb-4">
-              by {merchPage.book.author} — {merchPage.book.format}
-            </p>
-            <p className="text-sm text-muted leading-relaxed mb-6 max-w-xl">
-              {merchPage.book.description}
-            </p>
-            <div className="flex flex-wrap gap-4 mb-4">
-              <span className="text-xs text-muted border border-border px-3 py-1.5">
-                Kindle <span className="text-foreground font-bold">{merchPage.book.prices.kindle}</span>
-              </span>
-              <span className="text-xs text-muted border border-border px-3 py-1.5">
-                Paperback <span className="text-foreground font-bold">{merchPage.book.prices.paperback}</span>
-              </span>
-              <span className="text-xs text-accent border border-accent/30 px-3 py-1.5">
-                Hardcover <span className="text-accent font-bold">{merchPage.book.prices.hardcover}</span>
-              </span>
-            </div>
-            <span className="block text-xs text-muted/40 uppercase tracking-wider group-hover:text-accent/60 transition-colors">
-              Available on Amazon →
-            </span>
-          </a>
+          <div className="border border-border bg-surface p-8">
+            <p className="text-sm text-muted leading-relaxed">{merchPage.notice}</p>
+          </div>
         </div>
       </section>
 
@@ -150,7 +66,7 @@ export default function MerchPage() {
               &gt; BARCODE_NETWORK // SUPPLY_SYSTEM
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              {merchPage.terminalOutput.map((line, i) => (
+              {["SUPPLY ROUTE .............. LIMITED", "NEW ARTIFACTS ............ PENDING"].map((line, i) => (
                 <p key={i}>&gt; {line}</p>
               ))}
               <p className="text-accent mt-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { LiveBanner } from "@/components/LiveBanner";
 import { HeroHeading, StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
+import { SmartTikTokLink } from "@/components/SmartTikTokLink";
 
 function resolveHref(href: string): string {
   if (href.startsWith("EXTERNAL:")) {
@@ -122,6 +123,17 @@ export default function Home() {
                   {link.label}
                 </span>
               );
+
+              if (link.href === "EXTERNAL:tiktok") {
+                return (
+                  <SmartTikTokLink
+                    key={link.label}
+                    className={className}
+                    offlineLabel="TikTok Signal"
+                    liveLabel="TikTok Live // Tune In"
+                  />
+                );
+              }
 
               return isExternal ? (
                 <a

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -115,19 +115,25 @@ export default function RadioPage() {
       </section>
 
       {/* Go Deeper — lore hooks to pull them into the network */}
+      {(radioPage as { goDeeper?: {
+        label: string;
+        heading: string;
+        cards: { href: string; tag: string; title: string; description: string; cta: string }[];
+        footnote: string;
+      } }).goDeeper && (
       <section className="noise-bg">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
           <div className="text-center mb-10">
             <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-3">
-              {radioPage.goDeeper.label}
+              {(radioPage as { goDeeper: { label: string } }).goDeeper.label}
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-foreground/80">
-              {radioPage.goDeeper.heading}
+              {(radioPage as { goDeeper: { heading: string } }).goDeeper.heading}
             </h2>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {radioPage.goDeeper.cards.map((card) => (
+            {(radioPage as { goDeeper: { cards: { href: string; tag: string; title: string; description: string; cta: string }[] } }).goDeeper.cards.map((card) => (
               <Link
                 key={card.href}
                 href={card.href}
@@ -150,10 +156,11 @@ export default function RadioPage() {
           </div>
 
           <p className="text-center text-xs text-muted/30 mt-10 uppercase tracking-widest">
-            {radioPage.goDeeper.footnote}
+            {(radioPage as { goDeeper: { footnote: string } }).goDeeper.footnote}
           </p>
         </div>
       </section>
+      )}
     </div>
   );
 }

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -17,6 +17,15 @@ export const metadata: Metadata = {
 };
 
 export default function RadioPage() {
+  const goDeeper = (radioPage as unknown as {
+    goDeeper?: {
+      label: string;
+      heading: string;
+      cards: { href: string; tag: string; title: string; description: string; cta: string }[];
+      footnote: string;
+    };
+  }).goDeeper;
+
   return (
     <div className="pt-14">
       {/* Hero — Submit buttons FIRST, zero friction */}
@@ -115,25 +124,20 @@ export default function RadioPage() {
       </section>
 
       {/* Go Deeper — lore hooks to pull them into the network */}
-      {(radioPage as { goDeeper?: {
-        label: string;
-        heading: string;
-        cards: { href: string; tag: string; title: string; description: string; cta: string }[];
-        footnote: string;
-      } }).goDeeper && (
+      {goDeeper && (
       <section className="noise-bg">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
           <div className="text-center mb-10">
             <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-3">
-              {(radioPage as { goDeeper: { label: string } }).goDeeper.label}
+              {goDeeper.label}
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-foreground/80">
-              {(radioPage as { goDeeper: { heading: string } }).goDeeper.heading}
+              {goDeeper.heading}
             </h2>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {(radioPage as { goDeeper: { cards: { href: string; tag: string; title: string; description: string; cta: string }[] } }).goDeeper.cards.map((card) => (
+            {goDeeper.cards.map((card) => (
               <Link
                 key={card.href}
                 href={card.href}
@@ -156,7 +160,7 @@ export default function RadioPage() {
           </div>
 
           <p className="text-center text-xs text-muted/30 mt-10 uppercase tracking-widest">
-            {(radioPage as { goDeeper: { footnote: string } }).goDeeper.footnote}
+            {goDeeper.footnote}
           </p>
         </div>
       </section>

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -17,6 +17,15 @@ export const metadata: Metadata = {
 };
 
 export default function RadioPage() {
+  const goDeeper = (radioPage as unknown as {
+    goDeeper?: {
+      label: string;
+      heading: string;
+      cards: { href: string; tag: string; title: string; description: string; cta: string }[];
+      footnote: string;
+    };
+  }).goDeeper;
+
   return (
     <div className="pt-14">
       {/* Hero — Submit buttons FIRST, zero friction */}
@@ -115,19 +124,20 @@ export default function RadioPage() {
       </section>
 
       {/* Go Deeper — lore hooks to pull them into the network */}
+      {goDeeper && (
       <section className="noise-bg">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
           <div className="text-center mb-10">
             <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-3">
-              {radioPage.goDeeper.label}
+              {goDeeper.label}
             </p>
             <h2 className="text-2xl sm:text-3xl font-bold text-foreground/80">
-              {radioPage.goDeeper.heading}
+              {goDeeper.heading}
             </h2>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {radioPage.goDeeper.cards.map((card) => (
+            {goDeeper.cards.map((card) => (
               <Link
                 key={card.href}
                 href={card.href}
@@ -150,10 +160,11 @@ export default function RadioPage() {
           </div>
 
           <p className="text-center text-xs text-muted/30 mt-10 uppercase tracking-widest">
-            {radioPage.goDeeper.footnote}
+            {goDeeper.footnote}
           </p>
         </div>
       </section>
+      )}
     </div>
   );
 }

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import Image from "next/image";
 import { releasesPage } from "@/content";
 import { PageHero, SectionDot } from "@/components/LiveEffects";
@@ -8,162 +7,48 @@ export const metadata: Metadata = {
   title: "Releases — BARCODE Network",
   description:
     "Official transmission catalog. Audio artifacts indexed and released by BARCODE Network entities.",
-  openGraph: {
-    title: "Releases — BARCODE Network",
-    description:
-      "Official transmission catalog. Audio artifacts indexed and released by BARCODE Network entities.",
-  },
 };
 
-const releases = releasesPage.catalog;
+const releases = releasesPage.releases;
 
 export default function ReleasesPage() {
   return (
     <div className="pt-14">
-      {/* Header */}
       <section className="border-b border-border noise-bg">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 sm:py-24">
           <PageHero
             label={releasesPage.hero.label}
-            heading={releasesPage.hero.heading}
+            heading={`${releasesPage.hero.heading1} ${releasesPage.hero.heading2}`}
             description={releasesPage.hero.description}
           />
         </div>
       </section>
 
-      {/* Releases List */}
       <section className="border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
           <div className="flex items-center gap-3 mb-10">
             <SectionDot />
-            <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-              Catalog
-            </h2>
+            <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">Catalog</h2>
           </div>
 
           <div className="space-y-6">
             {releases.map((release, index) => (
-              <div
-                key={index}
-                className="border border-border bg-surface hover:border-accent/20 transition-colors"
-              >
-                <div className="flex flex-col sm:flex-row">
-                  {/* Album Art */}
+              <div key={index} className="border border-border bg-surface p-6">
+                <div className="flex flex-col sm:flex-row gap-4">
                   {release.cover && (
-                    <div className="relative w-full sm:w-48 sm:min-w-48 aspect-square sm:aspect-auto shrink-0 crt-scanlines crt-vignette">
-                      <Image
-                        src={release.cover}
-                        alt={release.title}
-                        fill
-                        className="object-cover"
-                        unoptimized
-                      />
+                    <div className="relative w-full sm:w-40 aspect-square shrink-0">
+                      <Image src={release.cover} alt={release.title} fill className="object-cover" unoptimized />
                     </div>
                   )}
-
-                  <div className="p-6 flex-1">
-                  <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-4">
-                    <div>
-                      <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-lg font-bold text-foreground">
-                          {release.title}
-                        </h3>
-                        <span
-                          className={`text-xs uppercase tracking-widest px-2 py-0.5 border ${
-                            release.status === "LATEST"
-                              ? "border-accent/30 text-accent"
-                              : release.status === "INCOMING"
-                              ? "border-red-500/30 text-red-400 animate-pulse"
-                              : "border-border-light text-muted"
-                          }`}
-                        >
-                          {release.status}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
-                        <span>{release.type}</span>
-                        <span className="text-border-light">|</span>
-                        <span>{release.date}</span>
-                      </div>
-                    </div>
+                  <div>
+                    <h3 className="text-lg font-bold text-foreground">{release.title}</h3>
+                    <p className="text-xs text-muted uppercase tracking-wider mb-3">{release.type} | {release.date}</p>
+                    <p className="text-sm text-muted">{release.description}</p>
                   </div>
-
-                  <p className="text-sm text-muted leading-relaxed mb-4">
-                    {release.description}
-                  </p>
-
-                  {/* Stream Links */}
-                  <div className="flex flex-wrap gap-2">
-                    {release.links.spotify && (
-                      <a
-                        href={release.links.spotify}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs uppercase tracking-wider px-3 py-1.5 border border-border text-muted hover:border-accent hover:text-accent transition-all"
-                      >
-                        Spotify
-                      </a>
-                    )}
-                    {release.links.apple && (
-                      <a
-                        href={release.links.apple}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs uppercase tracking-wider px-3 py-1.5 border border-border text-muted hover:border-accent hover:text-accent transition-all"
-                      >
-                        Apple Music
-                      </a>
-                    )}
-                    {release.links.youtube && (
-                      <a
-                        href={release.links.youtube}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs uppercase tracking-wider px-3 py-1.5 border border-border text-muted hover:border-accent hover:text-accent transition-all"
-                      >
-                        YouTube Music
-                      </a>
-                    )}
-                    {release.links.soundcloud && (
-                      <a
-                        href={release.links.soundcloud}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs uppercase tracking-wider px-3 py-1.5 border border-border text-muted hover:border-accent hover:text-accent transition-all"
-                      >
-                        SoundCloud
-                      </a>
-                    )}
-                    {Object.keys(release.links).length === 0 && (
-                      <span className="text-xs uppercase tracking-wider px-3 py-1.5 border border-red-400/20 text-red-400/60">
-                        SIGNAL LOST — FREQUENCIES UNAVAILABLE
-                      </span>
-                    )}
-                  </div>
-                </div>
                 </div>
               </div>
             ))}
           </div>
-
-          <p className="text-xs text-muted/50 mt-8 uppercase tracking-wider font-mono">
-            // {releases.length} TRANSMISSIONS INDEXED
-          </p>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section>
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 text-center">
-          <p className="text-base text-muted mb-6">
-            {releasesPage.bottomCta.text}
-          </p>
-          <Link
-            href={releasesPage.bottomCta.buttonHref}
-            className="inline-flex items-center px-6 py-3 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all"
-          >
-            {releasesPage.bottomCta.buttonText}
-          </Link>
         </div>
       </section>
     </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,10 +2,6 @@ import type { MetadataRoute } from "next";
 import { databasePage } from "@/content";
 import { getAllTransmissions } from "@/lib/transmissions";
 
-function slugify(name: string) {
-  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-}
-
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://barcode-network.com";
   const now = new Date();
@@ -22,8 +18,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
   ];
 
   // Dynamic database pages
-  const databasePages: MetadataRoute.Sitemap = databasePage.entries.map((entry) => ({
-    url: `${base}/database/${slugify(entry.name)}`,
+  const databasePages: MetadataRoute.Sitemap = databasePage.dossiers.map((entry) => ({
+    url: `${base}/database/${entry.slug}`,
     lastModified: now,
     changeFrequency: "monthly" as const,
     priority: 0.6,

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -47,14 +47,11 @@ export default function TerminalPage() {
               </div>
 
               <div className="space-y-4">
-                {terminalPage.dossier.map((row) => (
-                  <InfoRow
-                    key={row.label}
-                    label={row.label}
-                    value={row.value}
-                    accent={row.accent}
-                  />
-                ))}
+                <InfoRow label="Codename" value={terminalPage.dossier.codename} accent />
+                <InfoRow label="Designation" value={terminalPage.dossier.designation} />
+                <InfoRow label="Status" value={terminalPage.dossier.status} />
+                <InfoRow label="Classification" value={terminalPage.dossier.classification} />
+                <InfoRow label="First Seen" value={terminalPage.dossier.firstSeen} />
               </div>
             </div>
 
@@ -68,9 +65,8 @@ export default function TerminalPage() {
               </div>
 
               <div className="text-base text-foreground/70 leading-relaxed space-y-4">
-                {terminalPage.about.map((paragraph, i) => (
-                  <p key={i}>{paragraph}</p>
-                ))}
+                <p>{terminalPage.dossier.notes}</p>
+                <p>{terminalPage.quote}</p>
               </div>
             </div>
           </div>
@@ -108,7 +104,7 @@ export default function TerminalPage() {
               &gt; BARCODE_NETWORK // TERMINAL ACCESS
             </p>
             <div className="space-y-1 text-sm text-foreground/60">
-              {terminalPage.terminalOutput.map((line, i) => (
+              {terminalPage.terminalLines.map((line, i) => (
                 <p key={i}>&gt; {line}</p>
               ))}
               <p className="text-accent mt-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { siteConfig, externalLinks } from "@/content";
+import { SmartTikTokLink } from "./SmartTikTokLink";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
@@ -80,6 +81,9 @@ export function Footer() {
                 <a href={externalLinks.auxchord} target="_blank" rel="noopener noreferrer" className="text-sm text-foreground/70 hover:text-accent transition-colors">
                   Auxchord
                 </a>
+              </li>
+              <li>
+                <SmartTikTokLink className="text-sm text-foreground/70 hover:text-accent transition-colors" offlineLabel="TikTok Signal" liveLabel="TikTok Live // Tune In" />
               </li>
               <li>
                 <Link href="/merch" className="text-sm text-foreground/70 hover:text-accent transition-colors">

--- a/src/components/LiveStatusProvider.tsx
+++ b/src/components/LiveStatusProvider.tsx
@@ -15,7 +15,7 @@ interface LiveStatusContextType {
 const LiveStatusContext = createContext<LiveStatusContextType>({
   isLive: false,
   toggleLive: () => {},
-  streamUrl: "https://www.tiktok.com/@six.bit/live",
+  streamUrl: "https://www.tiktok.com/@six.bit",
   setStreamUrl: () => {},
   isScheduled: false,
   isAdmin: false,
@@ -29,7 +29,7 @@ export function useLiveStatus() {
 export function LiveStatusProvider({ children }: { children: ReactNode }) {
   const [isLive, setIsLive] = useState(false);
   const [isScheduled, setIsScheduled] = useState(false);
-  const [streamUrl, setStreamUrlState] = useState("https://www.tiktok.com/@six.bit/live");
+  const [streamUrl, setStreamUrlState] = useState("https://www.tiktok.com/@six.bit");
   const [manualOverride, setManualOverride] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
 

--- a/src/components/OBSOverlay.tsx
+++ b/src/components/OBSOverlay.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import type { QueueState, QueueEntry, QueueTier } from "@/lib/queue-types";
 import { normalizeTier } from "@/lib/queue-types";
 
-const LIVE_URL = "https://www.tiktok.com/@six.bit/live";
+const LIVE_URL = "https://www.tiktok.com/@six.bit";
 
 /* Google Drive /preview embed URLs */
 const DRIVE_BG = "https://drive.google.com/file/d/1HahJcc_ChAjEwerezfHjerQq2wOKuaAo/preview";
@@ -27,7 +27,7 @@ function isWithinBroadcastWindow(): boolean {
 
   if (weekday !== "Fri") return false;
   const t = hour * 60 + minute;
-  return t >= 18 * 60 + 30 && t < 23 * 60 + 30; // 6:30 PM – 11:30 PM PST
+  return t >= 18 * 60 + 40 && t < 23 * 60; // 6:40 PM – 11:00 PM PST
 }
 
 const TIER_CLASS: Record<QueueTier, string> = {

--- a/src/components/SmartTikTokLink.tsx
+++ b/src/components/SmartTikTokLink.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useLiveStatus } from "./LiveStatusProvider";
+
+interface SmartTikTokLinkProps {
+  className?: string;
+  offlineLabel: string;
+  liveLabel: string;
+}
+
+export function SmartTikTokLink({ className, offlineLabel, liveLabel }: SmartTikTokLinkProps) {
+  const { isLive, streamUrl } = useLiveStatus();
+
+  return (
+    <a
+      href={streamUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      <span className="text-sm text-muted group-hover:text-accent transition-colors uppercase tracking-wider">{isLive ? liveLabel : offlineLabel}</span>
+    </a>
+  );
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -171,6 +171,40 @@ export const radioPage = {
   ],
 };
 
+// ----- ARCHIVE: QUEUE PAGE -----
+// Kept for legacy archived route content that still compiles in some deployments.
+export const queuePage = {
+  hero: {
+    label: "// ARCHIVE PROGRAM: AI STREAM QUEUE",
+    heading: "AI Stream Queue",
+    description:
+      "Request a play in the B-show buffer. Free or priority tiers route into the active queue.",
+  },
+  steps: [
+    { number: "01", title: "Submit", description: "Send artist, title, and link into the queue intake form." },
+    { number: "02", title: "Route", description: "Your request is ranked by tier and queued for playback order." },
+    { number: "03", title: "Broadcast", description: "Tracks play through the stream pipeline and get logged." },
+  ],
+  rules: [
+    "Use music you own or are authorized to submit.",
+    "Include a valid playable link.",
+    "Queue priority follows selected tier and timestamp.",
+    "Requests may be removed if links are broken or non-compliant.",
+  ],
+  cta: {
+    label: "// A-SHOW HANDOFF",
+    heading: "Want the full live radio experience?",
+    description: "Jump to BARCODE Radio for the main transmission window.",
+    buttonText: "Enter BARCODE Radio →",
+  },
+  terminalOutput: [
+    "> QUEUE.PIPELINE ............... ACTIVE",
+    "> TIER.ROUTER .................. STABLE",
+    "> REQUEST.LOGGER ............... WRITING",
+    "> HANDOFF TARGET ............... /radio",
+  ],
+};
+
 // ----- TERMINAL PAGE -----
 
 export const terminalPage = {

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,7 +20,6 @@ export const externalLinks = {
   discord: "https://discord.gg/4tHazmD528",
   auxchord: "https://aux.fan/@barcode_radio",
   tiktok: "https://www.tiktok.com/@six.bit",
-  tiktokLive: "https://www.tiktok.com/@six.bit",
 };
 
 // ----- HOMEPAGE -----
@@ -82,6 +81,7 @@ export const homePage = {
     { label: "Discord", href: "EXTERNAL:discord" },
     { label: "Database", href: "/database" },
     { label: "Submit Music", href: "/radio" },
+    { label: "TikTok Signal", href: "EXTERNAL:tiktok" },
   ],
 };
 
@@ -314,15 +314,15 @@ export const databasePage = {
     },
     {
       slug: "tiktok",
-      title: "TikTok Live",
+      title: "TikTok Signal",
       category: "Interface",
       image: "/database/tiktok-logo.png",
       summary:
-        "Primary public broadcast feed. Used for BARCODE Radio live shows.",
+        "Primary public signal hub. Tune in here when BARCODE Radio goes live.",
       status: "ACTIVE",
       tags: ["live", "broadcast", "social"],
       notes:
-        "TikTok-first format. 6 Bit hosts the show live. Community engagement is core to the experience.",
+        "Primary TikTok signal hub for 6 Bit and BARCODE updates. Tune in from here when live starts.",
       link: "EXTERNAL:tiktok",
       files: [] as { name: string; url: string; type: "download" | "audio" | "video" | "image" }[],
     },
@@ -587,6 +587,6 @@ export const terminalLogin = {
 export const liveBanner = {
   active: true,
   text: "LIVE NOW — BARCODE Network is transmitting",
-  watchText: "Watch BARCODE Radio →",
+  watchText: "Lock into the TikTok signal →",
   watchHref: "/radio",
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,7 +20,6 @@ export const externalLinks = {
   discord: "https://discord.gg/4tHazmD528",
   auxchord: "https://aux.fan/@barcode_radio",
   tiktok: "https://www.tiktok.com/@six.bit",
-  tiktokLive: "https://www.tiktok.com/@six.bit",
 };
 
 // ----- HOMEPAGE -----
@@ -82,6 +81,7 @@ export const homePage = {
     { label: "Discord", href: "EXTERNAL:discord" },
     { label: "Database", href: "/database" },
     { label: "Submit Music", href: "/radio" },
+    { label: "TikTok Signal", href: "EXTERNAL:tiktok" },
   ],
 };
 
@@ -168,6 +168,40 @@ export const radioPage = {
       href: "EXTERNAL:discord",
       variant: "secondary",
     },
+  ],
+};
+
+// ----- ARCHIVE: QUEUE PAGE -----
+// Kept for legacy archived route content that still compiles in some deployments.
+export const queuePage = {
+  hero: {
+    label: "// ARCHIVE PROGRAM: AI STREAM QUEUE",
+    heading: "AI Stream Queue",
+    description:
+      "Request a play in the B-show buffer. Free or priority tiers route into the active queue.",
+  },
+  steps: [
+    { number: "01", title: "Submit", description: "Send artist, title, and link into the queue intake form." },
+    { number: "02", title: "Route", description: "Your request is ranked by tier and queued for playback order." },
+    { number: "03", title: "Broadcast", description: "Tracks play through the stream pipeline and get logged." },
+  ],
+  rules: [
+    "Use music you own or are authorized to submit.",
+    "Include a valid playable link.",
+    "Queue priority follows selected tier and timestamp.",
+    "Requests may be removed if links are broken or non-compliant.",
+  ],
+  cta: {
+    label: "// A-SHOW HANDOFF",
+    heading: "Want the full live radio experience?",
+    description: "Jump to BARCODE Radio for the main transmission window.",
+    buttonText: "Enter BARCODE Radio →",
+  },
+  terminalOutput: [
+    "> QUEUE.PIPELINE ............... ACTIVE",
+    "> TIER.ROUTER .................. STABLE",
+    "> REQUEST.LOGGER ............... WRITING",
+    "> HANDOFF TARGET ............... /radio",
   ],
 };
 
@@ -260,7 +294,7 @@ export const databasePage = {
       slug: "6-bit",
       title: "6 Bit",
       category: "Entity",
-      image: "/database/6-bit.png",
+      image: "/6-bit.png",
       summary:
         "Primary host entity of the BARCODE Network. Processes music, signal traffic, and public-facing transmissions.",
       status: "LIVE",
@@ -274,7 +308,7 @@ export const databasePage = {
       slug: "barcode-radio",
       title: "BARCODE Radio",
       category: "Interface",
-      image: "/database/barcode-radio.png",
+      image: "/barcode-radio.png",
       summary:
         "Live intake frequency for music submissions. Broadcasts every Friday.",
       status: "ACTIVE",
@@ -288,7 +322,7 @@ export const databasePage = {
       slug: "discord",
       title: "Discord",
       category: "Interface",
-      image: "/database/discord-logo.png",
+      image: "/discord-logo.png",
       summary:
         "Community hub. Moderation, announcements, and live discussion.",
       status: "OPEN",
@@ -302,7 +336,7 @@ export const databasePage = {
       slug: "auxchord",
       title: "Auxchord",
       category: "Interface",
-      image: "/database/auxchord-logo.png",
+      image: "/auxchord-logo.png",
       summary:
         "Submission intake system used to route tracks into BARCODE Radio.",
       status: "LINKED",
@@ -314,15 +348,15 @@ export const databasePage = {
     },
     {
       slug: "tiktok",
-      title: "TikTok Live",
+      title: "TikTok Signal",
       category: "Interface",
-      image: "/database/tiktok-logo.png",
+      image: "/tiktok-logo.png",
       summary:
-        "Primary public broadcast feed. Used for BARCODE Radio live shows.",
+        "Primary public signal hub. Tune in here when BARCODE Radio goes live.",
       status: "ACTIVE",
       tags: ["live", "broadcast", "social"],
       notes:
-        "TikTok-first format. 6 Bit hosts the show live. Community engagement is core to the experience.",
+        "Primary TikTok signal hub for 6 Bit and BARCODE updates. Tune in from here when live starts.",
       link: "EXTERNAL:tiktok",
       files: [] as { name: string; url: string; type: "download" | "audio" | "video" | "image" }[],
     },
@@ -330,7 +364,7 @@ export const databasePage = {
       slug: "mr-nice-guy-productions",
       title: "Mr. Nice Guy Productions",
       category: "Personnel",
-      image: "/database/MC-nice.png",
+      image: "/MC-nice.png",
       summary:
         "Discord and BARCODE Radio mod. Positive operator and network support node.",
       status: "ACTIVE",
@@ -344,7 +378,7 @@ export const databasePage = {
       slug: "mac-modem",
       title: "Mac Modem",
       category: "Entity",
-      image: "/database/mac-modem.png",
+      image: "/mac-modem.png",
       summary:
         "Glitch-virus entity. Multi-tool operative. Unstable but useful.",
       status: "VOLATILE",
@@ -358,7 +392,7 @@ export const databasePage = {
       slug: "dj-floppydisc",
       title: "DJ Floppydisc",
       category: "Personnel",
-      image: "/database/dj-floppydisc.png",
+      image: "/dj-floppydisc.png",
       summary:
         "Signal engineer. Mix/master operator. Long-running BARCODE mod.",
       status: "ACTIVE",
@@ -372,7 +406,7 @@ export const databasePage = {
       slug: "cache-back",
       title: "Cache Back",
       category: "Entity",
-      image: "/database/cache-back.png",
+      image: "/cache-back.png",
       summary:
         "Recovery-linked BARCODE member tied to preserved fragments and legacy data.",
       status: "ACTIVE",
@@ -386,7 +420,7 @@ export const databasePage = {
       slug: "studio-rats",
       title: "Studio Rats",
       category: "Entity",
-      image: "/database/studio-rats.png",
+      image: "/studio-rats.png",
       summary:
         "Signal infestation entities inhabiting the lower layers of the station.",
       status: "PRESENT",
@@ -400,7 +434,7 @@ export const databasePage = {
       slug: "vouchd",
       title: "Vouch’d",
       category: "Interface",
-      image: "/database/vouchd-logo.png",
+      image: "/vouchd-logo.png",
       summary:
         "External review and trust layer used to validate artists and brands.",
       status: "LINKED",
@@ -587,6 +621,6 @@ export const terminalLogin = {
 export const liveBanner = {
   active: true,
   text: "LIVE NOW — BARCODE Network is transmitting",
-  watchText: "Watch BARCODE Radio →",
+  watchText: "Lock into the TikTok signal →",
   watchHref: "/radio",
 };

--- a/src/lib/transmissions.ts
+++ b/src/lib/transmissions.ts
@@ -47,42 +47,6 @@ export const transmissions: Transmission[] = [
       "If you're reading this, you've already tuned in.",
     ],
   },
-  {
-    slug: "queue-system-explained",
-    title: "The Queue: A Breakdown of the Transmission Protocol",
-    date: "2025-07-08",
-    author: "BARCODE HQ",
-    tags: ["queue", "technical", "guide"],
-    excerpt:
-      "How submissions enter the BARCODE broadcast queue, how tiers work, and what happens when your transmission reaches the front of the line.",
-    body: [
-      "The BARCODE queue isn't a playlist. It's a priority-weighted transmission buffer. Submissions enter at the back and advance forward, but not all at the same speed.",
-      "<strong>Free tier</strong> — anyone can submit. Zero cost, zero friction. Your entry joins the back of the queue and advances naturally. Rate limited to 3 submissions per hour to prevent flooding.",
-      '<strong>Featured ($3)</strong> — a small signal boost. Your submission skips ahead of free entries and gets a green highlight in the queue display. Think of it as "I believe in this enough to buy it a coffee."',
-      "<strong>Fast Lane ($5)</strong> — meaningful queue advancement. Jumps ahead of both Free and Featured entries. The yellow tier. For when you want your transmission heard sooner rather than later.",
-      "<strong>Front Row ($10)</strong> — maximum priority. Your entry goes to the front of the queue, behind only other Front Row submissions. The red tier. First in line, first on air.",
-      "All payments are processed through Stripe. No accounts required — just submit, pay, and your transmission enters the buffer. The queue processes entries in tier-weighted order during live broadcasts.",
-      "Every submission that airs gets logged. Play counts, timestamps, tier — all tracked. The system remembers every signal that passed through.",
-    ],
-  },
-  {
-    slug: "building-in-public",
-    title: "Building in Public: The BARCODE Dev Log",
-    date: "2025-07-05",
-    author: "BARCODE HQ",
-    tags: ["dev-log", "technical", "open-source"],
-    excerpt:
-      "A look behind the broadcast — the tech stack, the decisions, and why we're building BARCODE the way we are.",
-    body: [
-      "BARCODE runs on Next.js, Tailwind CSS, Upstash Redis, and Stripe. It deploys to Vercel. The OBS overlay connects via iframe. The Discord bot polls the API. It's a frankenstein of modern web tools stitched together with intent.",
-      "Why Next.js? Because server-side rendering matters for SEO, and static generation matters for speed. Every database dossier is pre-rendered at build time. The queue page is dynamic. The admin panel is server-authenticated.",
-      "Why Upstash Redis? Because the queue needs to be fast, persistent, and accessible from both the website and external services (Discord bot, OBS overlay, future stream engine). Redis is the nervous system.",
-      "Why Stripe? Because musicians deserve to get paid, and payment infrastructure should be invisible. No accounts, no sign-ups. Scan → pay → you're in the queue. That's it.",
-      "The CRT aesthetic isn't decoration — it's philosophy. Old technology had character. Scan lines, phosphor glow, signal degradation — these aren't bugs, they're texture. BARCODE looks the way it sounds: analog warmth through digital pipes.",
-      "Everything is being built incrementally. Phase 1 was the core site. Phase 2 added the Discord bot. Phase 3 (you're reading it) is the blog. Phase 4 will be the AI stream automation engine. Each phase adds a new dimension to the broadcast.",
-      "We're documenting the process because building in public creates accountability. And because someone, somewhere, is trying to build something similar and could use a reference signal.",
-    ],
-  },
 ];
 
 // ── Utility Functions ───────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Unify and simplify site content shapes (use `dossiers`/`slug` and consolidated `externalLinks`) so pages can reliably resolve external targets and smaller bundles of content. 
- Provide a smarter TikTok link that responds to live status and remove hardcoded `/live` paths. 
- Tighten broadcast scheduling and make UI pages resilient to the updated content model.

### Description
- Reworked site content in `src/content.ts` (consolidated `externalLinks`, migrated `databasePage.entries` → `databasePage.dossiers`, simplified `releases` and `transmissions` data). 
- Added a new `SmartTikTokLink` component (`src/components/SmartTikTokLink.tsx`) that uses `useLiveStatus` to render live/offline labels and link to the current `streamUrl`. 
- Updated live/status handling: changed default TikTok URL and schedule window in `src/app/api/admin/live/route.ts`, `src/components/LiveStatusProvider.tsx`, `src/components/OBSOverlay.tsx` (schedule shifted to 6:40 PM–11:00 PM PST, removed `/live` suffix). 
- Adapted pages to the new content shape and fallback semantics: `src/app/database/[slug]/page.tsx` now resolves `dossiers` by `slug`, adds `resolveExternal`, normalizes missing fields; `src/app/database/page.tsx` maps `dossiers` into table entries with normalization helpers; `src/app/page.tsx` and `src/components/Footer.tsx` integrate `SmartTikTokLink`; `src/app/merch/page.tsx`, `src/app/releases/page.tsx`, `src/app/radio/page.tsx`, `src/app/terminal/page.tsx` simplified or made conditional to work with new content. 
- Updated `sitemap.ts` to emit `/database/{slug}` pages and `lib/transmissions.ts` to match reduced transmissions data. 

### Testing
- Ran a local build with `npm run build` (Next.js) to validate compilation and route changes, which completed successfully. 
- Ran static type checks and lint via `npm run typecheck` and `npm run lint`, both completed without errors. 
- Verified server API responses for `/api/admin/live` and that `SmartTikTokLink` reads `useLiveStatus` values during local testing (manual smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a77083d08321b203ae9b71c7431b)