### PR TITLE
Integrate SmartTikTokLink and add TikTok nav item; prune transmissions entries

### DIFF
--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { radioPage, externalLinks } from "@/content";
 import { RadioHero, SectionDot } from "@/components/LiveEffects";
 import { LocalSchedule } from "@/components/LocalSchedule";
+import { SmartTikTokLink } from "@/components/SmartTikTokLink";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -67,6 +68,13 @@ export default function RadioPage() {
               <span className="text-lg">{radioPage.hero.discordButton.emoji}</span>
               {radioPage.hero.discordButton.text}
             </a>
+          </div>
+          <div className="mt-4 max-w-lg">
+            <SmartTikTokLink
+              className="inline-flex w-full items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+              offlineLabel="TikTok Signal"
+              liveLabel="TikTok Live // Tune In"
+            />
           </div>
         </div>
       </section>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,8 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useLiveStatus } from "./LiveStatusProvider";
 import { GlitchText } from "./GlitchText";
-import { siteConfig } from "@/content";
+import { siteConfig, externalLinks } from "@/content";
+import { SmartTikTokLink } from "./SmartTikTokLink";
 
 const navItems = [
   { href: "/", label: "HQ" },
@@ -16,6 +17,7 @@ const navItems = [
   { href: "/releases", label: "Releases" },
   { href: "/transmissions", label: "Transmissions" },
   { href: "/merch", label: "Merch" },
+  { href: externalLinks.tiktok, label: "TikTok", external: true },
 ];
 
 export function Header() {
@@ -51,6 +53,16 @@ export function Header() {
           {/* Navigation */}
           <nav className="hidden md:flex items-center gap-1">
             {navItems.map((item) => {
+              if (item.external) {
+                return (
+                  <SmartTikTokLink
+                    key={item.href}
+                    className="px-3 py-1.5 text-sm uppercase tracking-widest transition-colors text-muted hover:text-foreground"
+                    offlineLabel={item.label}
+                    liveLabel="TikTok Live"
+                  />
+                );
+              }
               const isActive = pathname === item.href;
               return (
                 <Link
@@ -119,6 +131,16 @@ function MobileMenu({ pathname }: { pathname: string }) {
         <div className="absolute top-14 left-0 right-0 bg-background border-b border-border p-4">
           <nav className="flex flex-col gap-2">
             {navItems.map((item) => {
+              if (item.external) {
+                return (
+                  <SmartTikTokLink
+                    key={item.href}
+                    className="px-3 py-2 text-sm uppercase tracking-widest transition-colors text-muted hover:text-foreground"
+                    offlineLabel={item.label}
+                    liveLabel="TikTok Live // Tune In"
+                  />
+                );
+              }
               const isActive = pathname === item.href;
               return (
                 <Link

--- a/src/content.ts
+++ b/src/content.ts
@@ -508,20 +508,6 @@ export const transmissionsPage = {
         "Unauthorized propagation of BARCODE: Signal Breach detected across public channels. Internal containment failed.",
       status: "ARCHIVED",
     },
-    {
-      date: "2026.03.08",
-      title: "Interdimensional Signal Locked",
-      body:
-        "Artifact release confirmed. Initial public response logged. Feed remains stable.",
-      status: "ARCHIVED",
-    },
-    {
-      date: "2026.02.20",
-      title: "Broadcast Queue Saturation",
-      body:
-        "Submission volume exceeded standard handling capacity during live intake. Additional moderation strain observed.",
-      status: "ARCHIVED",
-    },
   ],
 };
 
@@ -563,18 +549,6 @@ export const transmissionsFeed = [
     time: "2026-03-16 00:14 PST",
     type: "ALERT",
     message: "Unauthorized propagation detected: BARCODE: Signal Breach.",
-  },
-  {
-    id: "transmission-002",
-    time: "2026-03-08 08:03 PST",
-    type: "NOTICE",
-    message: "Artifact lock confirmed: Interdimensional Signal Locked.",
-  },
-  {
-    id: "transmission-003",
-    time: "2026-02-20 19:42 PST",
-    type: "STATUS",
-    message: "Submission volume spike observed during live intake frequency.",
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Surface TikTok live status and a direct TikTok CTA in the header and radio CTAs for easier access to live streams.
- Render external links (TikTok) with the new `SmartTikTokLink` component to show offline vs live labels.
- Remove outdated transmissions feed entries to keep the feed current.

### Description
- Added `SmartTikTokLink` imports and integrated it into the radio page primary CTAs below the submit/discord buttons using `SmartTikTokLink` with `offlineLabel` and `liveLabel` props.
- Extended header navigation by adding a TikTok external nav item in `navItems` and updated the nav and mobile menu to render external items via `SmartTikTokLink` while preserving normal `Link` rendering for internal routes.
- Updated `Header.tsx` to import `externalLinks` from `@/content` and to conditionally render external nav items with appropriate classes and live labels.
- Removed several historical entries from `transmissionsPage.entries` and `transmissionsFeed` in `content.ts` to prune stale items.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- Ran the test suite with `npm test` and all tests passed.
- Ran TypeScript check with `tsc --noEmit` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24861cc708321baf17ac2fbbf4f30)