### PR TITLE
docs: add removal/scope/routing/verification guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,51 @@ Do not modify these unless explicitly requested:
 - Do not rewrite unrelated copy.
 - Do not rename files or reorganize folders unless explicitly requested.
 - Before finishing, summarize exactly which files changed and why.
+
+## Removal tasks
+
+When asked to remove a page, entry, article, route, feature, or public-facing item:
+
+- Search the repo for all active references before editing.
+- Check page routes under `src/app/`.
+- Check shared content/data files such as `src/content.ts`.
+- Check navigation components such as Header and Footer only if the removed item may be linked there.
+- Check sitemap and metadata files.
+- Check imports, cards, lists, indexes, and related CTAs.
+- Remove only active/public references unless explicitly asked to remove archived materials.
+- Do not delete archived/reference materials under `_archive/` unless explicitly requested.
+- After finishing, list every reference found and whether it was removed, left alone, or already inactive.
+
+## Scope interpretation
+
+- If a task says "remove from [specific page]," remove it from that page only, unless the user also says to scrub all references.
+- If a task says "remove from the site," "scrub," "delete everywhere," or "remove all traces," search and clean all active references.
+- If unclear, make the smallest safe change and report what related references still exist.
+
+## Routing safety
+
+- Do not create new public routes under `src/app/` unless explicitly requested.
+- Do not restore deleted routes from `_archive/`.
+- Do not move archived files back into active app routes unless explicitly requested.
+- Before adding or removing a route, check whether it affects Header, Footer, sitemap, metadata, or internal links.
+
+## Verification checklist
+
+Before finishing any task, verify:
+
+- The changed files match the requested scope.
+- No unrelated copy was rewritten.
+- No removed feature was restored.
+- No new route was created accidentally.
+- The app builds or type-checks if the task touched code.
+- The final response includes changed files and a short reason for each.
+
+## PR summary format
+
+At the end of every task, summarize:
+
+- Files changed
+- What changed
+- Why it changed
+- Anything intentionally left untouched
+- Any follow-up risks or manual checks needed


### PR DESCRIPTION
### Motivation

- Provide explicit agent guidance for safely removing pages, entries, routes, and other public-facing items. 
- Prevent accidental restoration or creation of routes and limit broad or unintended cleanup. 
- Standardize a verification checklist and PR summary format so removal tasks are consistent and auditable.

### Description

- Appended new sections to `AGENTS.md`: `Removal tasks`, `Scope interpretation`, `Routing safety`, `Verification checklist`, and `PR summary format`. 
- Added step-by-step expectations to search the repo for active references, check `src/app/`, `src/content.ts`, navigation, sitemaps/metadata, and avoid deleting `_archive/` unless requested. 
- Added a short verification checklist requiring scope validation and a requirement to build/type-check if code was touched, plus a required PR summary format.

### Testing

- Verified the repository contains `AGENTS.md` and the appended content with `nl -ba AGENTS.md | tail -n 120`, which showed the new sections successfully. 
- Confirmed the file changes are present and a pull request was created via the repository PR tooling. 
- No build or type-check was necessary because the change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3997d7fc88321883a7c57a2dae2b5)