### PR TITLE
Add TikTok link and CTA to radio page, footer, and content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,7 +112,7 @@ export default function Home() {
       {/* Quick Links / Status Grid */}
       <section>
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="grid grid-cols-5 gap-4">
             {homePage.quickLinks.map((link) => {
               const resolved = resolveHref(link.href);
               const isExternal = link.href.startsWith("EXTERNAL:");

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -64,7 +64,7 @@ export default function RadioPage() {
               href={externalLinks.tiktok}
               target="_blank"
               rel="noopener noreferrer"
-              className="w-[calc(50%-0.5rem)] min-w-[220px] inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+              className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
             >
               <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
               {radioPage.hero.tiktokButton.text}

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -59,6 +59,17 @@ export default function RadioPage() {
               {radioPage.hero.discordButton.text}
             </a>
           </div>
+          <div className="mt-4 max-w-lg">
+            <a
+              href={externalLinks.tiktok}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-[calc(50%-0.5rem)] min-w-[220px] inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+            >
+              <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
+              {radioPage.hero.tiktokButton.text}
+            </a>
+          </div>
         </div>
       </section>
 

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -87,7 +87,7 @@ export default function TerminalPage() {
             </h2>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-4 gap-4">
             {terminalPage.accessPoints.map((point) => (
               <ExternalLink
                 key={point.label}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -82,6 +82,11 @@ export function Footer() {
                 </a>
               </li>
               <li>
+                <a href={externalLinks.tiktok} target="_blank" rel="noopener noreferrer" className="text-sm text-foreground/70 hover:text-accent transition-colors">
+                  TikTok
+                </a>
+              </li>
+              <li>
                 <Link href="/merch" className="text-sm text-foreground/70 hover:text-accent transition-colors">
                   Merch
                 </Link>

--- a/src/content.ts
+++ b/src/content.ts
@@ -80,6 +80,7 @@ export const homePage = {
   },
   quickLinks: [
     { label: "Discord", href: "EXTERNAL:discord" },
+    { label: "TikTok", href: "EXTERNAL:tiktok" },
     { label: "Releases", href: "/releases" },
     { label: "Database", href: "/database" },
     { label: "Submit Music", href: "/radio" },
@@ -97,6 +98,7 @@ export const radioPage = {
       "A live intake frequency. Submit a track. It enters the broadcast and becomes part of the network.",
     submitButton: { text: "Submit Music", emoji: "🎵" },
     discordButton: { text: "Join Discord", emoji: "💬" },
+    tiktokButton: { text: "Watch TikTok", emoji: "📺" },
   },
 
   schedule: {


### PR DESCRIPTION
### Motivation
- Add TikTok as a first-class external destination across the site so visitors can access the project's TikTok from the radio hero, footer resources, and quick links.

### Description
- Added a TikTok CTA under the radio hero buttons in `src/app/radio/page.tsx` that links to `externalLinks.tiktok` and uses the new `tiktokButton` content.
- Added a TikTok resource link to the footer in `src/components/Footer.tsx` pointing to `externalLinks.tiktok` and placed it alongside existing resource links.
- Added `TikTok` to the global quick links and added `tiktokButton` metadata to `radioPage.hero` in `src/content.ts`.
- Minor layout/whitespace adjustments to accommodate the additional CTA.

### Testing
- Ran a production build with `npm run build` which completed successfully.
- Executed unit tests with `npm test` and all tests passed.
- Ran linting/type checking with `npm run lint` and `npm run typecheck`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ba7dfbb88321882b39a72f5ebab1)