### PR TITLE
Add TikTok link and CTA to radio page, footer, and content (#16)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,7 +112,7 @@ export default function Home() {
       {/* Quick Links / Status Grid */}
       <section>
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="grid grid-cols-5 gap-4">
             {homePage.quickLinks.map((link) => {
               const resolved = resolveHref(link.href);
               const isExternal = link.href.startsWith("EXTERNAL:");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,7 +112,7 @@ export default function Home() {
       {/* Quick Links / Status Grid */}
       <section>
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="grid grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
             {homePage.quickLinks.map((link) => {
               const resolved = resolveHref(link.href);
               const isExternal = link.href.startsWith("EXTERNAL:");

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -59,6 +59,17 @@ export default function RadioPage() {
               {radioPage.hero.discordButton.text}
             </a>
           </div>
+          <div className="mt-4 max-w-lg">
+            <a
+              href={externalLinks.tiktok}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+            >
+              <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
+              {radioPage.hero.tiktokButton.text}
+            </a>
+          </div>
         </div>
       </section>
 

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -87,7 +87,7 @@ export default function TerminalPage() {
             </h2>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-4 gap-4">
             {terminalPage.accessPoints.map((point) => (
               <ExternalLink
                 key={point.label}

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -87,7 +87,7 @@ export default function TerminalPage() {
             </h2>
           </div>
 
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {terminalPage.accessPoints.map((point) => (
               <ExternalLink
                 key={point.label}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -82,6 +82,11 @@ export function Footer() {
                 </a>
               </li>
               <li>
+                <a href={externalLinks.tiktok} target="_blank" rel="noopener noreferrer" className="text-sm text-foreground/70 hover:text-accent transition-colors">
+                  TikTok
+                </a>
+              </li>
+              <li>
                 <Link href="/merch" className="text-sm text-foreground/70 hover:text-accent transition-colors">
                   Merch
                 </Link>

--- a/src/content.ts
+++ b/src/content.ts
@@ -80,6 +80,7 @@ export const homePage = {
   },
   quickLinks: [
     { label: "Discord", href: "EXTERNAL:discord" },
+    { label: "TikTok", href: "EXTERNAL:tiktok" },
     { label: "Releases", href: "/releases" },
     { label: "Database", href: "/database" },
     { label: "Submit Music", href: "/radio" },
@@ -97,6 +98,7 @@ export const radioPage = {
       "A live intake frequency. Submit a track. It enters the broadcast and becomes part of the network.",
     submitButton: { text: "Submit Music", emoji: "🎵" },
     discordButton: { text: "Join Discord", emoji: "💬" },
+    tiktokButton: { text: "Watch TikTok", emoji: "📺" },
   },
 
   schedule: {


### PR DESCRIPTION
* Add TikTok links to footer, homepage quick links, and radio CTA

* Make radio TikTok CTA span full hero CTA width

* Set HQ and terminal link grids to single rows