### PR TITLE
Mark BARCODE: Signal Breach as LATEST and add streaming links (#19)

### DIFF
--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -70,7 +70,7 @@ export default function ReleasesPage() {
                         </h3>
                         <span
                           className={`text-xs uppercase tracking-widest px-2 py-0.5 border ${
-                            release.status === "LATEST"
+                            release.status === "LATEST" || release.status === "ACTIVE"
                               ? "border-accent/30 text-accent"
                               : release.status === "INCOMING"
                               ? "border-red-500/30 text-red-400 animate-pulse"

--- a/src/content.ts
+++ b/src/content.ts
@@ -607,6 +607,17 @@ type ReleaseLinks = {
   soundcloud?: string;
 };
 
+type ReleaseStatus = "LATEST" | "ACTIVE" | "INCOMING" | "ARCHIVED";
+type ReleaseItem = {
+  title: string;
+  type: string;
+  date: string;
+  status: ReleaseStatus;
+  cover: string;
+  description: string;
+  links: ReleaseLinks;
+};
+
 export const releasesPage = {
   hero: {
     label: "// ARCHIVE: RELEASES",
@@ -620,17 +631,21 @@ export const releasesPage = {
       title: "BARCODE: Signal Breach",
       type: "Album",
       date: "2026",
-      status: "INCOMING" as const,
+      status: "LATEST",
       cover: "/releases/signal-breach.png",
       description:
         "Unauthorized circulation of an internal BARCODE Network audio archive was detected following the Signal Breach incident. The breach has been contained. Further information will be issued shortly.",
-      links: {} as ReleaseLinks,
+      links: {
+        spotify: "https://open.spotify.com/album/1lglaBgYDfRIANiSfrhUGS?si=Ekdj3qrbRaKnrPiCnYbrlg",
+        apple: "https://music.apple.com/us/album/barcode-signal-breach/1883133732",
+        youtube: "https://music.youtube.com/playlist?list=OLAK5uy_lU6uSwmlRmWpKbd4-Ik99wzT-LFZWzwtw&si=BzfzAb6Ug8-s75pS",
+      },
     },
     {
       title: "BARCODE Vol. 1",
       type: "Album",
       date: "2025",
-      status: "LATEST" as const,
+      status: "ACTIVE",
       cover: "/releases/barcode-vol-1.png",
       description:
         "The inaugural transmission. A full-length broadcast from 6 Bit through the BARCODE Network.",
@@ -638,19 +653,19 @@ export const releasesPage = {
         spotify: "https://open.spotify.com/album/1PywhXFBsB4jue16x8ujNs",
         apple: "https://music.apple.com/us/album/barcode-vol-1/1817414054",
         youtube: "https://music.youtube.com/playlist?list=OLAK5uy_nsftWPdpLsRS7GYoLanK-ZtMt0tsmbh0Y",
-      } as ReleaseLinks,
+      },
     },
     {
       title: "[REDACTED]",
       type: "Album",
       date: "20██",
-      status: "ARCHIVED" as const,
+      status: "ARCHIVED",
       cover: "/releases/barcode-vol-0.png",
       description:
         "A lost transmission. Originally broadcast, then pulled from all frequencies. Remastered fragments scheduled for re-release in two parts. Origin data classified.",
-      links: {} as ReleaseLinks,
+      links: {},
     },
-  ],
+  ] as ReleaseItem[],
 
   bottomCta: {
     text: "Want to get your music on BARCODE Radio?",


### PR DESCRIPTION
* Update releases catalog to mark Signal Breach as latest

* Fix releases status typing for build compatibility

* Fix Signal Breach YouTube link and stabilize release catalog typing

* Mark BARCODE Vol. 1 as ACTIVE and style ACTIVE tag as latest