### PR TITLE
Radio: use TikTok live link and update CTA text

### DIFF
--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -61,7 +61,7 @@ export default function RadioPage() {
           </div>
           <div className="mt-4 max-w-lg">
             <a
-              href={externalLinks.tiktok}
+              href={externalLinks.tiktokLive}
               target="_blank"
               rel="noopener noreferrer"
               className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,7 +20,7 @@ export const externalLinks = {
   discord: "https://discord.gg/4tHazmD528",
   auxchord: "https://aux.fan/@barcode_radio",
   tiktok: "https://www.tiktok.com/@six.bit",
-  tiktokLive: "https://www.tiktok.com/@six.bit",
+  tiktokLive: "https://www.tiktok.com/@six.bit/live",
 };
 
 // ----- HOMEPAGE -----
@@ -98,7 +98,7 @@ export const radioPage = {
       "A live intake frequency. Submit a track. It enters the broadcast and becomes part of the network.",
     submitButton: { text: "Submit Music", emoji: "🎵" },
     discordButton: { text: "Join Discord", emoji: "💬" },
-    tiktokButton: { text: "Watch TikTok", emoji: "📺" },
+    tiktokButton: { text: "WATCH ON TIKTOK", emoji: "📺" },
   },
 
   schedule: {


### PR DESCRIPTION
### Motivation
- Make the BARCODE Radio TikTok call-to-action open the live stream and display the requested uppercase label so visitors land directly on the broadcast.

### Description
- Changed `src/content.ts` to set `externalLinks.tiktokLive` to `https://www.tiktok.com/@six.bit/live` and updated `radioPage.hero.tiktokButton.text` to `WATCH ON TIKTOK`, and updated `src/app/radio/page.tsx` to use `externalLinks.tiktokLive` for the radio page TikTok CTA.

### Testing
- Ran `npm run lint`, which failed due to pre-existing unrelated lint issues (e.g. `react/jsx-no-comment-textnodes` and `react-hooks/set-state-in-effect`), so no lint regressions attributable to this change were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f834aa4c832186c33ae28095a5d6)