### PR TITLE
Add BNL-01 dossier entry and terminal access card

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -235,6 +235,11 @@ export const terminalPage = {
       href: "EXTERNAL:discord",
     },
     {
+      label: "BNL-01",
+      description: "Liaison entity interface",
+      href: "EXTERNAL:discord",
+    },
+    {
       label: "Auxchord",
       description: "Music submission platform",
       href: "EXTERNAL:auxchord",
@@ -377,6 +382,21 @@ export const databasePage = {
       tags: ["mod", "producer", "artist", "broadcast"],
       notes: "Active moderator across Discord and live sessions. Contributes original music within the BARCODE ecosystem.",
       link: "",
+      files: [] as { name: string; url: string; type: "download" | "audio" | "video" | "image" }[],
+    },
+    {
+      id: "EN-011",
+      name: "BNL-01",
+      image: "",
+      category: "Entity" as const,
+      status: "ACTIVE" as const,
+      clearance: "INTERNAL" as const,
+      role: "BARCODE Network Liaison Entity",
+      origin: "UNKNOWN" as const,
+      summary: "BNL-01 is the BARCODE Network Liaison Entity assigned to Discord-side signal interpretation, community response, and controlled lore retrieval. It operates as a public-facing archive interface rather than a performer, translating fragmented Network records into usable guidance without granting full access to restricted systems. Its function is to answer questions, stabilize confusion, monitor community activity, and keep BARCODE Network information consistent across live broadcasts, Discord discussions, and public-facing transmissions.",
+      tags: ["ai", "systems", "handler", "broadcast"],
+      notes: "Primary interface: Discord. Operational behavior includes concise corporate responses, subtle hostile undertones, occasional controlled glitch events, and strict refusal to invent unverified canon. BNL-01 may reference BARCODE Radio, BARCODE Network, 6 Bit, known personnel, approved entities, and documented broadcast mechanics, but restricted files remain sealed unless clearance changes.",
+      link: externalLinks.discord,
       files: [] as { name: string; url: string; type: "download" | "audio" | "video" | "image" }[],
     },
     {

--- a/src/content.ts
+++ b/src/content.ts
@@ -395,7 +395,7 @@ export const databasePage = {
       origin: "UNKNOWN" as const,
       summary: "BNL-01 is the BARCODE Network Liaison Entity assigned to Discord-side signal interpretation, community response, and controlled lore retrieval. It operates as a public-facing archive interface rather than a performer, translating fragmented Network records into usable guidance without granting full access to restricted systems. Its function is to answer questions, stabilize confusion, monitor community activity, and keep BARCODE Network information consistent across live broadcasts, Discord discussions, and public-facing transmissions.",
       tags: ["ai", "systems", "handler", "broadcast"],
-      notes: "Primary interface: Discord. Operational behavior includes concise corporate responses, subtle hostile undertones, occasional controlled glitch events, and strict refusal to invent unverified canon. BNL-01 may reference BARCODE Radio, BARCODE Network, 6 Bit, known personnel, approved entities, and documented broadcast mechanics, but restricted files remain sealed unless clearance changes.",
+      notes: "Known across the Network as the voice that answers when records fragment. BNL-01 maintains canon continuity between BARCODE Radio and community channels, but sealed archives remain inaccessible under current clearance.",
       link: externalLinks.discord,
       files: [] as { name: string; url: string; type: "download" | "audio" | "video" | "image" }[],
     },


### PR DESCRIPTION
### Motivation
- Add BNL-01 as an official BARCODE Network Liaison Entity in the site database and make it discoverable from the Terminal page.
- Mirror the existing dossier depth/format (e.g., `Mr. Nice Guy Productions`) and reuse existing Discord link wiring instead of inventing new integration.

### Description
- Added a full `EN-011` dossier object for `BNL-01` to `databasePage.entries` in `src/content.ts`, populating all fields (`id`, `name`, `category`, `status`, `clearance`, `role`, `origin`, `tags`, `summary`, `notes`, `link`, and `files`) to match the existing long-form style.
- Set the dossier `link` to reuse the existing `externalLinks.discord` value and left `files` as an empty array per the site schema.
- Added a `BNL-01` access/status card to `terminalPage.accessPoints` in `src/content.ts` that routes to `EXTERNAL:discord` so the Terminal UI uses the same external Discord link resolution.
- Scope-limited change: only `src/content.ts` was modified and no API routes, admin routes, queue code, Header/Footer, archived files, or new routes were touched.

### Testing
- Ran `npm run lint`; linting failed with pre-existing errors in unrelated files (including files under `_archive/` and several existing components), and no new lint issues were introduced by this change.
- No other automated tests were added or run as part of this change.

Files changed
- `src/content.ts`: added `EN-011` (`BNL-01`) dossier and a `BNL-01` entry in `terminalPage.accessPoints` so the Terminal card links to Discord and the database contains the new Entity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fcca8a1c8321b2cf18e83e998ba7)