### PR TITLE
Add BNL-01 status API and Terminal status card

### DIFF
--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { Redis } from "@upstash/redis";
+
+export const dynamic = "force-dynamic";
+
+type BNLStatusValue = "ONLINE" | "OFFLINE";
+type BNLModeValue =
+  | "STANDBY"
+  | "OBSERVATION"
+  | "ACTIVE_LIAISON"
+  | "SIGNAL_DEGRADATION"
+  | "RESTRICTED";
+
+interface BNLStatus {
+  status: BNLStatusValue;
+  mode: BNLModeValue;
+  message: string;
+  lastSeen: string | null;
+}
+
+const KEY = "bnl:status";
+const DEFAULT_STATUS: BNLStatus = {
+  status: "OFFLINE",
+  mode: "STANDBY",
+  message: "BNL-01 relay awaiting signal.",
+  lastSeen: null,
+};
+
+const ALLOWED_STATUS = new Set<BNLStatusValue>(["ONLINE", "OFFLINE"]);
+const ALLOWED_MODES = new Set<BNLModeValue>([
+  "STANDBY",
+  "OBSERVATION",
+  "ACTIVE_LIAISON",
+  "SIGNAL_DEGRADATION",
+  "RESTRICTED",
+]);
+
+let memoryStatus: BNLStatus = { ...DEFAULT_STATUS };
+
+function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function sanitizeStoredStatus(value: unknown): BNLStatus {
+  if (!value || typeof value !== "object") return { ...DEFAULT_STATUS };
+
+  const record = value as Record<string, unknown>;
+  const status = ALLOWED_STATUS.has(record.status as BNLStatusValue)
+    ? (record.status as BNLStatusValue)
+    : DEFAULT_STATUS.status;
+  const mode = ALLOWED_MODES.has(record.mode as BNLModeValue)
+    ? (record.mode as BNLModeValue)
+    : DEFAULT_STATUS.mode;
+  const message =
+    typeof record.message === "string" && record.message.trim().length > 0
+      ? record.message.trim().slice(0, 240)
+      : DEFAULT_STATUS.message;
+  const lastSeen =
+    typeof record.lastSeen === "string" && record.lastSeen.length > 0
+      ? record.lastSeen
+      : null;
+
+  return { status, mode, message, lastSeen };
+}
+
+export async function GET() {
+  const redis = getRedis();
+
+  if (redis) {
+    const stored = await redis.get<unknown>(KEY);
+    const resolved = sanitizeStoredStatus(stored);
+    memoryStatus = resolved;
+    return NextResponse.json(resolved);
+  }
+
+  return NextResponse.json(memoryStatus);
+}
+
+export async function POST(req: Request) {
+  const expectedApiKey = process.env.BNL_API_KEY;
+  const providedApiKey = req.headers.get("x-api-key");
+
+  if (!expectedApiKey || providedApiKey !== expectedApiKey) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = (await req.json()) as Record<string, unknown>;
+    const allowedKeys = ["status", "mode", "message"];
+    const bodyKeys = Object.keys(body);
+    const hasOnlyAllowedKeys = bodyKeys.every((key) => allowedKeys.includes(key));
+
+    if (!hasOnlyAllowedKeys) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const status = body.status;
+    const mode = body.mode;
+    const message = body.message;
+
+    if (
+      !ALLOWED_STATUS.has(status as BNLStatusValue) ||
+      !ALLOWED_MODES.has(mode as BNLModeValue) ||
+      typeof message !== "string"
+    ) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const nextStatus: BNLStatus = {
+      status: status as BNLStatusValue,
+      mode: mode as BNLModeValue,
+      message: message.trim().slice(0, 240),
+      lastSeen: new Date().toISOString(),
+    };
+
+    const redis = getRedis();
+    if (redis) await redis.set(KEY, nextStatus);
+    memoryStatus = nextStatus;
+
+    return NextResponse.json({ ok: true, status: nextStatus, persisted: Boolean(redis) });
+  } catch (error) {
+    console.error("[bnl/status] error:", error);
+    return NextResponse.json({ error: "Failed to update status" }, { status: 500 });
+  }
+}

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -2,6 +2,7 @@ import { terminalPage, externalLinks } from "@/content";
 import Link from "next/link";
 import { TerminalLogin } from "@/components/TerminalLogin";
 import { SectionDot } from "@/components/LiveEffects";
+import { BNLStatusCard } from "@/components/BNLStatusCard";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -102,7 +103,8 @@ export default function TerminalPage() {
 
       {/* Terminal Output */}
       <section>
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 space-y-6">
+          <BNLStatusCard />
           <div className="bg-surface border border-border p-6 font-mono">
             <p className="text-xs text-muted mb-4">
               &gt; BARCODE_NETWORK // TERMINAL ACCESS

--- a/src/components/BNLStatusCard.tsx
+++ b/src/components/BNLStatusCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type BNLStatusValue = "ONLINE" | "OFFLINE";
+type BNLModeValue =
+  | "STANDBY"
+  | "OBSERVATION"
+  | "ACTIVE_LIAISON"
+  | "SIGNAL_DEGRADATION"
+  | "RESTRICTED";
+
+interface BNLStatus {
+  status: BNLStatusValue;
+  mode: BNLModeValue;
+  message: string;
+  lastSeen: string | null;
+}
+
+const FALLBACK_STATUS: BNLStatus = {
+  status: "OFFLINE",
+  mode: "STANDBY",
+  message: "BNL-01 relay awaiting signal.",
+  lastSeen: null,
+};
+
+export function BNLStatusCard() {
+  const [data, setData] = useState<BNLStatus>(FALLBACK_STATUS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadStatus = async () => {
+      try {
+        const res = await fetch("/api/bnl/status", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to load BNL status");
+        const payload = (await res.json()) as BNLStatus;
+        if (mounted) setData(payload);
+      } catch {
+        if (mounted) setData(FALLBACK_STATUS);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    loadStatus();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="bg-surface border border-border p-6 font-mono">
+      <p className="text-xs text-muted mb-4">&gt; BNL-01 // STATUS RELAY</p>
+      <div className="space-y-1 text-sm text-foreground/70">
+        <p>
+          &gt; STATUS: <span className={data.status === "ONLINE" ? "text-accent" : "text-muted"}>{data.status}</span>
+        </p>
+        <p>&gt; MODE: {data.mode}</p>
+        <p>&gt; MESSAGE: {data.message}</p>
+        <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
+        {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Expose a small BNL-01 status bridge so an external relay can publish current relay state and the site can surface it in the Terminal UI.
- Provide a minimal, secure write path and UI readout without changing existing admin/live behavior, queue code, header/footer, or other unrelated areas.

### Description
- Add a new `GET`/`POST` API at `src/app/api/bnl/status/route.ts` that persists status to Upstash Redis using `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` with an in-memory fallback, returns the default shape when empty, and sanitizes stored values.
- Secure `POST` updates by requiring `x-api-key` to match `process.env.BNL_API_KEY`, enforce strict payload keys (`status`, `mode`, `message`), validate allowed enum values, trim and cap `message` to 240 characters, set server-generated `lastSeen`, and return proper 401/400/500 responses for invalid or failed requests.
- Add a reusable client component `src/components/BNLStatusCard.tsx` that fetches `/api/bnl/status` (no-store) and renders the status in the existing BARCODE terminal style with a fallback default.
- Place the card only on the Terminal page by importing and rendering `BNLStatusCard` in `src/app/terminal/page.tsx`.
- Files changed:
  - `src/app/api/bnl/status/route.ts` — new API route implementing Redis-backed/in-memory BNL status read/write with validation and auth.
  - `src/components/BNLStatusCard.tsx` — new client React component that fetches and displays the BNL status in terminal style.
  - `src/app/terminal/page.tsx` — import and render the `BNLStatusCard` in the Terminal output area so the status is visible on that page only.

### Testing
- Ran `npm run lint`; the command reported pre-existing repository lint errors unrelated to these changes, so lint currently fails and no new lint failures specific to the added files were fixed as part of this change.
- No additional automated tests were added for this small feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f404e3c4a08321a3167fccabf189db)