### PR TITLE
Add BNL-01 network relay ticker and homepage/radio modules

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -445,3 +445,31 @@ body {
     rgba(0, 0, 0, 0.12) 2px
   );
 }
+@keyframes bnl-relay-crawl {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.bnl-relay-scroll {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.bnl-relay-scroll-track {
+  display: inline-flex;
+  gap: 2.5rem;
+  min-width: max-content;
+  padding-right: 2.5rem;
+  animation: bnl-relay-crawl 36s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bnl-relay-scroll-track {
+    animation: none;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -458,6 +458,7 @@ body {
 .bnl-relay-scroll {
   overflow: hidden;
   white-space: nowrap;
+  mask-image: linear-gradient(to right, transparent 0%, black 5%, black 95%, transparent 100%);
 }
 
 .bnl-relay-scroll-track {
@@ -465,7 +466,7 @@ body {
   gap: 2.5rem;
   min-width: max-content;
   padding-right: 2.5rem;
-  animation: bnl-relay-crawl 36s linear infinite;
+  animation: bnl-relay-crawl 48s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { LiveStatusProvider } from "@/components/LiveStatusProvider";
 import { DataStream } from "@/components/DataStream";
 import { SystemTicker } from "@/components/SystemTicker";
 import { LiveBanner } from "@/components/LiveBanner";
+import { BNLNetworkRelayTicker } from "@/components/BNLRelay";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -71,6 +72,7 @@ export default function RootLayout({
           <DataStream />
           <LiveBanner />
           <Header />
+          <BNLNetworkRelayTicker />
           <main className="min-h-screen animate-interference overflow-x-hidden">
             {children}
           </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { LiveBanner } from "@/components/LiveBanner";
 import { HeroHeading, StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
+import { BNLRelayModule } from "@/components/BNLRelay";
 
 function resolveHref(href: string): string {
   if (href.startsWith("EXTERNAL:")) {
@@ -56,6 +57,13 @@ export default function Home() {
               </Link>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* Latest Network Relay */}
+      <section className="border-b border-border">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10">
+          <BNLRelayModule title="Latest Network Relay" />
         </div>
       </section>
 

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -3,6 +3,7 @@ import { radioPage, externalLinks } from "@/content";
 import { RadioHero, SectionDot } from "@/components/LiveEffects";
 import { LocalSchedule } from "@/components/LocalSchedule";
 import type { Metadata } from "next";
+import { BNLRelayModule } from "@/components/BNLRelay";
 
 export const metadata: Metadata = {
   title: "BARCODE Radio — Submit Music & Listen Live",
@@ -70,6 +71,13 @@ export default function RadioPage() {
               {radioPage.hero.tiktokButton.text}
             </a>
           </div>
+        </div>
+      </section>
+
+      {/* BNL-01 Broadcast Monitor */}
+      <section className="border-b border-border">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+          <BNLRelayModule title="BNL-01 Broadcast Monitor" />
         </div>
       </section>
 

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useBNLStatus } from "@/components/useBNLStatus";
+
+function bnlTone(online: boolean) {
+  return online ? "text-accent" : "text-muted";
+}
+
+export function BNLNetworkRelayTicker() {
+  const { data } = useBNLStatus();
+  const online = data.status === "ONLINE";
+
+  return (
+    <div className="border-b border-border bg-surface/95 px-4 py-2 text-xs uppercase tracking-[0.18em] text-foreground/80">
+      <div className="mx-auto flex max-w-7xl items-center gap-4 overflow-hidden">
+        <span className="shrink-0 border border-border-light px-2 py-1 text-[10px] tracking-[0.25em] text-muted">
+          BNL-01 RELAY
+        </span>
+        <div className="bnl-relay-scroll min-w-0">
+          <div className="bnl-relay-scroll-track">
+            <span>
+              STATUS: <span className={bnlTone(online)}>{data.status}</span> · MODE: {data.mode} · MESSAGE: {data.message}
+              {data.lastSeen ? ` · LAST SEEN: ${data.lastSeen}` : ""} ·
+            </span>
+            <span aria-hidden>
+              STATUS: <span className={bnlTone(online)}>{data.status}</span> · MODE: {data.mode} · MESSAGE: {data.message}
+              {data.lastSeen ? ` · LAST SEEN: ${data.lastSeen}` : ""} ·
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function BNLRelayModule({ title }: { title: string }) {
+  const { data, loading } = useBNLStatus();
+  const online = data.status === "ONLINE";
+
+  return (
+    <div className="border border-border bg-surface p-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-xs uppercase tracking-[0.35em] text-muted">{title}</h2>
+        <span className={`text-xs uppercase tracking-[0.2em] ${bnlTone(online)}`}>{data.status}</span>
+      </div>
+      <div className="space-y-2 text-sm text-foreground/70">
+        <p>&gt; MODE: {data.mode}</p>
+        <p>&gt; MESSAGE: {data.message}</p>
+        <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
+        {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -3,7 +3,7 @@
 import { useBNLStatus } from "@/components/useBNLStatus";
 
 function bnlTone(online: boolean) {
-  return online ? "text-accent" : "text-muted";
+  return online ? "text-foreground" : "text-foreground/70";
 }
 
 export function BNLNetworkRelayTicker() {
@@ -11,20 +11,18 @@ export function BNLNetworkRelayTicker() {
   const online = data.status === "ONLINE";
 
   return (
-    <div className="border-b border-border bg-surface/95 px-4 py-2 text-xs uppercase tracking-[0.18em] text-foreground/80">
-      <div className="mx-auto flex max-w-7xl items-center gap-4 overflow-hidden">
-        <span className="shrink-0 border border-border-light px-2 py-1 text-[10px] tracking-[0.25em] text-muted">
-          BNL-01 RELAY
-        </span>
+    <div className="border-b border-border/80 bg-black px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-white">
+      <div className="mx-auto flex max-w-7xl items-center gap-3 overflow-hidden">
+        <span className="shrink-0 text-white/85">&gt; NETWORK RELAY // BNL-01</span>
         <div className="bnl-relay-scroll min-w-0">
           <div className="bnl-relay-scroll-track">
             <span>
-              STATUS: <span className={bnlTone(online)}>{data.status}</span> · MODE: {data.mode} · MESSAGE: {data.message}
-              {data.lastSeen ? ` · LAST SEEN: ${data.lastSeen}` : ""} ·
+              STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+              {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
             </span>
             <span aria-hidden>
-              STATUS: <span className={bnlTone(online)}>{data.status}</span> · MODE: {data.mode} · MESSAGE: {data.message}
-              {data.lastSeen ? ` · LAST SEEN: ${data.lastSeen}` : ""} ·
+              STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+              {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
             </span>
           </div>
         </div>

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -11,23 +11,26 @@ export function BNLNetworkRelayTicker() {
   const online = data.status === "ONLINE";
 
   return (
-    <div className="border-b border-border/80 bg-black px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-white">
-      <div className="mx-auto flex max-w-7xl items-center gap-3 overflow-hidden">
-        <span className="shrink-0 text-white/85">&gt; NETWORK RELAY // BNL-01</span>
-        <div className="bnl-relay-scroll min-w-0">
-          <div className="bnl-relay-scroll-track">
-            <span>
-              STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
-              {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
-            </span>
-            <span aria-hidden>
-              STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
-              {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
-            </span>
+    <>
+      <div aria-hidden className="h-8" />
+      <div className="fixed left-0 right-0 top-14 z-40 border-b border-border/80 bg-black px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-white">
+        <div className="mx-auto flex max-w-7xl items-center gap-3 overflow-hidden">
+          <span className="shrink-0 text-white/85">&gt; NETWORK RELAY // BNL-01</span>
+          <div className="bnl-relay-scroll min-w-0">
+            <div className="bnl-relay-scroll-track">
+              <span>
+                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+              </span>
+              <span aria-hidden>
+                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+              </span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/BNLStatusCard.tsx
+++ b/src/components/BNLStatusCard.tsx
@@ -1,55 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
-type BNLStatusValue = "ONLINE" | "OFFLINE";
-type BNLModeValue =
-  | "STANDBY"
-  | "OBSERVATION"
-  | "ACTIVE_LIAISON"
-  | "SIGNAL_DEGRADATION"
-  | "RESTRICTED";
-
-interface BNLStatus {
-  status: BNLStatusValue;
-  mode: BNLModeValue;
-  message: string;
-  lastSeen: string | null;
-}
-
-const FALLBACK_STATUS: BNLStatus = {
-  status: "OFFLINE",
-  mode: "STANDBY",
-  message: "BNL-01 relay awaiting signal.",
-  lastSeen: null,
-};
+import { useBNLStatus } from "@/components/useBNLStatus";
 
 export function BNLStatusCard() {
-  const [data, setData] = useState<BNLStatus>(FALLBACK_STATUS);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let mounted = true;
-
-    const loadStatus = async () => {
-      try {
-        const res = await fetch("/api/bnl/status", { cache: "no-store" });
-        if (!res.ok) throw new Error("Failed to load BNL status");
-        const payload = (await res.json()) as BNLStatus;
-        if (mounted) setData(payload);
-      } catch {
-        if (mounted) setData(FALLBACK_STATUS);
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    };
-
-    loadStatus();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const { data, loading } = useBNLStatus();
 
   return (
     <div className="bg-surface border border-border p-6 font-mono">

--- a/src/components/bnl-status.ts
+++ b/src/components/bnl-status.ts
@@ -1,0 +1,21 @@
+export type BNLStatusValue = "ONLINE" | "OFFLINE";
+export type BNLModeValue =
+  | "STANDBY"
+  | "OBSERVATION"
+  | "ACTIVE_LIAISON"
+  | "SIGNAL_DEGRADATION"
+  | "RESTRICTED";
+
+export interface BNLStatus {
+  status: BNLStatusValue;
+  mode: BNLModeValue;
+  message: string;
+  lastSeen: string | null;
+}
+
+export const FALLBACK_STATUS: BNLStatus = {
+  status: "OFFLINE",
+  mode: "STANDBY",
+  message: "BNL-01 relay awaiting signal.",
+  lastSeen: null,
+};

--- a/src/components/useBNLStatus.ts
+++ b/src/components/useBNLStatus.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BNLStatus, FALLBACK_STATUS } from "@/components/bnl-status";
+
+export function useBNLStatus() {
+  const [data, setData] = useState<BNLStatus>(FALLBACK_STATUS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadStatus = async () => {
+      try {
+        const res = await fetch("/api/bnl/status", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to load BNL status");
+        const payload = (await res.json()) as BNLStatus;
+        if (mounted) setData(payload);
+      } catch {
+        if (mounted) setData(FALLBACK_STATUS);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    loadStatus();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { data, loading };
+}


### PR DESCRIPTION
### Motivation
- Surface BNL-01 status more prominently across the site so relay updates feel visible and important rather than buried on Terminal. 
- Provide a small, reusable data layer and UI primitives that consume the existing `/api/bnl/status` endpoint with quiet fallback behavior.

### Description
- Added a shared BNL status data model and hook: `src/components/bnl-status.ts` and `src/components/useBNLStatus.ts` which fetch `/api/bnl/status` with `cache: "no-store"` and a non-disruptive fallback state.
- Added `BNLNetworkRelayTicker` (site-wide slim ticker) and `BNLRelayModule` (page modules) in `src/components/BNLRelay.tsx` that display `status`, `mode`, `message`, and optional `lastSeen` and respect reduced-motion preferences.
- Placed the ticker directly below the main header in `src/app/layout.tsx`, added a “Latest Network Relay” module to the homepage in `src/app/page.tsx`, and added a “BNL-01 Broadcast Monitor” module to the Radio page in `src/app/radio/page.tsx`.
- Refactored `src/components/BNLStatusCard.tsx` to use the shared `useBNLStatus` hook so Terminal retains its status card without being the only important placement.
- Added slow, readable crawl CSS for the relay and reduced-motion support in `src/app/globals.css`.
- Files changed/added: `src/components/bnl-status.ts` (new), `src/components/useBNLStatus.ts` (new), `src/components/BNLRelay.tsx` (new), `src/components/BNLStatusCard.tsx` (modified), `src/app/layout.tsx` (modified), `src/app/page.tsx` (modified), `src/app/radio/page.tsx` (modified), `src/app/globals.css` (modified).
- No API route, bot, admin, queue, archived, releases, or unrelated content modified and no new controls were introduced (display-only).

### Testing
- Ran targeted ESLint on affected files with `npx eslint src/components/BNLRelay.tsx src/components/BNLStatusCard.tsx src/components/useBNLStatus.ts src/components/bnl-status.ts src/app/layout.tsx src/app/page.tsx src/app/radio/page.tsx src/app/globals.css`, which completed with only a non-blocking warning about the CSS file being ignored.
- Ran full repo lint via `npm run lint`, which failed due to pre-existing, unrelated lint errors elsewhere in the repository and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4257f976483219638e5f72280c7ec)