### PR TITLE
Add BNL relay UI, hook and types; integrate ticker/module into pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -445,3 +445,32 @@ body {
     rgba(0, 0, 0, 0.12) 2px
   );
 }
+@keyframes bnl-relay-crawl {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.bnl-relay-scroll {
+  overflow: hidden;
+  white-space: nowrap;
+  mask-image: linear-gradient(to right, transparent 0%, black 5%, black 95%, transparent 100%);
+}
+
+.bnl-relay-scroll-track {
+  display: inline-flex;
+  gap: 2.5rem;
+  min-width: max-content;
+  padding-right: 2.5rem;
+  animation: bnl-relay-crawl 48s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bnl-relay-scroll-track {
+    animation: none;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { LiveStatusProvider } from "@/components/LiveStatusProvider";
 import { DataStream } from "@/components/DataStream";
 import { SystemTicker } from "@/components/SystemTicker";
 import { LiveBanner } from "@/components/LiveBanner";
+import { BNLNetworkRelayTicker } from "@/components/BNLRelay";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -71,6 +72,7 @@ export default function RootLayout({
           <DataStream />
           <LiveBanner />
           <Header />
+          <BNLNetworkRelayTicker />
           <main className="min-h-screen animate-interference overflow-x-hidden">
             {children}
           </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { LiveBanner } from "@/components/LiveBanner";
 import { HeroHeading, StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
+import { BNLRelayModule } from "@/components/BNLRelay";
 
 function resolveHref(href: string): string {
   if (href.startsWith("EXTERNAL:")) {
@@ -56,6 +57,13 @@ export default function Home() {
               </Link>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* Latest Network Relay */}
+      <section className="border-b border-border">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10">
+          <BNLRelayModule title="Latest Network Relay" />
         </div>
       </section>
 

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -3,6 +3,7 @@ import { radioPage, externalLinks } from "@/content";
 import { RadioHero, SectionDot } from "@/components/LiveEffects";
 import { LocalSchedule } from "@/components/LocalSchedule";
 import type { Metadata } from "next";
+import { BNLRelayModule } from "@/components/BNLRelay";
 
 export const metadata: Metadata = {
   title: "BARCODE Radio — Submit Music & Listen Live",
@@ -70,6 +71,13 @@ export default function RadioPage() {
               {radioPage.hero.tiktokButton.text}
             </a>
           </div>
+        </div>
+      </section>
+
+      {/* BNL-01 Broadcast Monitor */}
+      <section className="border-b border-border">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+          <BNLRelayModule title="BNL-01 Broadcast Monitor" />
         </div>
       </section>
 

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useBNLStatus } from "@/components/useBNLStatus";
+
+function bnlTone(online: boolean) {
+  return online ? "text-foreground" : "text-foreground/70";
+}
+
+export function BNLNetworkRelayTicker() {
+  const { data } = useBNLStatus();
+  const online = data.status === "ONLINE";
+
+  return (
+    <>
+      <div aria-hidden className="h-8" />
+      <div className="fixed left-0 right-0 top-14 z-40 border-b border-border/80 bg-black px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-white">
+        <div className="mx-auto flex max-w-7xl items-center gap-3 overflow-hidden">
+          <span className="shrink-0 text-white/85">&gt; NETWORK RELAY // BNL-01</span>
+          <div className="bnl-relay-scroll min-w-0">
+            <div className="bnl-relay-scroll-track">
+              <span>
+                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+              </span>
+              <span aria-hidden>
+                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function BNLRelayModule({ title }: { title: string }) {
+  const { data, loading } = useBNLStatus();
+  const online = data.status === "ONLINE";
+
+  return (
+    <div className="border border-border bg-surface p-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-xs uppercase tracking-[0.35em] text-muted">{title}</h2>
+        <span className={`text-xs uppercase tracking-[0.2em] ${bnlTone(online)}`}>{data.status}</span>
+      </div>
+      <div className="space-y-2 text-sm text-foreground/70">
+        <p>&gt; MODE: {data.mode}</p>
+        <p>&gt; MESSAGE: {data.message}</p>
+        <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
+        {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/BNLStatusCard.tsx
+++ b/src/components/BNLStatusCard.tsx
@@ -1,55 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
-type BNLStatusValue = "ONLINE" | "OFFLINE";
-type BNLModeValue =
-  | "STANDBY"
-  | "OBSERVATION"
-  | "ACTIVE_LIAISON"
-  | "SIGNAL_DEGRADATION"
-  | "RESTRICTED";
-
-interface BNLStatus {
-  status: BNLStatusValue;
-  mode: BNLModeValue;
-  message: string;
-  lastSeen: string | null;
-}
-
-const FALLBACK_STATUS: BNLStatus = {
-  status: "OFFLINE",
-  mode: "STANDBY",
-  message: "BNL-01 relay awaiting signal.",
-  lastSeen: null,
-};
+import { useBNLStatus } from "@/components/useBNLStatus";
 
 export function BNLStatusCard() {
-  const [data, setData] = useState<BNLStatus>(FALLBACK_STATUS);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let mounted = true;
-
-    const loadStatus = async () => {
-      try {
-        const res = await fetch("/api/bnl/status", { cache: "no-store" });
-        if (!res.ok) throw new Error("Failed to load BNL status");
-        const payload = (await res.json()) as BNLStatus;
-        if (mounted) setData(payload);
-      } catch {
-        if (mounted) setData(FALLBACK_STATUS);
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    };
-
-    loadStatus();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const { data, loading } = useBNLStatus();
 
   return (
     <div className="bg-surface border border-border p-6 font-mono">

--- a/src/components/bnl-status.ts
+++ b/src/components/bnl-status.ts
@@ -1,0 +1,21 @@
+export type BNLStatusValue = "ONLINE" | "OFFLINE";
+export type BNLModeValue =
+  | "STANDBY"
+  | "OBSERVATION"
+  | "ACTIVE_LIAISON"
+  | "SIGNAL_DEGRADATION"
+  | "RESTRICTED";
+
+export interface BNLStatus {
+  status: BNLStatusValue;
+  mode: BNLModeValue;
+  message: string;
+  lastSeen: string | null;
+}
+
+export const FALLBACK_STATUS: BNLStatus = {
+  status: "OFFLINE",
+  mode: "STANDBY",
+  message: "BNL-01 relay awaiting signal.",
+  lastSeen: null,
+};

--- a/src/components/useBNLStatus.ts
+++ b/src/components/useBNLStatus.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BNLStatus, FALLBACK_STATUS } from "@/components/bnl-status";
+
+export function useBNLStatus() {
+  const [data, setData] = useState<BNLStatus>(FALLBACK_STATUS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadStatus = async (isBackgroundRefresh = false) => {
+      try {
+        const res = await fetch("/api/bnl/status", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to load BNL status");
+        const payload = (await res.json()) as BNLStatus;
+        if (mounted) setData(payload);
+      } catch {
+        if (mounted && !isBackgroundRefresh) setData(FALLBACK_STATUS);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    loadStatus();
+    const interval = window.setInterval(() => loadStatus(true), 20_000);
+    const onFocus = () => loadStatus(true);
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, []);
+
+  return { data, loading };
+}

--- a/src/components/useBNLStatus.ts
+++ b/src/components/useBNLStatus.ts
@@ -12,7 +12,8 @@ export function useBNLStatus() {
 
     const loadStatus = async (isBackgroundRefresh = false) => {
       try {
-        const res = await fetch("/api/bnl/status", { cache: "no-store" });
+        const stamp = Date.now();
+        const res = await fetch(`/api/bnl/status?t=${stamp}`, { cache: "no-store" });
         if (!res.ok) throw new Error("Failed to load BNL status");
         const payload = (await res.json()) as BNLStatus;
         if (mounted) setData(payload);


### PR DESCRIPTION
### Motivation
- Surface the BNL-01 network relay status across the site with a persistent ticker and inline modules so visitors can see relay health and messages in real time.
- Centralize BNL status fetching logic to avoid repeated fetch code and enable background refresh and focus-based updates.
- Provide typed fallback data and small UI components for both a top ticker and contextual modules to reuse on multiple pages.

### Description
- Added a client hook `useBNLStatus` that polls `/api/bnl/status`, performs background refresh, and exposes `{ data, loading }` for consumers.
- Introduced typed models and fallback values in `bnl-status.ts` and replaced local fetch logic in `BNLStatusCard` to use the new hook.
- Implemented `BNLRelay.tsx` which exports `BNLNetworkRelayTicker` (fixed top ticker) and `BNLRelayModule` (compact module for pages) and integrated them into `layout.tsx`, `page.tsx`, and `radio/page.tsx`.
- Updated `globals.css` with scroll/crawl keyframes and styles (`bnl-relay-scroll`, `bnl-relay-scroll-track`, `bnl-relay-crawl`) plus minor formatting/whitespace normalizations.

### Testing
- Ran `npm run build` and the project build completed successfully.
- Ran `npm run lint` and no lint errors were reported.
- Verified type checks via the TypeScript build during `npm run build` which succeeded.
- No new unit tests were added for the BNL components in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4257f976483219638e5f72280c7ec)