### PR TITLE
Add admin RBAC & audit logging; migrate admin endpoints to use adminAccess

### DIFF
--- a/src/app/api/admin/live/route.ts
+++ b/src/app/api/admin/live/route.ts
@@ -7,7 +7,8 @@
 
 import { NextResponse } from "next/server";
 import { Redis } from "@upstash/redis";
-import { verifyAdminToken, COOKIE_NAME } from "@/lib/auth";
+import { requireAdminPermission } from "@/lib/adminAccess";
+import { writeAdminAuditLog } from "@/lib/adminAudit";
 import { isWithinBroadcastWindow } from "@/lib/broadcastSchedule";
 
 export const dynamic = "force-dynamic";
@@ -73,16 +74,8 @@ export async function GET() {
 // ---- POST: Update status (admin-only) ----
 
 export async function POST(req: Request) {
-  // Verify admin token
-  const cookieHeader = req.headers.get("cookie") || "";
-  const cookies = Object.fromEntries(
-    cookieHeader.split(";").map((c) => {
-      const [k, ...v] = c.trim().split("=");
-      return [k, v.join("=")];
-    })
-  );
-  const token = cookies[COOKIE_NAME];
-  if (!token || !(await verifyAdminToken(token))) {
+  const admin = await requireAdminPermission(req, "live:write");
+  if (!admin) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -124,6 +117,8 @@ export async function POST(req: Request) {
       if (redis) await redis.set(KEYS.url, streamUrl);
       memoryStreamUrl = streamUrl;
     }
+
+    await writeAdminAuditLog(admin, "admin.live.update", "stream:live", { action, streamUrlUpdated: Boolean(streamUrl) });
 
     return NextResponse.json({ ok: true, persisted: Boolean(redis) });
   } catch (error) {

--- a/src/app/api/admin/verify/route.ts
+++ b/src/app/api/admin/verify/route.ts
@@ -2,23 +2,16 @@
 // Returns 200 if authenticated, 401 if not
 
 import { NextResponse } from "next/server";
-import { verifyAdminToken, COOKIE_NAME } from "@/lib/auth";
+import { getAdminFromRequest } from "@/lib/adminAccess";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const cookieHeader = req.headers.get("cookie") || "";
-  const cookies = Object.fromEntries(
-    cookieHeader.split(";").map((c) => {
-      const [k, ...v] = c.trim().split("=");
-      return [k, v.join("=")];
-    })
-  );
-  const token = cookies[COOKIE_NAME];
+  const admin = await getAdminFromRequest(req);
 
-  if (!token || !(await verifyAdminToken(token))) {
+  if (!admin) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  return NextResponse.json({ ok: true, user: "admin" });
+  return NextResponse.json({ ok: true, user: admin.sub, role: admin.role, permissions: admin.permissions });
 }

--- a/src/lib/adminAccess.ts
+++ b/src/lib/adminAccess.ts
@@ -1,0 +1,27 @@
+import { AdminPermission, AdminTokenPayload, COOKIE_NAME, parseAdminToken } from "@/lib/auth";
+
+function parseCookies(cookieHeader: string): Record<string, string> {
+  return Object.fromEntries(
+    cookieHeader
+      .split(";")
+      .map((c) => c.trim())
+      .filter(Boolean)
+      .map((c) => {
+        const [k, ...v] = c.split("=");
+        return [k, v.join("=")];
+      })
+  );
+}
+
+export async function getAdminFromRequest(req: Request): Promise<AdminTokenPayload | null> {
+  const cookieHeader = req.headers.get("cookie") || "";
+  const token = parseCookies(cookieHeader)[COOKIE_NAME];
+  if (!token) return null;
+  return parseAdminToken(token);
+}
+
+export async function requireAdminPermission(req: Request, permission: AdminPermission): Promise<AdminTokenPayload | null> {
+  const admin = await getAdminFromRequest(req);
+  if (!admin) return null;
+  return admin.permissions.includes(permission) ? admin : null;
+}

--- a/src/lib/adminAudit.ts
+++ b/src/lib/adminAudit.ts
@@ -1,0 +1,52 @@
+import { Redis } from "@upstash/redis";
+import { AdminTokenPayload } from "@/lib/auth";
+
+type AuditAction = "admin.live.update";
+
+type AuditEntry = {
+  action: AuditAction;
+  actorRole: string;
+  actorSub: string;
+  target: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+};
+
+const AUDIT_KEY = "admin:audit:events";
+const MAX_AUDIT_EVENTS = 200;
+const memoryAuditLog: AuditEntry[] = [];
+
+function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+export async function writeAdminAuditLog(
+  actor: AdminTokenPayload,
+  action: AuditAction,
+  target: string,
+  metadata: Record<string, unknown>
+): Promise<void> {
+  const entry: AuditEntry = {
+    action,
+    actorRole: actor.role,
+    actorSub: actor.sub,
+    target,
+    metadata,
+    createdAt: new Date().toISOString(),
+  };
+
+  const redis = getRedis();
+  if (redis) {
+    await redis.lpush(AUDIT_KEY, JSON.stringify(entry));
+    await redis.ltrim(AUDIT_KEY, 0, MAX_AUDIT_EVENTS - 1);
+    return;
+  }
+
+  memoryAuditLog.unshift(entry);
+  if (memoryAuditLog.length > MAX_AUDIT_EVENTS) {
+    memoryAuditLog.length = MAX_AUDIT_EVENTS;
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,25 +1,25 @@
 // ============================================================
-// AUTH — Simple JWT-based admin authentication
-// ============================================================
-// Uses HMAC-SHA256 for signing. No external deps.
-// Cookie: barcode_admin (HttpOnly, Secure, SameSite=Lax)
+// AUTH — JWT-based admin authentication
 // ============================================================
 
 const COOKIE_NAME = "barcode_admin";
 const TOKEN_TTL = 60 * 60 * 24; // 24 hours in seconds
 
-// --------------- HMAC helpers (Web Crypto) ---------------
+export type AdminRole = "super_admin" | "producer";
+export type AdminPermission = "live:read" | "live:write";
+
+export type AdminTokenPayload = {
+  sub: "admin";
+  role: AdminRole;
+  permissions: AdminPermission[];
+  iat: number;
+  exp: number;
+};
 
 async function getKey(): Promise<CryptoKey> {
   const secret = process.env.JWT_SECRET || process.env.QUEUE_API_KEY || "dev-fallback-secret";
   const enc = new TextEncoder();
-  return crypto.subtle.importKey(
-    "raw",
-    enc.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign", "verify"]
-  );
+  return crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign", "verify"]);
 }
 
 function base64url(buf: ArrayBuffer): string {
@@ -37,45 +37,53 @@ function base64urlDecode(str: string): Uint8Array {
   return bytes;
 }
 
-// --------------- Token creation/verification ---------------
+function getDefaultPermissions(role: AdminRole): AdminPermission[] {
+  if (role === "super_admin") {
+    return ["live:read", "live:write"];
+  }
+  return ["live:read", "live:write"];
+}
 
-export async function createAdminToken(): Promise<string> {
+export async function createAdminToken(role: AdminRole = "super_admin"): Promise<string> {
   const key = await getKey();
   const header = base64url(new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" })).buffer as ArrayBuffer);
-  const payload = base64url(
-    new TextEncoder().encode(
-      JSON.stringify({
-        sub: "admin",
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + TOKEN_TTL,
-      })
-    ).buffer as ArrayBuffer
-  );
+  const payloadObj: AdminTokenPayload = {
+    sub: "admin",
+    role,
+    permissions: getDefaultPermissions(role),
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + TOKEN_TTL,
+  };
+  const payload = base64url(new TextEncoder().encode(JSON.stringify(payloadObj)).buffer as ArrayBuffer);
   const data = `${header}.${payload}`;
   const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
   return `${data}.${base64url(sig)}`;
 }
 
-export async function verifyAdminToken(token: string): Promise<boolean> {
+export async function parseAdminToken(token: string): Promise<AdminTokenPayload | null> {
   try {
     const parts = token.split(".");
-    if (parts.length !== 3) return false;
+    if (parts.length !== 3) return null;
 
     const key = await getKey();
     const data = `${parts[0]}.${parts[1]}`;
     const sig = base64urlDecode(parts[2]);
 
     const valid = await crypto.subtle.verify("HMAC", key, sig.buffer as ArrayBuffer, new TextEncoder().encode(data));
-    if (!valid) return false;
+    if (!valid) return null;
 
-    // Check expiration
-    const payload = JSON.parse(new TextDecoder().decode(base64urlDecode(parts[1])));
-    if (payload.exp < Math.floor(Date.now() / 1000)) return false;
-
-    return payload.sub === "admin";
+    const payload = JSON.parse(new TextDecoder().decode(base64urlDecode(parts[1]))) as AdminTokenPayload;
+    if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+    if (payload.sub !== "admin") return null;
+    if (!Array.isArray(payload.permissions)) return null;
+    return payload;
   } catch {
-    return false;
+    return null;
   }
+}
+
+export async function verifyAdminToken(token: string): Promise<boolean> {
+  return Boolean(await parseAdminToken(token));
 }
 
 export function getAdminPassword(): string {


### PR DESCRIPTION
### Motivation

- Introduce structured admin authentication (roles/permissions) and centralized request-based access checks to replace cookie-only verification.
- Add audit logging for admin actions so changes to live state are recorded for observability and debugging.

### Description

- Add `src/lib/adminAccess.ts` with `getAdminFromRequest` and `requireAdminPermission` to parse and enforce admin token permissions from the request cookie.
- Add `src/lib/adminAudit.ts` to persist audit entries to Upstash Redis (with in-memory fallback) and cap the stored events to `MAX_AUDIT_EVENTS`.
- Enhance `src/lib/auth.ts` to include `AdminRole`, `AdminPermission`, `AdminTokenPayload`, `createAdminToken`, and `parseAdminToken`, and keep `verifyAdminToken` as a wrapper around `parseAdminToken`.
- Update `src/app/api/admin/live/route.ts` to require `live:write` permission via `requireAdminPermission` and to call `writeAdminAuditLog` after updates; the existing Redis and memory fallback logic for live override and stream URL is preserved.
- Update `src/app/api/admin/verify/route.ts` to use `getAdminFromRequest` and return expanded admin info (`sub`, `role`, `permissions`) when authenticated.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43e23a7608321bcaddf544002bb0f)