### PR TITLE
Clarify BNL-01 admin relay actions and status sources

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react";
 
 type BNLStatusValue = "ONLINE" | "OFFLINE";
 type BNLModeValue = "STANDBY" | "OBSERVATION" | "ACTIVE_LIAISON" | "SIGNAL_DEGRADATION" | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "admin" | "reset" | "bot" | "startup" | "showday" | "heartbeat" | "showtest" | "unknown";
 
 interface BNLAdminState {
   status: BNLStatusValue;
@@ -25,6 +25,16 @@ interface BNLHistoryEntry {
 
 const defaultRelayMessage = "BNL-01 relay standing by. Discord-side signal monitoring active.";
 const defaultBNL: BNLAdminState = { status: "OFFLINE", mode: "STANDBY", message: "BNL-01 relay awaiting signal.", lastSeen: null };
+const sourceLabelMap: Record<BNLSourceValue, string> = {
+  admin: "Manual admin update",
+  reset: "Admin reset",
+  bot: "BNL bot",
+  startup: "Bot startup",
+  showday: "Show-day schedule",
+  heartbeat: "Website relay heartbeat",
+  showtest: "Test command",
+  unknown: "Unknown source",
+};
 
 export default function AdminPage() {
   const { isLive, toggleLive, streamUrl, setStreamUrl, isScheduled, manualOverride, lastError, persisted } = useLiveStatus();
@@ -71,6 +81,14 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   useEffect(() => { loadBnl(); }, []);
 
   const updateRelay = async (action: 'updateStatus' | 'resetStandby') => {
+    if (action === "updateStatus") {
+      const shouldPublish = window.confirm("Publish this exact message to the public website ticker?");
+      if (!shouldPublish) return;
+    }
+    if (action === "resetStandby") {
+      const shouldReset = window.confirm("This will replace the current public relay with the neutral standby message. It will not restart BNL or affect Discord.");
+      if (!shouldReset) return;
+    }
     await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(action === 'resetStandby' ? { action } : { action, ...relayForm }) });
     await loadBnl();
   };
@@ -86,13 +104,15 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   <div className="grid grid-cols-1 md:grid-cols-2 gap-8"><div className="border border-border bg-surface p-6"><h2 className="text-[10px] uppercase tracking-[0.5em] text-muted mb-6">BARCODE Radio — Live Status</h2><button onClick={toggleLive} className="w-full px-4 py-3 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all font-bold">{isLive ? 'GO OFFLINE':'GO LIVE'}</button><div className="text-xs text-muted/50 mt-3"><p>// Scheduled: {isScheduled ? 'YES' : 'NO'}</p><p>// Override: {manualOverride ? 'ACTIVE' : 'NONE'}</p><p>// Persistence: {persisted === null ? 'UNKNOWN' : persisted ? 'REDIS' : 'IN-MEMORY'}</p>{lastError && <p className='text-danger'>{lastError}</p>}</div></div><div className="border border-border bg-surface p-6"><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-6">Stream URL</h2><input type="url" value={urlInput} onChange={(e) => setUrlInput(e.target.value)} className="w-full bg-background border border-border px-3 py-2.5 text-sm" /><button onClick={() => setStreamUrl(urlInput)} className="mt-4 w-full px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Update Stream URL</button></div></div>
 
   <div className="border border-border bg-surface p-6 space-y-5"><div><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">BNL-01 Relay Control</h2><p className="text-xs text-muted/70 mt-2">Admin controls for relay state, safety flags, and operator history.</p></div>
+  <div className="border border-border bg-background/40 p-4 text-sm text-muted"><p>BNL-01 Relay Control changes what the public website displays in the Network Relay ticker. These controls do not restart the Discord bot, clear BNL memory, or change Discord messages unless explicitly stated.</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-muted"><p>BNL status API reachable: <span className="text-foreground">{bnlApiReachable ? 'yes':'no'}</span></p><p>Last seen age: <span className="text-foreground">{lastSeenAge}</span></p><p>Redis persistence: <span className="text-foreground">{bnl.persisted ? 'enabled':'in-memory fallback'}</span></p><p>Current mode: <span className="text-foreground">{bnl.mode}</span></p></div>
   <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Message: {bnl.message}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
-  <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
-  <textarea value={relayForm.message} maxLength={240} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,240)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" />
-  <div className="flex gap-3"><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Update BNL Relay</button><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset BNL Relay to Standby</button></div>
+  <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><div><p className="text-xs text-muted mb-2">Status: Whether the public site should show BNL as online or offline.</p><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="w-full bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select></div><div><p className="text-xs text-muted mb-2">Mode: The public operating state shown on the site.</p><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="w-full bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div></div>
+  <div><p className="text-xs text-muted mb-2">Message: The exact text displayed in the public Network Relay ticker. Maximum 240 characters.</p><textarea value={relayForm.message} maxLength={240} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,240)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" /></div>
+  <div className="space-y-3"><div><p className="text-xs text-muted mb-2">Use this to manually set exactly what the public website ticker says. This overrides the current relay message until BNL sends another update.</p><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Publish Manual Relay Message</button></div><div><p className="text-xs text-muted mb-2">Returns the public website relay to neutral BNL observation mode. This does not restart BNL, clear memory, or affect Discord.</p><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset Website Relay to Standby</button></div></div>
+  <div className="border border-dashed border-border p-4 bg-background/20"><h3 className="text-xs uppercase tracking-[0.35em] text-muted mb-2">Request Fresh BNL Relay</h3><p className="text-xs text-muted/80">Coming next: asks BNL to generate a new dynamic relay based on Discord/show context. This is different from manually publishing a message.</p><button disabled className="mt-3 px-4 py-2.5 text-xs uppercase tracking-widest border border-border text-muted/60 cursor-not-allowed">Unavailable in website admin</button></div>
   <div><p className="text-xs text-muted mb-2">Kill switches are stored for future bot consumption.</p>{Object.entries(flags).map(([k,v])=><label key={k} className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span>{k}</span><input type="checkbox" checked={v} onChange={(e)=>updateFlags({...flags,[k]:e.target.checked})} /></label>)}</div>
-  <div><p className="text-xs text-muted mb-2">Most recent 10 relay updates (bot/admin/showtest/heartbeat).</p><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{entry.timestamp} — {entry.status} / {entry.mode} ({entry.source || 'unknown'})</p><p>{entry.message}</p></div>)}</div></div>
+  <div><p className="text-xs text-muted mb-2">Most recent 10 relay updates with source labels.</p><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{entry.timestamp} — {entry.status} / {entry.mode} ({sourceLabelMap[entry.source] || sourceLabelMap.unknown})</p><p>{entry.message}</p></div>)}</div></div>
   </div>
 
   </div></section>;

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 
 type BNLStatusValue = "ONLINE" | "OFFLINE";
 type BNLModeValue = "STANDBY" | "OBSERVATION" | "ACTIVE_LIAISON" | "SIGNAL_DEGRADATION" | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "admin" | "reset" | "bot" | "startup" | "showday" | "heartbeat" | "showtest" | "unknown";
 
 type BNLFlags = {
   websiteRelayEnabled: boolean;
@@ -61,7 +61,7 @@ function sanitizeHistory(value: unknown): typeof memoryHistory {
         status: rec.status as BNLStatusValue,
         mode: rec.mode as BNLModeValue,
         message: rec.message.trim().slice(0, 240),
-        source: source === "bot" || source === "admin" || source === "showtest" || source === "heartbeat" ? source : "unknown",
+        source: source === "admin" || source === "reset" || source === "bot" || source === "startup" || source === "showday" || source === "showtest" || source === "heartbeat" ? source : "unknown",
       };
     })
     .filter((item): item is (typeof memoryHistory)[number] => Boolean(item))
@@ -140,7 +140,7 @@ export async function POST(req: Request) {
         status: status as BNLStatusValue,
         mode: mode as BNLModeValue,
         message: trimmedMessage,
-        source: "admin",
+        source: action === "resetStandby" ? "reset" : "admin",
       };
 
       if (redis) {

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -10,7 +10,7 @@ type BNLModeValue =
   | "ACTIVE_LIAISON"
   | "SIGNAL_DEGRADATION"
   | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "admin" | "reset" | "bot" | "startup" | "showday" | "heartbeat" | "showtest" | "unknown";
 
 interface BNLStatus {
   status: BNLStatusValue;
@@ -44,7 +44,7 @@ const ALLOWED_MODES = new Set<BNLModeValue>([
   "SIGNAL_DEGRADATION",
   "RESTRICTED",
 ]);
-const ALLOWED_SOURCES = new Set<BNLSourceValue>(["bot", "admin", "showtest", "heartbeat", "unknown"]);
+const ALLOWED_SOURCES = new Set<BNLSourceValue>(["admin", "reset", "bot", "startup", "showday", "showtest", "heartbeat", "unknown"]);
 
 let memoryStatus: BNLStatus = { ...DEFAULT_STATUS };
 let memoryHistory: BNLHistoryEntry[] = [];


### PR DESCRIPTION
### Motivation
- Make the BNL-01 admin controls safer and more explicit so operators cannot confuse manual publish, reset, and future dynamic relay requests. 
- Add plain-language field help and source labels so history and actions are self-explanatory without changing public site UI outside the admin area. 
- Preserve server-side auth and API key usage while preventing accidental exposure of `BNL_API_KEY` to client code. 

### Description
- Updated the admin BNL UI to add a top help panel explaining that these controls only affect the public website ticker and do not restart the Discord bot or clear memory.  
- Renamed action labels and added descriptions and confirmation prompts so manual and reset actions are distinct: `Update BNL Relay` → `Publish Manual Relay Message` (with confirmation “Publish this exact message to the public website ticker?”) and `Reset BNL Relay to Standby` → `Reset Website Relay to Standby` (with confirmation text warning it will not restart BNL or affect Discord).  
- Added field help text for `Status`, `Mode`, and `Message`, a 240-character cap is still enforced, and added a disabled placeholder block titled `Request Fresh BNL Relay` with explanatory copy that it is different from manual publish.  
- Improved history/source readability by mapping source codes to plain-language labels and extended allowed source values to include `reset`, `startup`, and `showday` so those values are preserved and shown as `Admin reset`, `Bot startup`, and `Show-day schedule` respectively.  
- Files changed: `src/app/admin/page.tsx` (UI text, labels, confirmations, disabled placeholder, source label map), `src/app/api/admin/bnl/route.ts` (BNL source typing/sanitization and tagging reset entries as `reset`), `src/app/api/bnl/status/route.ts` (allowed source set expanded).  
- Intentionally left untouched: header/footer, queue code, archived files, releases, canon content, and any client-side usage of `BNL_API_KEY`.  
- Follow-up risk/manual checks: confirm linter/React hook issues in the admin page are addressed separately (the project contains pre-existing hook/purity lint warnings unrelated to these copy and source-preservation changes). 

### Testing
- Ran ESLint on the touched files with `npm run lint -- src/app/admin/page.tsx src/app/api/admin/bnl/route.ts src/app/api/bnl/status/route.ts`, which executed but returned failures due to existing React hook/purity lint issues in `src/app/admin/page.tsx`.  
- No unit tests or build steps were added or changed as part of this work.  
- Authentication and server-side API key checks were not modified and remain enforced on `/api/admin/bnl` and `/api/bnl/status` POST endpoints.  
- Manual verification notes: visual/admin copy changes and confirmation prompts appear in the admin UI after these edits and source labels are shown in the history panel; no client-side exposure of `BNL_API_KEY` was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f469b10e8483219f6e0ea3c60694ed)