### PR TITLE
Add optional currentDirective support to BNL relay status and displays

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,7 @@ type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
 interface BNLAdminState {
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective: string;
   message: string;
   lastSeen: string | null;
   persisted?: boolean;
@@ -19,12 +20,13 @@ interface BNLHistoryEntry {
   timestamp: string;
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective?: string;
   message: string;
   source: BNLSourceValue;
 }
 
 const defaultRelayMessage = "BNL-01 relay standing by. Discord-side signal monitoring active.";
-const defaultBNL: BNLAdminState = { status: "OFFLINE", mode: "STANDBY", message: "BNL-01 relay awaiting signal.", lastSeen: null };
+const defaultBNL: BNLAdminState = { status: "OFFLINE", mode: "STANDBY", currentDirective: "Monitoring Discord-side relay traffic.", message: "BNL-01 relay awaiting signal.", lastSeen: null };
 
 export default function AdminPage() {
   const { isLive, toggleLive, streamUrl, setStreamUrl, isScheduled, manualOverride, lastError, persisted } = useLiveStatus();
@@ -50,7 +52,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   const [bnl, setBnl] = useState<BNLAdminState>(defaultBNL);
   const [history, setHistory] = useState<BNLHistoryEntry[]>([]);
   const [flags, setFlags] = useState({ websiteRelayEnabled: true, showdayDiscordPostsEnabled: true, heartbeatEnabled: true });
-  const [relayForm, setRelayForm] = useState({ status: "ONLINE" as BNLStatusValue, mode: "OBSERVATION" as BNLModeValue, message: defaultRelayMessage });
+  const [relayForm, setRelayForm] = useState({ status: "ONLINE" as BNLStatusValue, mode: "OBSERVATION" as BNLModeValue, currentDirective: "Monitoring Discord-side relay traffic.", message: defaultRelayMessage });
   const [bnlApiReachable, setBnlApiReachable] = useState(false);
 
   const loadBnl = async () => {
@@ -59,7 +61,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     if (publicRes.ok) {
       const publicData = await publicRes.json();
       setBnl(publicData);
-      setRelayForm((x) => ({ ...x, status: publicData.status, mode: publicData.mode, message: publicData.message }));
+      setRelayForm((x) => ({ ...x, status: publicData.status, mode: publicData.mode, currentDirective: publicData.currentDirective, message: publicData.message }));
     }
     if (adminRes.ok) {
       const adminData = await adminRes.json();
@@ -87,12 +89,13 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
 
   <div className="border border-border bg-surface p-6 space-y-5"><div><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">BNL-01 Relay Control</h2><p className="text-xs text-muted/70 mt-2">Admin controls for relay state, safety flags, and operator history.</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-muted"><p>BNL status API reachable: <span className="text-foreground">{bnlApiReachable ? 'yes':'no'}</span></p><p>Last seen age: <span className="text-foreground">{lastSeenAge}</span></p><p>Redis persistence: <span className="text-foreground">{bnl.persisted ? 'enabled':'in-memory fallback'}</span></p><p>Current mode: <span className="text-foreground">{bnl.mode}</span></p></div>
-  <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Message: {bnl.message}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
+  <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Current Directive: {bnl.currentDirective}</p><p>Message: {bnl.message}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
+  <div><label className="block text-xs text-muted mb-2">Current Directive</label><input type="text" value={relayForm.currentDirective} maxLength={160} onChange={(e)=>setRelayForm({...relayForm,currentDirective:e.target.value.slice(0,160)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" /><p className="text-xs text-muted/70 mt-2">What BNL-01 is currently doing. This appears on public relay displays where space allows.</p></div>
   <textarea value={relayForm.message} maxLength={240} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,240)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" />
   <div className="flex gap-3"><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Update BNL Relay</button><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset BNL Relay to Standby</button></div>
   <div><p className="text-xs text-muted mb-2">Kill switches are stored for future bot consumption.</p>{Object.entries(flags).map(([k,v])=><label key={k} className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span>{k}</span><input type="checkbox" checked={v} onChange={(e)=>updateFlags({...flags,[k]:e.target.checked})} /></label>)}</div>
-  <div><p className="text-xs text-muted mb-2">Most recent 10 relay updates (bot/admin/showtest/heartbeat).</p><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{entry.timestamp} — {entry.status} / {entry.mode} ({entry.source || 'unknown'})</p><p>{entry.message}</p></div>)}</div></div>
+  <div><p className="text-xs text-muted mb-2">Most recent 10 relay updates (bot/admin/showtest/heartbeat).</p><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{entry.timestamp} — {entry.status} / {entry.mode} ({entry.source || 'unknown'})</p>{entry.currentDirective ? <p>Directive: {entry.currentDirective}</p> : null}<p>{entry.message}</p></div>)}</div></div>
   </div>
 
   </div></section>;

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -50,12 +50,15 @@ async function isAuthenticated(req: Request): Promise<boolean> {
 function sanitizeHistory(value: unknown): typeof memoryHistory {
   if (!Array.isArray(value)) return [];
   return value
-    .map((item) => {
+    .map((item): (typeof memoryHistory)[number] | null => {
       if (!item || typeof item !== "object") return null;
       const rec = item as Record<string, unknown>;
       if (!ALLOWED_STATUS.has(rec.status as BNLStatusValue) || !ALLOWED_MODES.has(rec.mode as BNLModeValue)) return null;
       if (typeof rec.timestamp !== "string" || typeof rec.message !== "string") return null;
-      const source = rec.source as BNLSourceValue;
+      const source: BNLSourceValue =
+        rec.source === "bot" || rec.source === "admin" || rec.source === "showtest" || rec.source === "heartbeat"
+          ? rec.source
+          : "unknown";
       return {
         timestamp: rec.timestamp,
         status: rec.status as BNLStatusValue,
@@ -65,7 +68,7 @@ function sanitizeHistory(value: unknown): typeof memoryHistory {
             ? rec.currentDirective.trim().slice(0, 160)
             : undefined,
         message: rec.message.trim().slice(0, 240),
-        source: source === "bot" || source === "admin" || source === "showtest" || source === "heartbeat" ? source : "unknown",
+        source,
       };
     })
     .filter((item): item is (typeof memoryHistory)[number] => Boolean(item))

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -27,7 +27,7 @@ const DEFAULT_FLAGS: BNLFlags = {
 const ALLOWED_STATUS = new Set<BNLStatusValue>(["ONLINE", "OFFLINE"]);
 const ALLOWED_MODES = new Set<BNLModeValue>(["STANDBY", "OBSERVATION", "ACTIVE_LIAISON", "SIGNAL_DEGRADATION", "RESTRICTED"]);
 
-let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; message: string; source: BNLSourceValue }> = [];
+let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue }> = [];
 let memoryFlags: BNLFlags = { ...DEFAULT_FLAGS };
 
 function getRedis(): Redis | null {
@@ -60,6 +60,10 @@ function sanitizeHistory(value: unknown): typeof memoryHistory {
         timestamp: rec.timestamp,
         status: rec.status as BNLStatusValue,
         mode: rec.mode as BNLModeValue,
+        currentDirective:
+          typeof rec.currentDirective === "string" && rec.currentDirective.trim().length > 0
+            ? rec.currentDirective.trim().slice(0, 160)
+            : undefined,
         message: rec.message.trim().slice(0, 240),
         source: source === "bot" || source === "admin" || source === "showtest" || source === "heartbeat" ? source : "unknown",
       };
@@ -120,18 +124,24 @@ export async function POST(req: Request) {
       const message = action === "resetStandby"
         ? "BNL-01 relay standing by. Discord-side signal monitoring active."
         : body.message;
+      const currentDirective = action === "resetStandby" ? "Monitoring Discord-side relay traffic." : body.currentDirective;
 
-      if (!ALLOWED_STATUS.has(status as BNLStatusValue) || !ALLOWED_MODES.has(mode as BNLModeValue) || typeof message !== "string") {
+      if (!ALLOWED_STATUS.has(status as BNLStatusValue) || !ALLOWED_MODES.has(mode as BNLModeValue) || typeof message !== "string" || (currentDirective !== undefined && typeof currentDirective !== "string")) {
         return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
       }
 
       const trimmedMessage = message.trim().slice(0, 240);
+      const trimmedDirective =
+        typeof currentDirective === "string" && currentDirective.trim().length > 0
+          ? currentDirective.trim().slice(0, 160)
+          : "Monitoring Discord-side relay traffic.";
       if (!trimmedMessage) return NextResponse.json({ error: "Message required" }, { status: 400 });
 
       const now = new Date().toISOString();
       const nextStatus = {
         status: status as BNLStatusValue,
         mode: mode as BNLModeValue,
+        currentDirective: trimmedDirective,
         message: trimmedMessage,
         lastSeen: now,
       };
@@ -139,6 +149,7 @@ export async function POST(req: Request) {
         timestamp: now,
         status: status as BNLStatusValue,
         mode: mode as BNLModeValue,
+        currentDirective: trimmedDirective,
         message: trimmedMessage,
         source: "admin",
       };

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -88,7 +88,7 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
   if (!Array.isArray(value)) return [];
   return value
-    .map((item) => {
+    .map((item): BNLHistoryEntry | null => {
       if (!item || typeof item !== "object") return null;
       const rec = item as Record<string, unknown>;
       const status = ALLOWED_STATUS.has(rec.status as BNLStatusValue) ? (rec.status as BNLStatusValue) : null;

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -15,6 +15,7 @@ type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
 interface BNLStatus {
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective: string;
   message: string;
   lastSeen: string | null;
 }
@@ -23,6 +24,7 @@ interface BNLHistoryEntry {
   timestamp: string;
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective?: string;
   message: string;
   source: BNLSourceValue;
 }
@@ -32,6 +34,7 @@ const HISTORY_KEY = "bnl:history";
 const DEFAULT_STATUS: BNLStatus = {
   status: "OFFLINE",
   mode: "STANDBY",
+  currentDirective: "Monitoring Discord-side relay traffic.",
   message: "BNL-01 relay awaiting signal.",
   lastSeen: null,
 };
@@ -70,12 +73,16 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
     typeof record.message === "string" && record.message.trim().length > 0
       ? record.message.trim().slice(0, 240)
       : DEFAULT_STATUS.message;
+  const currentDirective =
+    typeof record.currentDirective === "string" && record.currentDirective.trim().length > 0
+      ? record.currentDirective.trim().slice(0, 160)
+      : DEFAULT_STATUS.currentDirective;
   const lastSeen =
     typeof record.lastSeen === "string" && record.lastSeen.length > 0
       ? record.lastSeen
       : null;
 
-  return { status, mode, message, lastSeen };
+  return { status, mode, currentDirective, message, lastSeen };
 }
 
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
@@ -91,8 +98,12 @@ function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
         : "unknown";
       const timestamp = typeof rec.timestamp === "string" && rec.timestamp ? rec.timestamp : null;
       const message = typeof rec.message === "string" ? rec.message.trim().slice(0, 240) : "";
+      const currentDirective =
+        typeof rec.currentDirective === "string" && rec.currentDirective.trim().length > 0
+          ? rec.currentDirective.trim().slice(0, 160)
+          : undefined;
       if (!status || !mode || !timestamp || !message) return null;
-      return { timestamp, status, mode, message, source };
+      return { timestamp, status, mode, currentDirective, message, source };
     })
     .filter((entry): entry is BNLHistoryEntry => Boolean(entry))
     .slice(0, 10);
@@ -128,7 +139,7 @@ export async function POST(req: Request) {
 
   try {
     const body = (await req.json()) as Record<string, unknown>;
-    const allowedKeys = ["status", "mode", "message", "source"];
+    const allowedKeys = ["status", "mode", "currentDirective", "message", "source"];
     const bodyKeys = Object.keys(body);
     const hasOnlyAllowedKeys = bodyKeys.every((key) => allowedKeys.includes(key));
 
@@ -138,12 +149,14 @@ export async function POST(req: Request) {
 
     const status = body.status;
     const mode = body.mode;
+    const currentDirective = body.currentDirective;
     const message = body.message;
     const source = body.source;
 
     if (
       !ALLOWED_STATUS.has(status as BNLStatusValue) ||
       !ALLOWED_MODES.has(mode as BNLModeValue) ||
+      (currentDirective !== undefined && typeof currentDirective !== "string") ||
       typeof message !== "string" ||
       (source !== undefined && !ALLOWED_SOURCES.has(source as BNLSourceValue))
     ) {
@@ -151,10 +164,15 @@ export async function POST(req: Request) {
     }
 
     const now = new Date().toISOString();
+    const trimmedDirective =
+      typeof currentDirective === "string" && currentDirective.trim().length > 0
+        ? currentDirective.trim().slice(0, 160)
+        : DEFAULT_STATUS.currentDirective;
     const trimmedMessage = message.trim().slice(0, 240);
     const nextStatus: BNLStatus = {
       status: status as BNLStatusValue,
       mode: mode as BNLModeValue,
+      currentDirective: trimmedDirective,
       message: trimmedMessage,
       lastSeen: now,
     };
@@ -167,6 +185,7 @@ export async function POST(req: Request) {
       timestamp: now,
       status: nextStatus.status,
       mode: nextStatus.mode,
+      currentDirective: nextStatus.currentDirective,
       message: nextStatus.message,
       source: ALLOWED_SOURCES.has(source as BNLSourceValue) ? (source as BNLSourceValue) : "unknown",
     });

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -46,6 +46,7 @@ export function BNLRelayModule({ title }: { title: string }) {
       </div>
       <div className="space-y-2 text-sm text-foreground/70">
         <p>&gt; MODE: {data.mode}</p>
+        <p className="text-xs text-muted">&gt; CURRENT_DIRECTIVE: {data.currentDirective}</p>
         <p>&gt; MESSAGE: {data.message}</p>
         <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}

--- a/src/components/BNLStatusCard.tsx
+++ b/src/components/BNLStatusCard.tsx
@@ -13,6 +13,7 @@ export function BNLStatusCard() {
           &gt; STATUS: <span className={data.status === "ONLINE" ? "text-accent" : "text-muted"}>{data.status}</span>
         </p>
         <p>&gt; MODE: {data.mode}</p>
+        <p>&gt; CURRENT_DIRECTIVE: {data.currentDirective}</p>
         <p>&gt; MESSAGE: {data.message}</p>
         <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}

--- a/src/components/bnl-status.ts
+++ b/src/components/bnl-status.ts
@@ -9,6 +9,7 @@ export type BNLModeValue =
 export interface BNLStatus {
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective: string;
   message: string;
   lastSeen: string | null;
 }
@@ -16,6 +17,7 @@ export interface BNLStatus {
 export const FALLBACK_STATUS: BNLStatus = {
   status: "OFFLINE",
   mode: "STANDBY",
+  currentDirective: "Monitoring Discord-side relay traffic.",
   message: "BNL-01 relay awaiting signal.",
   lastSeen: null,
 };


### PR DESCRIPTION
### Motivation
- Allow BNL-01 to report what it is currently doing in addition to its status/mode/message so public and admin UIs can surface that intent.
- Keep existing behavior: Redis persistence, in-memory fallback, API key auth, and the existing status/mode/message/lastSeen/source semantics must be preserved.

### Description
- Added an optional `currentDirective` string to the BNL status payload with a default of `"Monitoring Discord-side relay traffic."`, trimming and limiting input to 160 characters, and rejecting arbitrary extra fields. (Validation only accepts string or omitted.)
- Included `currentDirective` in history entries when present and preserved history sanitization for older entries that lack the field.
- Exposed `currentDirective` to admin controls (new input field labeled "Current Directive" with help text) and added it to admin status/historical entries saved via the admin API; reset behavior also uses the default directive.
- Updated public displays: left the compact ticker unchanged, added a `CURRENT_DIRECTIVE` line to the HQ/module and terminal/full BNL card components.

Files changed:
- `src/app/api/bnl/status/route.ts` — accept/return/validate `currentDirective`, defaulting and persisting it; include in history append.
- `src/app/api/admin/bnl/route.ts` — accept `currentDirective` in admin updates, sanitize and persist it, include in history entries.
- `src/components/bnl-status.ts` — added `currentDirective` to the shared BNL status type and fallback.
- `src/components/BNLRelay.tsx` — show `CURRENT_DIRECTIVE` in the relay module/card while keeping ticker compact.
- `src/components/BNLStatusCard.tsx` — added `CURRENT_DIRECTIVE` display to the status card.
- `src/app/admin/page.tsx` — added admin input for `Current Directive`, populated relay form, and surfaced directive in current status and history UI.

### Testing
- Ran `npm run lint`; the command completed but returned failures due to many pre-existing lint issues in unrelated files (including `_archive` and other components); none of the lint errors were introduced by these changes and no additional automated tests exist in this repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46d6d6a608321b00ea571e7b4cc5e)