### PR TITLE
Support bot fields in BNL status API and add control‑flags endpoint

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,12 +5,14 @@ import { useState, useEffect } from "react";
 
 type BNLStatusValue = "ONLINE" | "OFFLINE";
 type BNLModeValue = "STANDBY" | "OBSERVATION" | "ACTIVE_LIAISON" | "SIGNAL_DEGRADATION" | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "bot" | "startup" | "relay" | "heartbeat" | "showday" | "showtest" | "admin" | "reset" | "unknown";
 
 interface BNLAdminState {
   status: BNLStatusValue;
   mode: BNLModeValue;
   message: string;
+  currentDirective?: string;
+  source?: BNLSourceValue;
   lastSeen: string | null;
   persisted?: boolean;
 }
@@ -87,7 +89,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
 
   <div className="border border-border bg-surface p-6 space-y-5"><div><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">BNL-01 Relay Control</h2><p className="text-xs text-muted/70 mt-2">Admin controls for relay state, safety flags, and operator history.</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-muted"><p>BNL status API reachable: <span className="text-foreground">{bnlApiReachable ? 'yes':'no'}</span></p><p>Last seen age: <span className="text-foreground">{lastSeenAge}</span></p><p>Redis persistence: <span className="text-foreground">{bnl.persisted ? 'enabled':'in-memory fallback'}</span></p><p>Current mode: <span className="text-foreground">{bnl.mode}</span></p></div>
-  <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Message: {bnl.message}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
+  <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Message: {bnl.message}</p><p>Current directive: {bnl.currentDirective || 'Monitoring Discord-side relay traffic.'}</p><p>Source: {bnl.source || 'unknown'}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
   <textarea value={relayForm.message} maxLength={240} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,240)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" />
   <div className="flex gap-3"><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Update BNL Relay</button><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset BNL Relay to Standby</button></div>

--- a/src/app/api/bnl/status/control-flags/route.ts
+++ b/src/app/api/bnl/status/control-flags/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { Redis } from "@upstash/redis";
+
+export const dynamic = "force-dynamic";
+
+type BNLFlags = {
+  websiteRelayEnabled: boolean;
+  showdayDiscordPostsEnabled: boolean;
+  heartbeatEnabled: boolean;
+};
+
+const FLAGS_KEY = "bnl:flags";
+const DEFAULT_FLAGS: BNLFlags = {
+  websiteRelayEnabled: true,
+  showdayDiscordPostsEnabled: true,
+  heartbeatEnabled: true,
+};
+
+let memoryFlags: BNLFlags = { ...DEFAULT_FLAGS };
+
+function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function sanitizeFlags(value: unknown): BNLFlags {
+  if (!value || typeof value !== "object") return { ...DEFAULT_FLAGS };
+  const record = value as Record<string, unknown>;
+  return {
+    websiteRelayEnabled: typeof record.websiteRelayEnabled === "boolean" ? record.websiteRelayEnabled : DEFAULT_FLAGS.websiteRelayEnabled,
+    showdayDiscordPostsEnabled: typeof record.showdayDiscordPostsEnabled === "boolean" ? record.showdayDiscordPostsEnabled : DEFAULT_FLAGS.showdayDiscordPostsEnabled,
+    heartbeatEnabled: typeof record.heartbeatEnabled === "boolean" ? record.heartbeatEnabled : DEFAULT_FLAGS.heartbeatEnabled,
+  };
+}
+
+function isAuthorized(req: Request): boolean {
+  const expectedApiKey = process.env.BNL_API_KEY;
+  const providedApiKey = req.headers.get("x-api-key");
+  return Boolean(expectedApiKey && providedApiKey === expectedApiKey);
+}
+
+export async function GET() {
+  const redis = getRedis();
+
+  if (redis) {
+    const storedFlags = await redis.get<unknown>(FLAGS_KEY);
+    const resolved = sanitizeFlags(storedFlags);
+    memoryFlags = resolved;
+    return NextResponse.json({ ...resolved, persisted: true });
+  }
+
+  return NextResponse.json({ ...memoryFlags, persisted: false });
+}
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = (await req.json()) as Record<string, unknown>;
+    const allowedKeys = ["websiteRelayEnabled", "showdayDiscordPostsEnabled", "heartbeatEnabled"];
+    const keys = Object.keys(body);
+    if (!keys.every((key) => allowedKeys.includes(key))) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (
+      typeof body.websiteRelayEnabled !== "boolean" ||
+      typeof body.showdayDiscordPostsEnabled !== "boolean" ||
+      typeof body.heartbeatEnabled !== "boolean"
+    ) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const nextFlags: BNLFlags = {
+      websiteRelayEnabled: body.websiteRelayEnabled,
+      showdayDiscordPostsEnabled: body.showdayDiscordPostsEnabled,
+      heartbeatEnabled: body.heartbeatEnabled,
+    };
+
+    const redis = getRedis();
+    if (redis) await redis.set(FLAGS_KEY, nextFlags);
+    memoryFlags = nextFlags;
+
+    return NextResponse.json({ ok: true, flags: nextFlags, persisted: Boolean(redis) });
+  } catch (error) {
+    console.error("[bnl/status/control-flags] error:", error);
+    return NextResponse.json({ error: "Failed to update control flags" }, { status: 500 });
+  }
+}

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -10,12 +10,14 @@ type BNLModeValue =
   | "ACTIVE_LIAISON"
   | "SIGNAL_DEGRADATION"
   | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "bot" | "startup" | "relay" | "heartbeat" | "showday" | "showtest" | "admin" | "reset" | "unknown";
 
 interface BNLStatus {
   status: BNLStatusValue;
   mode: BNLModeValue;
   message: string;
+  currentDirective: string;
+  source: BNLSourceValue;
   lastSeen: string | null;
 }
 
@@ -29,10 +31,13 @@ interface BNLHistoryEntry {
 
 const KEY = "bnl:status";
 const HISTORY_KEY = "bnl:history";
+const DEFAULT_DIRECTIVE = "Monitoring Discord-side relay traffic.";
 const DEFAULT_STATUS: BNLStatus = {
   status: "OFFLINE",
   mode: "STANDBY",
   message: "BNL-01 relay awaiting signal.",
+  currentDirective: DEFAULT_DIRECTIVE,
+  source: "unknown",
   lastSeen: null,
 };
 
@@ -44,7 +49,7 @@ const ALLOWED_MODES = new Set<BNLModeValue>([
   "SIGNAL_DEGRADATION",
   "RESTRICTED",
 ]);
-const ALLOWED_SOURCES = new Set<BNLSourceValue>(["bot", "admin", "showtest", "heartbeat", "unknown"]);
+const ALLOWED_SOURCES = new Set<BNLSourceValue>(["bot", "startup", "relay", "heartbeat", "showday", "showtest", "admin", "reset", "unknown"]);
 
 let memoryStatus: BNLStatus = { ...DEFAULT_STATUS };
 let memoryHistory: BNLHistoryEntry[] = [];
@@ -70,12 +75,19 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
     typeof record.message === "string" && record.message.trim().length > 0
       ? record.message.trim().slice(0, 240)
       : DEFAULT_STATUS.message;
+  const currentDirective =
+    typeof record.currentDirective === "string" && record.currentDirective.trim().length > 0
+      ? record.currentDirective.trim().slice(0, 160)
+      : DEFAULT_STATUS.currentDirective;
+  const source = ALLOWED_SOURCES.has(record.source as BNLSourceValue)
+    ? (record.source as BNLSourceValue)
+    : DEFAULT_STATUS.source;
   const lastSeen =
     typeof record.lastSeen === "string" && record.lastSeen.length > 0
       ? record.lastSeen
       : null;
 
-  return { status, mode, message, lastSeen };
+  return { status, mode, message, currentDirective, source, lastSeen };
 }
 
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
@@ -128,34 +140,42 @@ export async function POST(req: Request) {
 
   try {
     const body = (await req.json()) as Record<string, unknown>;
-    const allowedKeys = ["status", "mode", "message", "source"];
+    const allowedKeys = ["status", "mode", "message", "currentDirective", "source"];
     const bodyKeys = Object.keys(body);
-    const hasOnlyAllowedKeys = bodyKeys.every((key) => allowedKeys.includes(key));
-
-    if (!hasOnlyAllowedKeys) {
+    if (!bodyKeys.every((key) => allowedKeys.includes(key))) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
     const status = body.status;
     const mode = body.mode;
     const message = body.message;
+    const currentDirective = body.currentDirective;
     const source = body.source;
 
-    if (
-      !ALLOWED_STATUS.has(status as BNLStatusValue) ||
-      !ALLOWED_MODES.has(mode as BNLModeValue) ||
-      typeof message !== "string" ||
-      (source !== undefined && !ALLOWED_SOURCES.has(source as BNLSourceValue))
-    ) {
+    if (!ALLOWED_STATUS.has(status as BNLStatusValue) || !ALLOWED_MODES.has(mode as BNLModeValue) || typeof message !== "string") {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || trimmedMessage.length > 240) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (currentDirective !== undefined && (typeof currentDirective !== "string" || currentDirective.trim().length === 0 || currentDirective.trim().length > 160)) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (source !== undefined && (!ALLOWED_SOURCES.has(source as BNLSourceValue) || typeof source !== "string")) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
     const now = new Date().toISOString();
-    const trimmedMessage = message.trim().slice(0, 240);
     const nextStatus: BNLStatus = {
       status: status as BNLStatusValue,
       mode: mode as BNLModeValue,
       message: trimmedMessage,
+      currentDirective: typeof currentDirective === "string" ? currentDirective.trim() : DEFAULT_DIRECTIVE,
+      source: typeof source === "string" && ALLOWED_SOURCES.has(source as BNLSourceValue) ? (source as BNLSourceValue) : "unknown",
       lastSeen: now,
     };
 
@@ -168,7 +188,7 @@ export async function POST(req: Request) {
       status: nextStatus.status,
       mode: nextStatus.mode,
       message: nextStatus.message,
-      source: ALLOWED_SOURCES.has(source as BNLSourceValue) ? (source as BNLSourceValue) : "unknown",
+      source: nextStatus.source,
     });
 
     return NextResponse.json({ ok: true, status: nextStatus, persisted: Boolean(redis) });

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -47,6 +47,8 @@ export function BNLRelayModule({ title }: { title: string }) {
       <div className="space-y-2 text-sm text-foreground/70">
         <p>&gt; MODE: {data.mode}</p>
         <p>&gt; MESSAGE: {data.message}</p>
+        <p>&gt; CURRENT_DIRECTIVE: {data.currentDirective ?? "Monitoring Discord-side relay traffic."}</p>
+        <p>&gt; SOURCE: {data.source ?? "unknown"}</p>
         <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
       </div>

--- a/src/components/BNLStatusCard.tsx
+++ b/src/components/BNLStatusCard.tsx
@@ -14,6 +14,8 @@ export function BNLStatusCard() {
         </p>
         <p>&gt; MODE: {data.mode}</p>
         <p>&gt; MESSAGE: {data.message}</p>
+        <p>&gt; CURRENT_DIRECTIVE: {data.currentDirective ?? "Monitoring Discord-side relay traffic."}</p>
+        <p>&gt; SOURCE: {data.source ?? "unknown"}</p>
         <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
       </div>

--- a/src/components/bnl-status.ts
+++ b/src/components/bnl-status.ts
@@ -6,10 +6,14 @@ export type BNLModeValue =
   | "SIGNAL_DEGRADATION"
   | "RESTRICTED";
 
+export type BNLSourceValue = "bot" | "startup" | "relay" | "heartbeat" | "showday" | "showtest" | "admin" | "reset" | "unknown";
+
 export interface BNLStatus {
   status: BNLStatusValue;
   mode: BNLModeValue;
   message: string;
+  currentDirective?: string;
+  source?: BNLSourceValue;
   lastSeen: string | null;
 }
 
@@ -17,5 +21,7 @@ export const FALLBACK_STATUS: BNLStatus = {
   status: "OFFLINE",
   mode: "STANDBY",
   message: "BNL-01 relay awaiting signal.",
+  currentDirective: "Monitoring Discord-side relay traffic.",
+  source: "unknown",
   lastSeen: null,
 };


### PR DESCRIPTION
### Motivation
- The BNL Discord bot began sending `currentDirective` and `source` and expecting a `/api/bnl/status/control-flags` route, and the live API rejected valid bot payloads or returned 404 for control flags. 
- The change aligns the site API with the bot contract while preserving existing persistence, auth, and UI stability without touching bot/queue/archived/branding code.

### Description
- Updated `/api/bnl/status` to accept `currentDirective` and `source`, validate enums and lengths, apply defaults (`currentDirective` -> `Monitoring Discord-side relay traffic.`, `source` -> `unknown`), reject unrelated fields, and preserve Redis persistence and in-memory fallback (`src/app/api/bnl/status/route.ts`).
- Added new control flags endpoint with `GET` and `POST` (requires `x-api-key` = `BNL_API_KEY`), Redis persistence with memory fallback, and strict boolean-only fields `websiteRelayEnabled`, `showdayDiscordPostsEnabled`, and `heartbeatEnabled` (`src/app/api/bnl/status/control-flags/route.ts`).
- Updated BNL typings and UI to safely include and display the new fields so components won’t break when fields are absent and the terminal/full BNL card shows `CURRENT_DIRECTIVE` (`src/components/bnl-status.ts`, `src/components/BNLRelay.tsx`, `src/components/BNLStatusCard.tsx`, `src/app/admin/page.tsx`).
- Files changed: `src/app/api/bnl/status/route.ts` (accept/validate new fields, defaults, history), `src/app/api/bnl/status/control-flags/route.ts` (new endpoint), `src/components/bnl-status.ts` (types + fallback), `src/components/BNLRelay.tsx` (display current directive/source), `src/components/BNLStatusCard.tsx` (display current directive/source), `src/app/admin/page.tsx` (admin display typing and readout). 
- Intentionally left untouched: queue code, archived files, header/footer, release canon, bot code, and any client-side exposure of `BNL_API_KEY` (the key is only read server-side and never returned in responses).

### Testing
- Ran `npm run lint`; the lint run completed but reported pre-existing unrelated lint errors elsewhere in the repo, so there were no new lint failures attributable to these changes (overall lint run returned non-zero due to unrelated files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4720da0888321a75f21261ab0aec2)