### PR TITLE
BNL admin: add force-pull, clear history, expanded metadata & larger messages

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,18 +15,70 @@ interface BNLAdminState {
   source?: BNLSourceValue;
   lastSeen: string | null;
   persisted?: boolean;
+  forcePullRequestedAt?: string | null;
 }
 
 interface BNLHistoryEntry {
   timestamp: string;
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  persisted?: boolean;
 }
 
 const defaultRelayMessage = "BNL-01 relay standing by. Discord-side signal monitoring active.";
 const defaultBNL: BNLAdminState = { status: "OFFLINE", mode: "STANDBY", message: "BNL-01 relay awaiting signal.", lastSeen: null };
+const SOURCE_LABELS: Record<BNLSourceValue, string> = {
+  bot: "BNL bot",
+  startup: "Bot startup",
+  relay: "Dynamic relay",
+  heartbeat: "Relay heartbeat",
+  showday: "Show-day schedule",
+  showtest: "Test command",
+  admin: "Manual admin update",
+  reset: "Admin reset",
+  unknown: "Unknown source",
+};
+
+function formatLastSeenAge(lastSeen: string | null): string {
+  if (!lastSeen) return "unknown";
+  const parsed = new Date(lastSeen).getTime();
+  if (Number.isNaN(parsed)) return "unknown";
+  const diffMs = Date.now() - parsed;
+  const minutes = Math.max(0, Math.floor(diffMs / 60000));
+  if (minutes === 0) return "just now";
+  if (minutes === 1) return "1 minute ago";
+  return `${minutes} minutes ago`;
+}
+
+function formatLocalTimestamp(value: string | null): string {
+  if (!value) return "unknown";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "long",
+  }).format(parsed);
+}
+
+function formatLastSeenSentence(value: string | null): string {
+  if (!value) return "unknown";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "unknown";
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(parsed);
+  const date = new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+  return `Last seen at ${time} on ${date}`;
+}
 
 export default function AdminPage() {
   const { isLive, toggleLive, streamUrl, setStreamUrl, isScheduled, manualOverride, lastError, persisted } = useLiveStatus();
@@ -54,6 +106,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   const [flags, setFlags] = useState({ websiteRelayEnabled: true, showdayDiscordPostsEnabled: true, heartbeatEnabled: true });
   const [relayForm, setRelayForm] = useState({ status: "ONLINE" as BNLStatusValue, mode: "OBSERVATION" as BNLModeValue, message: defaultRelayMessage });
   const [bnlApiReachable, setBnlApiReachable] = useState(false);
+  const [forcePullRequestedAt, setForcePullRequestedAt] = useState<string | null>(null);
 
   const loadBnl = async () => {
     const [publicRes, adminRes] = await Promise.all([fetch('/api/bnl/status', { cache: 'no-store' }), fetch('/api/admin/bnl', { cache: 'no-store' })]);
@@ -67,6 +120,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
       const adminData = await adminRes.json();
       setHistory(adminData.history || []);
       setFlags(adminData.flags || flags);
+      setForcePullRequestedAt(typeof adminData.forcePullRequestedAt === "string" ? adminData.forcePullRequestedAt : null);
     }
   };
 
@@ -81,20 +135,68 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     setFlags(next);
     await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'updateFlags', flags: next }) });
   };
+  const clearHistory = async () => {
+    const confirmed = window.confirm("This clears the admin history log only. It does not reset BNL, change the public ticker, or affect Discord.");
+    if (!confirmed) return;
+    await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'clearHistory' }) });
+    await loadBnl();
+  };
+  const requestForcePull = async () => {
+    await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'forcePull' }) });
+    await loadBnl();
+  };
 
-  const lastSeenAge = bnl.lastSeen ? `${Math.max(0, Math.floor((Date.now() - new Date(bnl.lastSeen).getTime()) / 60000))} minutes ago` : 'unknown';
+  const lastSeenAge = formatLastSeenAge(bnl.lastSeen);
+  const lastSeenLocal = formatLocalTimestamp(bnl.lastSeen);
+  const lastSeenSentence = formatLastSeenSentence(bnl.lastSeen);
 
   return <section><div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 space-y-8">{/* existing cards omitted for brevity in source */}
   <div className="grid grid-cols-1 md:grid-cols-2 gap-8"><div className="border border-border bg-surface p-6"><h2 className="text-[10px] uppercase tracking-[0.5em] text-muted mb-6">BARCODE Radio — Live Status</h2><button onClick={toggleLive} className="w-full px-4 py-3 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all font-bold">{isLive ? 'GO OFFLINE':'GO LIVE'}</button><div className="text-xs text-muted/50 mt-3"><p>// Scheduled: {isScheduled ? 'YES' : 'NO'}</p><p>// Override: {manualOverride ? 'ACTIVE' : 'NONE'}</p><p>// Persistence: {persisted === null ? 'UNKNOWN' : persisted ? 'REDIS' : 'IN-MEMORY'}</p>{lastError && <p className='text-danger'>{lastError}</p>}</div></div><div className="border border-border bg-surface p-6"><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-6">Stream URL</h2><input type="url" value={urlInput} onChange={(e) => setUrlInput(e.target.value)} className="w-full bg-background border border-border px-3 py-2.5 text-sm" /><button onClick={() => setStreamUrl(urlInput)} className="mt-4 w-full px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Update Stream URL</button></div></div>
 
   <div className="border border-border bg-surface p-6 space-y-5"><div><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">BNL-01 Relay Control</h2><p className="text-xs text-muted/70 mt-2">Admin controls for relay state, safety flags, and operator history.</p></div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-muted"><p>BNL status API reachable: <span className="text-foreground">{bnlApiReachable ? 'yes':'no'}</span></p><p>Last seen age: <span className="text-foreground">{lastSeenAge}</span></p><p>Redis persistence: <span className="text-foreground">{bnl.persisted ? 'enabled':'in-memory fallback'}</span></p><p>Current mode: <span className="text-foreground">{bnl.mode}</span></p></div>
-  <div className="text-sm border border-border p-4 bg-background/40"><p className="text-xs text-muted mb-2">Current BNL status from /api/bnl/status.</p><p>Status: {bnl.status}</p><p>Mode: {bnl.mode}</p><p>Message: {bnl.message}</p><p>Current directive: {bnl.currentDirective || 'Monitoring Discord-side relay traffic.'}</p><p>Source: {bnl.source || 'unknown'}</p><p>Last seen: {bnl.lastSeen || 'never'}</p></div>
+  <div className="space-y-3">
+    <div className="text-sm border border-border p-4 bg-background/40">
+      <p className="text-xs text-accent uppercase tracking-widest mb-2">Public Website Relay (what visitors see)</p>
+      <p>Status: {bnl.status}</p>
+      <p>Mode: {bnl.mode}</p>
+      <p>Message: {bnl.message}</p>
+      <p>Current Directive: {bnl.currentDirective || 'Monitoring Discord-side relay traffic.'}</p>
+      <p>{lastSeenSentence} (your local time)</p>
+      <p>Last Seen Age: {lastSeenAge}</p>
+    </div>
+    <div className="text-sm border border-border p-4 bg-background/30">
+      <p className="text-xs text-muted uppercase tracking-widest mb-2">Admin Relay Metadata (admin only)</p>
+      <p>Source Label: {SOURCE_LABELS[bnl.source || "unknown"]}</p>
+      <p>Raw Source Code: {bnl.source || "unknown"}</p>
+      <p>Persistence Layer: {bnl.persisted ? "Redis" : "In-memory fallback"}</p>
+      <p className="text-xs text-muted mt-2">This metadata is for admin visibility and is not part of the public ticker display.</p>
+    </div>
+    <div className="text-sm border border-border p-4 bg-background/20">
+      <p className="text-xs text-accent uppercase tracking-widest mb-2">BNL Admin Status Report</p>
+      <p><strong>Discord Source:</strong> <span className="text-foreground">{SOURCE_LABELS[bnl.source || "unknown"]}</span></p>
+      <p><strong>Discord Last Update:</strong> <span className="text-foreground">{lastSeenLocal}</span></p>
+      <p><strong>Website Relay Status:</strong> <span className="text-foreground">{bnl.status}</span> / <span className="text-foreground">{bnl.mode}</span></p>
+      <p><strong>Website Relay Message:</strong> {bnl.message}</p>
+      <p><strong>Sync Health:</strong> <span className="text-foreground">{lastSeenAge}</span> • <span className="text-foreground">{bnl.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</span></p>
+      <p className="text-xs text-muted mt-2">Admin view only. Use this to compare BNL Discord updates to current website relay output.</p>
+    </div>
+  </div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
-  <textarea value={relayForm.message} maxLength={240} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,240)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" />
-  <div className="flex gap-3"><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Update BNL Relay</button><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset BNL Relay to Standby</button></div>
-  <div><p className="text-xs text-muted mb-2">Kill switches are stored for future bot consumption.</p>{Object.entries(flags).map(([k,v])=><label key={k} className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span>{k}</span><input type="checkbox" checked={v} onChange={(e)=>updateFlags({...flags,[k]:e.target.checked})} /></label>)}</div>
-  <div><p className="text-xs text-muted mb-2">Most recent 10 relay updates (bot/admin/showtest/heartbeat).</p><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{entry.timestamp} — {entry.status} / {entry.mode} ({entry.source || 'unknown'})</p><p>{entry.message}</p></div>)}</div></div>
+  <textarea value={relayForm.message} maxLength={600} onChange={(e)=>setRelayForm({...relayForm,message:e.target.value.slice(0,600)})} className="w-full bg-background border border-border px-3 py-2.5 text-sm" />
+  <div className="flex flex-wrap gap-3"><button onClick={()=>updateRelay('updateStatus')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Update BNL Relay</button><button onClick={()=>updateRelay('resetStandby')} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Reset BNL Relay to Standby</button><button onClick={requestForcePull} className="px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Request Immediate BNL Check-in</button></div>
+  <div className="text-xs text-muted space-y-1">
+    <p><strong>Update BNL Relay:</strong> Publishes the status, mode, and message entered above to the public website relay immediately.</p>
+    <p><strong>Reset BNL Relay to Standby:</strong> Sets relay back to monitoring/standby messaging and marks source as admin reset.</p>
+  </div>
+  <p className="text-xs text-muted">Last immediate check-in request: {forcePullRequestedAt || "never"}.</p>
+  <p className="text-xs text-muted">This requests a bot-side check-in and does not itself generate a new relay message. If BNL has not posted new status data yet, the public relay may remain unchanged.</p>
+  <div><p className="text-xs text-muted mb-2">Kill switches are stored for future bot consumption.</p>
+    <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Website Relay Enabled:</strong> Allows BNL to update the public website relay automatically.</span><input type="checkbox" checked={flags.websiteRelayEnabled} onChange={(e)=>updateFlags({...flags,websiteRelayEnabled:e.target.checked})} /></label>
+    <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Show-Day Discord Posts Enabled:</strong> Allows BNL to post scheduled Friday show updates in Discord.</span><input type="checkbox" checked={flags.showdayDiscordPostsEnabled} onChange={(e)=>updateFlags({...flags,showdayDiscordPostsEnabled:e.target.checked})} /></label>
+    <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Heartbeat Enabled:</strong> Allows BNL to keep the website relay fresh with periodic status updates.</span><input type="checkbox" checked={flags.heartbeatEnabled} onChange={(e)=>updateFlags({...flags,heartbeatEnabled:e.target.checked})} /></label>
+  </div>
+  <div><div className="flex items-center justify-between"><p className="text-xs text-muted mb-2">Admin Relay History (admin only) — most recent 25 updates received from BNL/admin actions.</p><button onClick={clearHistory} className="px-3 py-1.5 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Clear Relay History</button></div><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{formatLocalTimestamp(entry.timestamp)} — {entry.status} / {entry.mode} ({SOURCE_LABELS[entry.source || 'unknown']})</p>{entry.currentDirective && <p>Directive: {entry.currentDirective}</p>}<p>{entry.message}</p><p className="text-muted">Persistence: {entry.persisted === undefined ? "unknown" : entry.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</p></div>)}</div></div>
   </div>
 
   </div></section>;

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 
 type BNLStatusValue = "ONLINE" | "OFFLINE";
 type BNLModeValue = "STANDBY" | "OBSERVATION" | "ACTIVE_LIAISON" | "SIGNAL_DEGRADATION" | "RESTRICTED";
-type BNLSourceValue = "bot" | "admin" | "showtest" | "heartbeat" | "unknown";
+type BNLSourceValue = "bot" | "startup" | "relay" | "heartbeat" | "showday" | "showtest" | "admin" | "reset" | "unknown";
 
 type BNLFlags = {
   websiteRelayEnabled: boolean;
@@ -17,6 +17,8 @@ type BNLFlags = {
 const STATUS_KEY = "bnl:status";
 const HISTORY_KEY = "bnl:history";
 const FLAGS_KEY = "bnl:flags";
+const FORCE_PULL_KEY = "bnl:force_pull_requested_at";
+const MAX_MESSAGE_LENGTH = 600;
 
 const DEFAULT_FLAGS: BNLFlags = {
   websiteRelayEnabled: true,
@@ -27,7 +29,7 @@ const DEFAULT_FLAGS: BNLFlags = {
 const ALLOWED_STATUS = new Set<BNLStatusValue>(["ONLINE", "OFFLINE"]);
 const ALLOWED_MODES = new Set<BNLModeValue>(["STANDBY", "OBSERVATION", "ACTIVE_LIAISON", "SIGNAL_DEGRADATION", "RESTRICTED"]);
 
-let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; message: string; source: BNLSourceValue }> = [];
+let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; persisted?: boolean }> = [];
 let memoryFlags: BNLFlags = { ...DEFAULT_FLAGS };
 
 function getRedis(): Redis | null {
@@ -49,23 +51,28 @@ async function isAuthenticated(req: Request): Promise<boolean> {
 
 function sanitizeHistory(value: unknown): typeof memoryHistory {
   if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      if (!item || typeof item !== "object") return null;
-      const rec = item as Record<string, unknown>;
-      if (!ALLOWED_STATUS.has(rec.status as BNLStatusValue) || !ALLOWED_MODES.has(rec.mode as BNLModeValue)) return null;
-      if (typeof rec.timestamp !== "string" || typeof rec.message !== "string") return null;
-      const source = rec.source as BNLSourceValue;
-      return {
-        timestamp: rec.timestamp,
-        status: rec.status as BNLStatusValue,
-        mode: rec.mode as BNLModeValue,
-        message: rec.message.trim().slice(0, 240),
-        source: source === "bot" || source === "admin" || source === "showtest" || source === "heartbeat" ? source : "unknown",
-      };
-    })
-    .filter((item): item is (typeof memoryHistory)[number] => Boolean(item))
-    .slice(0, 10);
+  const allowedSources = new Set<BNLSourceValue>(["bot", "startup", "relay", "heartbeat", "showday", "showtest", "admin", "reset", "unknown"]);
+  const normalized: typeof memoryHistory = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as Record<string, unknown>;
+    if (!ALLOWED_STATUS.has(rec.status as BNLStatusValue) || !ALLOWED_MODES.has(rec.mode as BNLModeValue)) continue;
+    if (typeof rec.timestamp !== "string" || typeof rec.message !== "string") continue;
+    const source = rec.source;
+    const normalizedSource: BNLSourceValue = typeof source === "string" && allowedSources.has(source as BNLSourceValue)
+      ? (source as BNLSourceValue)
+      : "unknown";
+    normalized.push({
+      timestamp: rec.timestamp,
+      status: rec.status as BNLStatusValue,
+      mode: rec.mode as BNLModeValue,
+      currentDirective: typeof rec.currentDirective === "string" ? rec.currentDirective.trim().slice(0, 160) : undefined,
+      message: rec.message.trim().slice(0, MAX_MESSAGE_LENGTH),
+      source: normalizedSource,
+      persisted: typeof rec.persisted === "boolean" ? rec.persisted : undefined,
+    });
+  }
+  return normalized.slice(0, 25);
 }
 
 function sanitizeFlags(value: unknown): BNLFlags {
@@ -78,6 +85,19 @@ function sanitizeFlags(value: unknown): BNLFlags {
   };
 }
 
+function sameHistoryContent(
+  a: (typeof memoryHistory)[number],
+  b: (typeof memoryHistory)[number],
+): boolean {
+  return (
+    a.status === b.status &&
+    a.mode === b.mode &&
+    a.source === b.source &&
+    a.message === b.message &&
+    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+  );
+}
+
 export async function GET(req: Request) {
   if (!(await isAuthenticated(req))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -87,21 +107,24 @@ export async function GET(req: Request) {
   let status: unknown = null;
   let history = memoryHistory;
   let flags = memoryFlags;
+  let forcePullRequestedAt: string | null = null;
 
   if (redis) {
-    const [s, h, f] = await Promise.all([
+    const [s, h, f, fp] = await Promise.all([
       redis.get<unknown>(STATUS_KEY),
       redis.get<unknown>(HISTORY_KEY),
       redis.get<unknown>(FLAGS_KEY),
+      redis.get<unknown>(FORCE_PULL_KEY),
     ]);
     status = s;
     history = sanitizeHistory(h) as typeof memoryHistory;
     flags = sanitizeFlags(f);
+    forcePullRequestedAt = typeof fp === "string" ? fp : null;
     memoryHistory = history;
     memoryFlags = flags;
   }
 
-  return NextResponse.json({ status, history, flags, persisted: Boolean(redis) });
+  return NextResponse.json({ status, history, flags, forcePullRequestedAt, persisted: Boolean(redis) });
 }
 
 export async function POST(req: Request) {
@@ -125,7 +148,7 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
       }
 
-      const trimmedMessage = message.trim().slice(0, 240);
+      const trimmedMessage = message.trim().slice(0, MAX_MESSAGE_LENGTH);
       if (!trimmedMessage) return NextResponse.json({ error: "Message required" }, { status: 400 });
 
       const now = new Date().toISOString();
@@ -133,25 +156,42 @@ export async function POST(req: Request) {
         status: status as BNLStatusValue,
         mode: mode as BNLModeValue,
         message: trimmedMessage,
+        currentDirective: action === "resetStandby" ? "Monitoring Discord-side relay traffic." : undefined,
+        source: action === "resetStandby" ? "reset" : "admin",
         lastSeen: now,
       };
       const nextEntry: (typeof memoryHistory)[number] = {
         timestamp: now,
         status: status as BNLStatusValue,
         mode: mode as BNLModeValue,
+        currentDirective: nextStatus.currentDirective,
         message: trimmedMessage,
-        source: "admin",
+        source: action === "resetStandby" ? "reset" : "admin",
+        persisted: Boolean(redis),
       };
 
       if (redis) {
         const priorHistory = sanitizeHistory(await redis.get<unknown>(HISTORY_KEY)) as typeof memoryHistory;
         await redis.set(STATUS_KEY, nextStatus);
-        await redis.set(HISTORY_KEY, [nextEntry, ...priorHistory].slice(0, 10));
+        const latest = priorHistory[0];
+        const nextHistory = latest && sameHistoryContent(latest, nextEntry)
+          ? priorHistory.slice(0, 25)
+          : [nextEntry, ...priorHistory].slice(0, 25);
+        await redis.set(HISTORY_KEY, nextHistory);
       } else {
-        memoryHistory = [nextEntry, ...memoryHistory].slice(0, 10);
+        const latest = memoryHistory[0];
+        memoryHistory = latest && sameHistoryContent(latest, nextEntry)
+          ? memoryHistory.slice(0, 25)
+          : [nextEntry, ...memoryHistory].slice(0, 25);
       }
 
       return NextResponse.json({ ok: true, status: nextStatus, persisted: Boolean(redis) });
+    }
+
+    if (action === "clearHistory") {
+      if (redis) await redis.set(HISTORY_KEY, []);
+      memoryHistory = [];
+      return NextResponse.json({ ok: true, cleared: true, persisted: Boolean(redis) });
     }
 
     if (action === "updateFlags") {
@@ -175,6 +215,17 @@ export async function POST(req: Request) {
       if (redis) await redis.set(FLAGS_KEY, nextFlags);
       memoryFlags = nextFlags;
       return NextResponse.json({ ok: true, flags: nextFlags, persisted: Boolean(redis) });
+    }
+
+    if (action === "forcePull") {
+      const now = new Date().toISOString();
+      if (redis) await redis.set(FORCE_PULL_KEY, now);
+      return NextResponse.json({
+        ok: true,
+        forcePullRequestedAt: now,
+        note: "Immediate check-in requested. BNL must consume this request to publish a new relay update.",
+        persisted: Boolean(redis),
+      });
     }
 
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -25,12 +25,15 @@ interface BNLHistoryEntry {
   timestamp: string;
   status: BNLStatusValue;
   mode: BNLModeValue;
+  currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  persisted?: boolean;
 }
 
 const KEY = "bnl:status";
 const HISTORY_KEY = "bnl:history";
+const MAX_MESSAGE_LENGTH = 600;
 const DEFAULT_DIRECTIVE = "Monitoring Discord-side relay traffic.";
 const DEFAULT_STATUS: BNLStatus = {
   status: "OFFLINE",
@@ -72,8 +75,8 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
     ? (record.mode as BNLModeValue)
     : DEFAULT_STATUS.mode;
   const message =
-    typeof record.message === "string" && record.message.trim().length > 0
-      ? record.message.trim().slice(0, 240)
+      typeof record.message === "string" && record.message.trim().length > 0
+      ? record.message.trim().slice(0, MAX_MESSAGE_LENGTH)
       : DEFAULT_STATUS.message;
   const currentDirective =
     typeof record.currentDirective === "string" && record.currentDirective.trim().length > 0
@@ -92,27 +95,43 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
 
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
   if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      if (!item || typeof item !== "object") return null;
-      const rec = item as Record<string, unknown>;
-      const status = ALLOWED_STATUS.has(rec.status as BNLStatusValue) ? (rec.status as BNLStatusValue) : null;
-      const mode = ALLOWED_MODES.has(rec.mode as BNLModeValue) ? (rec.mode as BNLModeValue) : null;
-      const source = ALLOWED_SOURCES.has(rec.source as BNLSourceValue)
-        ? (rec.source as BNLSourceValue)
-        : "unknown";
-      const timestamp = typeof rec.timestamp === "string" && rec.timestamp ? rec.timestamp : null;
-      const message = typeof rec.message === "string" ? rec.message.trim().slice(0, 240) : "";
-      if (!status || !mode || !timestamp || !message) return null;
-      return { timestamp, status, mode, message, source };
-    })
-    .filter((entry): entry is BNLHistoryEntry => Boolean(entry))
-    .slice(0, 10);
+  const normalized: BNLHistoryEntry[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as Record<string, unknown>;
+    const status = ALLOWED_STATUS.has(rec.status as BNLStatusValue) ? (rec.status as BNLStatusValue) : null;
+    const mode = ALLOWED_MODES.has(rec.mode as BNLModeValue) ? (rec.mode as BNLModeValue) : null;
+    const source = ALLOWED_SOURCES.has(rec.source as BNLSourceValue)
+      ? (rec.source as BNLSourceValue)
+      : "unknown";
+    const timestamp = typeof rec.timestamp === "string" && rec.timestamp ? rec.timestamp : null;
+    const message = typeof rec.message === "string" ? rec.message.trim().slice(0, MAX_MESSAGE_LENGTH) : "";
+    const currentDirective =
+      typeof rec.currentDirective === "string" && rec.currentDirective.trim().length > 0
+        ? rec.currentDirective.trim().slice(0, 160)
+        : undefined;
+    if (!status || !mode || !timestamp || !message) continue;
+    normalized.push({ timestamp, status, mode, currentDirective, message, source });
+  }
+  return normalized.slice(0, 25);
+}
+
+function sameHistoryContent(a: BNLHistoryEntry, b: BNLHistoryEntry): boolean {
+  return (
+    a.status === b.status &&
+    a.mode === b.mode &&
+    a.source === b.source &&
+    a.message === b.message &&
+    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+  );
 }
 
 async function appendHistory(redis: Redis | null, entry: BNLHistoryEntry) {
   const current = redis ? sanitizeHistory(await redis.get<unknown>(HISTORY_KEY)) : memoryHistory;
-  const nextHistory = [entry, ...current].slice(0, 10);
+  const latest = current[0];
+  const nextHistory = latest && sameHistoryContent(latest, entry)
+    ? current.slice(0, 25)
+    : [entry, ...current].slice(0, 25);
   if (redis) await redis.set(HISTORY_KEY, nextHistory);
   memoryHistory = nextHistory;
 }
@@ -157,7 +176,7 @@ export async function POST(req: Request) {
     }
 
     const trimmedMessage = message.trim();
-    if (!trimmedMessage || trimmedMessage.length > 240) {
+    if (!trimmedMessage || trimmedMessage.length > MAX_MESSAGE_LENGTH) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
@@ -187,8 +206,10 @@ export async function POST(req: Request) {
       timestamp: now,
       status: nextStatus.status,
       mode: nextStatus.mode,
+      currentDirective: nextStatus.currentDirective,
       message: nextStatus.message,
       source: nextStatus.source,
+      persisted: Boolean(redis),
     });
 
     return NextResponse.json({ ok: true, status: nextStatus, persisted: Boolean(redis) });

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -6,9 +6,27 @@ function bnlTone(online: boolean) {
   return online ? "text-foreground" : "text-foreground/70";
 }
 
+function formatLastSeenSentence(value: string | null): string {
+  if (!value) return "UNKNOWN";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "UNKNOWN";
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(parsed);
+  const date = new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+  return `LAST SEEN AT ${time} ON ${date}`;
+}
+
 export function BNLNetworkRelayTicker() {
   const { data } = useBNLStatus();
   const online = data.status === "ONLINE";
+  const lastSeenSentence = formatLastSeenSentence(data.lastSeen);
 
   return (
     <>
@@ -20,11 +38,11 @@ export function BNLNetworkRelayTicker() {
             <div className="bnl-relay-scroll-track">
               <span>
                 STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
-                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+                {data.lastSeen ? ` :: ${lastSeenSentence}` : ""} ::
               </span>
               <span aria-hidden>
                 STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
-                {data.lastSeen ? ` :: LAST SEEN ${data.lastSeen}` : ""} ::
+                {data.lastSeen ? ` :: ${lastSeenSentence}` : ""} ::
               </span>
             </div>
           </div>
@@ -37,6 +55,7 @@ export function BNLNetworkRelayTicker() {
 export function BNLRelayModule({ title }: { title: string }) {
   const { data, loading } = useBNLStatus();
   const online = data.status === "ONLINE";
+  const lastSeenSentence = formatLastSeenSentence(data.lastSeen);
 
   return (
     <div className="border border-border bg-surface p-6">
@@ -49,7 +68,7 @@ export function BNLRelayModule({ title }: { title: string }) {
         <p>&gt; MESSAGE: {data.message}</p>
         <p>&gt; CURRENT_DIRECTIVE: {data.currentDirective ?? "Monitoring Discord-side relay traffic."}</p>
         <p>&gt; SOURCE: {data.source ?? "unknown"}</p>
-        <p>&gt; LAST_SEEN: {data.lastSeen ?? "NULL"}</p>
+        <p>&gt; {lastSeenSentence}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Improve admin visibility into BNL relay state by surfacing human-friendly timestamps, source labels, and persistence metadata.
- Allow administrators to request an immediate bot check-in (`forcePull`) and to clear the admin history log from the UI.
- Make message handling and history retention more robust by increasing allowable message length, preserving a `persisted` flag, and avoiding duplicate back-to-back history entries.

### Description
- Added new BNL source kinds and labels (`startup`, `relay`, `showday`, `reset`) and a `SOURCE_LABELS` map for UI display.
- Introduced formatted timestamp helpers (`formatLastSeenAge`, `formatLocalTimestamp`, `formatLastSeenSentence`) and updated admin UI (`/src/app/admin/page.tsx`) to show local/relative times and richer admin-only metadata.
- Implemented `forcePull` support in admin API (`/api/admin/bnl/route.ts`) using a new `bnl:force_pull_requested_at` Redis key and returned `forcePullRequestedAt` from `GET`.
- Added a `clearHistory` admin action to truncate the admin history via `/api/admin/bnl` and exposed a UI button to trigger it.
- Increased allowed message length to 600 characters (`MAX_MESSAGE_LENGTH`) across admin and public status endpoints and enlarged admin relay textarea accordingly.
- Sanitization changes: history entries now include optional `currentDirective` and `persisted` properties, history normalization now accepts expanded sources, retains up to 25 entries, and deduplicates consecutive identical entries (`sameHistoryContent`) to avoid noisy duplicates.
- BNL public status endpoint (`/api/bnl/status/route.ts`) now persists `currentDirective` in history entries and marks `persisted` when stored in Redis, and updated history handling to the same 25-item limit and dedup behavior.
- Updated client ticker and module (`/src/components/BNLRelay.tsx`) to render formatted "last seen" sentences instead of raw timestamps.

### Testing
- Ran TypeScript type check and project build (`pnpm build` / Next.js dev build) and ensured successful compilation with the new types and helpers.
- Exercised the admin API flows manually via the UI: `updateStatus`, `resetStandby`, `updateFlags`, `forcePull`, and `clearHistory`, and confirmed API responses returned expected fields (`persisted`, `forcePullRequestedAt`) and HTTP 200 for valid requests.
- Verified that public status POSTs from the BNL API path accept the larger message length and that history entries are appended/deduped and exposed on the admin page (no automated test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e6d89660832193c823444645b7ec)