### PR TITLE
Align BNL relay defaults with Discord memory files

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -28,7 +28,7 @@ interface BNLHistoryEntry {
   persisted?: boolean;
 }
 
-const defaultRelayMessage = "BNL-01 relay standing by. Discord-side signal monitoring active.";
+const defaultRelayMessage = "BNL-01 relay standing by. Discord memory file monitoring active.";
 const defaultBNL: BNLAdminState = { status: "OFFLINE", mode: "STANDBY", message: "BNL-01 relay awaiting signal.", lastSeen: null };
 const SOURCE_LABELS: Record<BNLSourceValue, string> = {
   bot: "BNL bot",

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -33,7 +33,7 @@ interface BNLHistoryEntry {
 
 const KEY = "bnl:status";
 const HISTORY_KEY = "bnl:history";
-const DEFAULT_DIRECTIVE = "Monitoring Discord-side relay traffic.";
+const DEFAULT_DIRECTIVE = "Reading Discord memory files for relay updates.";
 const DEFAULT_STATUS: BNLStatus = {
   status: "OFFLINE",
   mode: "STANDBY",


### PR DESCRIPTION
### Motivation
- Ensure the site’s BNL relay defaults explicitly reference reading Discord memory files (instead of generic or promotional wording) so the public relay language matches the Discord-memory-driven status flow.

### Description
- Updated the default directive in `src/app/api/bnl/status/route.ts` to `"Reading Discord memory files for relay updates."` and updated the admin standby message in `src/app/admin/page.tsx` to `"BNL-01 relay standing by. Discord memory file monitoring active."`, and no other files or protected areas were changed.

### Testing
- Ran `npm run -s lint`, which failed due to existing repo-wide lint issues unrelated to these scoped string changes, so the change was applied but overall lint remains failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f512401c348321a510aa43f87157db)