### PR TITLE
Admin BNL: trigger forcePull webhook and surface delivery status in U…

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -107,6 +107,8 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   const [relayForm, setRelayForm] = useState({ status: "ONLINE" as BNLStatusValue, mode: "OBSERVATION" as BNLModeValue, message: defaultRelayMessage });
   const [bnlApiReachable, setBnlApiReachable] = useState(false);
   const [forcePullRequestedAt, setForcePullRequestedAt] = useState<string | null>(null);
+  const [relayActionError, setRelayActionError] = useState<string | null>(null);
+  const [relayActionNote, setRelayActionNote] = useState<string | null>(null);
 
   const loadBnl = async () => {
     const [publicRes, adminRes] = await Promise.all([fetch('/api/bnl/status', { cache: 'no-store' }), fetch('/api/admin/bnl', { cache: 'no-store' })]);
@@ -142,8 +144,25 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     await loadBnl();
   };
   const requestForcePull = async () => {
-    await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'forcePull' }) });
-    await loadBnl();
+    setRelayActionError(null);
+    setRelayActionNote(null);
+    try {
+      const res = await fetch('/api/admin/bnl', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'forcePull' }) });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const reason = typeof payload?.error === 'string' ? payload.error : `Request failed (${res.status})`;
+        throw new Error(reason);
+      }
+      if (typeof payload?.note === "string") setRelayActionNote(payload.note);
+      if (payload?.webhookDelivery && payload.webhookDelivery.delivered === false) {
+        console.warn("[admin] forcePull webhook delivery warning:", payload.webhookDelivery);
+      }
+      await loadBnl();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to request immediate check-in';
+      console.error('[admin] forcePull request failed:', error);
+      setRelayActionError(message);
+    }
   };
 
   const lastSeenAge = formatLastSeenAge(bnl.lastSeen);
@@ -191,6 +210,8 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
   </div>
   <p className="text-xs text-muted">Last immediate check-in request: {forcePullRequestedAt || "never"}.</p>
   <p className="text-xs text-muted">This requests a bot-side check-in and does not itself generate a new relay message. If BNL has not posted new status data yet, the public relay may remain unchanged.</p>
+  {relayActionError && <p className="text-xs text-danger">Immediate check-in request failed: {relayActionError}</p>}
+  {relayActionNote && <p className="text-xs text-muted">{relayActionNote}</p>}
   <div><p className="text-xs text-muted mb-2">Kill switches are stored for future bot consumption.</p>
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Website Relay Enabled:</strong> Allows BNL to update the public website relay automatically.</span><input type="checkbox" checked={flags.websiteRelayEnabled} onChange={(e)=>updateFlags({...flags,websiteRelayEnabled:e.target.checked})} /></label>
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Show-Day Discord Posts Enabled:</strong> Allows BNL to post scheduled Friday show updates in Discord.</span><input type="checkbox" checked={flags.showdayDiscordPostsEnabled} onChange={(e)=>updateFlags({...flags,showdayDiscordPostsEnabled:e.target.checked})} /></label>

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -85,6 +85,39 @@ function sanitizeFlags(value: unknown): BNLFlags {
   };
 }
 
+async function notifyForcePull(now: string): Promise<{ delivered: boolean; reason?: string; status?: number }> {
+  const webhookUrl = process.env.BNL_FORCE_PULL_WEBHOOK_URL;
+  if (!webhookUrl) return { delivered: false, reason: "BNL_FORCE_PULL_WEBHOOK_URL is not configured" };
+  const sharedSecret = process.env.BNL_FORCE_PULL_SHARED_SECRET || "";
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(sharedSecret ? { "x-bnl-secret": sharedSecret } : {}),
+      },
+      body: JSON.stringify({ action: "forcePull", requestedAt: now, source: "website-admin" }),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      console.error("[admin/bnl] forcePull webhook returned non-OK status", { status: response.status });
+      return { delivered: false, status: response.status, reason: `Webhook returned ${response.status}` };
+    }
+
+    return { delivered: true, status: response.status };
+  } catch (error) {
+    clearTimeout(timeout);
+    console.error("[admin/bnl] forcePull webhook request failed", error);
+    return { delivered: false, reason: "Webhook request failed" };
+  }
+}
+
 function sameHistoryContent(
   a: (typeof memoryHistory)[number],
   b: (typeof memoryHistory)[number],
@@ -219,11 +252,33 @@ export async function POST(req: Request) {
 
     if (action === "forcePull") {
       const now = new Date().toISOString();
-      if (redis) await redis.set(FORCE_PULL_KEY, now);
+      if (redis) {
+        await redis.set(FORCE_PULL_KEY, now);
+      } else {
+        console.warn('[admin/bnl] forcePull requested without redis persistence; request timestamp may not be visible across serverless instances');
+      }
+
+      const webhookDelivery = await notifyForcePull(now);
+
+      console.info('[admin/bnl] forcePull requested at', now, { webhookDelivered: webhookDelivery.delivered, webhookStatus: webhookDelivery.status ?? null });
+      if (!webhookDelivery.delivered) {
+        const statusCode = webhookDelivery.reason === "BNL_FORCE_PULL_WEBHOOK_URL is not configured" ? 503 : 502;
+        return NextResponse.json({
+          error: webhookDelivery.reason === "BNL_FORCE_PULL_WEBHOOK_URL is not configured"
+            ? "Immediate check-in relay is not configured."
+            : "Immediate check-in relay delivery failed.",
+          forcePullRequestedAt: now,
+          webhookDelivery,
+          persisted: Boolean(redis),
+        }, { status: statusCode });
+      }
       return NextResponse.json({
         ok: true,
         forcePullRequestedAt: now,
-        note: "Immediate check-in requested. BNL must consume this request to publish a new relay update.",
+        note: webhookDelivery.delivered
+          ? "Immediate check-in request delivered to BNL endpoint."
+          : "Immediate check-in recorded, but BNL webhook delivery failed or is not configured.",
+        webhookDelivery,
         persisted: Boolean(redis),
       });
     }


### PR DESCRIPTION
…I (#47)

* Wire force-pull action to optional bot webhook delivery

* Harden force-pull webhook delivery semantics

* Return explicit errors when force-pull relay is unavailable