### PR TITLE
Support optional adminNote in BNL status API and admin panel

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ interface BNLAdminState {
   source?: BNLSourceValue;
   lastSeen: string | null;
   persisted?: boolean;
+  adminNote?: string;
   forcePullRequestedAt?: string | null;
 }
 
@@ -25,6 +26,7 @@ interface BNLHistoryEntry {
   currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  adminNote?: string;
   persisted?: boolean;
 }
 
@@ -115,11 +117,14 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     setBnlApiReachable(publicRes.ok);
     if (publicRes.ok) {
       const publicData = await publicRes.json();
-      setBnl(publicData);
+      setBnl((prev) => ({ ...prev, ...publicData }));
       setRelayForm((x) => ({ ...x, status: publicData.status, mode: publicData.mode, message: publicData.message }));
     }
     if (adminRes.ok) {
       const adminData = await adminRes.json();
+      if (adminData.status && typeof adminData.status === "object") {
+        setBnl((prev) => ({ ...prev, ...(adminData.status as Partial<BNLAdminState>) }));
+      }
       setHistory(adminData.history || []);
       setFlags(adminData.flags || flags);
       setForcePullRequestedAt(typeof adminData.forcePullRequestedAt === "string" ? adminData.forcePullRequestedAt : null);
@@ -195,10 +200,9 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
       <p className="text-xs text-accent uppercase tracking-widest mb-2">BNL Admin Status Report</p>
       <p><strong>Discord Source:</strong> <span className="text-foreground">{SOURCE_LABELS[bnl.source || "unknown"]}</span></p>
       <p><strong>Discord Last Update:</strong> <span className="text-foreground">{lastSeenLocal}</span></p>
-      <p><strong>Website Relay Status:</strong> <span className="text-foreground">{bnl.status}</span> / <span className="text-foreground">{bnl.mode}</span></p>
-      <p><strong>Website Relay Message:</strong> {bnl.message}</p>
+      <p><strong>BNL Operator Note:</strong> <span className="text-foreground">{bnl.adminNote && bnl.adminNote.trim().length > 0 ? bnl.adminNote : "No fresh admin analysis for this relay."}</span></p>
       <p><strong>Sync Health:</strong> <span className="text-foreground">{lastSeenAge}</span> • <span className="text-foreground">{bnl.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</span></p>
-      <p className="text-xs text-muted mt-2">Admin view only. Use this to compare BNL Discord updates to current website relay output.</p>
+      <p className="text-xs text-muted mt-2">Operator-only context. This note does not appear in the public website relay.</p>
     </div>
   </div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
@@ -217,7 +221,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Show-Day Discord Posts Enabled:</strong> Allows BNL to post scheduled Friday show updates in Discord.</span><input type="checkbox" checked={flags.showdayDiscordPostsEnabled} onChange={(e)=>updateFlags({...flags,showdayDiscordPostsEnabled:e.target.checked})} /></label>
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Heartbeat Enabled:</strong> Allows BNL to keep the website relay fresh with periodic status updates.</span><input type="checkbox" checked={flags.heartbeatEnabled} onChange={(e)=>updateFlags({...flags,heartbeatEnabled:e.target.checked})} /></label>
   </div>
-  <div><div className="flex items-center justify-between"><p className="text-xs text-muted mb-2">Admin Relay History (admin only) — most recent 25 updates received from BNL/admin actions.</p><button onClick={clearHistory} className="px-3 py-1.5 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Clear Relay History</button></div><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{formatLocalTimestamp(entry.timestamp)} — {entry.status} / {entry.mode} ({SOURCE_LABELS[entry.source || 'unknown']})</p>{entry.currentDirective && <p>Directive: {entry.currentDirective}</p>}<p>{entry.message}</p><p className="text-muted">Persistence: {entry.persisted === undefined ? "unknown" : entry.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</p></div>)}</div></div>
+  <div><div className="flex items-center justify-between"><p className="text-xs text-muted mb-2">Admin Relay History (admin only) — most recent 25 updates received from BNL/admin actions.</p><button onClick={clearHistory} className="px-3 py-1.5 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Clear Relay History</button></div><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{formatLocalTimestamp(entry.timestamp)} — {entry.status} / {entry.mode} ({SOURCE_LABELS[entry.source || 'unknown']})</p>{entry.currentDirective && <p>Directive: {entry.currentDirective}</p>}<p>{entry.message}</p>{entry.adminNote && <p>Operator Note: {entry.adminNote}</p>}<p className="text-muted">Persistence: {entry.persisted === undefined ? "unknown" : entry.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</p></div>)}</div></div>
   </div>
 
   </div></section>;

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -29,7 +29,7 @@ const DEFAULT_FLAGS: BNLFlags = {
 const ALLOWED_STATUS = new Set<BNLStatusValue>(["ONLINE", "OFFLINE"]);
 const ALLOWED_MODES = new Set<BNLModeValue>(["STANDBY", "OBSERVATION", "ACTIVE_LIAISON", "SIGNAL_DEGRADATION", "RESTRICTED"]);
 
-let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; persisted?: boolean }> = [];
+let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; adminNote?: string; persisted?: boolean }> = [];
 let memoryFlags: BNLFlags = { ...DEFAULT_FLAGS };
 
 function getRedis(): Redis | null {
@@ -69,6 +69,7 @@ function sanitizeHistory(value: unknown): typeof memoryHistory {
       currentDirective: typeof rec.currentDirective === "string" ? rec.currentDirective.trim().slice(0, 160) : undefined,
       message: rec.message.trim().slice(0, MAX_MESSAGE_LENGTH),
       source: normalizedSource,
+      adminNote: typeof rec.adminNote === "string" && rec.adminNote.trim().length > 0 ? rec.adminNote.trim().slice(0, 400) : undefined,
       persisted: typeof rec.persisted === "boolean" ? rec.persisted : undefined,
     });
   }
@@ -127,7 +128,8 @@ function sameHistoryContent(
     a.mode === b.mode &&
     a.source === b.source &&
     a.message === b.message &&
-    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+    (a.currentDirective ?? "") === (b.currentDirective ?? "") &&
+    (a.adminNote ?? "") === (b.adminNote ?? "")
   );
 }
 

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -18,6 +18,7 @@ interface BNLStatus {
   message: string;
   currentDirective: string;
   source: BNLSourceValue;
+  adminNote?: string;
   lastSeen: string | null;
 }
 
@@ -28,6 +29,7 @@ interface BNLHistoryEntry {
   currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  adminNote?: string;
   persisted?: boolean;
 }
 
@@ -90,7 +92,12 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
       ? record.lastSeen
       : null;
 
-  return { status, mode, message, currentDirective, source, lastSeen };
+  const adminNote =
+    typeof record.adminNote === "string" && record.adminNote.trim().length > 0
+      ? record.adminNote.trim().slice(0, 400)
+      : undefined;
+
+  return { status, mode, message, currentDirective, source, adminNote, lastSeen };
 }
 
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
@@ -110,8 +117,12 @@ function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
       typeof rec.currentDirective === "string" && rec.currentDirective.trim().length > 0
         ? rec.currentDirective.trim().slice(0, 160)
         : undefined;
+    const adminNote =
+      typeof rec.adminNote === "string" && rec.adminNote.trim().length > 0
+        ? rec.adminNote.trim().slice(0, 400)
+        : undefined;
     if (!status || !mode || !timestamp || !message) continue;
-    normalized.push({ timestamp, status, mode, currentDirective, message, source });
+    normalized.push({ timestamp, status, mode, currentDirective, message, source, adminNote });
   }
   return normalized.slice(0, 25);
 }
@@ -122,7 +133,8 @@ function sameHistoryContent(a: BNLHistoryEntry, b: BNLHistoryEntry): boolean {
     a.mode === b.mode &&
     a.source === b.source &&
     a.message === b.message &&
-    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+    (a.currentDirective ?? "") === (b.currentDirective ?? "") &&
+    (a.adminNote ?? "") === (b.adminNote ?? "")
   );
 }
 
@@ -143,10 +155,12 @@ export async function GET() {
     const stored = await redis.get<unknown>(KEY);
     const resolved = sanitizeStoredStatus(stored);
     memoryStatus = resolved;
-    return NextResponse.json({ ...resolved, persisted: true });
+    const { adminNote: _adminNote, ...publicStatus } = resolved;
+    return NextResponse.json({ ...publicStatus, persisted: true });
   }
 
-  return NextResponse.json({ ...memoryStatus, persisted: false });
+  const { adminNote: _adminNote, ...publicStatus } = memoryStatus;
+  return NextResponse.json({ ...publicStatus, persisted: false });
 }
 
 export async function POST(req: Request) {
@@ -159,7 +173,7 @@ export async function POST(req: Request) {
 
   try {
     const body = (await req.json()) as Record<string, unknown>;
-    const allowedKeys = ["status", "mode", "message", "currentDirective", "source"];
+    const allowedKeys = ["status", "mode", "message", "currentDirective", "source", "adminNote"];
     const bodyKeys = Object.keys(body);
     if (!bodyKeys.every((key) => allowedKeys.includes(key))) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -170,6 +184,7 @@ export async function POST(req: Request) {
     const message = body.message;
     const currentDirective = body.currentDirective;
     const source = body.source;
+    const adminNote = body.adminNote;
 
     if (!ALLOWED_STATUS.has(status as BNLStatusValue) || !ALLOWED_MODES.has(mode as BNLModeValue) || typeof message !== "string") {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -188,6 +203,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
+    if (adminNote !== undefined && (typeof adminNote !== "string" || adminNote.trim().length > 400)) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
     const now = new Date().toISOString();
     const nextStatus: BNLStatus = {
       status: status as BNLStatusValue,
@@ -195,6 +214,7 @@ export async function POST(req: Request) {
       message: trimmedMessage,
       currentDirective: typeof currentDirective === "string" ? currentDirective.trim() : DEFAULT_DIRECTIVE,
       source: typeof source === "string" && ALLOWED_SOURCES.has(source as BNLSourceValue) ? (source as BNLSourceValue) : "unknown",
+      adminNote: typeof adminNote === "string" && adminNote.trim().length > 0 ? adminNote.trim() : undefined,
       lastSeen: now,
     };
 
@@ -209,6 +229,7 @@ export async function POST(req: Request) {
       currentDirective: nextStatus.currentDirective,
       message: nextStatus.message,
       source: nextStatus.source,
+      adminNote: nextStatus.adminNote,
       persisted: Boolean(redis),
     });
 


### PR DESCRIPTION
### Motivation
- BNL may send an optional operator-only `adminNote` alongside status payloads that must be stored for admins but never exposed publicly.
- The admin UI needs a dedicated operator note display separate from the public relay to avoid leaking internal analysis.
- History and de-duplication should preserve and compare `adminNote` so admin history is accurate when notes change.

### Description
- Accept `adminNote` (optional string) in `POST /api/bnl/status` and sanitize/trim it to 400 characters before storing in the status object and history entries in `src/app/api/bnl/status/route.ts`.
- Keep public `GET /api/bnl/status` responses safe by stripping `adminNote` from the returned payload so public consumers only receive `status`, `mode`, `message`, `currentDirective`, `source`, and `lastSeen` in `src/app/api/bnl/status/route.ts`.
- Preserve `adminNote` in admin-side history sanitization and include it in history de-duplication comparisons by updating `sameHistoryContent` and `sanitizeHistory` in `src/app/api/admin/bnl/route.ts`.
- Update the admin UI in `src/app/admin/page.tsx` to merge public and admin status sources safely, display the operator note prominently under “BNL Operator Note” with fallback text `"No fresh admin analysis for this relay."`, and show `adminNote` in admin history entries while keeping the Public Website Relay section unchanged.

### Testing
- Ran `npm run lint`; it failed due to pre-existing repo-wide lint errors unrelated to these changes (errors noted in several files), so no new lint regressions could be fully validated in this environment.
- Ran `npm run build`; it failed in this environment because Next.js attempted to fetch the Google Fonts resource `Geist Mono` from `fonts.googleapis.com`, causing a network fetch error during the build.
- Verified via code inspection that `adminNote` is accepted in the admin ingestion path, is stored and recorded to history, and is omitted from the public `GET` response, and that the admin panel renders the operator note with the specified fallback text.

Files changed
- `src/app/api/bnl/status/route.ts` — accept, sanitize, persist `adminNote`; strip it from public GET responses; include in history entries and de-dup logic.
- `src/app/api/admin/bnl/route.ts` — preserve `adminNote` in admin history sanitization and de-dup comparisons.
- `src/app/admin/page.tsx` — display `BNL Operator Note` in admin report and show `adminNote` per-history-entry while keeping the public relay UI unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53ca774fc8321bf6a7bb979cce999)