### PR TITLE
BNL blueprint P0: add control-flags compatibility route and public relay labels

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ interface BNLAdminState {
   source?: BNLSourceValue;
   lastSeen: string | null;
   persisted?: boolean;
+  adminNote?: string;
   forcePullRequestedAt?: string | null;
 }
 
@@ -25,6 +26,7 @@ interface BNLHistoryEntry {
   currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  adminNote?: string;
   persisted?: boolean;
 }
 
@@ -115,11 +117,14 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     setBnlApiReachable(publicRes.ok);
     if (publicRes.ok) {
       const publicData = await publicRes.json();
-      setBnl(publicData);
+      setBnl((prev) => ({ ...prev, ...publicData }));
       setRelayForm((x) => ({ ...x, status: publicData.status, mode: publicData.mode, message: publicData.message }));
     }
     if (adminRes.ok) {
       const adminData = await adminRes.json();
+      if (adminData.status && typeof adminData.status === "object") {
+        setBnl((prev) => ({ ...prev, ...(adminData.status as Partial<BNLAdminState>) }));
+      }
       setHistory(adminData.history || []);
       setFlags(adminData.flags || flags);
       setForcePullRequestedAt(typeof adminData.forcePullRequestedAt === "string" ? adminData.forcePullRequestedAt : null);
@@ -195,10 +200,9 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
       <p className="text-xs text-accent uppercase tracking-widest mb-2">BNL Admin Status Report</p>
       <p><strong>Discord Source:</strong> <span className="text-foreground">{SOURCE_LABELS[bnl.source || "unknown"]}</span></p>
       <p><strong>Discord Last Update:</strong> <span className="text-foreground">{lastSeenLocal}</span></p>
-      <p><strong>Website Relay Status:</strong> <span className="text-foreground">{bnl.status}</span> / <span className="text-foreground">{bnl.mode}</span></p>
-      <p><strong>Website Relay Message:</strong> {bnl.message}</p>
+      <p><strong>BNL Operator Note:</strong> <span className="text-foreground">{bnl.adminNote && bnl.adminNote.trim().length > 0 ? bnl.adminNote : "No fresh admin analysis for this relay."}</span></p>
       <p><strong>Sync Health:</strong> <span className="text-foreground">{lastSeenAge}</span> • <span className="text-foreground">{bnl.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</span></p>
-      <p className="text-xs text-muted mt-2">Admin view only. Use this to compare BNL Discord updates to current website relay output.</p>
+      <p className="text-xs text-muted mt-2">Operator-only context. This note does not appear in the public website relay.</p>
     </div>
   </div>
   <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><select value={relayForm.status} onChange={(e)=>setRelayForm({...relayForm,status:e.target.value as BNLStatusValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>ONLINE</option><option>OFFLINE</option></select><select value={relayForm.mode} onChange={(e)=>setRelayForm({...relayForm,mode:e.target.value as BNLModeValue})} className="bg-background border border-border px-3 py-2.5 text-sm"><option>STANDBY</option><option>OBSERVATION</option><option>ACTIVE_LIAISON</option><option>SIGNAL_DEGRADATION</option><option>RESTRICTED</option></select></div>
@@ -217,7 +221,7 @@ function AdminContent({ isLive, toggleLive, streamUrl, setStreamUrl, isScheduled
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Show-Day Discord Posts Enabled:</strong> Allows BNL to post scheduled Friday show updates in Discord.</span><input type="checkbox" checked={flags.showdayDiscordPostsEnabled} onChange={(e)=>updateFlags({...flags,showdayDiscordPostsEnabled:e.target.checked})} /></label>
     <label className="flex items-center justify-between text-sm border border-border px-3 py-2 mb-2"><span><strong>Heartbeat Enabled:</strong> Allows BNL to keep the website relay fresh with periodic status updates.</span><input type="checkbox" checked={flags.heartbeatEnabled} onChange={(e)=>updateFlags({...flags,heartbeatEnabled:e.target.checked})} /></label>
   </div>
-  <div><div className="flex items-center justify-between"><p className="text-xs text-muted mb-2">Admin Relay History (admin only) — most recent 25 updates received from BNL/admin actions.</p><button onClick={clearHistory} className="px-3 py-1.5 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Clear Relay History</button></div><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{formatLocalTimestamp(entry.timestamp)} — {entry.status} / {entry.mode} ({SOURCE_LABELS[entry.source || 'unknown']})</p>{entry.currentDirective && <p>Directive: {entry.currentDirective}</p>}<p>{entry.message}</p><p className="text-muted">Persistence: {entry.persisted === undefined ? "unknown" : entry.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</p></div>)}</div></div>
+  <div><div className="flex items-center justify-between"><p className="text-xs text-muted mb-2">Admin Relay History (admin only) — most recent 25 updates received from BNL/admin actions.</p><button onClick={clearHistory} className="px-3 py-1.5 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Clear Relay History</button></div><div className="space-y-2 text-xs">{history.map((entry, idx)=><div key={idx} className="border border-border p-2"><p>{formatLocalTimestamp(entry.timestamp)} — {entry.status} / {entry.mode} ({SOURCE_LABELS[entry.source || 'unknown']})</p>{entry.currentDirective && <p>Directive: {entry.currentDirective}</p>}<p>{entry.message}</p>{entry.adminNote && <p>Operator Note: {entry.adminNote}</p>}<p className="text-muted">Persistence: {entry.persisted === undefined ? "unknown" : entry.persisted ? "Stored in Redis (persistent shared storage)" : "In-memory fallback (temporary local storage)"}</p></div>)}</div></div>
   </div>
 
   </div></section>;

--- a/src/app/api/admin/bnl/route.ts
+++ b/src/app/api/admin/bnl/route.ts
@@ -29,7 +29,7 @@ const DEFAULT_FLAGS: BNLFlags = {
 const ALLOWED_STATUS = new Set<BNLStatusValue>(["ONLINE", "OFFLINE"]);
 const ALLOWED_MODES = new Set<BNLModeValue>(["STANDBY", "OBSERVATION", "ACTIVE_LIAISON", "SIGNAL_DEGRADATION", "RESTRICTED"]);
 
-let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; persisted?: boolean }> = [];
+let memoryHistory: Array<{ timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; adminNote?: string; persisted?: boolean }> = [];
 let memoryFlags: BNLFlags = { ...DEFAULT_FLAGS };
 
 function getRedis(): Redis | null {
@@ -69,6 +69,7 @@ function sanitizeHistory(value: unknown): typeof memoryHistory {
       currentDirective: typeof rec.currentDirective === "string" ? rec.currentDirective.trim().slice(0, 160) : undefined,
       message: rec.message.trim().slice(0, MAX_MESSAGE_LENGTH),
       source: normalizedSource,
+      adminNote: typeof rec.adminNote === "string" && rec.adminNote.trim().length > 0 ? rec.adminNote.trim().slice(0, 400) : undefined,
       persisted: typeof rec.persisted === "boolean" ? rec.persisted : undefined,
     });
   }
@@ -127,7 +128,8 @@ function sameHistoryContent(
     a.mode === b.mode &&
     a.source === b.source &&
     a.message === b.message &&
-    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+    (a.currentDirective ?? "") === (b.currentDirective ?? "") &&
+    (a.adminNote ?? "") === (b.adminNote ?? "")
   );
 }
 

--- a/src/app/api/bnl/control-flags/route.ts
+++ b/src/app/api/bnl/control-flags/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../status/control-flags/route";

--- a/src/app/api/bnl/status/route.ts
+++ b/src/app/api/bnl/status/route.ts
@@ -18,6 +18,7 @@ interface BNLStatus {
   message: string;
   currentDirective: string;
   source: BNLSourceValue;
+  adminNote?: string;
   lastSeen: string | null;
 }
 
@@ -28,6 +29,7 @@ interface BNLHistoryEntry {
   currentDirective?: string;
   message: string;
   source: BNLSourceValue;
+  adminNote?: string;
   persisted?: boolean;
 }
 
@@ -90,7 +92,12 @@ function sanitizeStoredStatus(value: unknown): BNLStatus {
       ? record.lastSeen
       : null;
 
-  return { status, mode, message, currentDirective, source, lastSeen };
+  const adminNote =
+    typeof record.adminNote === "string" && record.adminNote.trim().length > 0
+      ? record.adminNote.trim().slice(0, 400)
+      : undefined;
+
+  return { status, mode, message, currentDirective, source, adminNote, lastSeen };
 }
 
 function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
@@ -110,8 +117,12 @@ function sanitizeHistory(value: unknown): BNLHistoryEntry[] {
       typeof rec.currentDirective === "string" && rec.currentDirective.trim().length > 0
         ? rec.currentDirective.trim().slice(0, 160)
         : undefined;
+    const adminNote =
+      typeof rec.adminNote === "string" && rec.adminNote.trim().length > 0
+        ? rec.adminNote.trim().slice(0, 400)
+        : undefined;
     if (!status || !mode || !timestamp || !message) continue;
-    normalized.push({ timestamp, status, mode, currentDirective, message, source });
+    normalized.push({ timestamp, status, mode, currentDirective, message, source, adminNote });
   }
   return normalized.slice(0, 25);
 }
@@ -122,7 +133,8 @@ function sameHistoryContent(a: BNLHistoryEntry, b: BNLHistoryEntry): boolean {
     a.mode === b.mode &&
     a.source === b.source &&
     a.message === b.message &&
-    (a.currentDirective ?? "") === (b.currentDirective ?? "")
+    (a.currentDirective ?? "") === (b.currentDirective ?? "") &&
+    (a.adminNote ?? "") === (b.adminNote ?? "")
   );
 }
 
@@ -143,10 +155,12 @@ export async function GET() {
     const stored = await redis.get<unknown>(KEY);
     const resolved = sanitizeStoredStatus(stored);
     memoryStatus = resolved;
-    return NextResponse.json({ ...resolved, persisted: true });
+    const { adminNote: _adminNote, ...publicStatus } = resolved;
+    return NextResponse.json({ ...publicStatus, persisted: true });
   }
 
-  return NextResponse.json({ ...memoryStatus, persisted: false });
+  const { adminNote: _adminNote, ...publicStatus } = memoryStatus;
+  return NextResponse.json({ ...publicStatus, persisted: false });
 }
 
 export async function POST(req: Request) {
@@ -159,7 +173,7 @@ export async function POST(req: Request) {
 
   try {
     const body = (await req.json()) as Record<string, unknown>;
-    const allowedKeys = ["status", "mode", "message", "currentDirective", "source"];
+    const allowedKeys = ["status", "mode", "message", "currentDirective", "source", "adminNote"];
     const bodyKeys = Object.keys(body);
     if (!bodyKeys.every((key) => allowedKeys.includes(key))) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -170,6 +184,7 @@ export async function POST(req: Request) {
     const message = body.message;
     const currentDirective = body.currentDirective;
     const source = body.source;
+    const adminNote = body.adminNote;
 
     if (!ALLOWED_STATUS.has(status as BNLStatusValue) || !ALLOWED_MODES.has(mode as BNLModeValue) || typeof message !== "string") {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -188,6 +203,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
+    if (adminNote !== undefined && (typeof adminNote !== "string" || adminNote.trim().length > 400)) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
     const now = new Date().toISOString();
     const nextStatus: BNLStatus = {
       status: status as BNLStatusValue,
@@ -195,6 +214,7 @@ export async function POST(req: Request) {
       message: trimmedMessage,
       currentDirective: typeof currentDirective === "string" ? currentDirective.trim() : DEFAULT_DIRECTIVE,
       source: typeof source === "string" && ALLOWED_SOURCES.has(source as BNLSourceValue) ? (source as BNLSourceValue) : "unknown",
+      adminNote: typeof adminNote === "string" && adminNote.trim().length > 0 ? adminNote.trim() : undefined,
       lastSeen: now,
     };
 
@@ -209,6 +229,7 @@ export async function POST(req: Request) {
       currentDirective: nextStatus.currentDirective,
       message: nextStatus.message,
       source: nextStatus.source,
+      adminNote: nextStatus.adminNote,
       persisted: Boolean(redis),
     });
 

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -20,13 +20,42 @@ function formatLastSeenSentence(value: string | null): string {
     day: "numeric",
     year: "numeric",
   }).format(parsed);
-  return `LAST SEEN AT ${time} ON ${date}`;
+  return `LAST TRANSMISSION // ${time} // ${date}`;
+}
+
+const MODE_LABELS: Record<string, string> = {
+  STANDBY: "Standby Layer",
+  OBSERVATION: "Observation Layer Stable",
+  ACTIVE_LIAISON: "Host Band Active",
+  SIGNAL_DEGRADATION: "Signal Drift Detected",
+  RESTRICTED: "Restricted Layer Engaged",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  bot: "Liaison Core",
+  startup: "Wake Sequence",
+  relay: "Outer Channel",
+  heartbeat: "Carrier Trace",
+  showday: "Broadcast Band",
+  showtest: "Test Band",
+  admin: "Operator Console",
+  reset: "Cold Relay",
+  unknown: "Unmarked Signal",
+};
+
+function publicModeLabel(mode: string): string {
+  return MODE_LABELS[mode] ?? mode;
+}
+
+function publicSourceLabel(source?: string): string {
+  return SOURCE_LABELS[source ?? "unknown"] ?? "Unmarked Signal";
 }
 
 export function BNLNetworkRelayTicker() {
   const { data } = useBNLStatus();
   const online = data.status === "ONLINE";
   const lastSeenSentence = formatLastSeenSentence(data.lastSeen);
+  const signalCondition = publicModeLabel(data.mode);
 
   return (
     <>
@@ -37,11 +66,11 @@ export function BNLNetworkRelayTicker() {
           <div className="bnl-relay-scroll min-w-0">
             <div className="bnl-relay-scroll-track">
               <span>
-                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                SIGNAL CONDITION <span className={bnlTone(online)}>{signalCondition}</span> :: SURFACE READING {data.message}
                 {data.lastSeen ? ` :: ${lastSeenSentence}` : ""} ::
               </span>
               <span aria-hidden>
-                STATUS <span className={bnlTone(online)}>{data.status}</span> :: MODE {data.mode} :: MESSAGE {data.message}
+                SIGNAL CONDITION <span className={bnlTone(online)}>{signalCondition}</span> :: SURFACE READING {data.message}
                 {data.lastSeen ? ` :: ${lastSeenSentence}` : ""} ::
               </span>
             </div>
@@ -61,13 +90,13 @@ export function BNLRelayModule({ title }: { title: string }) {
     <div className="border border-border bg-surface p-6">
       <div className="mb-4 flex items-center justify-between gap-3">
         <h2 className="text-xs uppercase tracking-[0.35em] text-muted">{title}</h2>
-        <span className={`text-xs uppercase tracking-[0.2em] ${bnlTone(online)}`}>{data.status}</span>
+        <span className={`text-xs uppercase tracking-[0.2em] ${bnlTone(online)}`}>{online ? "LINK ACTIVE" : "LINK QUIET"}</span>
       </div>
       <div className="space-y-2 text-sm text-foreground/70">
-        <p>&gt; MODE: {data.mode}</p>
-        <p>&gt; MESSAGE: {data.message}</p>
-        <p>&gt; CURRENT_DIRECTIVE: {data.currentDirective ?? "Monitoring Discord-side relay traffic."}</p>
-        <p>&gt; SOURCE: {data.source ?? "unknown"}</p>
+        <p>&gt; SIGNAL CONDITION: {publicModeLabel(data.mode)}</p>
+        <p>&gt; SURFACE READING: {data.message}</p>
+        <p>&gt; NETWORK POSTURE: {data.currentDirective ?? "Monitoring Discord-side relay traffic."}</p>
+        <p>&gt; SIGNAL ORIGIN: {publicSourceLabel(data.source)}</p>
         <p>&gt; {lastSeenSentence}</p>
         {loading ? <p className="text-muted">&gt; FETCHING RELAY...</p> : null}
       </div>


### PR DESCRIPTION
## Summary
- Adds `GET /api/bnl/control-flags` as a compatibility route that reuses the existing `/api/bnl/status/control-flags` handler.
- Updates public BNL relay UI labels from backend-style fields to public-facing BARCODE Network language.
- Keeps backend status payloads, admin routes, Redis keys, and existing control-flags storage unchanged.

## Blueprint classification
- Control flags route mismatch: Hidden/Miswired.
- Public raw relay labels: UI transform.

## Acceptance checks
- `/api/bnl/control-flags` should stop 404 noise for bot polling.
- `/api/bnl/status/control-flags` should continue to work.
- Public relay module should show `SIGNAL CONDITION`, `SURFACE READING`, `NETWORK POSTURE`, `SIGNAL ORIGIN`, and `LAST TRANSMISSION` instead of raw `MODE`, `MESSAGE`, `CURRENT_DIRECTIVE`, and `SOURCE`.
- Admin literal view is untouched.