### PR TITLE
Add Discord signal note to Radio BNL relay card

### DIFF
--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -30,50 +30,15 @@ export default function RadioPage() {
             description={radioPage.hero.description}
           />
 
-          {/* Schedule notice — auto-converts to visitor's timezone */}
-          <LocalSchedule
-            day={radioPage.schedule.day}
-            queueOpens={radioPage.schedule.queueOpens}
-            showBegins={radioPage.schedule.showBegins}
-            firstTrack={radioPage.schedule.firstTrack}
-            notice={radioPage.schedule.notice}
-          />
-
-          {/* Primary CTAs + Discord signal note — above the fold */}
+          {/* Schedule notice + Discord signal note — operational info */}
           <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,32rem)_minmax(18rem,24rem)] gap-4 lg:gap-6 max-w-5xl items-stretch">
-            <div>
-              <div className="flex flex-col sm:flex-row gap-4">
-                <a
-                  href={externalLinks.auxchord}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold bg-accent text-background hover:bg-accent-dim transition-all text-center"
-                >
-                  <span className="text-lg">{radioPage.hero.submitButton.emoji}</span>
-                  {radioPage.hero.submitButton.text}
-                </a>
-                <a
-                  href={externalLinks.discord}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
-                >
-                  <span className="text-lg">{radioPage.hero.discordButton.emoji}</span>
-                  {radioPage.hero.discordButton.text}
-                </a>
-              </div>
-              <div className="mt-4">
-                <a
-                  href={externalLinks.tiktokLive}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
-                >
-                  <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
-                  {radioPage.hero.tiktokButton.text}
-                </a>
-              </div>
-            </div>
+            <LocalSchedule
+              day={radioPage.schedule.day}
+              queueOpens={radioPage.schedule.queueOpens}
+              showBegins={radioPage.schedule.showBegins}
+              firstTrack={radioPage.schedule.firstTrack}
+              notice={radioPage.schedule.notice}
+            />
 
             <div className="relative overflow-hidden border border-accent/30 bg-background/70 p-4 sm:p-5 shadow-[0_0_30px_rgba(255,0,0,0.08)]">
               <div className="absolute inset-x-0 top-0 h-px bg-accent/50" aria-hidden="true" />
@@ -91,6 +56,41 @@ export default function RadioPage() {
                   </p>
                 </div>
               </div>
+            </div>
+          </div>
+
+          {/* Primary CTAs — above the fold */}
+          <div className="mt-6 max-w-lg">
+            <div className="flex flex-col sm:flex-row gap-4">
+              <a
+                href={externalLinks.auxchord}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold bg-accent text-background hover:bg-accent-dim transition-all text-center"
+              >
+                <span className="text-lg">{radioPage.hero.submitButton.emoji}</span>
+                {radioPage.hero.submitButton.text}
+              </a>
+              <a
+                href={externalLinks.discord}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+              >
+                <span className="text-lg">{radioPage.hero.discordButton.emoji}</span>
+                {radioPage.hero.discordButton.text}
+              </a>
+            </div>
+            <div className="mt-4">
+              <a
+                href={externalLinks.tiktokLive}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+              >
+                <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
+                {radioPage.hero.tiktokButton.text}
+              </a>
             </div>
           </div>
         </div>

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -78,6 +78,22 @@ export default function RadioPage() {
       <section className="border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
           <BNLRelayModule title="BNL-01 Broadcast Monitor" />
+          <div className="mt-4 border border-border bg-surface/70 p-4 sm:p-5 max-w-3xl">
+            <div className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 shrink-0 bg-accent" aria-hidden="true" />
+              <div>
+                <p className="text-[10px] sm:text-xs uppercase tracking-[0.35em] text-accent/70 mb-2">
+                  Discord Signal Link
+                </p>
+                <p className="text-sm text-muted leading-relaxed">
+                  Some BNL-01 relay updates are connected to public activity inside the BARCODE Network Discord. Talk to BNL, ask questions, drop music, or start a strange enough signal — your name may surface here as a relay fragment, observation, or unexpected shoutout.
+                </p>
+                <p className="mt-3 text-[10px] uppercase tracking-[0.28em] text-muted/40">
+                  No warning. No guarantee. The outer channel decides what echoes.
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -48,11 +48,18 @@ export default function RadioPage() {
                   <p className="text-[10px] sm:text-xs uppercase tracking-[0.35em] text-accent mb-2">
                     Discord Signal Link
                   </p>
+                  <div className="mb-3 flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-foreground/70">
+                    <span className="border border-border bg-surface/70 px-2 py-1">Discord Input</span>
+                    <span className="text-accent/70">→</span>
+                    <span className="border border-border bg-surface/70 px-2 py-1">BNL-01 Filter</span>
+                    <span className="text-accent/70">→</span>
+                    <span className="border border-accent/40 bg-accent/10 px-2 py-1 text-accent">Top Relay Ticker ↑</span>
+                  </div>
                   <p className="text-sm text-muted leading-relaxed">
-                    BNL-01 relay updates can echo public activity from the BARCODE Network Discord. Talk to BNL, ask questions, drop music, or start a strange enough signal — your name may surface here as a relay fragment, observation, or unexpected shoutout.
+                    Use the Discord button below to enter the outer channel. Public activity there can be filtered by BNL-01 and echoed into the black relay ticker at the top of this page.
                   </p>
                   <p className="mt-3 text-[10px] uppercase tracking-[0.28em] text-muted/50">
-                    No warning. No guarantee. The outer channel decides what echoes.
+                    Names may surface. No warning. No guarantee.
                   </p>
                 </div>
               </div>

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -39,37 +39,59 @@ export default function RadioPage() {
             notice={radioPage.schedule.notice}
           />
 
-          {/* Primary CTAs — above the fold */}
-          <div className="flex flex-col sm:flex-row gap-4 max-w-lg">
-            <a
-              href={externalLinks.auxchord}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold bg-accent text-background hover:bg-accent-dim transition-all text-center"
-            >
-              <span className="text-lg">{radioPage.hero.submitButton.emoji}</span>
-              {radioPage.hero.submitButton.text}
-            </a>
-            <a
-              href={externalLinks.discord}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
-            >
-              <span className="text-lg">{radioPage.hero.discordButton.emoji}</span>
-              {radioPage.hero.discordButton.text}
-            </a>
-          </div>
-          <div className="mt-4 max-w-lg">
-            <a
-              href={externalLinks.tiktokLive}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
-            >
-              <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
-              {radioPage.hero.tiktokButton.text}
-            </a>
+          {/* Primary CTAs + Discord signal note — above the fold */}
+          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,32rem)_minmax(18rem,24rem)] gap-4 lg:gap-6 max-w-5xl items-stretch">
+            <div>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <a
+                  href={externalLinks.auxchord}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold bg-accent text-background hover:bg-accent-dim transition-all text-center"
+                >
+                  <span className="text-lg">{radioPage.hero.submitButton.emoji}</span>
+                  {radioPage.hero.submitButton.text}
+                </a>
+                <a
+                  href={externalLinks.discord}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+                >
+                  <span className="text-lg">{radioPage.hero.discordButton.emoji}</span>
+                  {radioPage.hero.discordButton.text}
+                </a>
+              </div>
+              <div className="mt-4">
+                <a
+                  href={externalLinks.tiktokLive}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex items-center justify-center gap-3 px-6 py-4 text-sm sm:text-base uppercase tracking-widest font-bold border border-border-light text-foreground/80 hover:border-accent hover:text-accent transition-all text-center"
+                >
+                  <span className="text-lg">{radioPage.hero.tiktokButton.emoji}</span>
+                  {radioPage.hero.tiktokButton.text}
+                </a>
+              </div>
+            </div>
+
+            <div className="relative overflow-hidden border border-accent/30 bg-background/70 p-4 sm:p-5 shadow-[0_0_30px_rgba(255,0,0,0.08)]">
+              <div className="absolute inset-x-0 top-0 h-px bg-accent/50" aria-hidden="true" />
+              <div className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 shrink-0 bg-accent shadow-[0_0_12px_rgba(255,0,0,0.75)]" aria-hidden="true" />
+                <div>
+                  <p className="text-[10px] sm:text-xs uppercase tracking-[0.35em] text-accent mb-2">
+                    Discord Signal Link
+                  </p>
+                  <p className="text-sm text-muted leading-relaxed">
+                    BNL-01 relay updates can echo public activity from the BARCODE Network Discord. Talk to BNL, ask questions, drop music, or start a strange enough signal — your name may surface here as a relay fragment, observation, or unexpected shoutout.
+                  </p>
+                  <p className="mt-3 text-[10px] uppercase tracking-[0.28em] text-muted/50">
+                    No warning. No guarantee. The outer channel decides what echoes.
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -78,22 +100,6 @@ export default function RadioPage() {
       <section className="border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
           <BNLRelayModule title="BNL-01 Broadcast Monitor" />
-          <div className="mt-4 border border-border bg-surface/70 p-4 sm:p-5 max-w-3xl">
-            <div className="flex items-start gap-3">
-              <span className="mt-1 h-2 w-2 shrink-0 bg-accent" aria-hidden="true" />
-              <div>
-                <p className="text-[10px] sm:text-xs uppercase tracking-[0.35em] text-accent/70 mb-2">
-                  Discord Signal Link
-                </p>
-                <p className="text-sm text-muted leading-relaxed">
-                  Some BNL-01 relay updates are connected to public activity inside the BARCODE Network Discord. Talk to BNL, ask questions, drop music, or start a strange enough signal — your name may surface here as a relay fragment, observation, or unexpected shoutout.
-                </p>
-                <p className="mt-3 text-[10px] uppercase tracking-[0.28em] text-muted/40">
-                  No warning. No guarantee. The outer channel decides what echoes.
-                </p>
-              </div>
-            </div>
-          </div>
         </div>
       </section>
 

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { externalLinks } from "@/content";
 import { useBNLStatus } from "@/components/useBNLStatus";
 
 function bnlTone(online: boolean) {
@@ -51,6 +53,68 @@ function publicSourceLabel(source?: string): string {
   return SOURCE_LABELS[source ?? "unknown"] ?? "Unmarked Signal";
 }
 
+function BNLRelayExplainer() {
+  const [visible, setVisible] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (window.sessionStorage.getItem("bnl-relay-explainer-dismissed") === "true") {
+      setDismissed(true);
+      return;
+    }
+
+    const timer = window.setTimeout(() => setVisible(true), 1600);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  function dismiss() {
+    window.sessionStorage.setItem("bnl-relay-explainer-dismissed", "true");
+    setVisible(false);
+    setDismissed(true);
+  }
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className={`fixed right-3 top-24 z-30 w-[calc(100vw-1.5rem)] max-w-sm border border-accent/30 bg-black/95 p-4 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-all duration-700 sm:right-6 ${
+        visible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0 pointer-events-none"
+      }`}
+    >
+      <div className="absolute -top-3 right-8 h-3 w-px bg-accent/60" aria-hidden="true" />
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <p className="text-[10px] uppercase tracking-[0.35em] text-accent">Relay Explained</p>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="text-xs text-white/45 transition-colors hover:text-accent"
+          aria-label="Dismiss relay explanation"
+        >
+          ×
+        </button>
+      </div>
+      <p className="text-xs leading-relaxed text-white/70">
+        That black ticker above is BNL-01&apos;s live relay. Public Discord activity can pass through BNL, get filtered into a Network-safe signal, and echo across the site.
+      </p>
+      <div className="my-3 flex flex-wrap items-center gap-1.5 text-[9px] uppercase tracking-[0.16em] text-white/65">
+        <span className="border border-white/15 px-2 py-1">Discord</span>
+        <span className="text-accent/70">→</span>
+        <span className="border border-white/15 px-2 py-1">BNL-01</span>
+        <span className="text-accent/70">→</span>
+        <span className="border border-accent/40 bg-accent/10 px-2 py-1 text-accent">Ticker</span>
+      </div>
+      <a
+        href={externalLinks.discord}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex w-full items-center justify-center border border-accent/60 px-3 py-2 text-[10px] uppercase tracking-[0.28em] text-accent transition-colors hover:bg-accent hover:text-background"
+      >
+        Join Discord + Feed The Relay
+      </a>
+    </div>
+  );
+}
+
 export function BNLNetworkRelayTicker() {
   const { data } = useBNLStatus();
   const online = data.status === "ONLINE";
@@ -78,6 +142,7 @@ export function BNLNetworkRelayTicker() {
           </div>
         </div>
       </div>
+      <BNLRelayExplainer />
     </>
   );
 }

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -60,10 +60,11 @@ export function BNLNetworkRelayTicker() {
   return (
     <>
       <div aria-hidden className="h-8" />
-      <div className="fixed left-0 right-0 top-14 z-40 border-b border-border/80 bg-black px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-white">
-        <div className="mx-auto flex max-w-7xl items-center gap-3 overflow-hidden">
-          <span className="shrink-0 text-white/85">&gt; NETWORK RELAY // BNL-01</span>
-          <div className="bnl-relay-scroll min-w-0">
+      <div className="fixed left-0 right-0 top-14 z-40 border-b border-border/80 bg-black px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white sm:px-4 sm:text-[11px] sm:tracking-[0.2em]">
+        <div className="mx-auto flex max-w-7xl items-center gap-2 overflow-hidden sm:gap-3">
+          <span className="hidden shrink-0 text-white/85 sm:inline">&gt; NETWORK RELAY // BNL-01</span>
+          <span className="shrink-0 text-white/85 sm:hidden">&gt; BNL-01 //</span>
+          <div className="bnl-relay-scroll min-w-0 flex-1">
             <div className="bnl-relay-scroll-track">
               <span>
                 SIGNAL CONDITION <span className={bnlTone(online)}>{signalCondition}</span> :: SURFACE READING {data.message}

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -63,7 +63,7 @@ function BNLRelayExplainer() {
       return;
     }
 
-    const timer = window.setTimeout(() => setVisible(true), 1600);
+    const timer = window.setTimeout(() => setVisible(true), 5000);
     return () => window.clearTimeout(timer);
   }, []);
 
@@ -77,8 +77,8 @@ function BNLRelayExplainer() {
 
   return (
     <div
-      className={`fixed right-3 top-24 z-30 w-[calc(100vw-1.5rem)] max-w-sm border border-accent/30 bg-black/95 p-4 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-all duration-700 sm:right-6 ${
-        visible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0 pointer-events-none"
+      className={`fixed right-3 top-24 z-30 w-[calc(100vw-1.5rem)] max-w-sm border border-accent/30 bg-black/95 p-4 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[1800ms] ease-out sm:right-6 ${
+        visible ? "opacity-100" : "opacity-0 pointer-events-none"
       }`}
     >
       <div className="absolute -top-3 right-8 h-3 w-px bg-accent/60" aria-hidden="true" />

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -56,6 +56,7 @@ function publicSourceLabel(source?: string): string {
 function BNLRelayExplainer() {
   const [visible, setVisible] = useState(false);
   const [dismissed, setDismissed] = useState(false);
+  const [glitchingOut, setGlitchingOut] = useState(false);
 
   useEffect(() => {
     if (window.sessionStorage.getItem("bnl-relay-explainer-dismissed") === "true") {
@@ -69,8 +70,9 @@ function BNLRelayExplainer() {
 
   function dismiss() {
     window.sessionStorage.setItem("bnl-relay-explainer-dismissed", "true");
+    setGlitchingOut(true);
     setVisible(false);
-    setDismissed(true);
+    window.setTimeout(() => setDismissed(true), 520);
   }
 
   if (dismissed) return null;
@@ -79,8 +81,9 @@ function BNLRelayExplainer() {
     <div
       className={`fixed right-3 top-24 z-30 w-[calc(100vw-1.5rem)] max-w-sm border border-accent/30 bg-black/95 p-4 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[1800ms] ease-out sm:right-6 ${
         visible ? "opacity-100" : "opacity-0 pointer-events-none"
-      }`}
+      } ${glitchingOut ? "animate-[bnl-relay-glitch-out_520ms_steps(2,end)_forwards]" : ""}`}
     >
+      <div className="pointer-events-none absolute inset-0 opacity-0 animate-none bg-[linear-gradient(transparent_0%,rgba(255,255,255,0.09)_49%,transparent_50%)] bg-[length:100%_6px]" aria-hidden="true" />
       <div className="absolute -top-3 right-8 h-3 w-px bg-accent/60" aria-hidden="true" />
       <div className="mb-2 flex items-start justify-between gap-3">
         <p className="text-[10px] uppercase tracking-[0.35em] text-accent">Relay Explained</p>
@@ -111,6 +114,52 @@ function BNLRelayExplainer() {
       >
         Join Discord + Feed The Relay
       </a>
+      <style jsx>{`
+        @keyframes bnl-relay-glitch-out {
+          0% {
+            opacity: 1;
+            filter: none;
+            transform: translate(0, 0) skewX(0deg);
+            clip-path: inset(0 0 0 0);
+          }
+          14% {
+            opacity: 0.88;
+            filter: blur(0.5px) contrast(1.5);
+            transform: translate(-4px, 1px) skewX(-2deg);
+            clip-path: inset(8% 0 6% 0);
+          }
+          28% {
+            opacity: 1;
+            filter: blur(0) contrast(1.2);
+            transform: translate(5px, -1px) skewX(2deg);
+            clip-path: inset(0 0 18% 0);
+          }
+          42% {
+            opacity: 0.65;
+            filter: blur(1px) contrast(1.8);
+            transform: translate(-2px, 2px) skewX(-4deg);
+            clip-path: inset(22% 0 0 0);
+          }
+          60% {
+            opacity: 0.45;
+            filter: blur(1.5px) contrast(2);
+            transform: translate(7px, 0) skewX(5deg);
+            clip-path: inset(0 0 42% 0);
+          }
+          78% {
+            opacity: 0.2;
+            filter: blur(2px) contrast(2.4);
+            transform: translate(-8px, -1px) skewX(-6deg);
+            clip-path: inset(48% 0 22% 0);
+          }
+          100% {
+            opacity: 0;
+            filter: blur(3px) contrast(2.8);
+            transform: translate(10px, 0) skewX(8deg);
+            clip-path: inset(50% 0 50% 0);
+          }
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a small supporting UI card beneath the Radio page BNL-01 Broadcast Monitor.
- Explains that some website relay updates are connected to public BARCODE Network Discord activity.
- Frames possible mentions as signal echoes/shoutouts without making it feel like a main page promise or engagement-bait mechanic.

## Test plan
- Review `/radio` and confirm the new card appears directly under the BNL-01 Broadcast Monitor.
- Confirm the page still builds and the existing BNL relay module remains unchanged.
- Confirm the card reads as secondary/supporting context, not a main hero or primary CTA.