### PR TITLE
Clean up Radio relay explainer UI

### DIFF
--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -30,44 +30,17 @@ export default function RadioPage() {
             description={radioPage.hero.description}
           />
 
-          {/* Schedule notice + Discord signal note — operational info */}
-          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,32rem)_minmax(18rem,24rem)] gap-4 lg:gap-6 max-w-5xl items-stretch">
-            <LocalSchedule
-              day={radioPage.schedule.day}
-              queueOpens={radioPage.schedule.queueOpens}
-              showBegins={radioPage.schedule.showBegins}
-              firstTrack={radioPage.schedule.firstTrack}
-              notice={radioPage.schedule.notice}
-            />
-
-            <div className="relative overflow-hidden border border-accent/30 bg-background/70 p-4 sm:p-5 shadow-[0_0_30px_rgba(255,0,0,0.08)]">
-              <div className="absolute inset-x-0 top-0 h-px bg-accent/50" aria-hidden="true" />
-              <div className="flex items-start gap-3">
-                <span className="mt-1 h-2 w-2 shrink-0 bg-accent shadow-[0_0_12px_rgba(255,0,0,0.75)]" aria-hidden="true" />
-                <div>
-                  <p className="text-[10px] sm:text-xs uppercase tracking-[0.35em] text-accent mb-2">
-                    Discord Signal Link
-                  </p>
-                  <div className="mb-3 flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-foreground/70">
-                    <span className="border border-border bg-surface/70 px-2 py-1">Discord Input</span>
-                    <span className="text-accent/70">→</span>
-                    <span className="border border-border bg-surface/70 px-2 py-1">BNL-01 Filter</span>
-                    <span className="text-accent/70">→</span>
-                    <span className="border border-accent/40 bg-accent/10 px-2 py-1 text-accent">Top Relay Ticker ↑</span>
-                  </div>
-                  <p className="text-sm text-muted leading-relaxed">
-                    Use the Discord button below to enter the outer channel. Public activity there can be filtered by BNL-01 and echoed into the black relay ticker at the top of this page.
-                  </p>
-                  <p className="mt-3 text-[10px] uppercase tracking-[0.28em] text-muted/50">
-                    Names may surface. No warning. No guarantee.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
+          {/* Schedule notice — auto-converts to visitor's timezone */}
+          <LocalSchedule
+            day={radioPage.schedule.day}
+            queueOpens={radioPage.schedule.queueOpens}
+            showBegins={radioPage.schedule.showBegins}
+            firstTrack={radioPage.schedule.firstTrack}
+            notice={radioPage.schedule.notice}
+          />
 
           {/* Primary CTAs — above the fold */}
-          <div className="mt-6 max-w-lg">
+          <div className="max-w-lg">
             <div className="flex flex-col sm:flex-row gap-4">
               <a
                 href={externalLinks.auxchord}

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -79,38 +79,38 @@ function BNLRelayExplainer() {
 
   return (
     <div
-      className={`fixed right-3 top-24 z-30 w-[calc(100vw-1.5rem)] max-w-sm border border-accent/30 bg-black/95 p-4 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[1800ms] ease-out sm:right-6 ${
+      className={`fixed inset-x-3 top-24 z-30 border border-accent/30 bg-black/95 p-3 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[1800ms] ease-out sm:inset-x-auto sm:right-6 sm:w-[calc(100vw-1.5rem)] sm:max-w-sm sm:p-4 ${
         visible ? "opacity-100" : "opacity-0 pointer-events-none"
       } ${glitchingOut ? "animate-[bnl-relay-glitch-out_520ms_steps(2,end)_forwards]" : ""}`}
     >
       <div className="pointer-events-none absolute inset-0 opacity-0 animate-none bg-[linear-gradient(transparent_0%,rgba(255,255,255,0.09)_49%,transparent_50%)] bg-[length:100%_6px]" aria-hidden="true" />
       <div className="absolute -top-3 right-8 h-3 w-px bg-accent/60" aria-hidden="true" />
-      <div className="mb-2 flex items-start justify-between gap-3">
-        <p className="text-[10px] uppercase tracking-[0.35em] text-accent">Relay Explained</p>
+      <div className="mb-1.5 flex items-start justify-between gap-3 sm:mb-2">
+        <p className="text-[9px] uppercase tracking-[0.28em] text-accent sm:text-[10px] sm:tracking-[0.35em]">Relay Explained</p>
         <button
           type="button"
           onClick={dismiss}
-          className="text-xs text-white/45 transition-colors hover:text-accent"
+          className="-m-2 p-2 text-sm leading-none text-white/55 transition-colors hover:text-accent sm:text-xs"
           aria-label="Dismiss relay explanation"
         >
           ×
         </button>
       </div>
-      <p className="text-xs leading-relaxed text-white/70">
-        That black ticker above is BNL-01&apos;s live relay. Public Discord activity can pass through BNL, get filtered into a Network-safe signal, and echo across the site.
+      <p className="text-[11px] leading-relaxed text-white/70 sm:text-xs">
+        The black ticker is BNL-01&apos;s live relay. Public Discord activity can pass through BNL and echo across the site.
       </p>
-      <div className="my-3 flex flex-wrap items-center gap-1.5 text-[9px] uppercase tracking-[0.16em] text-white/65">
-        <span className="border border-white/15 px-2 py-1">Discord</span>
+      <div className="my-2 flex flex-wrap items-center gap-1 text-[8px] uppercase tracking-[0.12em] text-white/65 sm:my-3 sm:gap-1.5 sm:text-[9px] sm:tracking-[0.16em]">
+        <span className="border border-white/15 px-1.5 py-0.5 sm:px-2 sm:py-1">Discord</span>
         <span className="text-accent/70">→</span>
-        <span className="border border-white/15 px-2 py-1">BNL-01</span>
+        <span className="border border-white/15 px-1.5 py-0.5 sm:px-2 sm:py-1">BNL-01</span>
         <span className="text-accent/70">→</span>
-        <span className="border border-accent/40 bg-accent/10 px-2 py-1 text-accent">Ticker</span>
+        <span className="border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-accent sm:px-2 sm:py-1">Ticker</span>
       </div>
       <a
         href={externalLinks.discord}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex w-full items-center justify-center border border-accent/60 px-3 py-2 text-[10px] uppercase tracking-[0.28em] text-accent transition-colors hover:bg-accent hover:text-background"
+        className="inline-flex w-full items-center justify-center border border-accent/60 px-3 py-1.5 text-[9px] uppercase tracking-[0.2em] text-accent transition-colors hover:bg-accent hover:text-background sm:py-2 sm:text-[10px] sm:tracking-[0.28em]"
       >
         Join Discord + Feed The Relay
       </a>


### PR DESCRIPTION
## Summary
- Removes the redundant Discord Signal Link card from the Radio page hero now that the relay explainer pop-up handles that job.
- Restores the Radio page schedule and CTA area to a cleaner layout.
- Applies the compact mobile relay explainer so it does not cover too much of the page for submitters.

## Test plan
- Review `/radio` on desktop and mobile.
- Confirm the schedule box appears alone above the CTA buttons.
- Confirm the Discord Signal Link card is gone from the page body.
- Confirm the top relay explainer still appears after 5 seconds, fades in slowly, glitches out on close, and is compact on mobile.