### PR TITLE
Build BARCODE Radio Queue v1 skeleton

### DIFF
--- a/src/app/admin/queue/page.tsx
+++ b/src/app/admin/queue/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { QueueAdminAction, QueueState, QueueTrack, RadioQueueLane } from "@/lib/queue-types";
+
+type AdminTab = "active" | "completed" | "removed";
+
+const LANE_LABELS: Record<RadioQueueLane, string> = {
+  priority: "Priority Lane",
+  wheel: "Wheel Winners",
+  regular: "Regular Queue",
+};
+
+function formatRuntime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) return `${hours}h ${mins}m ${String(secs).padStart(2, "0")}s`;
+  return `${mins}m ${String(secs).padStart(2, "0")}s`;
+}
+
+function trackRuntime(track: QueueTrack): string {
+  const seconds = track.detectedDurationSeconds ?? track.fallbackDurationSeconds;
+  const source = track.detectedDurationSeconds ? track.durationSource : "fallback/unknown";
+  return `${formatRuntime(seconds)} · ${source}`;
+}
+
+export default function AdminQueuePage() {
+  const [authenticated, setAuthenticated] = useState(false);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [passInput, setPassInput] = useState("");
+  const [authError, setAuthError] = useState("");
+  const [state, setState] = useState<QueueState | null>(null);
+  const [tab, setTab] = useState<AdminTab>("active");
+  const [actionError, setActionError] = useState("");
+
+  async function verify() {
+    try {
+      const res = await fetch("/api/admin/verify", { cache: "no-store" });
+      setAuthenticated(res.ok);
+      if (res.ok) await loadQueue();
+    } catch {
+      setAuthenticated(false);
+    } finally {
+      setAuthLoading(false);
+    }
+  }
+
+  async function loadQueue() {
+    const res = await fetch("/api/admin/queue", { cache: "no-store" });
+    if (res.ok) setState(await res.json());
+  }
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      void verify();
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleLogin() {
+    setAuthError("");
+    const res = await fetch("/api/admin/auth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password: passInput }),
+    });
+    if (res.ok) {
+      setAuthenticated(true);
+      setPassInput("");
+      await loadQueue();
+    } else {
+      setAuthError("ACCESS DENIED");
+    }
+  }
+
+  async function handleLogout() {
+    await fetch("/api/admin/auth", { method: "DELETE" });
+    setAuthenticated(false);
+  }
+
+  async function queueAction(action: QueueAdminAction, id?: string, queueOpen?: boolean) {
+    setActionError("");
+    const res = await fetch("/api/admin/queue", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action, id, queueOpen }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setActionError(data.error || "Queue action failed");
+      return;
+    }
+    setState(data);
+  }
+
+  async function copyLink(url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      setActionError("Clipboard unavailable. Open the link and copy it manually.");
+    }
+  }
+
+  if (authLoading) return <div className="pt-14 min-h-screen flex items-center justify-center"><p className="text-xs uppercase tracking-[0.5em] text-muted animate-pulse">{"// AUTHENTICATING..."}</p></div>;
+  if (!authenticated) return <div className="pt-14 min-h-screen flex items-center justify-center"><div className="border border-border bg-surface p-8 max-w-sm w-full"><p className="text-xs uppercase tracking-[0.5em] text-muted mb-6">{"// ADMIN ACCESS REQUIRED"}</p><div className="space-y-4"><input type="password" value={passInput} onChange={(e) => setPassInput(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") handleLogin(); }} placeholder="Enter access code" className="w-full bg-background border border-border px-3 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:border-accent focus:outline-none" /><button onClick={handleLogin} className="w-full px-4 py-2.5 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all">Authenticate</button>{authError && <p className="text-xs text-danger">{authError}</p>}</div></div></div>;
+
+  return (
+    <main className="pt-14 min-h-screen">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12 flex items-start justify-between gap-6">
+          <div>
+            <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-4">{"// ADMIN: BARCODE RADIO QUEUE"}</p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground mb-2"><span className="text-accent text-glow">Queue</span> Control</h1>
+            <p className="text-sm text-muted">Skeleton controls only. Stripe, BNL automation, and Discord routing are intentionally not connected.</p>
+          </div>
+          <button onClick={handleLogout} className="px-4 py-2 text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger hover:text-background transition-all">Logout</button>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-6">
+        {state && <RuntimePanel state={state} onToggle={(open) => queueAction("setOpen", undefined, open)} />}
+        {actionError && <p className="border border-danger/40 bg-danger/10 p-3 text-sm text-danger">{actionError}</p>}
+
+        <div className="flex flex-wrap gap-2">
+          {(["active", "completed", "removed"] as AdminTab[]).map((name) => (
+            <button key={name} onClick={() => setTab(name)} className={`border px-4 py-2 text-xs uppercase tracking-widest transition-all ${tab === name ? "border-accent text-accent" : "border-border text-muted hover:border-accent hover:text-accent"}`}>
+              {name === "active" ? "Active Queue" : name === "completed" ? "Completed Tracks" : "Removed"}
+            </button>
+          ))}
+        </div>
+
+        {!state ? <p className="text-muted">Loading queue...</p> : (
+          <div className="space-y-6">
+            {tab === "active" && <ActiveQueue state={state} onAction={queueAction} onCopy={copyLink} />}
+            {tab === "completed" && <TrackList title="Completed Tracks" tracks={state.completed} empty="No completed tracks yet." onAction={queueAction} onCopy={copyLink} readonly />}
+            {tab === "removed" && <TrackList title="Removed" tracks={state.removed} empty="No removed tracks yet." onAction={queueAction} onCopy={copyLink} readonly />}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function RuntimePanel({ state, onToggle }: { state: QueueState; onToggle: (open: boolean) => void }) {
+  const items = [
+    ["Active track count", String(state.summary.activeTrackCount)],
+    ["Active runtime", formatRuntime(state.summary.activeRuntimeSeconds)],
+    ["Completed count", String(state.summary.completedCount)],
+    ["Completed runtime", formatRuntime(state.summary.completedRuntimeSeconds)],
+    ["Projected total session", formatRuntime(state.summary.projectedTotalSessionSeconds)],
+  ];
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-[1fr_auto] border border-border bg-surface p-5">
+      <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {items.map(([label, value]) => <div key={label}><dt className="text-[10px] uppercase tracking-widest text-muted">{label}</dt><dd className="text-lg text-foreground">{value}</dd></div>)}
+      </dl>
+      <button onClick={() => onToggle(!state.summary.queueOpen)} className={`border px-4 py-2 text-xs uppercase tracking-widest ${state.summary.queueOpen ? "border-accent text-accent" : "border-danger text-danger"}`}>
+        Queue {state.summary.queueOpen ? "Open" : "Closed"}
+      </button>
+    </div>
+  );
+}
+
+function ActiveQueue({ state, onAction, onCopy }: { state: QueueState; onAction: (action: QueueAdminAction, id?: string) => void; onCopy: (url: string) => void }) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      <div className="space-y-6">
+        {(["priority", "wheel", "regular"] as RadioQueueLane[]).map((lane) => (
+          <TrackList key={lane} title={LANE_LABELS[lane]} tracks={state.active[lane]} empty={`No tracks in ${LANE_LABELS[lane]}.`} onAction={onAction} onCopy={onCopy} />
+        ))}
+      </div>
+      <TrackList title="Spotlight list" tracks={state.spotlight} empty="No spotlight tracks yet." onAction={onAction} onCopy={onCopy} readonly />
+    </div>
+  );
+}
+
+function TrackList({ title, tracks, empty, onAction, onCopy, readonly = false }: { title: string; tracks: QueueTrack[]; empty: string; onAction: (action: QueueAdminAction, id?: string) => void; onCopy: (url: string) => void; readonly?: boolean }) {
+  return (
+    <section className="border border-border bg-surface p-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-sm uppercase tracking-[0.3em] text-accent">{title}</h2>
+        <span className="text-xs text-muted">{tracks.length} tracks</span>
+      </div>
+      {tracks.length === 0 ? <p className="border border-border bg-background p-4 text-sm text-muted">{empty}</p> : <div className="space-y-3">{tracks.map((track) => <TrackCard key={`${title}-${track.id}`} track={track} readonly={readonly} onAction={onAction} onCopy={onCopy} />)}</div>}
+    </section>
+  );
+}
+
+function TrackCard({ track, readonly, onAction, onCopy }: { track: QueueTrack; readonly: boolean; onAction: (action: QueueAdminAction, id?: string) => void; onCopy: (url: string) => void }) {
+  return (
+    <article className="border border-border bg-background p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-base font-bold text-foreground">{track.artistName} — {track.songTitle}</p>
+          <p className="break-all text-xs text-muted">{track.songUrl}</p>
+          <div className="mt-2 flex flex-wrap gap-2 text-[11px] uppercase tracking-wider text-muted">
+            <span>{track.lane}</span><span>·</span><span>{track.status}</span><span>·</span><span>{trackRuntime(track)}</span>
+          </div>
+          {(track.submitterContact || track.note) && <p className="mt-2 text-xs text-muted">{track.submitterContact && `Contact: ${track.submitterContact}. `}{track.note}</p>}
+        </div>
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          <a href={track.songUrl} target="_blank" rel="noreferrer" className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Open Link</a>
+          <button onClick={() => onCopy(track.songUrl)} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Copy Link</button>
+          {!readonly && <>
+            {track.lane !== "priority" && <button onClick={() => onAction("moveToPriority", track.id)} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Move to Priority Lane</button>}
+            <button onClick={() => onAction("spotlight", track.id)} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Spotlight</button>
+            <button onClick={() => onAction("finish", track.id)} className="border border-accent/60 px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Finish</button>
+            <button onClick={() => onAction("remove", track.id)} className="border border-danger/60 px-3 py-1.5 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background">Remove</button>
+          </>}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/api/admin/queue/route.ts
+++ b/src/app/api/admin/queue/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { verifyAdminToken, COOKIE_NAME } from "@/lib/auth";
+import { getQueueState, updateQueueTrack } from "@/lib/queue";
+import type { QueueAdminAction } from "@/lib/queue-types";
+
+export const dynamic = "force-dynamic";
+
+async function requireAdmin(req: Request): Promise<boolean> {
+  const cookieHeader = req.headers.get("cookie") || "";
+  const cookies = Object.fromEntries(
+    cookieHeader.split(";").map((cookie) => {
+      const [key, ...value] = cookie.trim().split("=");
+      return [key, value.join("=")];
+    }),
+  );
+  const token = cookies[COOKIE_NAME];
+  return Boolean(token && (await verifyAdminToken(token)));
+}
+
+export async function GET(req: Request) {
+  if (!(await requireAdmin(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getQueueState());
+  } catch (error) {
+    console.error("[admin/queue:get]", error);
+    return NextResponse.json({ error: "Queue unavailable" }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: Request) {
+  if (!(await requireAdmin(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const action = String(body.action ?? "") as QueueAdminAction;
+    const id = String(body.id ?? "");
+    const queueOpen = typeof body.queueOpen === "boolean" ? body.queueOpen : undefined;
+
+    if (!action) return NextResponse.json({ error: "Action is required" }, { status: 400 });
+    if (action !== "setOpen" && !id) return NextResponse.json({ error: "Track id is required" }, { status: 400 });
+
+    const state = await updateQueueTrack(id, action, queueOpen);
+    return NextResponse.json(state);
+  } catch (error) {
+    if (error instanceof Error && error.message === "TRACK_NOT_FOUND") {
+      return NextResponse.json({ error: "Track not found" }, { status: 404 });
+    }
+    console.error("[admin/queue:patch]", error);
+    return NextResponse.json({ error: "Queue action failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getQueueState } from "@/lib/queue";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getQueueState());
+  } catch (error) {
+    console.error("[queue/get]", error);
+    return NextResponse.json({ error: "Queue unavailable" }, { status: 500 });
+  }
+}

--- a/src/app/api/queue/submit/route.ts
+++ b/src/app/api/queue/submit/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { submitQueueTrack } from "@/lib/queue";
+import { DEFAULT_FALLBACK_DURATION_SECONDS } from "@/lib/queue-types";
+
+export const dynamic = "force-dynamic";
+
+function validateUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const artistName = String(body.artistName ?? "").trim();
+    const songTitle = String(body.songTitle ?? "").trim();
+    const songUrl = String(body.songUrl ?? "").trim();
+    const submitterContact = String(body.submitterContact ?? "").trim();
+    const note = String(body.note ?? "").trim();
+    const requestedFallback = Number(body.fallbackDurationSeconds);
+
+    if (!artistName || !songTitle || !songUrl) {
+      return NextResponse.json({ error: "Artist, song title, and link are required." }, { status: 400 });
+    }
+
+    if (!validateUrl(songUrl)) {
+      return NextResponse.json({ error: "Submit a valid http(s) song link." }, { status: 400 });
+    }
+
+    const fallbackDurationSeconds = Number.isFinite(requestedFallback) && requestedFallback > 0
+      ? Math.round(requestedFallback)
+      : DEFAULT_FALLBACK_DURATION_SECONDS;
+
+    const track = await submitQueueTrack({
+      artistName,
+      songTitle,
+      songUrl,
+      submitterContact: submitterContact || undefined,
+      note: note || undefined,
+      fallbackDurationSeconds,
+    });
+
+    return NextResponse.json({ ok: true, track }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "QUEUE_CLOSED") {
+      return NextResponse.json({ error: "Queue is currently closed." }, { status: 403 });
+    }
+    console.error("[queue/submit]", error);
+    return NextResponse.json({ error: "Submission failed." }, { status: 500 });
+  }
+}

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import type { QueueRuntimeSummary } from "@/lib/queue-types";
+
+const DEFAULT_DURATION_SECONDS = 240;
+
+function formatRuntime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${String(secs).padStart(2, "0")}s`;
+}
+
+export default function QueuePage() {
+  const [summary, setSummary] = useState<QueueRuntimeSummary | null>(null);
+  const [form, setForm] = useState({
+    artistName: "",
+    songTitle: "",
+    songUrl: "",
+    submitterContact: "",
+    note: "",
+    fallbackDurationSeconds: DEFAULT_DURATION_SECONDS,
+  });
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  async function loadQueue() {
+    const res = await fetch("/api/queue", { cache: "no-store" });
+    if (res.ok) {
+      const data = await res.json();
+      setSummary(data.summary);
+    }
+  }
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      void loadQueue();
+    });
+  }, []);
+
+  async function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/queue/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Submission failed");
+
+      setStatus("success");
+      setMessage("Track added to the bottom of the Regular Queue.");
+      setForm({ artistName: "", songTitle: "", songUrl: "", submitterContact: "", note: "", fallbackDurationSeconds: DEFAULT_DURATION_SECONDS });
+      await loadQueue();
+    } catch (error) {
+      setStatus("error");
+      setMessage(error instanceof Error ? error.message : "Submission failed");
+    }
+  }
+
+  const queueOpen = summary?.queueOpen ?? true;
+
+  return (
+    <main className="pt-14 min-h-screen">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 py-16">
+          <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-4">{"// BARCODE RADIO QUEUE v1"}</p>
+          <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-4">
+            Submit to <span className="text-accent text-glow">BARCODE Radio</span>
+          </h1>
+          <p className="text-muted max-w-2xl">
+            Queue groundwork is live: submit a track link for admin review during the weekly BARCODE Radio workflow.
+            Paid skips and automation are not active yet.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-4 sm:px-6 py-10 grid gap-6 lg:grid-cols-[1fr_320px]">
+        <form onSubmit={submit} className="border border-border bg-surface p-6 space-y-5">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-accent mb-2">Public Submission</p>
+            <h2 className="text-2xl font-bold">Regular Queue Intake</h2>
+          </div>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Artist Name</span>
+            <input required value={form.artistName} onChange={(e) => setForm({ ...form, artistName: e.target.value })} className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground focus:border-accent focus:outline-none" />
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Song Title</span>
+            <input required value={form.songTitle} onChange={(e) => setForm({ ...form, songTitle: e.target.value })} className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground focus:border-accent focus:outline-none" />
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Song Link</span>
+            <input required type="url" value={form.songUrl} onChange={(e) => setForm({ ...form, songUrl: e.target.value })} placeholder="https://..." className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground placeholder:text-muted/50 focus:border-accent focus:outline-none" />
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Submitter Contact Optional</span>
+            <input value={form.submitterContact} onChange={(e) => setForm({ ...form, submitterContact: e.target.value })} placeholder="email, Discord, or handle" className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground placeholder:text-muted/50 focus:border-accent focus:outline-none" />
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Fallback Duration Seconds</span>
+            <input type="number" min="1" value={form.fallbackDurationSeconds} onChange={(e) => setForm({ ...form, fallbackDurationSeconds: Number(e.target.value) })} className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground focus:border-accent focus:outline-none" />
+            <span className="mt-1 block text-xs text-muted">Used until a duration detector is connected. Unknown tracks clearly use this fallback runtime.</span>
+          </label>
+
+          <label className="block text-sm">
+            <span className="text-muted uppercase tracking-widest text-xs">Note Optional</span>
+            <textarea value={form.note} onChange={(e) => setForm({ ...form, note: e.target.value })} rows={4} className="mt-2 w-full bg-background border border-border px-3 py-2.5 text-foreground focus:border-accent focus:outline-none" />
+          </label>
+
+          <button disabled={!queueOpen || status === "submitting"} className="w-full border border-accent px-4 py-3 text-sm uppercase tracking-widest text-accent transition-all hover:bg-accent hover:text-background disabled:cursor-not-allowed disabled:border-muted disabled:text-muted disabled:hover:bg-transparent">
+            {status === "submitting" ? "Submitting..." : queueOpen ? "Submit to Regular Queue" : "Queue Closed"}
+          </button>
+          {message && <p className={`text-sm ${status === "error" ? "text-danger" : "text-accent"}`}>{message}</p>}
+        </form>
+
+        <aside className="space-y-4">
+          <div className="border border-border bg-surface p-5">
+            <p className="text-xs uppercase tracking-[0.35em] text-muted mb-3">Runtime Summary</p>
+            <dl className="space-y-3 text-sm">
+              <div className="flex justify-between"><dt className="text-muted">Queue State</dt><dd className={queueOpen ? "text-accent" : "text-danger"}>{queueOpen ? "Open" : "Closed"}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted">Active Tracks</dt><dd>{summary?.activeTrackCount ?? 0}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted">Active Runtime</dt><dd>{formatRuntime(summary?.activeRuntimeSeconds ?? 0)}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted">Completed</dt><dd>{summary?.completedCount ?? 0}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted">Projected Session</dt><dd>{formatRuntime(summary?.projectedTotalSessionSeconds ?? 0)}</dd></div>
+            </dl>
+          </div>
+          <div className="border border-border bg-background p-5 text-xs text-muted space-y-2">
+            <p>New submissions enter the bottom of the Regular Queue.</p>
+            <p>Priority Lane and Wheel Winners exist for admin organization, but paid skips and wheel automation are not implemented yet.</p>
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,6 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     { url: base, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
     { url: `${base}/radio`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${base}/queue`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
     { url: `${base}/database`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: `${base}/releases`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
     { url: `${base}/merch`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -1,29 +1,83 @@
 // ============================================================
-// QUEUE SYSTEM — TYPE DEFINITIONS
+// BARCODE RADIO QUEUE v1 — TYPE DEFINITIONS
 // ============================================================
 
-export type QueueTier = "free" | "featured" | "fastlane" | "frontrow";
+export type RadioQueueLane = "priority" | "wheel" | "regular";
+export type RadioQueueStatus = "active" | "completed" | "removed";
+export type RadioQueueDurationSource = "detected" | "fallback" | "unknown";
 
-export interface QueueEntry {
+export interface QueueTrack {
   id: string;
+  artistName: string;
+  songTitle: string;
+  songUrl: string;
+  submitterContact?: string;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+  lane: RadioQueueLane;
+  status: RadioQueueStatus;
+  detectedDurationSeconds: number | null;
+  durationSource: RadioQueueDurationSource;
+  fallbackDurationSeconds: number;
+  completedAt?: string;
+  removedAt?: string;
+  spotlightedAt?: string;
+
+  // Legacy display aliases kept so older overlay/components can render safely
+  // until they are retired from the previous queue experiment.
   artist: string;
   title: string;
   link: string;
   tier: QueueTier;
-  amount: number; // cents
-  stripeSessionId: string | null;
-  status: "pending" | "queued" | "playing" | "played" | "refunded" | "expired";
-  createdAt: string; // ISO
   playedAt: string | null;
 }
 
+export interface QueueRuntimeSummary {
+  activeTrackCount: number;
+  activeRuntimeSeconds: number;
+  completedCount: number;
+  completedRuntimeSeconds: number;
+  projectedTotalSessionSeconds: number;
+  queueOpen: boolean;
+}
+
+export interface QueueActiveLanes {
+  priority: QueueTrack[];
+  wheel: QueueTrack[];
+  regular: QueueTrack[];
+}
+
 export interface QueueState {
-  nowPlaying: QueueEntry | null;
-  queue: QueueEntry[];
-  history: QueueEntry[];
+  active: QueueActiveLanes;
+  completed: QueueTrack[];
+  removed: QueueTrack[];
+  spotlight: QueueTrack[];
+  summary: QueueRuntimeSummary;
+
+  // Legacy state aliases for the retired AI-stream queue clients.
+  nowPlaying: QueueTrack | null;
+  queue: QueueTrack[];
+  history: QueueTrack[];
   totalPlayed: number;
   streamStatus: "online" | "offline";
 }
+
+export interface QueueSubmissionInput {
+  artistName: string;
+  songTitle: string;
+  songUrl: string;
+  submitterContact?: string;
+  note?: string;
+  fallbackDurationSeconds?: number;
+}
+
+export type QueueAdminAction = "finish" | "remove" | "moveToPriority" | "spotlight" | "setOpen";
+
+export type QueueTier = "free" | "featured" | "fastlane" | "frontrow";
+export type QueueEntry = QueueTrack;
+
+export const DEFAULT_FALLBACK_DURATION_SECONDS = 240;
 
 export const TIERS = {
   free: {
@@ -31,36 +85,35 @@ export const TIERS = {
     price: 0,
     label: "FREE",
     priority: 0,
-    description: "Join the queue for free. Plays when no paid requests are waiting.",
+    description: "Join the regular BARCODE Radio queue.",
     icon: "○",
   },
   featured: {
     name: "Featured",
-    price: 300, // $3.00
+    price: 300,
     label: "$3",
     priority: 1,
-    description: "Skip the free line. Plays when no Fast Lane or Front Row requests are queued.",
+    description: "Reserved legacy tier. Stripe is not active in Radio Queue v1.",
     icon: "▸",
   },
   fastlane: {
     name: "Fast Lane",
-    price: 500, // $5.00
+    price: 500,
     label: "$5",
     priority: 2,
-    description: "Skip ahead — plays when no Front Row requests are in the queue.",
+    description: "Reserved legacy tier. Stripe is not active in Radio Queue v1.",
     icon: "▸▸",
   },
   frontrow: {
     name: "Front Row",
-    price: 1000, // $10.00
+    price: 1000,
     label: "$10",
     priority: 3,
-    description: "Top of the queue. Guaranteed next play. Stacks in order paid.",
+    description: "Reserved legacy tier. Stripe is not active in Radio Queue v1.",
     icon: "▸▸▸",
   },
 } as const;
 
-/** Tiers a user can upgrade TO from a given tier (pay difference) */
 export const UPGRADE_PATHS: Record<QueueTier, QueueTier[]> = {
   free: ["featured", "fastlane", "frontrow"],
   featured: ["fastlane", "frontrow"],
@@ -68,22 +121,19 @@ export const UPGRADE_PATHS: Record<QueueTier, QueueTier[]> = {
   frontrow: [],
 };
 
-/** Map legacy tier names (from Redis) to current tier names */
 const LEGACY_TIER_MAP: Record<string, QueueTier> = {
   expedited: "featured",
   priority: "fastlane",
   vip: "frontrow",
 };
 
-/** Normalize a tier value — handles old entries still stored in Redis */
 export function normalizeTier(tier: string): QueueTier {
   if (tier in TIERS) return tier as QueueTier;
   return LEGACY_TIER_MAP[tier] ?? "free";
 }
 
-/** Generate a unique queue entry ID */
 export function generateQueueId(): string {
   const ts = Date.now().toString(36);
   const rand = Math.random().toString(36).slice(2, 8);
-  return `q_${ts}_${rand}`;
+  return `rq_${ts}_${rand}`;
 }

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,15 +1,31 @@
 // ============================================================
-// QUEUE OPERATIONS — Upstash Redis
+// BARCODE RADIO QUEUE v1 — Redis-backed storage helpers
 // ============================================================
-// Uses sorted sets for priority ordering.
-// Falls back to in-memory store when Redis is not configured.
+// Stores the v1 skeleton as one JSON document in Upstash Redis.
+// Falls back to module memory for local development when Redis is absent.
 // ============================================================
 
 import { Redis } from "@upstash/redis";
-import { QueueEntry, QueueState, TIERS, generateQueueId } from "./queue-types";
-import type { QueueTier } from "./queue-types";
+import {
+  DEFAULT_FALLBACK_DURATION_SECONDS,
+  generateQueueId,
+  type QueueAdminAction,
+  type QueueRuntimeSummary,
+  type QueueState,
+  type QueueSubmissionInput,
+  type QueueTrack,
+  type RadioQueueLane,
+} from "./queue-types";
 
-// --------------- Redis client ---------------
+const STATE_KEY = "radio-queue:v1:state";
+
+interface StoredQueueState {
+  queueOpen: boolean;
+  active: Record<RadioQueueLane, QueueTrack[]>;
+  completed: QueueTrack[];
+  removed: QueueTrack[];
+  spotlight: QueueTrack[];
+}
 
 function getRedis(): Redis | null {
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -18,295 +34,238 @@ function getRedis(): Redis | null {
   return new Redis({ url, token });
 }
 
-// Redis keys
-const KEYS = {
-  queue: "queue:entries",       // sorted set: score = priority*1e13 + (1e13 - timestamp)
-  nowPlaying: "queue:current",  // string (JSON)
-  history: "queue:history",     // list (JSON entries, most recent first)
-  totalPlayed: "queue:played",  // counter
-  streamStatus: "queue:status", // string: "online" | "offline"
-  entry: (id: string) => `queue:entry:${id}`, // hash
-};
-
-// --------------- In-memory fallback (dev) ---------------
-
-const mem: {
-  entries: QueueEntry[];
-  nowPlaying: QueueEntry | null;
-  history: QueueEntry[];
-  totalPlayed: number;
-  streamStatus: "online" | "offline";
-} = {
-  entries: [],
-  nowPlaying: null,
-  history: [],
-  totalPlayed: 0,
-  streamStatus: "offline",
-};
-
-// --------------- Priority score ---------------
-
-function priorityScore(tier: QueueTier, createdAt: string): number {
-  const tierWeight = TIERS[tier].priority;
-  const ts = new Date(createdAt).getTime();
-  // Higher tier = higher score. Within same tier, earlier = higher score.
-  return tierWeight * 1e13 + (1e13 - ts);
+function emptyStoredState(): StoredQueueState {
+  return {
+    queueOpen: true,
+    active: { priority: [], wheel: [], regular: [] },
+    completed: [],
+    removed: [],
+    spotlight: [],
+  };
 }
 
-// --------------- Public API ---------------
+let mem = emptyStoredState();
 
-/** Add a confirmed entry to the queue */
-export async function addToQueue(entry: Omit<QueueEntry, "id" | "status" | "playedAt">): Promise<QueueEntry> {
-  const full: QueueEntry = {
-    ...entry,
+function cloneState(state: StoredQueueState): StoredQueueState {
+  return JSON.parse(JSON.stringify(state)) as StoredQueueState;
+}
+
+function normalizeSeconds(value: unknown, fallback = DEFAULT_FALLBACK_DURATION_SECONDS): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.round(parsed);
+}
+
+function durationFor(track: QueueTrack): number {
+  if (typeof track.detectedDurationSeconds === "number" && track.detectedDurationSeconds > 0) {
+    return track.detectedDurationSeconds;
+  }
+  return normalizeSeconds(track.fallbackDurationSeconds);
+}
+
+function summarize(state: StoredQueueState): QueueRuntimeSummary {
+  const activeTracks = [
+    ...state.active.priority,
+    ...state.active.wheel,
+    ...state.active.regular,
+  ];
+  const activeRuntimeSeconds = activeTracks.reduce((total, track) => total + durationFor(track), 0);
+  const completedRuntimeSeconds = state.completed.reduce((total, track) => total + durationFor(track), 0);
+
+  return {
+    activeTrackCount: activeTracks.length,
+    activeRuntimeSeconds,
+    completedCount: state.completed.length,
+    completedRuntimeSeconds,
+    projectedTotalSessionSeconds: activeRuntimeSeconds + completedRuntimeSeconds,
+    queueOpen: state.queueOpen,
+  };
+}
+
+function toPublicState(state: StoredQueueState): QueueState {
+  const summary = summarize(state);
+  const queue = [...state.active.priority, ...state.active.wheel, ...state.active.regular];
+  return {
+    active: {
+      priority: [...state.active.priority],
+      wheel: [...state.active.wheel],
+      regular: [...state.active.regular],
+    },
+    completed: [...state.completed],
+    removed: [...state.removed],
+    spotlight: [...state.spotlight],
+    summary,
+
+    nowPlaying: null,
+    queue,
+    history: [...state.completed],
+    totalPlayed: state.completed.length,
+    streamStatus: state.queueOpen ? "online" : "offline",
+  };
+}
+
+async function readStoredState(): Promise<StoredQueueState> {
+  const redis = getRedis();
+  if (!redis) return cloneState(mem);
+
+  const raw = await redis.get<StoredQueueState | string>(STATE_KEY);
+  if (!raw) return emptyStoredState();
+  if (typeof raw === "string") return JSON.parse(raw) as StoredQueueState;
+  return raw;
+}
+
+async function writeStoredState(state: StoredQueueState): Promise<void> {
+  const redis = getRedis();
+  if (redis) {
+    await redis.set(STATE_KEY, JSON.stringify(state));
+    return;
+  }
+  mem = cloneState(state);
+}
+
+function makeTrack(input: QueueSubmissionInput): QueueTrack {
+  const now = new Date().toISOString();
+  const fallbackDurationSeconds = normalizeSeconds(input.fallbackDurationSeconds);
+  const artistName = input.artistName.trim();
+  const songTitle = input.songTitle.trim();
+  const songUrl = input.songUrl.trim();
+
+  return {
     id: generateQueueId(),
-    status: "queued",
+    artistName,
+    songTitle,
+    songUrl,
+    submitterContact: input.submitterContact?.trim() || undefined,
+    note: input.note?.trim() || undefined,
+    createdAt: now,
+    updatedAt: now,
+    lane: "regular",
+    status: "active",
+    detectedDurationSeconds: null,
+    durationSource: "unknown",
+    fallbackDurationSeconds,
+    artist: artistName,
+    title: songTitle,
+    link: songUrl,
+    tier: "free",
     playedAt: null,
   };
-
-  const redis = getRedis();
-  if (redis) {
-    const score = priorityScore(full.tier, full.createdAt);
-    await redis.zadd(KEYS.queue, { score, member: JSON.stringify(full) });
-    await redis.set(KEYS.entry(full.id), JSON.stringify(full));
-  } else {
-    mem.entries.push(full);
-    // Sort: higher priority first, then earlier timestamp
-    mem.entries.sort((a, b) => priorityScore(b.tier, b.createdAt) - priorityScore(a.tier, a.createdAt));
-  }
-
-  return full;
 }
 
-/** Get the full queue state */
-export async function getQueueState(): Promise<QueueState> {
-  const redis = getRedis();
-
-  if (redis) {
-    const [queueRaw, nowPlayingRaw, historyRaw, totalPlayed, streamStatus] = await Promise.all([
-      redis.zrange(KEYS.queue, 0, -1, { rev: true }),
-      redis.get<string>(KEYS.nowPlaying),
-      redis.lrange(KEYS.history, 0, 19), // last 20
-      redis.get<number>(KEYS.totalPlayed),
-      redis.get<string>(KEYS.streamStatus),
-    ]);
-
-    const queue: QueueEntry[] = (queueRaw as string[]).map((raw) =>
-      typeof raw === "string" ? JSON.parse(raw) : raw
-    );
-
-    const nowPlaying: QueueEntry | null = nowPlayingRaw
-      ? (typeof nowPlayingRaw === "string" ? JSON.parse(nowPlayingRaw) : nowPlayingRaw)
-      : null;
-
-    const history: QueueEntry[] = (historyRaw as string[]).map((raw) =>
-      typeof raw === "string" ? JSON.parse(raw) : raw
-    );
-
-    return {
-      nowPlaying,
-      queue,
-      history,
-      totalPlayed: totalPlayed ?? 0,
-      streamStatus: (streamStatus as "online" | "offline") ?? "offline",
-    };
-  }
-
-  // In-memory fallback
-  return {
-    nowPlaying: mem.nowPlaying,
-    queue: [...mem.entries],
-    history: mem.history.slice(0, 20),
-    totalPlayed: mem.totalPlayed,
-    streamStatus: mem.streamStatus,
-  };
-}
-
-/** Advance: move current to history, pop next from queue */
-export async function advanceQueue(): Promise<QueueEntry | null> {
-  const redis = getRedis();
-
-  if (redis) {
-    // Move current to history
-    const currentRaw = await redis.get<string>(KEYS.nowPlaying);
-    if (currentRaw) {
-      const current: QueueEntry = typeof currentRaw === "string" ? JSON.parse(currentRaw) : currentRaw;
-      current.status = "played";
-      current.playedAt = new Date().toISOString();
-      await redis.lpush(KEYS.history, JSON.stringify(current));
-      await redis.ltrim(KEYS.history, 0, 99); // keep last 100
-      await redis.incr(KEYS.totalPlayed);
-      await redis.del(KEYS.entry(current.id));
+function removeFromActive(state: StoredQueueState, id: string): QueueTrack | null {
+  for (const lane of ["priority", "wheel", "regular"] as RadioQueueLane[]) {
+    const index = state.active[lane].findIndex((track) => track.id === id);
+    if (index !== -1) {
+      const [track] = state.active[lane].splice(index, 1);
+      return track;
     }
-
-    // Pop highest priority entry
-    const top = await redis.zrange(KEYS.queue, -1, -1);
-    if (!top || top.length === 0) {
-      await redis.del(KEYS.nowPlaying);
-      return null;
-    }
-
-    const nextRaw = top[0] as string;
-    const next: QueueEntry = typeof nextRaw === "string" ? JSON.parse(nextRaw) : nextRaw;
-    next.status = "playing";
-
-    // Remove from sorted set and set as now playing
-    await redis.zrem(KEYS.queue, nextRaw);
-    await redis.set(KEYS.nowPlaying, JSON.stringify(next));
-    await redis.set(KEYS.entry(next.id), JSON.stringify(next));
-
-    return next;
   }
-
-  // In-memory fallback
-  if (mem.nowPlaying) {
-    mem.nowPlaying.status = "played";
-    mem.nowPlaying.playedAt = new Date().toISOString();
-    mem.history.unshift(mem.nowPlaying);
-    if (mem.history.length > 100) mem.history.pop();
-    mem.totalPlayed++;
-  }
-
-  const next = mem.entries.shift() ?? null;
-  if (next) next.status = "playing";
-  mem.nowPlaying = next;
-  return next;
-}
-
-/** Reset the queue (nightly). Refunds/carries over paid entries. */
-export async function resetQueue(): Promise<{ cleared: number; preserved: number }> {
-  const redis = getRedis();
-
-  if (redis) {
-    const allRaw = await redis.zrange(KEYS.queue, 0, -1);
-    const entries: QueueEntry[] = (allRaw as string[]).map((raw) =>
-      typeof raw === "string" ? JSON.parse(raw) : raw
-    );
-
-    // Paid entries that haven't played get preserved (carry-over)
-    const paid = entries.filter((e) => e.amount > 0);
-    const free = entries.filter((e) => e.amount === 0);
-
-    // Clear the queue
-    await redis.del(KEYS.queue);
-    await redis.del(KEYS.nowPlaying);
-
-    // Re-add paid entries
-    if (paid.length > 0) {
-      for (const e of paid) {
-        await redis.zadd(KEYS.queue, {
-          score: priorityScore(e.tier, e.createdAt),
-          member: JSON.stringify(e),
-        });
-      }
-    }
-
-    return { cleared: free.length, preserved: paid.length };
-  }
-
-  // In-memory
-  const paid = mem.entries.filter((e) => e.amount > 0);
-  const cleared = mem.entries.length - paid.length;
-  mem.entries = paid;
-  mem.nowPlaying = null;
-  return { cleared, preserved: paid.length };
-}
-
-/** Set stream status */
-export async function setStreamStatus(status: "online" | "offline"): Promise<void> {
-  const redis = getRedis();
-  if (redis) {
-    await redis.set(KEYS.streamStatus, status);
-  } else {
-    mem.streamStatus = status;
-  }
-}
-
-/** Get a single entry by ID */
-export async function getEntry(id: string): Promise<QueueEntry | null> {
-  const redis = getRedis();
-  if (redis) {
-    const raw = await redis.get<string>(KEYS.entry(id));
-    if (!raw) return null;
-    return typeof raw === "string" ? JSON.parse(raw) : raw;
-  }
-  const found = mem.entries.find((e) => e.id === id);
-  if (found) return found;
-  if (mem.nowPlaying?.id === id) return mem.nowPlaying;
   return null;
 }
 
-/** Upgrade an existing queue entry to a higher tier */
-export async function upgradeEntryTier(id: string, newTier: QueueTier, additionalAmount: number): Promise<QueueEntry | null> {
-  const redis = getRedis();
+export async function getQueueState(): Promise<QueueState> {
+  return toPublicState(await readStoredState());
+}
 
-  if (redis) {
-    // Find the entry in the sorted set
-    const allRaw = await redis.zrange(KEYS.queue, 0, -1, { rev: true });
-    let found: QueueEntry | null = null;
-    let foundRaw: string | null = null;
+export async function submitQueueTrack(input: QueueSubmissionInput): Promise<QueueTrack> {
+  const state = await readStoredState();
+  if (!state.queueOpen) throw new Error("QUEUE_CLOSED");
+  const track = makeTrack(input);
+  state.active.regular.push(track);
+  await writeStoredState(state);
+  return track;
+}
 
-    for (const raw of allRaw as string[]) {
-      const entry: QueueEntry = typeof raw === "string" ? JSON.parse(raw) : raw;
-      if (entry.id === id) {
-        found = entry;
-        foundRaw = typeof raw === "string" ? raw : JSON.stringify(raw);
-        break;
-      }
+export async function setQueueOpen(queueOpen: boolean): Promise<QueueState> {
+  const state = await readStoredState();
+  state.queueOpen = queueOpen;
+  await writeStoredState(state);
+  return toPublicState(state);
+}
+
+export async function updateQueueTrack(id: string, action: QueueAdminAction, queueOpen?: boolean): Promise<QueueState> {
+  if (action === "setOpen") return setQueueOpen(Boolean(queueOpen));
+
+  const state = await readStoredState();
+  const now = new Date().toISOString();
+
+  if (action === "spotlight") {
+    const existing = [...state.active.priority, ...state.active.wheel, ...state.active.regular, ...state.completed]
+      .find((track) => track.id === id);
+    if (!existing) throw new Error("TRACK_NOT_FOUND");
+    if (!state.spotlight.some((track) => track.id === id)) {
+      state.spotlight.push({ ...existing, spotlightedAt: now, updatedAt: now });
     }
-
-    if (!found || !foundRaw) return null;
-
-    // Remove old entry from sorted set
-    await redis.zrem(KEYS.queue, foundRaw);
-
-    // Update tier and amount
-    found.tier = newTier;
-    found.amount += additionalAmount;
-
-    // Re-add with new priority score
-    const score = priorityScore(found.tier, found.createdAt);
-    await redis.zadd(KEYS.queue, { score, member: JSON.stringify(found) });
-    await redis.set(KEYS.entry(found.id), JSON.stringify(found));
-
-    return found;
+    await writeStoredState(state);
+    return toPublicState(state);
   }
 
-  // In-memory fallback
-  const idx = mem.entries.findIndex((e) => e.id === id);
-  if (idx === -1) return null;
+  const track = removeFromActive(state, id);
+  if (!track) throw new Error("TRACK_NOT_FOUND");
 
-  mem.entries[idx].tier = newTier;
-  mem.entries[idx].amount += additionalAmount;
-  mem.entries.sort((a, b) => priorityScore(b.tier, b.createdAt) - priorityScore(a.tier, a.createdAt));
+  const updated: QueueTrack = { ...track, updatedAt: now };
 
-  return mem.entries[idx];
+  if (action === "finish") {
+    updated.status = "completed";
+    updated.completedAt = now;
+    updated.playedAt = now;
+    state.completed.unshift(updated);
+  } else if (action === "remove") {
+    updated.status = "removed";
+    updated.removedAt = now;
+    state.removed.unshift(updated);
+  } else if (action === "moveToPriority") {
+    updated.status = "active";
+    updated.lane = "priority";
+    state.active.priority.push(updated);
+  } else {
+    throw new Error("UNSUPPORTED_ACTION");
+  }
+
+  await writeStoredState(state);
+  return toPublicState(state);
 }
 
-// --------------- Stripe session dedup ---------------
-
-const STRIPE_KEY = (sessionId: string) => `queue:stripe:${sessionId}`;
-
-/** Check if a Stripe session has already been processed */
-export async function isStripeSessionProcessed(sessionId: string): Promise<boolean> {
-  const redis = getRedis();
-  if (redis) {
-    const exists = await redis.exists(STRIPE_KEY(sessionId));
-    return exists === 1;
-  }
-  // In-memory: check entries + nowPlaying + history
-  return (
-    mem.entries.some((e) => e.stripeSessionId === sessionId) ||
-    mem.nowPlaying?.stripeSessionId === sessionId ||
-    mem.history.some((e) => e.stripeSessionId === sessionId)
-  );
+// Legacy wrappers kept for retired stream-engine clients. They now operate on
+// the BARCODE Radio Queue v1 skeleton and do not trigger payments or playback.
+export async function addToQueue(entry: { artist?: string; title?: string; link?: string; artistName?: string; songTitle?: string; songUrl?: string; createdAt?: string; fallbackDurationSeconds?: number }): Promise<QueueTrack> {
+  return submitQueueTrack({
+    artistName: entry.artistName ?? entry.artist ?? "Unknown Artist",
+    songTitle: entry.songTitle ?? entry.title ?? "Untitled Track",
+    songUrl: entry.songUrl ?? entry.link ?? "",
+    fallbackDurationSeconds: entry.fallbackDurationSeconds,
+  });
 }
 
-/** Mark a Stripe session as processed (with 48h TTL) */
-export async function markStripeSessionProcessed(sessionId: string): Promise<void> {
-  const redis = getRedis();
-  if (redis) {
-    await redis.set(STRIPE_KEY(sessionId), "1", { ex: 172800 }); // 48h TTL
-  }
-  // In-memory: no-op (dedup handled by isStripeSessionProcessed check)
+export async function advanceQueue(): Promise<QueueTrack | null> {
+  const state = await readStoredState();
+  const next = state.active.priority[0] ?? state.active.wheel[0] ?? state.active.regular[0] ?? null;
+  if (!next) return null;
+  await updateQueueTrack(next.id, "finish");
+  return { ...next, status: "completed", playedAt: new Date().toISOString() };
+}
+
+export async function resetQueue(): Promise<{ cleared: number; preserved: number }> {
+  const state = await readStoredState();
+  const cleared = state.active.regular.length + state.active.wheel.length + state.active.priority.length;
+  state.active = { priority: [], wheel: [], regular: [] };
+  await writeStoredState(state);
+  return { cleared, preserved: 0 };
+}
+
+export async function setStreamStatus(status: "online" | "offline"): Promise<void> {
+  await setQueueOpen(status === "online");
+}
+
+export async function getEntry(id: string): Promise<QueueTrack | null> {
+  const state = await readStoredState();
+  return [...state.active.priority, ...state.active.wheel, ...state.active.regular, ...state.completed, ...state.removed]
+    .find((track) => track.id === id) ?? null;
+}
+
+export async function upgradeEntryTier(id: string): Promise<QueueTrack | null> {
+  const before = await getEntry(id);
+  if (!before || before.status !== "active") return null;
+  await updateQueueTrack(id, "moveToPriority");
+  return getEntry(id);
 }


### PR DESCRIPTION
### Motivation
- Provide a clean BARCODE Radio Queue v1 groundwork implementing the public intake and admin controls while auditing and not restoring the archived AI-stream/Stripe queue flow.
- Replace the previous paid/AI-stream-first queue internals with a simple Redis-backed v1 state model that can be extended later for paid skips, wheel winners, or automation.
- Keep the change scoped: do not integrate Stripe, BNL automation, Discord routing, sponsor features, or restore archived `/queue` routes from `_archive/`.
- Preserve legacy aliases so existing queue clients/overlays remain compatible while migrating to the v1 skeleton.

### Description
- Added new queue types and helpers: introduced `src/lib/queue-types.ts` and a Redis+in-memory store `src/lib/queue.ts` that persist a single JSON state document (`radio-queue:v1:state`) and compute runtime summaries from `detectedDurationSeconds`/`fallbackDurationSeconds`.
- Implemented public and admin APIs: added `GET /api/queue` (`src/app/api/queue/route.ts`) and `POST /api/queue/submit` (`src/app/api/queue/submit/route.ts`), and an authenticated admin endpoint `GET|PATCH /api/admin/queue` (`src/app/api/admin/queue/route.ts`) to read state and run admin actions (`finish`, `remove`, `moveToPriority`, `spotlight`, `setOpen`).
- Created UI pages: public submission page at `/queue` (`src/app/queue/page.tsx`) with fallback duration input and runtime summary, and an authenticated admin UI at `/admin/queue` (`src/app/admin/queue/page.tsx`) with tabs for Active Queue / Completed / Removed, lanes (Priority, Wheel, Regular), Spotlight list, and admin actions (Open Link, Copy Link, Move to Priority, Spotlight, Finish, Remove, Queue open/close toggle).
- Kept compatibility and boundaries: legacy wrappers (`addToQueue`, `advanceQueue`, etc.) map to the v1 skeleton so older consumers won't immediately break; Stripe, BNL, Discord, header/footer, middleware, and other protected content were intentionally left unchanged; `/queue` was added to the sitemap (`src/app/sitemap.ts`).
- Files changed (high-level): `src/lib/queue-types.ts`, `src/lib/queue.ts`, `src/app/queue/page.tsx`, `src/app/admin/queue/page.tsx`, `src/app/api/queue/route.ts`, `src/app/api/queue/submit/route.ts`, `src/app/api/admin/queue/route.ts`, `src/app/sitemap.ts`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it passed for the modified code.
- Targeted lint: ran `npx eslint` against the new/modified queue files and the lint run for those files passed; a full `npm run lint` still fails due to pre-existing unrelated lint errors in archived/current files outside this change.
- Local build: `npm run build` failed in this environment due to an external Google Fonts fetch error during Next.js font handling (network/CI environment issue), not due to the new queue code.
- API smoke tests (automated curl scripts executed locally): `GET /api/queue` succeeded; `POST /api/queue/submit` succeeded (new submission appears in Regular Queue); admin auth (`POST /api/admin/auth`) succeeded and authenticated admin `PATCH /api/admin/queue` actions (`moveToPriority`, `finish`, `remove`, `spotlight`, `setOpen`) succeeded and updated runtime summaries as expected.
- Summary of automated results: targeted ESLint (modified files) — passed; `npx tsc --noEmit` — passed; full `npm run lint` — failed due to unrelated legacy issues; `npm run build` — blocked by environment font fetch (external), not code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2451219083218a30addf39b29cf6)