### PR TITLE
PR #70: Admin Manual Resolver Override

### DIFF
--- a/src/app/api/admin/queue/route.ts
+++ b/src/app/api/admin/queue/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
   if (body.action === "archiveSession") return NextResponse.json(await archiveCurrentQueueSession());
   if (body.action === "activateSession" && typeof body.sessionId === "string") return NextResponse.json(await activateQueueSession(body.sessionId));
   if (body.action === "viewSession" && typeof body.sessionId === "string") return NextResponse.json(await getRadioQueueState(body.sessionId));
-  if (["pullNext", "startShow", "addWheelSpinOwed", "addSimulationFreeTrack", "addSimulationPaidPriority", "addSimulationCheckoutPending", "addSimulationPaymentFailed", "addSimulationHeldPriority", "clearSimulationTracks"].includes(body.action)) return NextResponse.json(await updateRadioTrack("", body.action));
+  if (["pullNext", "pullWheelChosen", "pullFreeTransmission", "startShow", "addWheelSpinOwed", "addSimulationFreeTrack", "addSimulationPaidPriority", "addSimulationCheckoutPending", "addSimulationPaymentFailed", "addSimulationHeldPriority", "clearSimulationTracks"].includes(body.action)) return NextResponse.json(await updateRadioTrack("", body.action));
   if (["load", "finish", "remove", "priority", "regular", "wheel", "moveBack", "spotlight", "removeSpotlight", "restoreRegular", "restorePriority", "markPriorityManual", "markPriorityRequested", "markPriorityCheckoutPending", "pausePriority", "resumePriority"].includes(body.action) && typeof body.id === "string") {
     return NextResponse.json(await updateRadioTrack(body.id, body.action));
   }

--- a/src/components/AdminRadioQueueControl.tsx
+++ b/src/components/AdminRadioQueueControl.tsx
@@ -7,7 +7,7 @@ import { formatRuntime, getTrackRuntimeSeconds } from "@/lib/queue-types";
 import type { QueueEntry, QueueLane, QueueState } from "@/lib/queue-types";
 
 type Tab = "active" | "completed" | "removed";
-type AdminQueueAction = "pullNext" | "startShow" | "addWheelSpinOwed" | "load" | "finish" | "remove" | "priority" | "regular" | "wheel" | "moveBack" | "spotlight" | "removeSpotlight" | "restoreRegular" | "restorePriority" | "pausePriority" | "resumePriority";
+type AdminQueueAction = "pullNext" | "pullWheelChosen" | "pullFreeTransmission" | "startShow" | "addWheelSpinOwed" | "load" | "finish" | "remove" | "priority" | "regular" | "wheel" | "moveBack" | "spotlight" | "removeSpotlight" | "restoreRegular" | "restorePriority" | "pausePriority" | "resumePriority";
 type SimulationSpeed = "slow" | "normal" | "fast";
 type SimulationAction = "addSimulationFreeTrack" | "addSimulationPaidPriority" | "addSimulationCheckoutPending" | "addSimulationPaymentFailed" | "addSimulationHeldPriority" | "clearSimulationTracks";
 
@@ -143,7 +143,7 @@ export function AdminRadioQueueControl() {
     setState(next);
     return next;
   }
-  async function action(id: string, next: AdminQueueAction) { await post(next === "pullNext" || next === "startShow" || next === "addWheelSpinOwed" ? { action: next } : { id, action: next }); }
+  async function action(id: string, next: AdminQueueAction) { await post(next === "pullNext" || next === "pullWheelChosen" || next === "pullFreeTransmission" || next === "startShow" || next === "addWheelSpinOwed" ? { action: next } : { id, action: next }); }
   async function simulationAction(next: SimulationAction, label: string) {
     const updated = await post({ action: next });
     setSimulationMessage(updated ? label : "Simulation action failed. Confirm admin auth and active session.");
@@ -275,6 +275,11 @@ export function AdminRadioQueueControl() {
     return entry.lane === "priority" && !entry.priorityPausedAt && (entry.priorityUpgradeStatus === "paid" || entry.priorityUpgradeStatus === "manual") && (entry.status === "queued" || entry.status === "next");
   }).length;
   const heldPriorityCount = (state?.queue ?? []).filter((entry) => isPaidPriorityTrack(entry) && Boolean(entry.priorityPausedAt)).length;
+  const nextInLineHasActivePriority = Boolean(nextInLine && nextInLine.lane === "priority" && !nextInLine.priorityPausedAt && (nextInLine.priorityUpgradeStatus === "paid" || nextInLine.priorityUpgradeStatus === "manual"));
+  const queuedActivePriorityExists = (state?.queue ?? []).some((entry) => entry.lane === "priority" && !entry.priorityPausedAt && (entry.priorityUpgradeStatus === "paid" || entry.priorityUpgradeStatus === "manual") && entry.status === "queued");
+  const resolverOverrideBlocked = nextInLineHasActivePriority || queuedActivePriorityExists;
+  const canPullWheelChosen = !resolverOverrideBlocked && (state?.queue ?? []).some((entry) => entry.lane === "wheel" && entry.status === "queued");
+  const canPullFreeTransmission = !resolverOverrideBlocked && (state?.queue ?? []).some((entry) => (!entry.lane || entry.lane === "regular") && entry.status === "queued");
 
   return (
     <div className={`${playerPadding} space-y-6`}>
@@ -313,7 +318,7 @@ export function AdminRadioQueueControl() {
               <div className="border border-border bg-background/40 p-4"><p className="text-xs text-muted">Pressure</p><p>{state?.publicStatus?.pressure ?? "syncing"}</p></div>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              {canControlSession && <button onClick={() => action("", "pullNext")} className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Pull Next Track</button>}{canControlSession && state?.session?.showStarted !== true && <button onClick={() => action("", "startShow")} className="border border-foreground/50 px-4 py-2 text-xs uppercase tracking-widest text-foreground hover:bg-foreground hover:text-background">Start Broadcast</button>}{canControlSession && <button onClick={() => action("", "addWheelSpinOwed")} className="border border-cyan-300/60 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Add Owed Wheel Spin</button>}
+              {canControlSession && <button onClick={() => action("", "pullNext")} className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Pull Next Track</button>}{canControlSession && <details className="group relative"><summary className="list-none cursor-pointer border border-border/80 px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-foreground/60 hover:text-foreground">Resolver Override ▾</summary><div className="absolute left-0 z-30 mt-2 w-64 space-y-2 border border-border bg-background p-3 shadow-xl"><p className="text-[10px] uppercase tracking-[0.2em] text-muted">Use for live manual correction. This does not count the current slot as played.</p><button type="button" onClick={() => action("", "pullWheelChosen")} disabled={!canPullWheelChosen} className="block w-full border border-cyan-300/60 px-3 py-2 text-left text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background disabled:cursor-not-allowed disabled:opacity-40">Pull Wheel Chosen</button><button type="button" onClick={() => action("", "pullFreeTransmission")} disabled={!canPullFreeTransmission} className="block w-full border border-foreground/40 px-3 py-2 text-left text-xs uppercase tracking-widest text-foreground hover:bg-foreground hover:text-background disabled:cursor-not-allowed disabled:opacity-40">Pull Free Transmission</button>{resolverOverrideBlocked && <p className="text-[10px] uppercase tracking-[0.16em] text-[#ffaa00]">Blocked while active Priority owns the resolver.</p>}</div></details>}{canControlSession && state?.session?.showStarted !== true && <button onClick={() => action("", "startShow")} className="border border-foreground/50 px-4 py-2 text-xs uppercase tracking-widest text-foreground hover:bg-foreground hover:text-background">Start Broadcast</button>}{canControlSession && <button onClick={() => action("", "addWheelSpinOwed")} className="border border-cyan-300/60 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Add Owed Wheel Spin</button>}
               {canControlSession && <button onClick={() => toggleOpen(!state?.publicStatus?.isOpen)} className={`${state?.publicStatus?.isOpen ? "border-danger/50 text-danger hover:bg-danger" : "border-accent text-accent hover:bg-accent"} border px-4 py-2 text-xs uppercase tracking-widest hover:text-background`}>{state?.publicStatus?.isOpen ? "Close Submissions" : "Open Submissions"}</button>}
             </div>
           </div>

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -508,7 +508,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
       <div className="grid gap-2 border border-border bg-surface p-3 text-xs sm:grid-cols-4">
         <div><p className="text-[10px] uppercase tracking-widest text-muted">Session</p><p className="truncate text-foreground">{session?.title ?? "BARCODE Radio"}</p></div>
         <div><p className="text-[10px] uppercase tracking-widest text-muted">Queue</p><p className={status?.isOpen ? "text-accent" : "text-danger"}>{status?.isOpen ? "Open" : "Closed"}</p></div>
-        <div><p className="text-[10px] uppercase tracking-widest text-muted">Active Transmissions</p><p>{status ? `${status.activeCount}/${status.capacity}` : "—"}</p></div>
+        <div><p className="text-[10px] uppercase tracking-widest text-muted">Remaining</p><p>{status ? `${status.activeCount}/${status.capacity}` : "—"}</p></div>
         <div><p className="text-[10px] uppercase tracking-widest text-muted">Pressure</p><p>{pressureLabel(status)}</p></div>
       </div>
 

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -40,7 +40,7 @@ const DEFAULT_PRIORITY_UPGRADE_PRICE_CENTS = 1000;
 const DEFAULT_PRIORITY_UPGRADE_CURRENCY = "usd";
 const PRE_SHOW_ROUTING_DELAY_MS = (20 * 60 + 15) * 1000;
 
-type QueueAdminAction = "pullNext" | "startShow" | "addWheelSpinOwed" | "load" | "finish" | "remove" | "priority" | "regular" | "wheel" | "moveBack" | "spotlight" | "removeSpotlight" | "restoreRegular" | "restorePriority" | "markPriorityManual" | "markPriorityRequested" | "markPriorityCheckoutPending" | "pausePriority" | "resumePriority" | "addSimulationFreeTrack" | "addSimulationPaidPriority" | "addSimulationCheckoutPending" | "addSimulationPaymentFailed" | "addSimulationHeldPriority" | "clearSimulationTracks";
+type QueueAdminAction = "pullNext" | "pullWheelChosen" | "pullFreeTransmission" | "startShow" | "addWheelSpinOwed" | "load" | "finish" | "remove" | "priority" | "regular" | "wheel" | "moveBack" | "spotlight" | "removeSpotlight" | "restoreRegular" | "restorePriority" | "markPriorityManual" | "markPriorityRequested" | "markPriorityCheckoutPending" | "pausePriority" | "resumePriority" | "addSimulationFreeTrack" | "addSimulationPaidPriority" | "addSimulationCheckoutPending" | "addSimulationPaymentFailed" | "addSimulationHeldPriority" | "clearSimulationTracks";
 
 export interface PriorityUpgradeSettingsInput {
   enabled?: boolean;
@@ -322,6 +322,35 @@ function resolveNextInLine(session: QueueSession, excludeId?: string, force = fa
 
 function pullNextInLine(session: QueueSession, excludeId?: string, force = false): void {
   resolveNextInLine(session, excludeId, force);
+}
+
+
+function requestedLaneTop(session: QueueSession, lane: QueueNonPriorityLane, excludeId?: string): QueueEntry | null {
+  return sortActive(session.queue).find((entry) => {
+    if (entry.id === excludeId || entry.status !== "queued") return false;
+    const entryLane = entry.lane ?? "regular";
+    if (lane === "wheel") return entryLane === "wheel";
+    return entryLane === "regular";
+  }) ?? null;
+}
+
+function pullNextInLineFromLane(session: QueueSession, lane: QueueNonPriorityLane): boolean {
+  const current = session.nextInLineTrack ?? null;
+  if (session.loadedTrack && session.nextInLineTrack?.id === session.loadedTrack.id) return false;
+  if (isActivePriorityTrack(current)) return false;
+  if (laneTop(session, "priority", session.loadedTrackId ?? undefined)) return false;
+
+  const currentLane = current?.lane ?? "regular";
+  if (current && currentLane === lane) return false;
+
+  const candidate = requestedLaneTop(session, lane, session.loadedTrackId ?? undefined);
+  if (!candidate) return false;
+
+  if (current) moveNextInLineBackToQueue(session);
+  const next = session.queue.find((entry) => entry.id === candidate.id);
+  if (!next) return false;
+  stageNextInLineTrack(session, next);
+  return true;
 }
 
 function clearNextInLine(session: QueueSession): QueueEntry | null {
@@ -1958,6 +1987,14 @@ export async function updateRadioTrack(id: string, action: QueueAdminAction): Pr
     session.autoRoutingPaused = false;
     session.nextInLineHoldTrackId = null;
     pullNextInLine(session, undefined, true);
+    const nextStore = replaceSession(store, session);
+    await writeStore(nextStore);
+    return queueStateFromSession(session, nextStore);
+  }
+
+  if (action === "pullWheelChosen" || action === "pullFreeTransmission") {
+    const lane: QueueNonPriorityLane = action === "pullWheelChosen" ? "wheel" : "regular";
+    pullNextInLineFromLane(session, lane);
     const nextStore = replaceSession(store, session);
     await writeStore(nextStore);
     return queueStateFromSession(session, nextStore);


### PR DESCRIPTION
### Motivation
- Provide a narrow admin recovery/control hook so hosts can manually pull a Wheel Chosen or Free transmission into Next In Line without counting the current slot as played or advancing the Free/Wheel alternation.
- Keep resolver rules intact (Priority guard, Payment Processing rules, Next In Line semantics) while adding an explicit admin override path for live show corrections.

### Description
- Added two admin-only actions `pullWheelChosen` and `pullFreeTransmission` to the queue action union and allowed them through the admin API so the existing admin endpoint can dispatch the overrides (files changed: `src/lib/queue.ts`, `src/app/api/admin/queue/route.ts`).
- Implemented `pullNextInLineFromLane` and a helper `requestedLaneTop` in `src/lib/queue.ts` to choose the top queued candidate for a specific non-priority lane, restore the current Next In Line back to the queue safely, and stage the requested candidate without finishing, removing, or advancing `nextNonPriorityLane`.
- Added a compact admin-only Resolver Override dropdown next to existing queue controls with two menu items `Pull Wheel Chosen` and `Pull Free Transmission`, plus client-side guard/disabled logic that blocks the controls while active Priority owns the resolver or when no eligible candidate exists (file changed: `src/components/AdminRadioQueueControl.tsx`).
- Small public-facing copy cleanup: replaced the HUD label `Active Transmissions` with `Remaining` (file changed: `src/components/RadioQueueForm.tsx`).

### Testing
- Ran lint/TS checks: `npx eslint src/lib/queue.ts src/app/api/admin/queue/route.ts src/components/AdminRadioQueueControl.tsx src/components/RadioQueueForm.tsx` and `npx tsc --noEmit`, which completed for the modified files without errors.
- `npm run lint` surfaced pre-existing unrelated lint errors in archived/other files (not introduced by this change) and therefore the full project lint run did not pass end-to-end.
- `npm run build` failed in this environment due to the Next.js font fetch (`Geist Mono` from Google Fonts) and is environment-specific; the introduced changes do not rely on build-time network fetches and are isolated to admin controls.
- Manual verification recommended: exercise the two overrides in admin UI for the scenarios in the ticket (Free in Next + Wheel waiting, Wheel in Next + Free waiting, Priority present blocking overrides, no-candidate disabling).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040b284fe48321bfab5ad2da914012)