### PR TITLE
Duration Metadata Capture + Provider Feasibility Foundation

### DIFF
--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -178,7 +178,7 @@ async function submitTrackFromBody(body: Record<string, unknown>): Promise<NextR
       mimeType,
       sourceType: "upload",
       detectedDurationSeconds,
-      durationSource: detectedDurationSeconds ? "upload_metadata" : "file_metadata",
+      durationSource: detectedDurationSeconds ? "upload_metadata" : "estimated",
       note,
       submitterArtistName: artist,
       tiktokHandle,

--- a/src/components/PublicQueueSession.tsx
+++ b/src/components/PublicQueueSession.tsx
@@ -889,7 +889,6 @@ function PersonalSignalStatusBar({ snapshot, mounted }: { snapshot: QueuePublicS
     const paymentNotCompleted = allSubmitted.some((track) => "priorityUpgradeStatus" in track && (track.priorityUpgradeStatus === "failed" || track.priorityUpgradeStatus === "refunded"));
     const closestQueueIndex = (snapshot?.queue ?? []).findIndex((track) => submittedIds.has(track.id));
     const songsAway = closestQueueIndex >= 0 ? closestQueueIndex + 1 : null;
-    const waitMinutes = songsAway ? songsAway * 5 : null;
     main = `${pluralizeSongs(status.used)} submitted${status.used === 1 && waiting.length > 0 ? " · waiting in the free queue." : ""}`;
     detail = `${waiting.length} waiting · ${played.length} already played.`;
     if (nowPlaying) { main = "Your track is playing now."; detail = "Personal receiver locked to your submitted track."; }
@@ -898,7 +897,7 @@ function PersonalSignalStatusBar({ snapshot, mounted }: { snapshot: QueuePublicS
     else if (priorityActive) { main = "Priority Signal active."; detail = "Confirmed skip is active."; }
     else if (paymentNotCompleted) { main = "Payment was not completed."; detail = "Song stays in the free queue if still active."; }
     else if (waiting.length === 0 && played.length > 0) { main = status.used === 1 ? "Your track already played tonight." : `${pluralizeSongs(status.used)} submitted · ${played.length} already played.`; detail = "Played songs remain visible in Recently Played while available."; }
-    else if (songsAway && waitMinutes) detail = `Closest track: ${songsAway} ${songsAway === 1 ? "song" : "songs"} away · Estimated wait: about ${waitMinutes} min.`;
+    else if (songsAway) detail = `Closest track: ${songsAway} ${songsAway === 1 ? "song" : "songs"} away.`;
   }
   const band = <section className="personal-signal-bar pointer-events-none fixed inset-x-0 z-[8995] w-screen overflow-hidden border-b border-accent/35 border-t border-border/70 bg-black/95 font-mono text-white backdrop-blur-md" aria-label="Your Signal Status" role="status" aria-live="polite"><div className="personal-signal-scan pointer-events-none absolute inset-0" aria-hidden="true" /><div className="personal-signal-line pointer-events-none absolute inset-x-0 bottom-0 h-px bg-accent/55" aria-hidden="true" /><div className="relative mx-auto flex min-h-[5rem] max-w-7xl flex-col justify-center px-3 py-3 sm:min-h-[6rem] sm:px-4"><p className="text-[10px] font-bold uppercase tracking-[0.34em] text-accent sm:text-xs">Your Signal Status</p><p className="mt-1 truncate text-sm font-bold text-foreground sm:text-lg">{main}</p><p className="mt-1 line-clamp-2 text-[11px] leading-snug text-muted sm:text-sm">{detail}</p></div><style jsx>{`.personal-signal-bar{top:calc(5.375rem + env(safe-area-inset-top))}.personal-signal-spacer{height:5.25rem}.personal-signal-scan{background:linear-gradient(transparent 50%,rgba(255,255,255,.06) 50%);background-size:100% 6px;opacity:.14}@media (min-width:900px){.personal-signal-spacer{height:6rem}}@media (max-width:640px){.personal-signal-bar p{max-width:100%}.personal-signal-spacer{height:5rem}}`}</style></section>;
   return <><div className="personal-signal-spacer" aria-hidden="true" />{mounted && createPortal(band, document.body)}</>;

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -81,7 +81,7 @@ function readAudioDuration(file: File): Promise<number | null> {
   });
 }
 
-function publicTrackFromApi(track: { id: string; submittedArtistName?: string; submittedSongTitle?: string; artist?: string; title?: string; sourceType?: QueuePublicTrack["sourceType"]; lane?: QueuePublicTrack["lane"]; detectedArtistName?: string | null; detectedSongTitle?: string | null; detectedDurationSeconds?: number | null; durationIsEstimate?: boolean; sourceArtworkUrl?: string | null; publicSourceUrl?: string | null; tiktokHandle?: string | null; priorityUpgradeRequested?: boolean; priorityUpgradeStatus?: QueuePublicTrack["priorityUpgradeStatus"] }): QueuePublicTrack {
+function publicTrackFromApi(track: { id: string; submittedArtistName?: string; submittedSongTitle?: string; artist?: string; title?: string; sourceType?: QueuePublicTrack["sourceType"]; lane?: QueuePublicTrack["lane"]; detectedArtistName?: string | null; detectedSongTitle?: string | null; detectedDurationSeconds?: number | null; durationLabel?: string; durationIsEstimate?: boolean; sourceArtworkUrl?: string | null; publicSourceUrl?: string | null; tiktokHandle?: string | null; priorityUpgradeRequested?: boolean; priorityUpgradeStatus?: QueuePublicTrack["priorityUpgradeStatus"] }): QueuePublicTrack {
   return {
     id: track.id,
     submittedArtistName: track.submittedArtistName ?? track.artist ?? "Submitted artist",
@@ -90,7 +90,7 @@ function publicTrackFromApi(track: { id: string; submittedArtistName?: string; s
     detectedSongTitle: track.detectedSongTitle ?? null,
     sourceType: track.sourceType ?? "other",
     lane: track.lane ?? "regular",
-    durationLabel: track.durationIsEstimate === false && track.detectedDurationSeconds ? formatRuntime(track.detectedDurationSeconds) : "estimated/pending",
+    durationLabel: track.durationLabel ?? (track.durationIsEstimate === false && track.detectedDurationSeconds ? formatRuntime(track.detectedDurationSeconds) : "est. 5:00"),
     durationIsEstimate: track.durationIsEstimate ?? true,
     sourceArtworkUrl: track.sourceArtworkUrl ?? null,
     publicSourceUrl: track.publicSourceUrl ?? null,

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -263,6 +263,11 @@ export function getTrackRuntimeSeconds(entry: Pick<QueueEntry, "detectedDuration
   return entry.detectedDurationSeconds ?? entry.estimatedDurationSeconds ?? INTERNAL_BUFFER_DURATION_SECONDS;
 }
 
+export function getTrackDurationLabel(entry: Pick<QueueEntry, "detectedDurationSeconds" | "estimatedDurationSeconds" | "durationIsEstimate">): string {
+  const runtime = getTrackRuntimeSeconds(entry);
+  return entry.durationIsEstimate ? `est. ${formatRuntime(runtime)}` : formatRuntime(runtime);
+}
+
 export function formatRuntime(seconds: number): string {
   const safe = Math.max(0, Math.round(seconds));
   const h = Math.floor(safe / 3600);

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -7,7 +7,7 @@ export type QueueSourceType = "upload" | "link" | "youtube" | "soundcloud" | "sp
 export type QueueLane = "priority" | "wheel" | "regular";
 export type QueueNonPriorityLane = "wheel" | "regular";
 export type QueueTrackStatus = "queued" | "completed" | "removed" | "playing" | "next" | "pending" | "played" | "refunded" | "expired";
-export type QueueDurationSource = "upload_metadata" | "file_metadata" | "youtube" | "soundcloud" | "spotify" | "provider_metadata" | "internal_estimate" | "unknown";
+export type QueueDurationSource = "upload_metadata" | "file_metadata" | "youtube" | "soundcloud" | "spotify" | "youtube_api" | "spotify_api" | "soundcloud_api" | "direct_metadata" | "provider_metadata" | "internal_estimate" | "estimated" | "unknown";
 export type QueueSessionStatus = "prepared" | "open" | "closed" | "archived";
 export type QueueBroadcastPhase = "warmup" | "submission_window" | "broadcast_active" | "ended";
 export type PriorityUpgradeStatus = "none" | "requested" | "manual" | "checkout_pending" | "paid" | "paid_needs_attention" | "failed" | "refunded";
@@ -229,7 +229,7 @@ export function getTrackArtworkUrl(track: Pick<QueueEntry, "sourceType" | "sourc
   return null;
 }
 
-export const INTERNAL_BUFFER_DURATION_SECONDS = 240;
+export const INTERNAL_BUFFER_DURATION_SECONDS = 300;
 export const RADIO_QUEUE_CAPACITY = 40;
 
 export const TIERS = {

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -3,6 +3,7 @@
 // ============================================================
 
 import { Redis } from "@upstash/redis";
+import { detectTrackDurationFromLink, parseIso8601DurationToSeconds, parseSpotifyTrackId, parseYouTubeVideoId as parseTrackDurationYouTubeVideoId } from "./track-duration";
 import {
   INTERNAL_BUFFER_DURATION_SECONDS,
   detectQueueSourceType,
@@ -650,10 +651,13 @@ function normalizeDurationSource(source: QueueDurationSource | string | undefine
   if (source === "browser-audio-metadata" || source === "upload_metadata") return "upload_metadata";
   if (source === "file-metadata" || source === "file_metadata") return "file_metadata";
   if (source === "provider-metadata" || source === "provider_metadata") return sourceType === "youtube" || sourceType === "soundcloud" || sourceType === "spotify" ? sourceType : "provider_metadata";
-  if (source === "internal-estimate" || source === "internal_estimate") return "internal_estimate";
+  if (source === "internal-estimate" || source === "internal_estimate" || source === "estimated") return source === "estimated" ? "estimated" : "internal_estimate";
+  if (source === "youtube_api" || source === "spotify_api" || source === "soundcloud_api" || source === "direct_metadata") return source;
   if (source === "youtube" || source === "soundcloud" || source === "spotify" || source === "unknown") return source;
   if (detected && sourceType === "upload") return "upload_metadata";
-  if (detected && (sourceType === "youtube" || sourceType === "soundcloud" || sourceType === "spotify")) return sourceType;
+  if (detected && sourceType === "youtube") return "youtube_api";
+  if (detected && sourceType === "spotify") return "spotify_api";
+  if (detected && sourceType === "soundcloud") return "soundcloud_api";
   return detected ? "provider_metadata" : "internal_estimate";
 }
 
@@ -775,21 +779,11 @@ function blankProvider(source: QueueDurationSource = "internal_estimate"): Provi
 }
 
 export function parseYouTubeVideoId(link: string): string | null {
-  try {
-    const url = new URL(link);
-    const host = url.hostname.replace(/^www\./, "").toLowerCase();
-    if (host === "youtu.be") return url.pathname.split("/").filter(Boolean)[0] ?? null;
-    if (host.includes("youtube.com")) return url.searchParams.get("v") || url.pathname.match(/\/shorts\/([^/?#]+)/)?.[1] || url.pathname.match(/\/embed\/([^/?#]+)/)?.[1] || null;
-    return null;
-  } catch {
-    return null;
-  }
+  return parseTrackDurationYouTubeVideoId(link);
 }
 
 export function parseYouTubeDuration(duration: string): number | null {
-  const match = duration.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
-  if (!match) return null;
-  return (Number(match[1] ?? 0) * 3600) + (Number(match[2] ?? 0) * 60) + Number(match[3] ?? 0);
+  return parseIso8601DurationToSeconds(duration);
 }
 
 async function lookupYouTubeMetadata(link: string): Promise<ProviderMetadata> {
@@ -804,7 +798,7 @@ async function lookupYouTubeMetadata(link: string): Promise<ProviderMetadata> {
   const duration = item?.contentDetails?.duration ? parseYouTubeDuration(item.contentDetails.duration) : null;
   const providerTitle = typeof item?.snippet?.title === "string" ? item.snippet.title : null;
   const channelTitle = typeof item?.snippet?.channelTitle === "string" ? item.snippet.channelTitle : null;
-  return { detectedArtistName: channelTitle, detectedSongTitle: providerTitle, providerTitle, detectedDurationSeconds: duration, durationSource: duration ? "youtube" : "internal_estimate", artworkUrl: id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : null };
+  return { detectedArtistName: channelTitle, detectedSongTitle: providerTitle, providerTitle, detectedDurationSeconds: duration, durationSource: duration ? "youtube_api" : "internal_estimate", artworkUrl: id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : null };
 }
 
 function spotifyOEmbedUrl(link: string): string {
@@ -825,8 +819,7 @@ async function lookupSpotifyMetadata(link: string): Promise<ProviderMetadata> {
   const fallback = () => lookupSpotifyOEmbed(link).catch(() => blankProvider("internal_estimate"));
   const clientId = process.env.SPOTIFY_CLIENT_ID;
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
-  const match = link.match(/spotify\.com\/track\/([a-zA-Z0-9]+)/) || link.match(/spotify:track:([a-zA-Z0-9]+)/);
-  const trackId = match?.[1];
+  const trackId = parseSpotifyTrackId(link);
   if (!trackId || !clientId || !clientSecret) return fallback();
   const tokenRes = await fetch("https://accounts.spotify.com/api/token", {
     method: "POST",
@@ -844,7 +837,7 @@ async function lookupSpotifyMetadata(link: string): Promise<ProviderMetadata> {
   const artist = Array.isArray(track.artists) ? track.artists.map((item: { name?: string }) => item.name).filter(Boolean).join(", ") : null;
   const title = typeof track.name === "string" ? track.name : null;
   const artworkUrl = Array.isArray(track.album?.images) ? track.album.images.find((image: { url?: string }) => typeof image.url === "string")?.url ?? null : null;
-  const metadata = { detectedArtistName: artist || null, detectedSongTitle: title, providerTitle: title, detectedDurationSeconds: seconds, durationSource: seconds ? "spotify" as const : "internal_estimate" as const, artworkUrl };
+  const metadata = { detectedArtistName: artist || null, detectedSongTitle: title, providerTitle: title, detectedDurationSeconds: seconds, durationSource: seconds ? "spotify_api" as const : "internal_estimate" as const, artworkUrl };
   return artworkUrl ? metadata : lookupSpotifyOEmbed(link, metadata).catch(() => metadata);
 }
 
@@ -868,16 +861,26 @@ async function lookupSoundCloudMetadata(link: string): Promise<ProviderMetadata>
   const title = typeof track.title === "string" ? track.title : null;
   const artist = typeof track.user?.username === "string" ? track.user.username : null;
   const artworkUrl = typeof track.artwork_url === "string" ? track.artwork_url.replace("-large.", "-t500x500.") : null;
-  const metadata = { detectedArtistName: artist, detectedSongTitle: title, providerTitle: title, detectedDurationSeconds: seconds, durationSource: seconds ? "soundcloud" as const : "internal_estimate" as const, artworkUrl };
+  const metadata = { detectedArtistName: artist, detectedSongTitle: title, providerTitle: title, detectedDurationSeconds: seconds, durationSource: seconds ? "soundcloud_api" as const : "internal_estimate" as const, artworkUrl };
   return artworkUrl ? metadata : lookupSoundCloudOEmbed(link, metadata).catch(() => metadata);
 }
 
 export async function detectProviderMetadata(sourceType: QueueSourceType, link: string): Promise<ProviderMetadata> {
   try {
-    if (sourceType === "youtube") return lookupYouTubeMetadata(link);
-    if (sourceType === "spotify") return lookupSpotifyMetadata(link);
-    if (sourceType === "soundcloud") return lookupSoundCloudMetadata(link);
-    return blankProvider("internal_estimate");
+    let metadata = blankProvider("internal_estimate");
+    if (sourceType === "youtube") metadata = await lookupYouTubeMetadata(link);
+    else if (sourceType === "spotify") metadata = await lookupSpotifyMetadata(link);
+    else if (sourceType === "soundcloud") metadata = await lookupSoundCloudMetadata(link);
+    else return metadata;
+
+    if (metadata.detectedDurationSeconds) return metadata;
+
+    const duration = await detectTrackDurationFromLink(link);
+    if (duration.durationSeconds && duration.durationIsEstimate === false) {
+      return { ...metadata, detectedDurationSeconds: duration.durationSeconds, durationSource: duration.durationSource };
+    }
+
+    return metadata;
   } catch (error) {
     console.warn("[queue] provider metadata lookup failed", error);
     return blankProvider("internal_estimate");
@@ -922,7 +925,7 @@ function parseProviderId(sourceType: QueueSourceType, link: string): string | nu
     return id ? `youtube:${id}` : null;
   }
   if (sourceType === "spotify") {
-    const id = link.match(/spotify\.com\/track\/([a-zA-Z0-9]+)/)?.[1] ?? link.match(/spotify:track:([a-zA-Z0-9]+)/)?.[1];
+    const id = parseSpotifyTrackId(link);
     return id ? `spotify:${id}` : null;
   }
   if (sourceType === "soundcloud") {
@@ -1052,7 +1055,7 @@ export async function createQueueTrack(input: {
     : providerMetadata.detectedDurationSeconds;
   const durationSource = detectedDurationSeconds
     ? input.durationSource ?? providerMetadata.durationSource ?? (sourceType === "upload" ? "upload_metadata" : "provider_metadata")
-    : "internal_estimate";
+    : "estimated";
 
   return normalizeEntry({
     id: generateQueueId(),

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -7,9 +7,9 @@ import { detectTrackDurationFromLink, parseIso8601DurationToSeconds, parseSpotif
 import {
   INTERNAL_BUFFER_DURATION_SECONDS,
   detectQueueSourceType,
-  formatRuntime,
   generateQueueId,
   getTrackRuntimeSeconds,
+  getTrackDurationLabel,
   getTrackArtworkUrl,
   normalizeTier,
 } from "./queue-types";
@@ -1277,7 +1277,7 @@ export function toPublicQueueTrack(entry: QueueEntry): QueuePublicTrack {
     providerTitle: isUpload ? null : normalized.providerTitle ?? null,
     sourceType: normalized.sourceType ?? "other",
     lane: normalized.lane ?? "regular",
-    durationLabel: normalized.durationIsEstimate ? "estimated/pending" : formatRuntime(getTrackRuntimeSeconds(normalized)),
+    durationLabel: getTrackDurationLabel(normalized),
     durationIsEstimate: normalized.durationIsEstimate ?? true,
     sourceArtworkUrl: publicArtworkUrlForTrack(normalized),
     publicSourceUrl: publicSourceUrlForTrack(normalized),

--- a/src/lib/track-duration.ts
+++ b/src/lib/track-duration.ts
@@ -1,0 +1,176 @@
+import { INTERNAL_BUFFER_DURATION_SECONDS } from "./queue-types";
+
+export type TrackDurationProvider = "youtube" | "spotify" | "soundcloud" | "direct" | "other";
+
+export type TrackDurationSource =
+  | "upload_metadata"
+  | "youtube_api"
+  | "spotify_api"
+  | "soundcloud_api"
+  | "direct_metadata"
+  | "estimated"
+  | "unknown";
+
+export interface TrackDurationDetectionResult {
+  durationSeconds: number | null;
+  durationIsEstimate: boolean;
+  durationSource: TrackDurationSource;
+  provider?: TrackDurationProvider;
+  providerTrackId?: string;
+  notes: string[];
+}
+
+export interface ParsedTrackProviderUrl {
+  provider: TrackDurationProvider;
+  providerTrackId?: string;
+  normalizedUrl: string;
+}
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{6,}$/;
+const SPOTIFY_TRACK_ID_PATTERN = /^[a-zA-Z0-9]{10,}$/;
+const FETCH_TIMEOUT_MS = 2500;
+
+function positiveSeconds(value: unknown): number | null {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.max(1, Math.round(numeric)) : null;
+}
+
+function unavailable(provider: TrackDurationProvider | undefined, notes: string[], providerTrackId?: string): TrackDurationDetectionResult {
+  return { durationSeconds: null, durationIsEstimate: true, durationSource: "unknown", provider, providerTrackId, notes };
+}
+
+export function estimatedTrackDurationResult(notes: string[] = ["No detected duration was available; using the internal fallback estimate."]): TrackDurationDetectionResult {
+  return { durationSeconds: INTERNAL_BUFFER_DURATION_SECONDS, durationIsEstimate: true, durationSource: "estimated", provider: "other", notes };
+}
+
+export function uploadTrackDurationResult(durationSeconds: unknown): TrackDurationDetectionResult {
+  const detected = positiveSeconds(durationSeconds);
+  if (!detected) return estimatedTrackDurationResult(["Upload duration metadata was not available from the client."]);
+  return { durationSeconds: detected, durationIsEstimate: false, durationSource: "upload_metadata", provider: "direct", notes: ["Upload duration came from client-side audio metadata."] };
+}
+
+export function parseYouTubeVideoId(link?: string | null): string | null {
+  if (!link) return null;
+  try {
+    const url = new URL(link);
+    const host = url.hostname.replace(/^www\./, "").toLowerCase();
+    if (host === "youtu.be") {
+      const id = url.pathname.split("/").filter(Boolean)[0] ?? null;
+      return id && YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+    }
+    if (host === "youtube.com" || host === "m.youtube.com" || host === "music.youtube.com") {
+      const id = url.searchParams.get("v") || url.pathname.match(/\/shorts\/([^/?#]+)/)?.[1] || url.pathname.match(/\/embed\/([^/?#]+)/)?.[1] || null;
+      return id && YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSpotifyTrackId(link?: string | null): string | null {
+  if (!link) return null;
+  const uriMatch = link.match(/^spotify:track:([a-zA-Z0-9]+)$/);
+  if (uriMatch?.[1] && SPOTIFY_TRACK_ID_PATTERN.test(uriMatch[1])) return uriMatch[1];
+  try {
+    const url = new URL(link);
+    const host = url.hostname.replace(/^www\./, "").toLowerCase();
+    if (host !== "open.spotify.com") return null;
+    const [kind, id] = url.pathname.split("/").filter(Boolean);
+    return kind === "track" && id && SPOTIFY_TRACK_ID_PATTERN.test(id) ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSoundCloudPublicUrl(link?: string | null): string | null {
+  if (!link) return null;
+  try {
+    const url = new URL(link);
+    const host = url.hostname.replace(/^www\./, "").toLowerCase();
+    if (host !== "soundcloud.com" || url.pathname.split("/").filter(Boolean).length < 2) return null;
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function parseSafeTrackProviderUrl(link?: string | null): ParsedTrackProviderUrl | null {
+  const youtubeId = parseYouTubeVideoId(link);
+  if (youtubeId) return { provider: "youtube", providerTrackId: youtubeId, normalizedUrl: `https://www.youtube.com/watch?v=${youtubeId}` };
+  const spotifyId = parseSpotifyTrackId(link);
+  if (spotifyId) return { provider: "spotify", providerTrackId: spotifyId, normalizedUrl: `https://open.spotify.com/track/${spotifyId}` };
+  const soundcloudUrl = parseSoundCloudPublicUrl(link);
+  if (soundcloudUrl) return { provider: "soundcloud", normalizedUrl: soundcloudUrl };
+  return null;
+}
+
+export function parseIso8601DurationToSeconds(duration: string): number | null {
+  const match = duration.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!match) return null;
+  const seconds = (Number(match[1] ?? 0) * 3600) + (Number(match[2] ?? 0) * 60) + Number(match[3] ?? 0);
+  return seconds > 0 ? seconds : null;
+}
+
+async function fetchJsonWithTimeout(url: string, init: RequestInit = {}): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal, cache: "no-store" });
+    if (!res.ok) return null;
+    return res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function detectYouTubeDuration(videoId: string): Promise<TrackDurationDetectionResult> {
+  const key = process.env.YOUTUBE_API_KEY || process.env.YOUTUBE_DATA_API_KEY;
+  if (!key) return unavailable("youtube", ["YouTube Data API key is not configured; duration unavailable."], videoId);
+  const url = `https://www.googleapis.com/youtube/v3/videos?part=contentDetails&id=${encodeURIComponent(videoId)}&key=${encodeURIComponent(key)}`;
+  const payload = await fetchJsonWithTimeout(url);
+  const item = Array.isArray((payload as { items?: unknown[] } | null)?.items) ? (payload as { items: Array<{ contentDetails?: { duration?: string } }> }).items[0] : null;
+  const duration = typeof item?.contentDetails?.duration === "string" ? parseIso8601DurationToSeconds(item.contentDetails.duration) : null;
+  if (!duration) return unavailable("youtube", ["YouTube API did not return a usable duration."], videoId);
+  return { durationSeconds: duration, durationIsEstimate: false, durationSource: "youtube_api", provider: "youtube", providerTrackId: videoId, notes: ["Duration came from YouTube Data API contentDetails."] };
+}
+
+async function detectSpotifyDuration(trackId: string): Promise<TrackDurationDetectionResult> {
+  const clientId = process.env.SPOTIFY_CLIENT_ID;
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return unavailable("spotify", ["Spotify client credentials are not configured; duration unavailable."], trackId);
+  const tokenPayload = await fetchJsonWithTimeout("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: { Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: "grant_type=client_credentials",
+  });
+  const token = typeof (tokenPayload as { access_token?: unknown } | null)?.access_token === "string" ? (tokenPayload as { access_token: string }).access_token : null;
+  if (!token) return unavailable("spotify", ["Spotify token request did not return an access token."], trackId);
+  const track = await fetchJsonWithTimeout(`https://api.spotify.com/v1/tracks/${encodeURIComponent(trackId)}`, { headers: { Authorization: `Bearer ${token}` } });
+  const duration = positiveSeconds(typeof (track as { duration_ms?: unknown } | null)?.duration_ms === "number" ? (track as { duration_ms: number }).duration_ms / 1000 : null);
+  if (!duration) return unavailable("spotify", ["Spotify API did not return a usable duration."], trackId);
+  return { durationSeconds: duration, durationIsEstimate: false, durationSource: "spotify_api", provider: "spotify", providerTrackId: trackId, notes: ["Duration came from Spotify Web API duration_ms."] };
+}
+
+async function detectSoundCloudDuration(normalizedUrl: string): Promise<TrackDurationDetectionResult> {
+  const clientId = process.env.SOUNDCLOUD_CLIENT_ID;
+  if (!clientId) return unavailable("soundcloud", ["SoundCloud API client id is not configured; duration unavailable."]);
+  const payload = await fetchJsonWithTimeout(`https://api-v2.soundcloud.com/resolve?url=${encodeURIComponent(normalizedUrl)}&client_id=${encodeURIComponent(clientId)}`);
+  const duration = positiveSeconds(typeof (payload as { duration?: unknown } | null)?.duration === "number" ? (payload as { duration: number }).duration / 1000 : null);
+  if (!duration) return unavailable("soundcloud", ["SoundCloud API did not return a usable duration."]);
+  return { durationSeconds: duration, durationIsEstimate: false, durationSource: "soundcloud_api", provider: "soundcloud", notes: ["Duration came from existing SoundCloud API resolve access."] };
+}
+
+export async function detectTrackDurationFromLink(link?: string | null): Promise<TrackDurationDetectionResult> {
+  const parsed = parseSafeTrackProviderUrl(link);
+  if (!parsed) return unavailable(undefined, ["Link host is not a supported duration provider."]);
+  try {
+    if (parsed.provider === "youtube" && parsed.providerTrackId) return detectYouTubeDuration(parsed.providerTrackId);
+    if (parsed.provider === "spotify" && parsed.providerTrackId) return detectSpotifyDuration(parsed.providerTrackId);
+    if (parsed.provider === "soundcloud") return detectSoundCloudDuration(parsed.normalizedUrl);
+    return unavailable(parsed.provider, ["Provider is parsed but duration fetching is not enabled."], parsed.providerTrackId);
+  } catch (error) {
+    return unavailable(parsed.provider, [error instanceof Error ? `Duration lookup failed: ${error.message}` : "Duration lookup failed."], parsed.providerTrackId);
+  }
+}

--- a/src/lib/track-duration.ts
+++ b/src/lib/track-duration.ts
@@ -26,6 +26,13 @@ export interface ParsedTrackProviderUrl {
   normalizedUrl: string;
 }
 
+export interface TrackDurationStorageFields {
+  detectedDurationSeconds: number | null;
+  estimatedDurationSeconds: number;
+  durationIsEstimate: boolean;
+  durationSource: TrackDurationSource;
+}
+
 const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{6,}$/;
 const SPOTIFY_TRACK_ID_PATTERN = /^[a-zA-Z0-9]{10,}$/;
 const FETCH_TIMEOUT_MS = 2500;
@@ -47,6 +54,24 @@ export function uploadTrackDurationResult(durationSeconds: unknown): TrackDurati
   const detected = positiveSeconds(durationSeconds);
   if (!detected) return estimatedTrackDurationResult(["Upload duration metadata was not available from the client."]);
   return { durationSeconds: detected, durationIsEstimate: false, durationSource: "upload_metadata", provider: "direct", notes: ["Upload duration came from client-side audio metadata."] };
+}
+
+export function trackDurationStorageFields(result: TrackDurationDetectionResult): TrackDurationStorageFields {
+  if (result.durationSeconds && result.durationIsEstimate === false) {
+    return {
+      detectedDurationSeconds: result.durationSeconds,
+      estimatedDurationSeconds: result.durationSeconds,
+      durationIsEstimate: false,
+      durationSource: result.durationSource,
+    };
+  }
+
+  return {
+    detectedDurationSeconds: null,
+    estimatedDurationSeconds: INTERNAL_BUFFER_DURATION_SECONDS,
+    durationIsEstimate: true,
+    durationSource: "estimated",
+  };
 }
 
 export function parseYouTubeVideoId(link?: string | null): string | null {
@@ -155,7 +180,7 @@ async function detectSpotifyDuration(trackId: string): Promise<TrackDurationDete
 
 async function detectSoundCloudDuration(normalizedUrl: string): Promise<TrackDurationDetectionResult> {
   const clientId = process.env.SOUNDCLOUD_CLIENT_ID;
-  if (!clientId) return unavailable("soundcloud", ["SoundCloud API client id is not configured; duration unavailable."]);
+  if (!clientId) return unavailable("soundcloud", ["SoundCloud client id is not configured; duration unavailable."]);
   const payload = await fetchJsonWithTimeout(`https://api-v2.soundcloud.com/resolve?url=${encodeURIComponent(normalizedUrl)}&client_id=${encodeURIComponent(clientId)}`);
   const duration = positiveSeconds(typeof (payload as { duration?: unknown } | null)?.duration === "number" ? (payload as { duration: number }).duration / 1000 : null);
   if (!duration) return unavailable("soundcloud", ["SoundCloud API did not return a usable duration."]);

--- a/tests/track-duration.test.mjs
+++ b/tests/track-duration.test.mjs
@@ -30,6 +30,35 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 const require = createRequire(import.meta.url);
 const duration = require("../src/lib/track-duration.ts");
 
+function withoutProviderEnv(callback) {
+  const original = {
+    YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+    YOUTUBE_DATA_API_KEY: process.env.YOUTUBE_DATA_API_KEY,
+    SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID,
+    SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET,
+    SOUNDCLOUD_CLIENT_ID: process.env.SOUNDCLOUD_CLIENT_ID,
+  };
+  delete process.env.YOUTUBE_API_KEY;
+  delete process.env.YOUTUBE_DATA_API_KEY;
+  delete process.env.SPOTIFY_CLIENT_ID;
+  delete process.env.SPOTIFY_CLIENT_SECRET;
+  delete process.env.SOUNDCLOUD_CLIENT_ID;
+  return Promise.resolve(callback()).finally(() => {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+function mockFetch(json) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => json });
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
 test("parses YouTube watch, short, and shorts URLs", () => {
   assert.equal(duration.parseYouTubeVideoId("https://www.youtube.com/watch?v=abc123_DEF45"), "abc123_DEF45");
   assert.equal(duration.parseYouTubeVideoId("https://youtu.be/abc123_DEF45?si=test"), "abc123_DEF45");
@@ -41,10 +70,38 @@ test("parses Spotify track URLs", () => {
   assert.equal(duration.parseSpotifyTrackId("spotify:track:4uLU6hMCjMI75M1A2tKUQC"), "4uLU6hMCjMI75M1A2tKUQC");
 });
 
+test("parses SoundCloud public URLs", () => {
+  assert.equal(duration.parseSafeTrackProviderUrl("https://soundcloud.com/artist-name/track-name")?.provider, "soundcloud");
+});
+
 test("parses ISO 8601 provider durations", () => {
   assert.equal(duration.parseIso8601DurationToSeconds("PT3M20S"), 200);
   assert.equal(duration.parseIso8601DurationToSeconds("PT1H2M3S"), 3723);
 });
+
+test("missing YouTube API key returns unavailable without crashing", async () => withoutProviderEnv(async () => {
+  const result = await duration.detectTrackDurationFromLink("https://www.youtube.com/watch?v=abc123_DEF45");
+  assert.equal(result.durationSeconds, null);
+  assert.equal(result.durationIsEstimate, true);
+  assert.equal(result.durationSource, "unknown");
+  assert.match(result.notes.join(" "), /YouTube Data API key is not configured/);
+}));
+
+test("missing Spotify credentials return unavailable without crashing", async () => withoutProviderEnv(async () => {
+  const result = await duration.detectTrackDurationFromLink("https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC");
+  assert.equal(result.durationSeconds, null);
+  assert.equal(result.durationIsEstimate, true);
+  assert.equal(result.durationSource, "unknown");
+  assert.match(result.notes.join(" "), /Spotify client credentials are not configured/);
+}));
+
+test("missing SoundCloud client id returns unavailable without crashing", async () => withoutProviderEnv(async () => {
+  const result = await duration.detectTrackDurationFromLink("https://soundcloud.com/artist-name/track-name");
+  assert.equal(result.durationSeconds, null);
+  assert.equal(result.durationIsEstimate, true);
+  assert.equal(result.durationSource, "unknown");
+  assert.match(result.notes.join(" "), /SoundCloud client id is not configured/);
+}));
 
 test("unknown providers return unavailable detection", async () => {
   const result = await duration.detectTrackDurationFromLink("https://example.com/song.mp3");
@@ -53,11 +110,93 @@ test("unknown providers return unavailable detection", async () => {
   assert.equal(result.durationSource, "unknown");
 });
 
-test("missing detected duration can be represented as an estimate", () => {
+test("upload duration result stores detected upload duration", () => {
+  const result = duration.uploadTrackDurationResult(187.4);
+  assert.equal(result.durationSeconds, 187);
+  assert.equal(result.durationIsEstimate, false);
+  assert.equal(result.durationSource, "upload_metadata");
+});
+
+test("upload missing duration falls back to 300 estimated seconds", () => {
   const result = duration.uploadTrackDurationResult(null);
   assert.equal(result.durationSeconds, 300);
   assert.equal(result.durationIsEstimate, true);
   assert.equal(result.durationSource, "estimated");
+});
+
+test("link unavailable result can be converted to stored 300 second estimate", async () => {
+  const result = await duration.detectTrackDurationFromLink("https://example.com/song.mp3");
+  assert.deepEqual(duration.trackDurationStorageFields(result), {
+    detectedDurationSeconds: null,
+    estimatedDurationSeconds: 300,
+    durationIsEstimate: true,
+    durationSource: "estimated",
+  });
+});
+
+test("successful YouTube lookup stores detected duration source", async () => {
+  const originalKey = process.env.YOUTUBE_API_KEY;
+  process.env.YOUTUBE_API_KEY = "test-key";
+  const restoreFetch = mockFetch({ items: [{ contentDetails: { duration: "PT3M20S" } }] });
+  try {
+    const result = await duration.detectTrackDurationFromLink("https://www.youtube.com/watch?v=abc123_DEF45");
+    assert.deepEqual(duration.trackDurationStorageFields(result), {
+      detectedDurationSeconds: 200,
+      estimatedDurationSeconds: 200,
+      durationIsEstimate: false,
+      durationSource: "youtube_api",
+    });
+  } finally {
+    restoreFetch();
+    if (originalKey === undefined) delete process.env.YOUTUBE_API_KEY;
+    else process.env.YOUTUBE_API_KEY = originalKey;
+  }
+});
+
+test("successful Spotify lookup stores detected duration source", async () => {
+  const originalClientId = process.env.SPOTIFY_CLIENT_ID;
+  const originalClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  process.env.SPOTIFY_CLIENT_ID = "test-client";
+  process.env.SPOTIFY_CLIENT_SECRET = "test-secret";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("accounts.spotify.com")) return { ok: true, json: async () => ({ access_token: "token" }) };
+    return { ok: true, json: async () => ({ duration_ms: 201500 }) };
+  };
+  try {
+    const result = await duration.detectTrackDurationFromLink("https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC");
+    assert.deepEqual(duration.trackDurationStorageFields(result), {
+      detectedDurationSeconds: 202,
+      estimatedDurationSeconds: 202,
+      durationIsEstimate: false,
+      durationSource: "spotify_api",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalClientId === undefined) delete process.env.SPOTIFY_CLIENT_ID;
+    else process.env.SPOTIFY_CLIENT_ID = originalClientId;
+    if (originalClientSecret === undefined) delete process.env.SPOTIFY_CLIENT_SECRET;
+    else process.env.SPOTIFY_CLIENT_SECRET = originalClientSecret;
+  }
+});
+
+test("successful SoundCloud lookup stores detected duration source", async () => {
+  const originalClientId = process.env.SOUNDCLOUD_CLIENT_ID;
+  process.env.SOUNDCLOUD_CLIENT_ID = "test-client";
+  const restoreFetch = mockFetch({ duration: 199900 });
+  try {
+    const result = await duration.detectTrackDurationFromLink("https://soundcloud.com/artist-name/track-name");
+    assert.deepEqual(duration.trackDurationStorageFields(result), {
+      detectedDurationSeconds: 200,
+      estimatedDurationSeconds: 200,
+      durationIsEstimate: false,
+      durationSource: "soundcloud_api",
+    });
+  } finally {
+    restoreFetch();
+    if (originalClientId === undefined) delete process.env.SOUNDCLOUD_CLIENT_ID;
+    else process.env.SOUNDCLOUD_CLIENT_ID = originalClientId;
+  }
 });
 
 test("unsupported file hosts are not safe duration sources", () => {

--- a/tests/track-duration.test.mjs
+++ b/tests/track-duration.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  if (request.startsWith("@/")) return path.join(projectRoot, "src", request.slice(2));
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+Module._extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+const require = createRequire(import.meta.url);
+const duration = require("../src/lib/track-duration.ts");
+
+test("parses YouTube watch, short, and shorts URLs", () => {
+  assert.equal(duration.parseYouTubeVideoId("https://www.youtube.com/watch?v=abc123_DEF45"), "abc123_DEF45");
+  assert.equal(duration.parseYouTubeVideoId("https://youtu.be/abc123_DEF45?si=test"), "abc123_DEF45");
+  assert.equal(duration.parseYouTubeVideoId("https://www.youtube.com/shorts/abc123_DEF45"), "abc123_DEF45");
+});
+
+test("parses Spotify track URLs", () => {
+  assert.equal(duration.parseSpotifyTrackId("https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC?si=test"), "4uLU6hMCjMI75M1A2tKUQC");
+  assert.equal(duration.parseSpotifyTrackId("spotify:track:4uLU6hMCjMI75M1A2tKUQC"), "4uLU6hMCjMI75M1A2tKUQC");
+});
+
+test("parses ISO 8601 provider durations", () => {
+  assert.equal(duration.parseIso8601DurationToSeconds("PT3M20S"), 200);
+  assert.equal(duration.parseIso8601DurationToSeconds("PT1H2M3S"), 3723);
+});
+
+test("unknown providers return unavailable detection", async () => {
+  const result = await duration.detectTrackDurationFromLink("https://example.com/song.mp3");
+  assert.equal(result.durationSeconds, null);
+  assert.equal(result.durationIsEstimate, true);
+  assert.equal(result.durationSource, "unknown");
+});
+
+test("missing detected duration can be represented as an estimate", () => {
+  const result = duration.uploadTrackDurationResult(null);
+  assert.equal(result.durationSeconds, 300);
+  assert.equal(result.durationIsEstimate, true);
+  assert.equal(result.durationSource, "estimated");
+});
+
+test("unsupported file hosts are not safe duration sources", () => {
+  assert.equal(duration.parseSafeTrackProviderUrl("https://drive.google.com/file/d/abc/view"), null);
+  assert.equal(duration.parseSafeTrackProviderUrl("https://www.dropbox.com/s/abc/song.wav"), null);
+  assert.equal(duration.parseSafeTrackProviderUrl("https://random.example/audio/song.mp3"), null);
+});


### PR DESCRIPTION
### Motivation
- Provide a safe, centralized foundation to capture and store track duration metadata for link submissions so later wait estimates can use real durations when available. 
- Avoid fragile scraping or downloading arbitrary files and preserve existing upload privacy and client-provided upload-duration behavior. 
- Add provider URL parsing and a conservative API-fetch policy so provider durations are usable only when official credentials exist or oEmbed/resolvers are safe.

### Description
- Audit summary: the repo already contains `detectedDurationSeconds`, `estimatedDurationSeconds`, `durationIsEstimate`, `durationSource`, `durationLabel`, `getTrackRuntimeSeconds()`, and `INTERNAL_BUFFER_DURATION_SECONDS`; uploads accept client `detectedDurationSeconds` in `src/app/api/queue/route.ts` and link submissions run provider metadata lookups in `createQueueTrack()`; unknown durations previously fell back to the internal buffer. (Kept behavior and preserved privacy.)
- New helper and types: added `src/lib/track-duration.ts` with a display-neutral `TrackDurationDetectionResult`, safe provider URL parsers for YouTube/Spotify/SoundCloud, ISO 8601 duration parsing, provider API helpers with short timeouts, and upload/estimated helper results. 
- Wiring and typing: expanded `QueueDurationSource` in `src/lib/queue-types.ts` to include `youtube_api`, `spotify_api`, `soundcloud_api`, `direct_metadata`, and `estimated`; set the internal unknown-duration fallback to 5 minutes (`INTERNAL_BUFFER_DURATION_SECONDS = 300`).
- Integration (non-blocking): `src/lib/queue.ts` was updated so `detectProviderMetadata()` first uses existing provider lookups and, only if they return no duration, calls the centralized `detectTrackDurationFromLink()` helper as a safe fallback; `createQueueTrack()` stores provider-detected durations as `detectedDurationSeconds` and tags `durationSource` appropriately; if detection fails the code preserves the estimate fallback. 
- Upload preservation and privacy: `src/app/api/queue/route.ts` still accepts client `detectedDurationSeconds` for uploads and validates private blob URLs; uploads without client duration are now marked `durationSource:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04fead4a408321a0770550897909b2)