### PR TITLE
Commercial Break Timing Gate / 2-Hour Eligibility

### DIFF
--- a/src/components/AdminRadioQueueControl.tsx
+++ b/src/components/AdminRadioQueueControl.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AdminLiveOverlayControl } from "@/components/AdminLiveOverlayControl";
-import { buildQueueTimingDisplay, formatHoursMinutes, queueTimingInputFromAdminState, sponsorStatusLabel } from "@/lib/queue-timing-display";
+import { buildQueueTimingDisplay, formatHoursMinutes, queueTimingInputFromAdminState } from "@/lib/queue-timing-display";
 import { parseYouTubeVideoId } from "@/lib/track-duration";
 import { formatRuntime, getTrackRuntimeSeconds } from "@/lib/queue-types";
 import type { QueueEntry, QueueLane, QueueState } from "@/lib/queue-types";
@@ -549,12 +549,12 @@ function AdminRuntimeDiagnostics({ timingSummary, canControl, onSponsorAction }:
         <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Line Fit</p><p className="mt-1 font-bold text-foreground">{timingSummary.lineFitCopy}</p></div>
       </div>
       <div className="grid gap-3 md:grid-cols-4">
-        <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Sponsor Break</p><p className="mt-1 font-bold text-foreground">{sponsor.statusLabel}</p><p className="mt-1 text-muted">Due after {sponsor.dueAfterTracks ?? "—"} playable tracks · {sponsor.durationLabel} duration</p></div>
+        <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Commercial Break</p><p className="mt-1 font-bold text-foreground">{sponsor.diagnosticLabel}</p><p className="mt-1 text-muted">{sponsor.durationLabel} duration · {sponsor.minElapsedLabel} minimum · midpoint {sponsor.completedPlayableCount}/{sponsor.totalPlayableNonRemovedCount ?? "—"} playable</p></div>
         <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Wheel Timing</p><p className="mt-1 font-bold text-foreground">{wheel.owed} wheel spins owed</p><p className="mt-1 text-muted">{wheel.overheadLabel} ceremony overhead included</p></div>
         <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Unknown Durations</p><p className="mt-1 font-bold text-foreground">{timingSummary.showRuntimeSummary.unknownDurationCount}</p><p className="mt-1 text-muted">Tracks using est. 5:00</p></div>
         <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Known Durations</p><p className="mt-1 font-bold text-foreground">{timingSummary.showRuntimeSummary.knownDurationCount}</p><p className="mt-1 text-muted">Detected/provider/upload durations</p></div>
       </div>
-      <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Current Runtime Notes</p><p className="mt-1 text-muted">Sponsor: {sponsorStatusLabel(sponsor.status)} · Wheel overhead: {formatHoursMinutes(wheel.overheadSeconds)} · {timingSummary.showRuntimeSummary.notes[0] ?? "No projection warnings."}</p></div>
+      <div className="border border-border bg-surface p-3"><p className="uppercase tracking-widest text-muted">Current Runtime Notes</p><p className="mt-1 text-muted">Commercial: {sponsor.diagnosticLabel} · Wheel overhead: {formatHoursMinutes(wheel.overheadSeconds)} · {timingSummary.showRuntimeSummary.notes[0] ?? "No projection warnings."}</p></div>
     </section>
   );
 }

--- a/src/lib/queue-timing-display.ts
+++ b/src/lib/queue-timing-display.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SPONSOR_BREAK_SECONDS,
+  DEFAULT_SPONSOR_BREAK_MIN_ELAPSED_SECONDS,
   estimateExistingTrackTiming,
   estimateNewSubmissionTiming,
   estimatePriorityImpact,
@@ -50,8 +51,12 @@ export interface QueueTimingDisplaySummary {
   sponsorBreakSummary: {
     status: string;
     statusLabel: string;
+    diagnosticLabel: string;
     dueAfterTracks: number | null;
     durationLabel: string;
+    minElapsedLabel: string;
+    completedPlayableCount: number;
+    totalPlayableNonRemovedCount: number | null;
     included: boolean;
   };
   wheelTimingSummary: {
@@ -118,6 +123,7 @@ function sessionTimingFields(session: QueuePublicSnapshot["session"] | QueueSess
     sponsorBreakSeconds: session.sponsorBreakSeconds,
     sponsorBreakMode: session.sponsorBreakMode,
     sponsorBreakStatus: session.sponsorBreakStatus,
+    broadcastStartedAt: session.broadcastStartedAt,
     sponsorBreakStartedAt: session.sponsorBreakStartedAt,
     sponsorBreakCompletedAt: session.sponsorBreakCompletedAt,
     sponsorBreakCompletedAfterPlayableCount: session.sponsorBreakCompletedAfterPlayableCount,
@@ -151,8 +157,12 @@ export function buildQueueTimingDisplay(input: QueueTimingInput, options: { prio
     sponsorBreakSummary: {
       status: snapshot.sponsorBreakStatus,
       statusLabel: sponsorStatusLabel(snapshot.sponsorBreakStatus),
+      diagnosticLabel: sponsorDiagnosticLabel(snapshot.sponsorBreak),
       dueAfterTracks: snapshot.sponsorBreak.sponsorBreakThreshold,
       durationLabel: formatHoursMinutes(snapshot.sponsorBreak.sponsorBreakSeconds || DEFAULT_SPONSOR_BREAK_SECONDS),
+      minElapsedLabel: formatHoursMinutes(snapshot.sponsorBreak.sponsorBreakMinElapsedSeconds || DEFAULT_SPONSOR_BREAK_MIN_ELAPSED_SECONDS),
+      completedPlayableCount: snapshot.sponsorBreak.completedPlayableCount,
+      totalPlayableNonRemovedCount: snapshot.sponsorBreak.totalPlayableNonRemovedCount,
       included: snapshot.sponsorBreakSecondsIncluded > 0,
     },
     wheelTimingSummary: {
@@ -230,6 +240,18 @@ export function targetStatusLabel(status: QueueTimingTargetStatus): string {
   if (status === "over_target") return "Over target";
   if (status === "warning_ceiling") return "Warning ceiling";
   return "Unknown";
+}
+
+export function sponsorDiagnosticLabel(sponsor: { sponsorBreakStatus?: string | null; midpointReached?: boolean | null; minElapsedGateReached?: boolean | null; secondsUntilMinElapsedGate?: number | null; sponsorBreakIncluded?: boolean | null; broadcastStartedAt?: string | null }): string {
+  if (sponsor.sponsorBreakStatus === "completed") return "Completed";
+  if (sponsor.sponsorBreakStatus === "skipped") return "Skipped";
+  if (sponsor.sponsorBreakStatus === "running") return "Running";
+  if (sponsor.sponsorBreakIncluded || (sponsor.midpointReached === true && sponsor.minElapsedGateReached === true)) return "Due now";
+  if (!sponsor.broadcastStartedAt || sponsor.minElapsedGateReached === null) return "Waiting for playback start";
+  if (sponsor.midpointReached === true && sponsor.minElapsedGateReached === false) return "Midpoint reached · waiting for 2h mark";
+  if (sponsor.midpointReached === false && sponsor.minElapsedGateReached === true) return "2h mark reached · waiting for midpoint";
+  const remaining = typeof sponsor.secondsUntilMinElapsedGate === "number" ? ` · ${formatHoursMinutes(sponsor.secondsUntilMinElapsedGate)} until 2h mark` : "";
+  return `Not eligible yet${remaining}`;
 }
 
 export function sponsorStatusLabel(status?: string | null): string {

--- a/src/lib/queue-timing.ts
+++ b/src/lib/queue-timing.ts
@@ -5,6 +5,7 @@ export const DEFAULT_PRE_TRACK_TALK_SECONDS = 60;
 export const DEFAULT_POST_TRACK_TALK_SECONDS = 60;
 export const DEFAULT_HOST_TALK_BUFFER_SECONDS = DEFAULT_PRE_TRACK_TALK_SECONDS + DEFAULT_POST_TRACK_TALK_SECONDS;
 export const DEFAULT_SPONSOR_BREAK_SECONDS = 630;
+export const DEFAULT_SPONSOR_BREAK_MIN_ELAPSED_SECONDS = 7200;
 export const DEFAULT_WHEEL_CEREMONY_SECONDS = 120;
 export const TARGET_SHOW_SECONDS = 14400;
 export const WARNING_SHOW_SECONDS = 18000;
@@ -29,11 +30,13 @@ export interface QueueTimingOptions {
   postTrackTalkSeconds?: number;
   hostTalkBufferSeconds?: number;
   sponsorBreakSeconds?: number;
+  sponsorBreakMinElapsedSeconds?: number;
   wheelCeremonySeconds?: number;
   targetShowSeconds?: number;
   warningShowSeconds?: number;
   sponsorBreakAlreadyRun?: boolean | null;
   includeHostBufferForNowPlaying?: boolean;
+  now?: Date;
 }
 
 export interface QueueTimingInput {
@@ -53,6 +56,7 @@ export interface QueueTimingInput {
     sponsorBreakSeconds?: number | null;
     sponsorBreakMode?: SponsorBreakMode | null;
     sponsorBreakStatus?: SponsorBreakStatus | null;
+    broadcastStartedAt?: string | null;
     sponsorBreakStartedAt?: string | null;
     sponsorBreakCompletedAt?: string | null;
     sponsorBreakCompletedAfterPlayableCount?: number | null;
@@ -68,6 +72,7 @@ interface NormalizedQueueTimingOptions {
   postTrackTalkSeconds: number;
   hostTalkBufferSeconds: number;
   sponsorBreakSeconds: number;
+  sponsorBreakMinElapsedSeconds: number;
   wheelCeremonySeconds: number;
   targetShowSeconds: number;
   warningShowSeconds: number;
@@ -98,6 +103,14 @@ export interface SponsorBreakEstimate {
   completedPlayableNonRemovedCount: number;
   sponsorBreakThreshold: number | null;
   sponsorBreakSeconds: number;
+  sponsorBreakMinElapsedSeconds: number;
+  broadcastStartedAt: string | null;
+  broadcastElapsedSeconds: number | null;
+  minElapsedGateReached: boolean | null;
+  secondsUntilMinElapsedGate: number | null;
+  midpointReached: boolean | null;
+  commercialBreakEligible: boolean;
+  commercialBreakPointSeconds: number | null;
   sponsorBreakIncluded: boolean;
   sponsorBreakAlreadyRun: boolean | null;
   sponsorBreakStatus: SponsorBreakStatus;
@@ -252,6 +265,7 @@ function normalizeOptions(options?: QueueTimingOptions): NormalizedQueueTimingOp
     postTrackTalkSeconds,
     hostTalkBufferSeconds: preTrackTalkSeconds + postTrackTalkSeconds,
     sponsorBreakSeconds: safeNonNegativeSeconds(options?.sponsorBreakSeconds) ?? DEFAULT_SPONSOR_BREAK_SECONDS,
+    sponsorBreakMinElapsedSeconds: safeNonNegativeSeconds(options?.sponsorBreakMinElapsedSeconds) ?? DEFAULT_SPONSOR_BREAK_MIN_ELAPSED_SECONDS,
     wheelCeremonySeconds: safeNonNegativeSeconds(options?.wheelCeremonySeconds) ?? DEFAULT_WHEEL_CEREMONY_SECONDS,
     targetShowSeconds: safePositiveSeconds(options?.targetShowSeconds) ?? TARGET_SHOW_SECONDS,
     warningShowSeconds: safePositiveSeconds(options?.warningShowSeconds) ?? WARNING_SHOW_SECONDS,
@@ -368,6 +382,32 @@ function countTotalNonRemoved(input: QueueTimingInput): number | null {
   return total > 0 ? total : null;
 }
 
+
+function validIsoString(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? value : null;
+}
+
+function deriveBroadcastStartedAt(input: QueueTimingInput): string | null {
+  const explicit = validIsoString(input.session?.broadcastStartedAt);
+  if (explicit) return explicit;
+  const candidates = [
+    validIsoString(input.nowPlaying?.playedAt),
+    ...(input.completed ?? []).map((track) => validIsoString(track?.playedAt) ?? validIsoString(track?.completedAt)),
+  ].filter((value): value is string => Boolean(value));
+  if (candidates.length === 0) return null;
+  return candidates.sort((a, b) => Date.parse(a) - Date.parse(b))[0];
+}
+
+function secondsSince(iso: string | null, now = new Date()): number | null {
+  if (!iso) return null;
+  const started = Date.parse(iso);
+  const current = now.getTime();
+  if (!Number.isFinite(started) || !Number.isFinite(current)) return null;
+  return Math.max(0, Math.floor((current - started) / 1000));
+}
+
 function explicitSponsorStatus(input: QueueTimingInput, normalized: NormalizedQueueTimingOptions): SponsorBreakStatus | null {
   const status = input.session?.sponsorBreakStatus;
   if (status === "completed" || status === "skipped" || status === "running" || status === "due" || status === "not_due") return status;
@@ -375,19 +415,31 @@ function explicitSponsorStatus(input: QueueTimingInput, normalized: NormalizedQu
   return null;
 }
 
-export function estimateSponsorBreakPlacement(input: QueueTimingInput, options?: QueueTimingOptions & { targetSongsAhead?: number | null }): SponsorBreakEstimate {
+export function estimateSponsorBreakPlacement(input: QueueTimingInput, options?: QueueTimingOptions & { targetSongsAhead?: number | null; targetProjectedSecondsAhead?: number | null; now?: Date }): SponsorBreakEstimate {
   const normalized = normalizeOptions({ ...options, sponsorBreakSeconds: options?.sponsorBreakSeconds ?? input.session?.sponsorBreakSeconds ?? undefined });
   const completedPlayableCount = countCompletedPlayable(input);
   const totalNonRemovedSubmissions = countTotalNonRemoved(input);
   const sponsorBreakThreshold = totalNonRemovedSubmissions ? Math.ceil(totalNonRemovedSubmissions / 2) : null;
   const targetSongsAhead = safeNonNegativeInteger(options?.targetSongsAhead);
+  const targetProjectedSecondsAhead = safeNonNegativeSeconds(options?.targetProjectedSecondsAhead) ?? 0;
   const targetStartCompletedCount = completedPlayableCount + targetSongsAhead;
   const sponsorBreakNotes: string[] = [];
   const explicitStatus = explicitSponsorStatus(input, normalized);
+  const broadcastStartedAt = deriveBroadcastStartedAt(input);
+  const broadcastElapsedSeconds = secondsSince(broadcastStartedAt, options?.now);
+  const secondsUntilMinElapsedGate = broadcastElapsedSeconds === null ? null : Math.max(0, normalized.sponsorBreakMinElapsedSeconds - broadcastElapsedSeconds);
+  const minElapsedGateReached = broadcastElapsedSeconds === null ? null : targetProjectedSecondsAhead >= secondsUntilMinElapsedGate!;
+  const midpointReached = sponsorBreakThreshold === null ? null : targetStartCompletedCount >= sponsorBreakThreshold;
+  const midpointPointSeconds = midpointReached ? 0 : null;
+  const minElapsedPointSeconds = secondsUntilMinElapsedGate;
+  const commercialBreakPointSeconds = midpointPointSeconds === null || minElapsedPointSeconds === null ? null : Math.max(midpointPointSeconds, minElapsedPointSeconds);
+  const commercialBreakEligible = midpointReached === true && minElapsedGateReached === true;
 
-  if (!explicitStatus) sponsorBreakNotes.push("Sponsor break status is derived from completed playable count and midpoint threshold.");
+  if (!explicitStatus) sponsorBreakNotes.push("Sponsor break status is derived from completed playable count, midpoint threshold, and the 2-hour broadcast gate.");
   if (input.session?.sponsorBreakManualNote) sponsorBreakNotes.push(input.session.sponsorBreakManualNote);
   if (totalNonRemovedSubmissions === null) sponsorBreakNotes.push("Non-removed submission total is unavailable, so sponsor midpoint placement is unknown.");
+  if (!broadcastStartedAt) sponsorBreakNotes.push("Broadcast playback start is unavailable, so the 2-hour sponsor break gate is unknown.");
+  if (broadcastStartedAt) sponsorBreakNotes.push("Sponsor break cannot be included before 2 hours of broadcast playback have elapsed.");
 
   let sponsorBreakStatus: SponsorBreakStatus = explicitStatus ?? "unknown";
   let sponsorBreakIncluded = false;
@@ -396,23 +448,20 @@ export function estimateSponsorBreakPlacement(input: QueueTimingInput, options?:
   } else if (explicitStatus === "running") {
     sponsorBreakIncluded = true;
     sponsorBreakNotes.push("Sponsor break is marked running; full stored break duration is included conservatively.");
-  } else if (explicitStatus === "due") {
-    sponsorBreakIncluded = true;
-  } else if (explicitStatus === "not_due") {
-    sponsorBreakIncluded = sponsorBreakThreshold !== null && targetStartCompletedCount >= sponsorBreakThreshold;
-  } else if (sponsorBreakThreshold === null) {
-    sponsorBreakStatus = "unknown";
-  } else if (completedPlayableCount >= sponsorBreakThreshold) {
+  } else if (commercialBreakEligible) {
     sponsorBreakStatus = "due";
     sponsorBreakIncluded = true;
+  } else if (sponsorBreakThreshold === null || broadcastElapsedSeconds === null) {
+    sponsorBreakStatus = "unknown";
   } else {
     sponsorBreakStatus = "not_due";
-    sponsorBreakIncluded = targetStartCompletedCount >= sponsorBreakThreshold;
   }
 
   const sponsorBreakAlreadyCompleted = sponsorBreakStatus === "completed" || sponsorBreakStatus === "skipped";
   const sponsorBreakSecondsIncluded = sponsorBreakIncluded && !sponsorBreakAlreadyCompleted ? normalized.sponsorBreakSeconds : 0;
-  if (sponsorBreakStatus === "due") sponsorBreakNotes.push("Sponsor midpoint has been reached and should be included until completed or skipped.");
+  if (sponsorBreakStatus === "due") sponsorBreakNotes.push("Sponsor midpoint and 2-hour broadcast gate have both been reached; include until completed or skipped.");
+  if (midpointReached === true && minElapsedGateReached === false) sponsorBreakNotes.push("Sponsor midpoint is reached; waiting for the 2-hour broadcast mark.");
+  if (midpointReached === false && minElapsedGateReached === true) sponsorBreakNotes.push("2-hour broadcast mark is reached; waiting for the sponsor midpoint.");
   if (sponsorBreakAlreadyCompleted && input.session?.sponsorBreakCompletedAt) sponsorBreakNotes.push(`Sponsor break completion recorded at ${input.session.sponsorBreakCompletedAt}.`);
 
   return {
@@ -422,6 +471,14 @@ export function estimateSponsorBreakPlacement(input: QueueTimingInput, options?:
     completedPlayableNonRemovedCount: completedPlayableCount,
     sponsorBreakThreshold,
     sponsorBreakSeconds: normalized.sponsorBreakSeconds,
+    sponsorBreakMinElapsedSeconds: normalized.sponsorBreakMinElapsedSeconds,
+    broadcastStartedAt,
+    broadcastElapsedSeconds,
+    minElapsedGateReached,
+    secondsUntilMinElapsedGate,
+    midpointReached,
+    commercialBreakEligible,
+    commercialBreakPointSeconds,
     sponsorBreakIncluded,
     sponsorBreakAlreadyRun: sponsorBreakAlreadyCompleted ? true : normalized.sponsorBreakAlreadyRun,
     sponsorBreakStatus,
@@ -460,25 +517,37 @@ function segmentStats(segments: readonly ProjectedShowSegment[]) {
   };
 }
 
-export function buildProjectedShowTimeline(input: QueueTimingInput, options?: QueueTimingOptions & { targetSongsAhead?: number | null; includeWheelCeremony?: boolean }): ProjectedTimeline {
+export function buildProjectedShowTimeline(input: QueueTimingInput, options?: QueueTimingOptions & { targetSongsAhead?: number | null; targetProjectedSecondsAhead?: number | null; includeWheelCeremony?: boolean; now?: Date }): ProjectedTimeline {
   const normalized = normalizeOptions(options);
   const tracks = activeTracksInResolvedOrder(input);
   const segments: ProjectedShowSegment[] = [];
   const completedPlayableCount = countCompletedPlayable(input);
-  const sponsorBreak = estimateSponsorBreakPlacement(input, { ...normalized, targetSongsAhead: options?.targetSongsAhead ?? tracks.length });
   const wheelCeremony = estimateWheelCeremonySeconds(input.wheelSpinsOwed ?? input.session?.wheelSpinsOwed, normalized);
   let sponsorInserted = false;
+  let projectedSecondsAhead = 0;
+  let sponsorBreak = estimateSponsorBreakPlacement(input, { ...normalized, targetSongsAhead: options?.targetSongsAhead ?? tracks.length, targetProjectedSecondsAhead: options?.targetProjectedSecondsAhead ?? 0, now: options?.now });
 
   tracks.forEach((track, index) => {
-    if (!sponsorInserted && sponsorBreak.sponsorBreakIncluded && sponsorBreak.sponsorBreakThreshold !== null && completedPlayableCount + index >= sponsorBreak.sponsorBreakThreshold) {
+    const sponsorAtThisPoint = estimateSponsorBreakPlacement(input, { ...normalized, targetSongsAhead: index, targetProjectedSecondsAhead: projectedSecondsAhead, now: options?.now });
+    if (!sponsorInserted && sponsorAtThisPoint.sponsorBreakIncluded) {
+      segments.push({ type: "sponsor_break", label: "Mid-show sponsor break", seconds: sponsorAtThisPoint.sponsorBreakSecondsIncluded, isEstimate: sponsorAtThisPoint.sponsorBreakStatus === "running", notes: sponsorAtThisPoint.sponsorBreakNotes });
+      projectedSecondsAhead += sponsorAtThisPoint.sponsorBreakSecondsIncluded;
+      sponsorInserted = true;
+      sponsorBreak = sponsorAtThisPoint;
+    }
+    const trackSegments = segmentsForTrack(track, normalized, index === 0 && input.nowPlaying?.id === track.id);
+    segments.push(...trackSegments);
+    projectedSecondsAhead += sumSegments(trackSegments);
+  });
+
+  if (!sponsorInserted) {
+    const finalTargetSongsAhead = options?.targetSongsAhead ?? tracks.length;
+    const finalTargetSecondsAhead = options?.targetProjectedSecondsAhead ?? projectedSecondsAhead;
+    sponsorBreak = estimateSponsorBreakPlacement(input, { ...normalized, targetSongsAhead: finalTargetSongsAhead, targetProjectedSecondsAhead: finalTargetSecondsAhead, now: options?.now });
+    if (sponsorBreak.sponsorBreakIncluded) {
       segments.push({ type: "sponsor_break", label: "Mid-show sponsor break", seconds: sponsorBreak.sponsorBreakSecondsIncluded, isEstimate: sponsorBreak.sponsorBreakStatus === "running", notes: sponsorBreak.sponsorBreakNotes });
       sponsorInserted = true;
     }
-    segments.push(...segmentsForTrack(track, normalized, index === 0 && input.nowPlaying?.id === track.id));
-  });
-
-  if (!sponsorInserted && sponsorBreak.sponsorBreakIncluded) {
-    segments.push({ type: "sponsor_break", label: "Mid-show sponsor break", seconds: sponsorBreak.sponsorBreakSecondsIncluded, isEstimate: sponsorBreak.sponsorBreakStatus === "running", notes: sponsorBreak.sponsorBreakNotes });
   }
 
   if (options?.includeWheelCeremony !== false && wheelCeremony.wheelCeremonySeconds > 0) {
@@ -507,7 +576,7 @@ export function buildProjectedShowTimeline(input: QueueTimingInput, options?: Qu
 
 export function buildQueueTimingSnapshot(input: QueueTimingInput, options?: QueueTimingOptions): QueueTimingSnapshot {
   const normalized = normalizeOptions(options);
-  const timeline = buildProjectedShowTimeline(input, normalized);
+  const timeline = buildProjectedShowTimeline(input, { ...normalized, now: options?.now });
   const activeRuntime = estimateRuntimeForTracks(activeTracksInResolvedOrder(input), normalized);
   const completedRuntimeSeconds = safePositiveSeconds(input.completedRuntimeSeconds) ?? safePositiveSeconds(input.session?.completedRuntimeSeconds) ?? null;
   const completedEstimatedRuntime = completedRuntimeSeconds ?? estimateRuntimeForTracks(input.completed ?? [], normalized).slotSeconds;

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -113,6 +113,7 @@ export interface QueueSessionSummary {
   preShowEndsAt?: string | null;
   wheelSpinsOwed?: number;
   broadcastPhase?: QueueBroadcastPhase;
+  broadcastStartedAt?: string | null;
   nextInLineTrackId?: string | null;
   nextInLineHoldTrackId?: string | null;
   loadedTrackId?: string | null;
@@ -182,7 +183,7 @@ export interface QueuePublicSubmitterStatus {
 }
 
 export interface QueuePublicSnapshot {
-  session: Pick<QueueSessionSummary, "sessionId" | "title" | "showDate" | "status" | "description" | "completedCount" | "completedRuntimeSeconds" | "activeCount" | "removedCount" | "submissionCooldownSeconds" | "queueOpen" | "showStarted" | "preShowEndsAt" | "broadcastPhase" | "nextInLineTrackId" | "loadedTrackId" | "wheelSpinsOwed" | "priorityUpgradesEnabled" | "priorityUpgradeLabel" | "priorityUpgradeInstructions" | "priorityUpgradePriceCents" | "priorityUpgradeCurrency" | "priorityUpgradePaymentsEnabled" | "sponsorBreakSeconds" | "sponsorBreakMode" | "sponsorBreakStatus" | "sponsorBreakStartedAt" | "sponsorBreakCompletedAt" | "sponsorBreakCompletedAfterPlayableCount" | "sponsorBreakManualNote">;
+  session: Pick<QueueSessionSummary, "sessionId" | "title" | "showDate" | "status" | "description" | "completedCount" | "completedRuntimeSeconds" | "activeCount" | "removedCount" | "submissionCooldownSeconds" | "queueOpen" | "showStarted" | "preShowEndsAt" | "broadcastPhase" | "broadcastStartedAt" | "nextInLineTrackId" | "loadedTrackId" | "wheelSpinsOwed" | "priorityUpgradesEnabled" | "priorityUpgradeLabel" | "priorityUpgradeInstructions" | "priorityUpgradePriceCents" | "priorityUpgradeCurrency" | "priorityUpgradePaymentsEnabled" | "sponsorBreakSeconds" | "sponsorBreakMode" | "sponsorBreakStatus" | "sponsorBreakStartedAt" | "sponsorBreakCompletedAt" | "sponsorBreakCompletedAfterPlayableCount" | "sponsorBreakManualNote">;
   status: QueuePublicStatus;
   queue: QueuePublicTrack[];
   completed: QueuePublicTrack[];

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -149,6 +149,7 @@ function defaultSession(options: { title?: string; showDate?: string; descriptio
     nextNonPriorityLane: "wheel",
     showStarted: false,
     preShowEndsAt: null,
+    broadcastStartedAt: null,
     wheelSpinsOwed: 0,
     nextInLineTrack: null,
     nextInLineTrackId: null,
@@ -383,6 +384,7 @@ function setLoadedTrack(session: QueueSession, entry: QueueEntry, previousLane?:
   session.loadedTrackWasNextInLine = wasNextInLine;
   session.loadedTrackFallbackForLane = entry.stagedAsFallbackForLane ?? null;
   if (session.showStarted !== true) session.showStarted = true;
+  if (!session.broadcastStartedAt) session.broadcastStartedAt = loaded.playedAt ?? new Date().toISOString();
   session.queue = session.queue.filter((track) => track.id !== loaded.id);
   if (session.nextInLineTrack?.id === loaded.id) clearNextInLine(session);
   return loaded;
@@ -551,6 +553,7 @@ function summarizeSession(session: QueueSession): QueueSessionSummary {
     nextNonPriorityLane: session.nextNonPriorityLane ?? "wheel",
     showStarted: session.showStarted === true,
     preShowEndsAt: session.preShowEndsAt ?? null,
+    broadcastStartedAt: session.broadcastStartedAt ?? null,
     wheelSpinsOwed: normalizeWheelSpinsOwed(session.wheelSpinsOwed),
     broadcastPhase: broadcastPhaseForSession(session),
     priorityUpgradesEnabled: normalizePaidPriorityEnabled(session),
@@ -689,6 +692,7 @@ function normalizeSession(raw: Partial<QueueSession> & { sessionId: string; titl
     nextNonPriorityLane: raw.nextNonPriorityLane === "regular" ? "regular" : "wheel",
     showStarted: raw.showStarted === true,
     preShowEndsAt: typeof raw.preShowEndsAt === "string" && raw.preShowEndsAt ? raw.preShowEndsAt : null,
+    broadcastStartedAt: typeof raw.broadcastStartedAt === "string" && raw.broadcastStartedAt ? raw.broadcastStartedAt : null,
     wheelSpinsOwed: normalizeWheelSpinsOwed(raw.wheelSpinsOwed),
     nextInLineTrack: raw.nextInLineTrack ? normalizeEntry(raw.nextInLineTrack) : null,
     nextInLineTrackId: raw.nextInLineTrack?.id ?? raw.nextInLineTrackId ?? null,
@@ -2081,7 +2085,9 @@ export async function updateRadioTrack(id: string, action: QueueAdminAction): Pr
       session.nextInLineHoldTrackId = null;
       const current = clearLoadedTrack(session);
       if (current) {
-        session.completed.unshift({ ...current, status: "played", playedAt: current.playedAt ?? new Date().toISOString(), completedAt: new Date().toISOString() });
+        const now = new Date().toISOString();
+        if (!session.broadcastStartedAt) session.broadcastStartedAt = current.playedAt ?? now;
+        session.completed.unshift({ ...current, status: "played", playedAt: current.playedAt ?? now, completedAt: now });
         advanceNonPriorityLaneAfter(session, current.lane);
       }
     }
@@ -2115,7 +2121,9 @@ export async function updateRadioTrack(id: string, action: QueueAdminAction): Pr
     if (action === "finish") {
       const current = clearNextInLine(session);
       if (current) {
-        session.completed.unshift({ ...current, status: "played", playedAt: new Date().toISOString(), completedAt: new Date().toISOString() });
+        const now = new Date().toISOString();
+        if (!session.broadcastStartedAt) session.broadcastStartedAt = current.playedAt ?? now;
+        session.completed.unshift({ ...current, status: "played", playedAt: current.playedAt ?? now, completedAt: now });
         advanceNonPriorityLaneAfter(session, current.lane);
       }
       pullNextInLine(session);

--- a/tests/queue-timing-display.test.mjs
+++ b/tests/queue-timing-display.test.mjs
@@ -32,7 +32,7 @@ test("range formatting keeps rough about labels and widens low confidence", () =
 test("sponsor included and completed public notes reflect current projection", () => {
   const completed = Array.from({ length: 20 }, (_, index) => track(`done-${index}`, { status: "completed" }));
   const queue = Array.from({ length: 20 }, (_, index) => track(`queued-${index}`));
-  const withSponsor = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "not_due" } });
+  const withSponsor = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "not_due", broadcastStartedAt: "2026-01-01T00:00:00.000Z" } });
   assert.ok(withSponsor.publicNotes.includes("Estimate includes the mid-show sponsor break."));
   const completedSponsor = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "completed", sponsorBreakCompletedAt: "2026-01-01T00:00:00.000Z" } });
   const skippedSponsor = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "skipped", sponsorBreakCompletedAt: "2026-01-01T00:00:00.000Z" } });
@@ -109,4 +109,23 @@ test("Personal Signal Status does not include global projected show time copy", 
   const end = source.indexOf("function estimateExistingTrackForDisplay", start);
   const block = source.slice(start, end);
   assert.ok(!block.includes("Projected Show Time"));
+});
+
+
+test("admin sponsor diagnostics explain gate states compactly", () => {
+  assert.match(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "not_due", broadcastStartedAt: "2026-01-01T00:00:00.000Z", midpointReached: false, minElapsedGateReached: false, secondsUntilMinElapsedGate: 24 * 60 }), /Not eligible yet/);
+  assert.equal(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "not_due", broadcastStartedAt: "2026-01-01T00:00:00.000Z", midpointReached: true, minElapsedGateReached: false }), "Midpoint reached · waiting for 2h mark");
+  assert.equal(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "not_due", broadcastStartedAt: "2026-01-01T00:00:00.000Z", midpointReached: false, minElapsedGateReached: true }), "2h mark reached · waiting for midpoint");
+  assert.equal(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "due", broadcastStartedAt: "2026-01-01T00:00:00.000Z", midpointReached: true, minElapsedGateReached: true, sponsorBreakIncluded: true }), "Due now");
+  assert.equal(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "completed" }), "Completed");
+  assert.equal(display.sponsorDiagnosticLabel({ sponsorBreakStatus: "skipped" }), "Skipped");
+});
+
+test("public sponsor note appears only when the gated break is included", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`public-done-${index}`, { status: "completed" }));
+  const queue = [track("public-queued-target", { detectedDurationSeconds: 60 })];
+  const early = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "not_due", broadcastStartedAt: new Date(Date.now() - 90 * 60 * 1000).toISOString() } });
+  const included = display.buildQueueTimingDisplay({ completed, queue, session: { sponsorBreakStatus: "not_due", broadcastStartedAt: "2026-01-01T00:00:00.000Z" } });
+  assert.ok(!early.publicNotes.includes("Estimate includes the mid-show sponsor break."));
+  assert.ok(included.publicNotes.includes("Estimate includes the mid-show sponsor break."));
 });

--- a/tests/queue-timing.test.mjs
+++ b/tests/queue-timing.test.mjs
@@ -30,6 +30,11 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 const require = createRequire(import.meta.url);
 const timing = require("../src/lib/queue-timing.ts");
 
+const NOW = new Date("2026-01-01T02:20:00.000Z");
+const START_2H20_AGO = "2026-01-01T00:00:00.000Z";
+const START_1H30_AGO = "2026-01-01T00:50:00.000Z";
+const START_1H45_AGO = "2026-01-01T00:35:00.000Z";
+
 function track(id, overrides = {}) {
   return { id, status: "queued", ...overrides };
 }
@@ -70,7 +75,7 @@ test("observed average track runtime is not inflated by host buffer", () => {
 test("sponsor break is due after half of forty non-removed submissions have completed", () => {
   const completed = Array.from({ length: 20 }, (_, index) => track(`played-${index}`, { status: "played", completedAt: "2026-01-01T00:00:00.000Z" }));
   const queue = Array.from({ length: 20 }, (_, index) => track(`queued-${index}`));
-  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue }, { sponsorBreakAlreadyRun: false });
+  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_2H20_AGO } }, { sponsorBreakAlreadyRun: false, now: NOW });
   assert.equal(estimate.totalNonRemovedSubmissions, 40);
   assert.equal(estimate.completedPlayableCount, 20);
   assert.equal(estimate.sponsorBreakThreshold, 20);
@@ -97,7 +102,7 @@ test("three owed wheel spins add at least six minutes ceremony overhead", () => 
 test("sponsor break and wheel ceremony seconds can be explicitly set to zero", () => {
   const completed = Array.from({ length: 20 }, (_, index) => track(`played-zero-${index}`, { status: "played", completedAt: "2026-01-01T00:00:00.000Z" }));
   const queue = Array.from({ length: 20 }, (_, index) => track(`queued-zero-${index}`));
-  const sponsor = timing.estimateSponsorBreakPlacement({ completed, queue }, { sponsorBreakAlreadyRun: false, sponsorBreakSeconds: 0 });
+  const sponsor = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_2H20_AGO } }, { sponsorBreakAlreadyRun: false, sponsorBreakSeconds: 0, now: NOW });
   const wheel = timing.estimateWheelCeremonySeconds(3, { wheelCeremonySeconds: 0 });
   assert.equal(sponsor.sponsorBreakIncluded, true);
   assert.equal(sponsor.sponsorBreakSeconds, 0);
@@ -236,4 +241,73 @@ test("range formatting widens low-confidence ranges", () => {
   const low = timing.buildProjectionRangeSeconds(20 * 60, "low");
   assert.ok(low.min < medium.min);
   assert.ok(low.max > medium.max);
+});
+
+
+test("sponsor break is not included before 2h even when midpoint is reached", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`pre2h-done-${index}`, { status: "played", completedAt: START_1H30_AGO }));
+  const queue = Array.from({ length: 20 }, (_, index) => track(`pre2h-queued-${index}`, { detectedDurationSeconds: 60 }));
+  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_1H30_AGO } }, { targetSongsAhead: 1, targetProjectedSecondsAhead: 20 * 60, now: NOW });
+  assert.equal(estimate.midpointReached, true);
+  assert.equal(estimate.minElapsedGateReached, false);
+  assert.equal(estimate.sponsorBreakIncluded, false);
+});
+
+test("sponsor break is included after 2h when midpoint was already reached", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`post2h-done-${index}`, { status: "played", completedAt: START_1H45_AGO }));
+  const queue = Array.from({ length: 20 }, (_, index) => track(`post2h-queued-${index}`, { detectedDurationSeconds: 60 }));
+  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_1H45_AGO } }, { targetSongsAhead: 1, targetProjectedSecondsAhead: 23 * 60, now: NOW });
+  assert.equal(estimate.midpointReached, true);
+  assert.equal(estimate.minElapsedGateReached, true);
+  assert.equal(estimate.sponsorBreakIncluded, true);
+});
+
+test("sponsor break waits for midpoint after 2h gate", () => {
+  const completed = Array.from({ length: 10 }, (_, index) => track(`wait-mid-done-${index}`, { status: "played", completedAt: START_2H20_AGO }));
+  const queue = Array.from({ length: 30 }, (_, index) => track(`wait-mid-queued-${index}`, { detectedDurationSeconds: 60 }));
+  const beforeMidpoint = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_2H20_AGO } }, { targetSongsAhead: 9, targetProjectedSecondsAhead: 10 * 60, now: NOW });
+  const atMidpoint = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_2H20_AGO } }, { targetSongsAhead: 10, targetProjectedSecondsAhead: 12 * 60, now: NOW });
+  assert.equal(beforeMidpoint.minElapsedGateReached, true);
+  assert.equal(beforeMidpoint.midpointReached, false);
+  assert.equal(beforeMidpoint.sponsorBreakIncluded, false);
+  assert.equal(atMidpoint.sponsorBreakIncluded, true);
+});
+
+test("sponsor break point is the later of midpoint and the 2h gate", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`later-gate-done-${index}`, { status: "played" }));
+  const queue = Array.from({ length: 20 }, (_, index) => track(`later-gate-queued-${index}`, { detectedDurationSeconds: 60 }));
+  const waitsForGate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_1H45_AGO } }, { targetSongsAhead: 0, targetProjectedSecondsAhead: 5 * 60, now: NOW });
+  const crossesGate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { broadcastStartedAt: START_1H45_AGO } }, { targetSongsAhead: 0, targetProjectedSecondsAhead: 20 * 60, now: NOW });
+  const waitsForMidpoint = timing.estimateSponsorBreakPlacement({ completed: completed.slice(0, 10), queue: Array.from({ length: 30 }, (_, index) => track(`later-mid-${index}`)), session: { broadcastStartedAt: START_2H20_AGO } }, { targetSongsAhead: 9, targetProjectedSecondsAhead: 20 * 60, now: NOW });
+  assert.equal(waitsForGate.sponsorBreakIncluded, false);
+  assert.equal(crossesGate.sponsorBreakIncluded, true);
+  assert.equal(waitsForMidpoint.sponsorBreakIncluded, false);
+});
+
+test("skipped sponsor break is not included", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`played-skipped-sponsor-${index}`, { status: "played", completedAt: START_2H20_AGO }));
+  const queue = Array.from({ length: 20 }, (_, index) => track(`queued-skipped-sponsor-${index}`));
+  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue, session: { sponsorBreakStatus: "skipped", sponsorBreakCompletedAt: NOW.toISOString(), broadcastStartedAt: START_2H20_AGO } }, { now: NOW });
+  assert.equal(estimate.sponsorBreakStatus, "skipped");
+  assert.equal(estimate.sponsorBreakIncluded, false);
+});
+
+test("unknown broadcast start keeps sponsor gate conservative without exact 2h claim", () => {
+  const completed = Array.from({ length: 20 }, (_, index) => track(`unknown-start-done-${index}`, { status: "played" }));
+  const queue = Array.from({ length: 20 }, (_, index) => track(`unknown-start-queued-${index}`));
+  const estimate = timing.estimateSponsorBreakPlacement({ completed, queue }, { targetSongsAhead: 20, targetProjectedSecondsAhead: 3 * 3600, now: NOW });
+  assert.equal(estimate.broadcastStartedAt, null);
+  assert.equal(estimate.minElapsedGateReached, null);
+  assert.equal(estimate.sponsorBreakIncluded, false);
+  assert.ok(estimate.sponsorBreakNotes.some((note) => note.includes("playback start is unavailable")));
+});
+
+test("projected show runtime includes sponsor break only when show crosses final break point", () => {
+  const shortQueue = Array.from({ length: 5 }, (_, index) => track(`short-${index}`, { detectedDurationSeconds: 60 }));
+  const longCompleted = Array.from({ length: 20 }, (_, index) => track(`long-done-${index}`, { status: "played", completedAt: START_1H45_AGO }));
+  const longQueue = Array.from({ length: 20 }, (_, index) => track(`long-${index}`, { detectedDurationSeconds: 60 }));
+  const shortSnapshot = timing.buildQueueTimingSnapshot({ queue: shortQueue, session: { broadcastStartedAt: START_1H30_AGO } }, { now: NOW });
+  const longSnapshot = timing.buildQueueTimingSnapshot({ completed: longCompleted, queue: longQueue, session: { broadcastStartedAt: START_1H45_AGO } }, { now: NOW });
+  assert.equal(shortSnapshot.sponsorBreakSecondsIncluded, 0);
+  assert.equal(longSnapshot.sponsorBreakSecondsIncluded, timing.DEFAULT_SPONSOR_BREAK_SECONDS);
 });


### PR DESCRIPTION
### Motivation
- Prevent the mid-show commercial/sponsor break from being scheduled before 2 hours of actual broadcast playback while preserving the midpoint placement rule.
- Record a reliable broadcast start for timing when available and otherwise fall back to best-effort derivation from playback timestamps.

### Description
- Add a 2-hour minimum-elapsed constant `DEFAULT_SPONSOR_BREAK_MIN_ELAPSED_SECONDS = 7200` and expose it in timing/display code. (src/lib/queue-timing.ts)
- Extend the sponsor placement helper to consider both the midpoint threshold and a 2‑hour broadcast elapsed gate, deriving `broadcastStartedAt` from explicit session metadata or first-played/loaded timestamps when available; break inclusion now requires the later of the two. (src/lib/queue-timing.ts)
- Add `broadcastStartedAt` session metadata and initialize/set it only when playback actually begins (on first load/played completion), not when intake opens. (src/lib/queue.ts, src/lib/queue-types.ts)
- Update projected timeline generation so segments only insert the sponsor break when the projection crosses the final break point (midpoint OR 2h gate). (src/lib/queue-timing.ts)
- Surface compact admin diagnostics and labels explaining gate state (Not eligible yet, Midpoint reached · waiting for 2h mark, 2h mark reached · waiting for midpoint, Due now, Completed, Skipped) while keeping public copy minimal (public note only appears when the break is actually included). (src/lib/queue-timing-display.ts, src/components/AdminRadioQueueControl.tsx)
- Add conservative/robust helper behavior for unknown broadcast start (returns null/unknown and avoids overconfident 2h claims). (src/lib/queue-timing.ts)
- Tests added/updated to cover the new gate logic and admin/public diagnostics. (tests/queue-timing.test.mjs, tests/queue-timing-display.test.mjs)
- No changes were made to resolver/payment/checkout/webhook, priority overlay, wheel alternation, finish/remove semantics, provider duration fetching, or upload UI behavior.

Files changed: src/lib/queue-timing.ts, src/lib/queue-timing-display.ts, src/lib/queue-types.ts, src/lib/queue.ts, src/components/AdminRadioQueueControl.tsx, tests/queue-timing.test.mjs, tests/queue-timing-display.test.mjs

### Testing
- Ran unit tests: `node --test tests/queue-timing.test.mjs` and `node --test tests/queue-timing-display.test.mjs`, both passed.
- Ran typecheck: `npx tsc --noEmit --pretty false`, which passed.
- Ran lint on changed files: `npm run lint -- src/lib/queue-timing.ts src/lib/queue-timing-display.ts src/lib/queue-types.ts src/lib/queue.ts src/components/AdminRadioQueueControl.tsx`, which passed.
- Verified `git diff --check` for whitespace/errors; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0534d694288321b25a61ecd9068b92)