### PR TITLE
Wheel Ceremony Overlay + Spin Control

### DIFF
--- a/public/audio/wheel/README.md
+++ b/public/audio/wheel/README.md
@@ -1,0 +1,43 @@
+# BARCODE Radio Wheel Audio
+
+Drop approved wheel spin music and sound effects in this folder.
+
+## First expected wheel spin filenames
+
+Use these exact names when adding local MP3s so the wheel audio manifest can reference them cleanly later:
+
+```text
+wheel-spin-01-creepy-circus-astronautflute.mp3
+wheel-spin-02-dark-circus-top-sue.mp3
+wheel-spin-03-comedy-circus-top-sue.mp3
+wheel-spin-04-circus-fast-andorios.mp3
+wheel-spin-05-carousel-circus-chakong.mp3
+wheel-spin-06-circus-bear-studiokolomna.mp3
+wheel-spin-07-upbeat-corporate-kornevmusic.mp3
+wheel-spin-08-corporate-music-absolutesound.mp3
+wheel-spin-09-corporate-music-2-absolutesound.mp3
+wheel-spin-10-this-heavy-metal-mrclaps.mp3
+wheel-spin-11-metal-dark-matter-alexgrohl.mp3
+wheel-spin-12-burn-it-down-alexgrohl.mp3
+wheel-spin-13-8bit-retro-the-mountain.mp3
+wheel-spin-14-retro-swing-the-mountain.mp3
+wheel-spin-15-retro-arcade-mondamusic.mp3
+wheel-spin-16-synthwave-retro-80s-monume.mp3
+wheel-spin-17-retro-game-arcade-moodmode.mp3
+wheel-spin-18-retro-surf-rock-tunetank.mp3
+```
+
+## Optional future SFX filenames
+
+```text
+sfx-reencrypt.mp3
+sfx-result-lock.mp3
+sfx-confirm.mp3
+```
+
+## Rules
+
+- Only add audio that BARCODE owns, generated in-house, or has a clear license for this use.
+- Keep third-party license notes outside this folder or in a future `CREDITS.md` if needed.
+- Do not hotlink audio from external sites for live wheel playback.
+- Keep file names lowercase, hyphenated, and stable once referenced in code.

--- a/src/app/api/admin/overlay/live/route.ts
+++ b/src/app/api/admin/overlay/live/route.ts
@@ -18,5 +18,9 @@ export async function GET() {
 export async function POST(req: Request) {
   if (!(await assertAdmin())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await req.json().catch(() => ({}));
-  return NextResponse.json(await setLiveOverlayState(body), { headers: { "Cache-Control": "no-store" } });
+  try {
+    return NextResponse.json(await setLiveOverlayState(body), { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Overlay update failed." }, { status: 400, headers: { "Cache-Control": "no-store" } });
+  }
 }

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -312,169 +312,221 @@ body > div:last-of-type {
   font-size: clamp(0.85rem, 2.35vmin, 1.9rem);
 }
 
-.live-overlay-wheel-scene {
-  position: relative;
-  display: grid;
-  width: 88vmin;
-  grid-template-columns: minmax(0, 0.9fr) minmax(34vmin, 1.1fr);
-  gap: 4vmin;
-  align-items: center;
+
+.live-overlay-stage--wheel-ceremony .live-overlay-header {
+  left: 3.6vmin;
+  right: 3.6vmin;
+  top: 2.7vmin;
+  z-index: 8;
+  color: rgba(255, 255, 255, 0.66);
 }
 
-.live-overlay-wheel-copy h1 {
+.live-overlay-stage--wheel-ceremony .live-overlay-content {
+  padding: 0;
+}
+
+.live-overlay-stage--wheel-ceremony .live-overlay-corners::before,
+.live-overlay-stage--wheel-ceremony .live-overlay-corners::after {
+  opacity: 0.48;
+}
+
+.live-overlay-wheel-scene {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.live-overlay-wheel-heading {
+  position: absolute;
+  top: 7.2vmin;
+  left: 7vmin;
+  z-index: 7;
+  max-width: 38vmin;
+  border-left: 0.45vmin solid #67e8f9;
+  background: linear-gradient(90deg, rgba(2, 6, 23, 0.86), rgba(2, 6, 23, 0.2), transparent);
+  padding: 1.4vmin 1.8vmin;
+  text-shadow: 0 0 1.6vmin rgba(0, 0, 0, 0.95);
+}
+
+.live-overlay-wheel-heading .live-overlay-mode {
+  margin: 0 0 0.7vmin;
+  font-size: clamp(0.56rem, 1.25vmin, 0.82rem);
+}
+
+.live-overlay-wheel-heading h1 {
   margin: 0;
   color: #fff;
-  font-size: clamp(2rem, 7.6vmin, 6rem);
+  font-size: clamp(1.1rem, 3.4vmin, 2.7rem);
   font-weight: 950;
-  line-height: 0.9;
-  text-transform: uppercase;
-  text-shadow: 0.16rem 0 #22d3ee, -0.12rem 0 rgba(255,255,255,0.28);
-}
-
-.live-overlay-wheel-copy h2 {
-  margin: 1.4vmin 0 0;
-  color: #a5f3fc;
-  font-size: clamp(1rem, 3.8vmin, 2.8rem);
-  letter-spacing: 0.18em;
+  line-height: 0.88;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .live-overlay-wheel-wrap {
-  position: relative;
+  position: absolute;
+  inset: 4.9vmin;
   display: grid;
-  aspect-ratio: 1 / 1;
   place-items: center;
 }
 
 .live-overlay-wheel-pointer {
   position: absolute;
-  top: 0.5vmin;
-  z-index: 3;
+  top: -0.15vmin;
+  z-index: 9;
   width: 0;
   height: 0;
-  border-right: 2.2vmin solid transparent;
-  border-left: 2.2vmin solid transparent;
-  border-top: 5vmin solid #fff;
-  filter: drop-shadow(0 0 1.2vmin rgba(34, 211, 238, 0.9));
+  border-right: 3.1vmin solid transparent;
+  border-left: 3.1vmin solid transparent;
+  border-top: 7.2vmin solid #fff;
+  filter: drop-shadow(0 0 1.5vmin rgba(34, 211, 238, 0.95)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9));
 }
 
 .live-overlay-wheel {
   position: relative;
   display: grid;
-  width: min(43vmin, 100%);
+  width: min(91.5vmin, 100%);
   aspect-ratio: 1 / 1;
   place-items: center;
-  border: 0.6vmin solid rgba(165, 243, 252, 0.95);
+  border: 0.75vmin solid rgba(219, 252, 255, 0.96);
   border-radius: 999px;
+  background: #03131a;
+  box-shadow:
+    inset 0 0 0 0.25vmin rgba(2, 6, 23, 0.9),
+    inset 0 0 8vmin rgba(0, 0, 0, 0.66),
+    0 0 7vmin rgba(34, 211, 238, 0.42);
+}
+
+.live-overlay-wheel-slices {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
   background:
-    radial-gradient(circle at center, #02151b 0 24%, transparent 25%),
-    conic-gradient(from 0deg, rgba(34, 211, 238, 0.92), rgba(2, 132, 199, 0.5), rgba(255,255,255,0.88), rgba(34, 211, 238, 0.92));
-  box-shadow: inset 0 0 4vmin rgba(0, 0, 0, 0.72), 0 0 4vmin rgba(34, 211, 238, 0.35);
+    radial-gradient(circle at center, transparent 0 19%, rgba(2, 6, 23, 0.18) 19.5% 100%),
+    var(--wheel-slice-background);
+  overflow: hidden;
+}
+
+.live-overlay-wheel-slices::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  border-radius: inherit;
+  background:
+    radial-gradient(circle, transparent 0 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.4) 100%);
 }
 
 .live-overlay-wheel-scene--spinning .live-overlay-wheel {
   animation: live-wheel-spin var(--wheel-spin-duration, 6.5s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
 }
 
-.live-overlay-wheel-name {
+.live-overlay-wheel-slice-label {
   position: absolute;
-  display: inline-block;
-  max-width: 15vmin;
+  z-index: 2;
+  top: 50%;
+  left: 50%;
+  width: 50%;
+  height: 0;
+  transform: rotate(calc(var(--wheel-label-angle) - 90deg));
+  transform-origin: 0 0;
+}
+
+.live-overlay-wheel-slice-label > span {
+  position: absolute;
+  right: 10.4vmin;
+  display: block;
+  width: 28vmin;
   overflow: hidden;
-  color: #001015;
-  font-size: clamp(0.55rem, 1.35vmin, 0.9rem);
-  font-weight: 900;
-  letter-spacing: 0.08em;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.23);
+  padding: 0.45vmin 0.8vmin;
+  color: #03131a;
+  font-size: clamp(0.6rem, var(--wheel-name-size, 1.28vmin), 1.58rem);
+  font-weight: 950;
+  letter-spacing: 0.07em;
+  line-height: 1;
   text-align: center;
   text-overflow: ellipsis;
+  text-shadow: 0 0 0.5vmin rgba(255, 255, 255, 0.55);
   text-transform: uppercase;
   white-space: nowrap;
-  transform-origin: 50% 21vmin;
+  transform: translateY(-50%);
 }
 
 .live-overlay-wheel-core {
   position: absolute;
+  z-index: 5;
   display: grid;
-  width: 16vmin;
+  width: 20vmin;
   aspect-ratio: 1 / 1;
   place-items: center;
-  border: 0.35vmin solid rgba(255,255,255,0.85);
+  border: 0.45vmin solid rgba(255,255,255,0.9);
   border-radius: 999px;
-  background: #020617;
+  background: radial-gradient(circle, #082f49 0 24%, #020617 72%);
   color: #67e8f9;
   text-align: center;
-  box-shadow: 0 0 2vmin rgba(0,0,0,0.7);
+  box-shadow: 0 0 3.5vmin rgba(0,0,0,0.85), inset 0 0 2.5vmin rgba(103, 232, 249, 0.2);
 }
 
 .live-overlay-wheel-core span {
-  font-size: clamp(1.5rem, 5vmin, 3.4rem);
+  font-size: clamp(1.9rem, 6.3vmin, 4.5rem);
   font-weight: 950;
-  line-height: 0.8;
+  line-height: 0.75;
 }
 
 .live-overlay-wheel-core small {
-  color: rgba(255,255,255,0.74);
-  font-size: clamp(0.48rem, 1.2vmin, 0.75rem);
-  letter-spacing: 0.16em;
+  color: rgba(255,255,255,0.78);
+  font-size: clamp(0.5rem, 1.35vmin, 0.9rem);
+  letter-spacing: 0.18em;
 }
 
 .live-overlay-wheel-empty {
+  z-index: 3;
   color: #020617;
-  font-size: clamp(0.8rem, 2vmin, 1.2rem);
-  font-weight: 900;
-  letter-spacing: 0.14em;
-}
-
-.live-overlay-wheel-roster {
-  position: absolute;
-  right: 2vmin;
-  bottom: -5vmin;
-  left: 2vmin;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.8vmin;
-}
-
-.live-overlay-wheel-roster span {
-  border: 1px solid rgba(103, 232, 249, 0.35);
-  background: rgba(2, 6, 23, 0.68);
-  padding: 0.6vmin 0.9vmin;
-  color: rgba(255,255,255,0.78);
-  font-size: clamp(0.52rem, 1.25vmin, 0.82rem);
+  font-size: clamp(0.9rem, 2.2vmin, 1.4rem);
+  font-weight: 950;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
-.live-overlay-wheel-result {
+.live-overlay-wheel-status {
   position: absolute;
-  right: 1vmin;
-  bottom: 4vmin;
-  left: 1vmin;
-  z-index: 4;
-  border: 0.35vmin solid rgba(103, 232, 249, 0.9);
-  background: rgba(2, 6, 23, 0.92);
-  padding: 2vmin;
+  right: 8vmin;
+  bottom: 7vmin;
+  left: 8vmin;
+  z-index: 7;
+  display: grid;
+  justify-items: center;
+  border: 0.35vmin solid rgba(103, 232, 249, 0.82);
+  background: rgba(2, 6, 23, 0.87);
+  padding: 1.4vmin 2vmin;
   text-align: center;
-  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.32);
+  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.26);
 }
 
-.live-overlay-wheel-result span,
-.live-overlay-wheel-result em {
+.live-overlay-wheel-status span,
+.live-overlay-wheel-status em {
   display: block;
   color: #a5f3fc;
-  font-size: clamp(0.65rem, 1.5vmin, 1rem);
+  font-size: clamp(0.6rem, 1.45vmin, 0.95rem);
   font-style: normal;
   letter-spacing: 0.24em;
   text-transform: uppercase;
 }
 
-.live-overlay-wheel-result strong {
+.live-overlay-wheel-status strong {
   display: block;
-  margin: 0.5vmin 0;
+  max-width: 78vmin;
+  overflow: hidden;
   color: #fff;
-  font-size: clamp(1.4rem, 4.5vmin, 3.4rem);
-  line-height: 0.92;
+  font-size: clamp(1rem, 3.2vmin, 2.7rem);
+  font-weight: 950;
+  line-height: 0.95;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 @keyframes live-wheel-spin {
@@ -484,20 +536,22 @@ body > div:last-of-type {
 }
 
 @media (max-aspect-ratio: 4 / 5) {
-  .live-overlay-wheel-scene {
-    width: 82vmin;
-    grid-template-columns: 1fr;
-    gap: 2vmin;
-    text-align: center;
-  }
-
   .live-overlay-wheel-wrap {
-    width: 48vmin;
-    justify-self: center;
+    inset: 5.8vmin;
   }
 
-  .live-overlay-wheel-roster {
-    position: static;
-    margin-top: 1vmin;
+  .live-overlay-wheel {
+    width: min(90vmin, 100%);
+  }
+
+  .live-overlay-wheel-slice-label > span {
+    right: 9.4vmin;
+    width: 26vmin;
+  }
+
+  .live-overlay-wheel-status {
+    right: 6vmin;
+    bottom: 6vmin;
+    left: 6vmin;
   }
 }

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -418,7 +418,8 @@ body > div:last-of-type {
     radial-gradient(circle, transparent 0 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.4) 100%);
 }
 
-.live-overlay-wheel-scene--spinning .live-overlay-wheel {
+.live-overlay-wheel-scene--spinning .live-overlay-wheel,
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel {
   animation: live-wheel-spin var(--wheel-spin-duration, 6.5s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
 }
 
@@ -435,12 +436,12 @@ body > div:last-of-type {
 
 .live-overlay-wheel-slice-label > span {
   position: absolute;
-  right: 10.4vmin;
+  right: var(--wheel-label-distance, 10.4vmin);
   display: block;
-  width: 28vmin;
+  width: var(--wheel-label-width, 28vmin);
   overflow: hidden;
   border-radius: 999px;
-  background: rgba(2, 6, 23, 0.23);
+  background: rgba(255, 255, 255, 0.66);
   padding: 0.45vmin 0.8vmin;
   color: #03131a;
   font-size: clamp(0.6rem, var(--wheel-name-size, 1.28vmin), 1.58rem);
@@ -449,7 +450,7 @@ body > div:last-of-type {
   line-height: 1;
   text-align: center;
   text-overflow: ellipsis;
-  text-shadow: 0 0 0.5vmin rgba(255, 255, 255, 0.55);
+  text-shadow: 0 0 0.5vmin rgba(255, 255, 255, 0.35);
   text-transform: uppercase;
   white-space: nowrap;
   transform: translateY(-50%);
@@ -506,6 +507,57 @@ body > div:last-of-type {
   box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.26);
 }
 
+
+.live-overlay-wheel-scene--spinning .live-overlay-wheel-slices,
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slices {
+  animation: live-wheel-slice-glow 0.7s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-scene--spinning .live-overlay-wheel-pointer,
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-pointer {
+  animation: live-wheel-pointer-pulse 0.62s ease-in-out infinite;
+}
+
+.live-overlay-wheel-scene--spinning .live-overlay-wheel-core,
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-core {
+  animation: live-wheel-core-glow 1.1s ease-in-out infinite;
+}
+
+.live-overlay-wheel-scene--reencrypting::before {
+  position: absolute;
+  inset: 0;
+  z-index: 6;
+  content: "";
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, transparent 0 15%, rgba(103, 232, 249, 0.32) 18%, transparent 21% 52%, rgba(255, 43, 109, 0.24) 55%, transparent 58%),
+    repeating-linear-gradient(0deg, transparent 0 1.4vmin, rgba(255, 255, 255, 0.16) 1.45vmin 1.7vmin, transparent 1.75vmin 3.2vmin);
+  mix-blend-mode: screen;
+  animation: live-wheel-reencrypt-sweep 0.42s steps(3, end) infinite;
+}
+
+.live-overlay-wheel-glitch {
+  position: absolute;
+  top: 45%;
+  left: 50%;
+  z-index: 10;
+  border: 0.28vmin solid rgba(255, 255, 255, 0.82);
+  background: rgba(2, 6, 23, 0.9);
+  padding: 1vmin 1.6vmin;
+  color: #67e8f9;
+  font-size: clamp(0.8rem, 2.4vmin, 1.8rem);
+  font-weight: 950;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 3vmin rgba(103, 232, 249, 0.45);
+  animation: live-wheel-glitch-card 0.5s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-scene--confirmed .live-overlay-wheel-status {
+  animation: live-wheel-result-lock 0.9s ease-out both;
+}
+
 .live-overlay-wheel-status span,
 .live-overlay-wheel-status em {
   display: block;
@@ -529,6 +581,39 @@ body > div:last-of-type {
   white-space: nowrap;
 }
 
+
+@keyframes live-wheel-slice-glow {
+  0%, 100% { filter: saturate(1.1) brightness(1); }
+  50% { filter: saturate(1.45) brightness(1.18); }
+}
+
+@keyframes live-wheel-pointer-pulse {
+  0%, 100% { transform: translateY(0); filter: drop-shadow(0 0 1.5vmin rgba(34, 211, 238, 0.95)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9)); }
+  50% { transform: translateY(0.55vmin); filter: drop-shadow(0 0 2.6vmin rgba(255, 255, 255, 1)) drop-shadow(0 0 1.2vmin rgba(34, 211, 238, 1)); }
+}
+
+@keyframes live-wheel-core-glow {
+  0%, 100% { box-shadow: 0 0 3.5vmin rgba(0,0,0,0.85), inset 0 0 2.5vmin rgba(103, 232, 249, 0.2); }
+  50% { box-shadow: 0 0 5vmin rgba(103, 232, 249, 0.58), inset 0 0 3.4vmin rgba(103, 232, 249, 0.35); }
+}
+
+@keyframes live-wheel-reencrypt-sweep {
+  0% { transform: translateX(-12%); opacity: 0.16; }
+  50% { opacity: 0.52; }
+  100% { transform: translateX(12%); opacity: 0.22; }
+}
+
+@keyframes live-wheel-glitch-card {
+  0%, 100% { clip-path: inset(0 0 0 0); transform: translate(-50%, -50%) skewX(0deg); }
+  35% { clip-path: inset(10% 0 18% 0); transform: translate(-49%, -51%) skewX(-6deg); }
+  70% { clip-path: inset(18% 0 8% 0); transform: translate(-51%, -49%) skewX(5deg); }
+}
+
+@keyframes live-wheel-result-lock {
+  0% { transform: scale(0.96); filter: brightness(1.8); }
+  100% { transform: scale(1); filter: brightness(1); }
+}
+
 @keyframes live-wheel-spin {
   0% { transform: rotate(0deg); }
   82% { transform: rotate(calc(var(--wheel-final-rotation, 1260deg) - 22deg)); }
@@ -545,8 +630,8 @@ body > div:last-of-type {
   }
 
   .live-overlay-wheel-slice-label > span {
-    right: 9.4vmin;
-    width: 26vmin;
+    right: var(--wheel-label-distance, 9.4vmin);
+    width: var(--wheel-label-width, 26vmin);
   }
 
   .live-overlay-wheel-status {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -318,7 +318,9 @@ body > div:last-of-type {
   right: 3.6vmin;
   top: 2.7vmin;
   z-index: 8;
-  color: rgba(255, 255, 255, 0.66);
+  color: rgba(255, 255, 255, 0.74);
+  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
+  text-shadow: 0 0 1.2vmin rgba(103, 232, 249, 0.42);
 }
 
 .live-overlay-stage--wheel-ceremony .live-overlay-content {
@@ -330,38 +332,58 @@ body > div:last-of-type {
   opacity: 0.48;
 }
 
+.live-overlay-stage--wheel-ceremony::before {
+  position: absolute;
+  inset: 2.2vmin;
+  z-index: 0;
+  content: "";
+  border: 1px solid rgba(103, 232, 249, 0.16);
+  background:
+    linear-gradient(90deg, rgba(103, 232, 249, 0.12), transparent 18% 82%, rgba(255, 43, 109, 0.1)),
+    repeating-linear-gradient(90deg, transparent 0 8vmin, rgba(103, 232, 249, 0.035) 8.1vmin 8.25vmin),
+    repeating-linear-gradient(0deg, transparent 0 6vmin, rgba(255, 255, 255, 0.025) 6.1vmin 6.2vmin);
+  clip-path: polygon(0 0, 28% 0, 30% 1.2vmin, 70% 1.2vmin, 72% 0, 100% 0, 100% 100%, 72% 100%, 70% calc(100% - 1.2vmin), 30% calc(100% - 1.2vmin), 28% 100%, 0 100%);
+  pointer-events: none;
+}
+
 .live-overlay-wheel-scene {
   position: absolute;
   inset: 0;
   display: grid;
   place-items: center;
   overflow: hidden;
+  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", "Space Mono", monospace;
 }
 
 .live-overlay-wheel-heading {
   position: absolute;
-  top: 7.2vmin;
-  left: 7vmin;
+  top: 6.6vmin;
+  left: 6.4vmin;
   z-index: 7;
-  max-width: 38vmin;
-  border-left: 0.45vmin solid #67e8f9;
-  background: linear-gradient(90deg, rgba(2, 6, 23, 0.86), rgba(2, 6, 23, 0.2), transparent);
-  padding: 1.4vmin 1.8vmin;
-  text-shadow: 0 0 1.6vmin rgba(0, 0, 0, 0.95);
+  max-width: 42vmin;
+  border: 1px solid rgba(103, 232, 249, 0.38);
+  border-left: 0.62vmin solid #67e8f9;
+  background: linear-gradient(90deg, rgba(2, 6, 23, 0.92), rgba(8, 47, 73, 0.42), rgba(2, 6, 23, 0.08));
+  padding: 1.3vmin 1.9vmin 1.35vmin;
+  box-shadow: 0.8vmin 0.8vmin 0 rgba(2, 6, 23, 0.55), inset 0 0 2vmin rgba(103, 232, 249, 0.14), 0 0 3vmin rgba(34, 211, 238, 0.12);
+  text-shadow: 0 0 1.6vmin rgba(0, 0, 0, 0.95), 0 0 1vmin rgba(103, 232, 249, 0.34);
+  clip-path: polygon(0 0, calc(100% - 2.2vmin) 0, 100% 2.2vmin, 100% 100%, 0 100%);
 }
 
 .live-overlay-wheel-heading .live-overlay-mode {
-  margin: 0 0 0.7vmin;
-  font-size: clamp(0.56rem, 1.25vmin, 0.82rem);
+  margin: 0 0 0.65vmin;
+  color: #67e8f9;
+  font-size: clamp(0.6rem, 1.32vmin, 0.88rem);
+  letter-spacing: 0.34em;
 }
 
 .live-overlay-wheel-heading h1 {
   margin: 0;
   color: #fff;
-  font-size: clamp(1.1rem, 3.4vmin, 2.7rem);
+  font-size: clamp(1.25rem, 3.6vmin, 2.9rem);
   font-weight: 950;
-  line-height: 0.88;
-  letter-spacing: 0.08em;
+  line-height: 0.86;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -387,16 +409,19 @@ body > div:last-of-type {
 .live-overlay-wheel {
   position: relative;
   display: grid;
-  width: min(91.5vmin, 100%);
+  width: min(92.5vmin, 100%);
   aspect-ratio: 1 / 1;
   place-items: center;
-  border: 0.75vmin solid rgba(219, 252, 255, 0.96);
+  border: 0.8vmin solid rgba(219, 252, 255, 0.98);
   border-radius: 999px;
-  background: #03131a;
+  background: radial-gradient(circle, #06131c 0 46%, #020617 100%);
   box-shadow:
-    inset 0 0 0 0.25vmin rgba(2, 6, 23, 0.9),
-    inset 0 0 8vmin rgba(0, 0, 0, 0.66),
-    0 0 7vmin rgba(34, 211, 238, 0.42);
+    inset 0 0 0 0.28vmin rgba(2, 6, 23, 0.96),
+    inset 0 0 0 1.3vmin rgba(103, 232, 249, 0.12),
+    inset 0 0 11vmin rgba(0, 0, 0, 0.72),
+    0 0 0 0.85vmin rgba(2, 6, 23, 0.7),
+    0 0 8vmin rgba(34, 211, 238, 0.5),
+    0 0 13vmin rgba(255, 43, 109, 0.12);
 }
 
 .live-overlay-wheel-slices {
@@ -415,7 +440,30 @@ body > div:last-of-type {
   content: "";
   border-radius: inherit;
   background:
-    radial-gradient(circle, transparent 0 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.4) 100%);
+    repeating-conic-gradient(from -90deg, rgba(2, 6, 23, 0.72) 0deg 0.38deg, transparent 0.38deg calc(360deg / var(--wheel-slice-count, 8))),
+    radial-gradient(circle, transparent 0 49%, rgba(255, 255, 255, 0.12) 50% 50.4%, transparent 51% 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.46) 100%);
+}
+
+.live-overlay-wheel::before,
+.live-overlay-wheel::after {
+  position: absolute;
+  content: "";
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.live-overlay-wheel::before {
+  inset: -1.6vmin;
+  border: 0.18vmin solid rgba(103, 232, 249, 0.38);
+  background: repeating-conic-gradient(from -90deg, rgba(103, 232, 249, 0.8) 0deg 0.9deg, transparent 0.9deg 7.5deg);
+  mask: radial-gradient(circle, transparent 0 48.5%, #000 49% 51%, transparent 51.5%);
+  opacity: 0.9;
+}
+
+.live-overlay-wheel::after {
+  inset: 2.6vmin;
+  border: 0.28vmin dashed rgba(2, 6, 23, 0.52);
+  box-shadow: inset 0 0 2.8vmin rgba(2, 6, 23, 0.32), 0 0 2.2vmin rgba(255, 255, 255, 0.1);
 }
 
 .live-overlay-wheel-scene--spinning .live-overlay-wheel,
@@ -434,41 +482,56 @@ body > div:last-of-type {
   transform-origin: 0 0;
 }
 
+.live-overlay-wheel-slice-label::before {
+  position: absolute;
+  right: calc(var(--wheel-label-distance, 10.4vmin) + 1vmin);
+  width: var(--wheel-rail-length, 20vmin);
+  height: 0.24vmin;
+  content: "";
+  background: linear-gradient(90deg, transparent, rgba(2, 6, 23, 0.46), rgba(255, 255, 255, 0.5));
+  transform: translateY(-50%);
+  opacity: 0.66;
+}
+
 .live-overlay-wheel-slice-label > span {
   position: absolute;
   right: var(--wheel-label-distance, 10.4vmin);
   display: block;
   width: var(--wheel-label-width, 28vmin);
   overflow: hidden;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.66);
-  padding: 0.45vmin 0.8vmin;
-  color: #03131a;
-  font-size: clamp(0.6rem, var(--wheel-name-size, 1.28vmin), 1.58rem);
+  border: 0.14vmin solid rgba(2, 6, 23, 0.46);
+  border-radius: 0.7vmin;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(219, 252, 255, 0.72), rgba(255, 255, 255, 0.5));
+  padding: 0.62vmin 1.05vmin 0.68vmin;
+  color: #020617;
+  font-size: clamp(0.72rem, var(--wheel-name-size, 1.45vmin), 4.5vmin);
   font-weight: 950;
-  letter-spacing: 0.07em;
-  line-height: 1;
+  letter-spacing: var(--wheel-letter-spacing, 0.06em);
+  line-height: 0.88;
   text-align: center;
   text-overflow: ellipsis;
-  text-shadow: 0 0 0.5vmin rgba(255, 255, 255, 0.35);
+  text-shadow: 0.08vmin 0 rgba(255, 255, 255, 0.72), 0 0 0.75vmin rgba(255, 255, 255, 0.55);
   text-transform: uppercase;
   white-space: nowrap;
   transform: translateY(-50%);
+  box-shadow: 0.35vmin 0.35vmin 0 rgba(2, 6, 23, 0.35), inset 0 0 1.2vmin rgba(103, 232, 249, 0.14);
 }
 
 .live-overlay-wheel-core {
   position: absolute;
   z-index: 5;
   display: grid;
-  width: 20vmin;
+  width: 21.5vmin;
   aspect-ratio: 1 / 1;
   place-items: center;
-  border: 0.45vmin solid rgba(255,255,255,0.9);
+  border: 0.5vmin solid rgba(255,255,255,0.92);
   border-radius: 999px;
-  background: radial-gradient(circle, #082f49 0 24%, #020617 72%);
+  background:
+    linear-gradient(135deg, rgba(103, 232, 249, 0.18), transparent 34% 66%, rgba(255, 43, 109, 0.14)),
+    radial-gradient(circle, #0c4a6e 0 18%, #082f49 19% 42%, #020617 74%);
   color: #67e8f9;
   text-align: center;
-  box-shadow: 0 0 3.5vmin rgba(0,0,0,0.85), inset 0 0 2.5vmin rgba(103, 232, 249, 0.2);
+  box-shadow: 0 0 4vmin rgba(0,0,0,0.9), 0 0 5vmin rgba(103, 232, 249, 0.28), inset 0 0 3vmin rgba(103, 232, 249, 0.24);
 }
 
 .live-overlay-wheel-core span {
@@ -478,9 +541,9 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-core small {
-  color: rgba(255,255,255,0.78);
+  color: rgba(255,255,255,0.82);
   font-size: clamp(0.5rem, 1.35vmin, 0.9rem);
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
 }
 
 .live-overlay-wheel-empty {
@@ -494,17 +557,19 @@ body > div:last-of-type {
 
 .live-overlay-wheel-status {
   position: absolute;
-  right: 8vmin;
-  bottom: 7vmin;
-  left: 8vmin;
+  right: 7vmin;
+  bottom: 6.4vmin;
+  left: 7vmin;
   z-index: 7;
   display: grid;
   justify-items: center;
-  border: 0.35vmin solid rgba(103, 232, 249, 0.82);
-  background: rgba(2, 6, 23, 0.87);
-  padding: 1.4vmin 2vmin;
+  border: 1px solid rgba(103, 232, 249, 0.52);
+  border-top: 0.36vmin solid rgba(103, 232, 249, 0.92);
+  background: linear-gradient(90deg, rgba(2, 6, 23, 0.94), rgba(8, 47, 73, 0.72), rgba(2, 6, 23, 0.94));
+  padding: 1.35vmin 2.4vmin 1.5vmin;
   text-align: center;
-  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.26);
+  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.28), inset 0 0 2.2vmin rgba(103, 232, 249, 0.11);
+  clip-path: polygon(2.4vmin 0, calc(100% - 2.4vmin) 0, 100% 50%, calc(100% - 2.4vmin) 100%, 2.4vmin 100%, 0 50%);
 }
 
 
@@ -562,23 +627,25 @@ body > div:last-of-type {
 .live-overlay-wheel-status em {
   display: block;
   color: #a5f3fc;
-  font-size: clamp(0.6rem, 1.45vmin, 0.95rem);
+  font-size: clamp(0.62rem, 1.5vmin, 1rem);
   font-style: normal;
-  letter-spacing: 0.24em;
+  font-weight: 850;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
 }
 
 .live-overlay-wheel-status strong {
   display: block;
-  max-width: 78vmin;
+  max-width: 82vmin;
   overflow: hidden;
   color: #fff;
-  font-size: clamp(1rem, 3.2vmin, 2.7rem);
+  font-size: clamp(1.1rem, 3.45vmin, 2.95rem);
   font-weight: 950;
-  line-height: 0.95;
+  line-height: 0.92;
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
+  text-shadow: 0.12vmin 0 rgba(103, 232, 249, 0.55), -0.08vmin 0 rgba(255, 43, 109, 0.36);
 }
 
 
@@ -626,7 +693,7 @@ body > div:last-of-type {
   }
 
   .live-overlay-wheel {
-    width: min(90vmin, 100%);
+    width: min(90.5vmin, 100%);
   }
 
   .live-overlay-wheel-slice-label > span {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -311,3 +311,193 @@ body > div:last-of-type {
   color: rgba(255, 255, 255, 0.78);
   font-size: clamp(0.85rem, 2.35vmin, 1.9rem);
 }
+
+.live-overlay-wheel-scene {
+  position: relative;
+  display: grid;
+  width: 88vmin;
+  grid-template-columns: minmax(0, 0.9fr) minmax(34vmin, 1.1fr);
+  gap: 4vmin;
+  align-items: center;
+}
+
+.live-overlay-wheel-copy h1 {
+  margin: 0;
+  color: #fff;
+  font-size: clamp(2rem, 7.6vmin, 6rem);
+  font-weight: 950;
+  line-height: 0.9;
+  text-transform: uppercase;
+  text-shadow: 0.16rem 0 #22d3ee, -0.12rem 0 rgba(255,255,255,0.28);
+}
+
+.live-overlay-wheel-copy h2 {
+  margin: 1.4vmin 0 0;
+  color: #a5f3fc;
+  font-size: clamp(1rem, 3.8vmin, 2.8rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-wrap {
+  position: relative;
+  display: grid;
+  aspect-ratio: 1 / 1;
+  place-items: center;
+}
+
+.live-overlay-wheel-pointer {
+  position: absolute;
+  top: 0.5vmin;
+  z-index: 3;
+  width: 0;
+  height: 0;
+  border-right: 2.2vmin solid transparent;
+  border-left: 2.2vmin solid transparent;
+  border-top: 5vmin solid #fff;
+  filter: drop-shadow(0 0 1.2vmin rgba(34, 211, 238, 0.9));
+}
+
+.live-overlay-wheel {
+  position: relative;
+  display: grid;
+  width: min(43vmin, 100%);
+  aspect-ratio: 1 / 1;
+  place-items: center;
+  border: 0.6vmin solid rgba(165, 243, 252, 0.95);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at center, #02151b 0 24%, transparent 25%),
+    conic-gradient(from 0deg, rgba(34, 211, 238, 0.92), rgba(2, 132, 199, 0.5), rgba(255,255,255,0.88), rgba(34, 211, 238, 0.92));
+  box-shadow: inset 0 0 4vmin rgba(0, 0, 0, 0.72), 0 0 4vmin rgba(34, 211, 238, 0.35);
+}
+
+.live-overlay-wheel-scene--spinning .live-overlay-wheel {
+  animation: live-wheel-spin var(--wheel-spin-duration, 6.5s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
+}
+
+.live-overlay-wheel-name {
+  position: absolute;
+  display: inline-block;
+  max-width: 15vmin;
+  overflow: hidden;
+  color: #001015;
+  font-size: clamp(0.55rem, 1.35vmin, 0.9rem);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transform-origin: 50% 21vmin;
+}
+
+.live-overlay-wheel-core {
+  position: absolute;
+  display: grid;
+  width: 16vmin;
+  aspect-ratio: 1 / 1;
+  place-items: center;
+  border: 0.35vmin solid rgba(255,255,255,0.85);
+  border-radius: 999px;
+  background: #020617;
+  color: #67e8f9;
+  text-align: center;
+  box-shadow: 0 0 2vmin rgba(0,0,0,0.7);
+}
+
+.live-overlay-wheel-core span {
+  font-size: clamp(1.5rem, 5vmin, 3.4rem);
+  font-weight: 950;
+  line-height: 0.8;
+}
+
+.live-overlay-wheel-core small {
+  color: rgba(255,255,255,0.74);
+  font-size: clamp(0.48rem, 1.2vmin, 0.75rem);
+  letter-spacing: 0.16em;
+}
+
+.live-overlay-wheel-empty {
+  color: #020617;
+  font-size: clamp(0.8rem, 2vmin, 1.2rem);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.live-overlay-wheel-roster {
+  position: absolute;
+  right: 2vmin;
+  bottom: -5vmin;
+  left: 2vmin;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8vmin;
+}
+
+.live-overlay-wheel-roster span {
+  border: 1px solid rgba(103, 232, 249, 0.35);
+  background: rgba(2, 6, 23, 0.68);
+  padding: 0.6vmin 0.9vmin;
+  color: rgba(255,255,255,0.78);
+  font-size: clamp(0.52rem, 1.25vmin, 0.82rem);
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-result {
+  position: absolute;
+  right: 1vmin;
+  bottom: 4vmin;
+  left: 1vmin;
+  z-index: 4;
+  border: 0.35vmin solid rgba(103, 232, 249, 0.9);
+  background: rgba(2, 6, 23, 0.92);
+  padding: 2vmin;
+  text-align: center;
+  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.32);
+}
+
+.live-overlay-wheel-result span,
+.live-overlay-wheel-result em {
+  display: block;
+  color: #a5f3fc;
+  font-size: clamp(0.65rem, 1.5vmin, 1rem);
+  font-style: normal;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-result strong {
+  display: block;
+  margin: 0.5vmin 0;
+  color: #fff;
+  font-size: clamp(1.4rem, 4.5vmin, 3.4rem);
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+@keyframes live-wheel-spin {
+  0% { transform: rotate(0deg); }
+  82% { transform: rotate(calc(var(--wheel-final-rotation, 1260deg) - 22deg)); }
+  100% { transform: rotate(var(--wheel-final-rotation, 1260deg)); }
+}
+
+@media (max-aspect-ratio: 4 / 5) {
+  .live-overlay-wheel-scene {
+    width: 82vmin;
+    grid-template-columns: 1fr;
+    gap: 2vmin;
+    text-align: center;
+  }
+
+  .live-overlay-wheel-wrap {
+    width: 48vmin;
+    justify-self: center;
+  }
+
+  .live-overlay-wheel-roster {
+    position: static;
+    margin-top: 1vmin;
+  }
+}

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -80,6 +80,7 @@ export function AdminLiveOverlayControl() {
             <p className="mt-1 text-sm text-muted">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</p>
             {!wheelActive && wheelOwed > 0 && <p className="mt-1 text-sm text-muted">Launch when you are ready to show the wheel on air. Launch does not choose a winner, consume spins, or change queue state.</p>}
             {ceremony?.status === "ready" && <p className="mt-1 text-sm text-muted">Candidates: {ceremony.candidateCount}. Awaiting host spin.</p>}
+            {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting signal before the next reveal…</p>}
             {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
             {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
             {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
@@ -89,10 +90,11 @@ export function AdminLiveOverlayControl() {
             {canLaunch && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel ceremony launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel</button>}
             {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
             {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel" }, "Wheel Chosen confirmed through queue admin.")} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background">Confirm Wheel Chosen</button>}
-            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel reroll started.")} disabled={candidates.length === 0} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Spin Again / Reroll</button>}
+            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={candidates.length === 0} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
             {wheelActive && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
+        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Scramble and spin again before confirmation.</p>}
         {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
       </section>
 

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -37,7 +37,8 @@ export function AdminLiveOverlayControl() {
       body: JSON.stringify(body),
     });
     if (!res.ok) {
-      setStatus("Overlay update failed.");
+      const errorBody = await res.json().catch(() => ({}));
+      setStatus(typeof errorBody.error === "string" ? errorBody.error : "Overlay update failed.");
       return;
     }
     setSnapshot(await res.json());
@@ -47,6 +48,11 @@ export function AdminLiveOverlayControl() {
   const scene = snapshot?.scene;
   const wheelOwed = scene?.wheelSpinsOwed ?? 0;
   const wheelActive = scene?.wheelOverlayActive === true;
+  const ceremony = scene?.wheelCeremony;
+  const candidates = snapshot?.wheelCandidates ?? [];
+  const result = ceremony?.resultTrack;
+  const canLaunch = wheelOwed > 0 && !wheelActive;
+  const canSpin = wheelOwed > 0 && ceremony?.status === "ready" && candidates.length > 0;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;
   const wheelAttention = wheelOwed > 0 || wheelActive;
 
@@ -67,17 +73,27 @@ export function AdminLiveOverlayControl() {
       </div>
 
       <section className={wheelAttention ? "space-y-3 border border-cyan-300/50 bg-cyan-300/10 p-4" : "space-y-3 border border-border bg-surface p-4 opacity-80"}>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-cyan-200">Wheel</p>
-            <h3 className="mt-1 text-lg font-bold text-foreground">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</h3>
-            {wheelAttention && <p className="mt-1 text-sm text-muted">Launch when ready to show the wheel on air. This visual trigger does not choose a winner, consume spins, or change queue state.</p>}
+            <h3 className="mt-1 text-lg font-bold text-foreground">{wheelActive ? sceneLabel(ceremony?.status) : wheelOwed > 0 ? "Wheel Spin Waiting" : "No Wheel Spin Waiting"}</h3>
+            <p className="mt-1 text-sm text-muted">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</p>
+            {!wheelActive && wheelOwed > 0 && <p className="mt-1 text-sm text-muted">Launch when you are ready to show the wheel on air. Launch does not choose a winner, consume spins, or change queue state.</p>}
+            {ceremony?.status === "ready" && <p className="mt-1 text-sm text-muted">Candidates: {ceremony.candidateCount}. Awaiting host spin.</p>}
+            {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
+            {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
+            {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
+            {wheelActive && candidates.length === 0 && <p className="mt-2 border border-danger/40 bg-danger/10 p-2 text-sm text-danger">No eligible Free/Regular queued tracks are available for Wheel Chosen.</p>}
           </div>
           <div className="flex flex-wrap gap-2">
-            {wheelOwed > 0 && !wheelActive && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel overlay launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel Overlay</button>}
-            {wheelActive && <button type="button" onClick={() => post({ action: "clearWheel" }, "Wheel overlay cleared; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Clear Wheel Overlay / Return to Auto</button>}
+            {canLaunch && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel ceremony launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel</button>}
+            {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
+            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel" }, "Wheel Chosen confirmed through queue admin.")} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background">Confirm Wheel Chosen</button>}
+            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel reroll started.")} disabled={candidates.length === 0} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Spin Again / Reroll</button>}
+            {wheelActive && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
+        {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
       </section>
 
       <details className="border border-border bg-background/40 p-4">

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import type { LiveOverlayYouTubeSync, ResolvedLiveOverlayScene } from "@/lib/live-overlay";
 
 type YTPlayer = {
@@ -42,7 +43,10 @@ function fallbackScene(): ResolvedLiveOverlayScene {
 function modeLabel(mode: ResolvedLiveOverlayScene["mode"]): string {
   if (mode === "now_playing") return "NOW PLAYING";
   if (mode === "artist_card") return "ARTIST CARD";
-  if (mode === "wheel_ready") return "WHEEL SIGNAL";
+  if (mode === "wheel_ready") return "WHEEL READY";
+  if (mode === "wheel_spinning") return "WHEEL SPINNING";
+  if (mode === "wheel_result") return "WHEEL RESULT";
+  if (mode === "wheel_confirmed") return "WHEEL CHOSEN";
   if (mode === "video_placeholder") return "VIDEO LINK";
   if (mode === "system_message") return "SYSTEM";
   if (mode === "session_active") return "LIVE INTAKE";
@@ -51,7 +55,7 @@ function modeLabel(mode: ResolvedLiveOverlayScene["mode"]): string {
 }
 
 function frameTone(mode: ResolvedLiveOverlayScene["mode"]): string {
-  if (mode === "wheel_ready") return "live-overlay-stage--wheel";
+  if (mode === "wheel_ready" || mode === "wheel_spinning" || mode === "wheel_result" || mode === "wheel_confirmed") return "live-overlay-stage--wheel";
   if (mode === "sponsor" || mode === "system_message") return "live-overlay-stage--message";
   if (mode === "video_placeholder") return "live-overlay-stage--video";
   return "";
@@ -59,6 +63,42 @@ function frameTone(mode: ResolvedLiveOverlayScene["mode"]): string {
 
 function showTrack(scene: ResolvedLiveOverlayScene): boolean {
   return Boolean((scene.mode === "now_playing" || scene.mode === "artist_card") && scene.track);
+}
+
+
+function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
+  const ceremony = scene.wheelCeremony;
+  const candidates = ceremony?.displayCandidates ?? [];
+  const result = ceremony?.resultTrack;
+  const spinning = ceremony?.status === "spinning";
+  const wheelStyle = { "--wheel-final-rotation": `${1080 + Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id)) * 31}deg`, "--wheel-spin-duration": `${Math.max(5, (ceremony?.spinDurationMs ?? 6500) / 1000)}s` } as CSSProperties;
+
+  return (
+    <div className={`live-overlay-wheel-scene ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`}>
+      <div className="live-overlay-wheel-copy">
+        <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
+        <h1>{scene.title}</h1>
+        {scene.subtitle && <h2>{scene.subtitle}</h2>}
+        <p className="live-overlay-message">{scene.message}</p>
+      </div>
+      <div className="live-overlay-wheel-wrap">
+        <div className="live-overlay-wheel-pointer" aria-hidden="true" />
+        <div className="live-overlay-wheel" style={wheelStyle}>
+          {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => (
+            <span key={candidate.id} className="live-overlay-wheel-name" style={{ transform: `rotate(${(360 / candidates.length) * index}deg) translateY(-21vmin)` }}>
+              {candidate.artistName}
+            </span>
+          ))}
+          <div className="live-overlay-wheel-core"><span>10K</span><small>TAP WHEEL</small></div>
+        </div>
+      </div>
+      <div className="live-overlay-wheel-roster">
+        {candidates.slice(0, 5).map((candidate) => <span key={candidate.id}>{candidate.artistName} — {candidate.trackTitle}</span>)}
+        {(ceremony?.hiddenCandidateCount ?? 0) > 0 && <span>+ {ceremony?.hiddenCandidateCount} more signals</span>}
+      </div>
+      {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-result"><span>{ceremony.status === "confirmed" ? "LOCKED" : "RESULT"}</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em></div>}
+    </div>
+  );
 }
 
 function expectedYouTubeTime(sync: LiveOverlayYouTubeSync): number {
@@ -165,6 +205,7 @@ export function LiveOverlayReceiver() {
   const label = useMemo(() => modeLabel(scene.mode), [scene.mode]);
   const trackVisible = showTrack(scene);
   const youtubeVisible = scene.mode === "now_playing" && scene.automatic && scene.youtube && scene.track;
+  const wheelVisible = Boolean(scene.wheelCeremony);
 
   return (
     <div className="live-overlay-shell" aria-label="BARCODE Radio live overlay receiver">
@@ -177,7 +218,9 @@ export function LiveOverlayReceiver() {
         </div>
 
         <main className="live-overlay-content">
-          {youtubeVisible && scene.youtube && scene.track ? (
+          {wheelVisible ? (
+            <WheelCeremonyOverlay scene={scene} />
+          ) : youtubeVisible && scene.youtube && scene.track ? (
             <div className="live-overlay-youtube-scene">
               <YouTubeOverlayPlayer sync={scene.youtube} />
               <div className="live-overlay-youtube-lower">

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -66,37 +66,60 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
 }
 
 
+function shortWheelLabel(value: string, maxLength: number): string {
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, Math.max(1, maxLength - 1)).trim()}…`;
+}
+
 function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const ceremony = scene.wheelCeremony;
   const candidates = ceremony?.displayCandidates ?? [];
   const result = ceremony?.resultTrack;
   const spinning = ceremony?.status === "spinning";
-  const wheelStyle = { "--wheel-final-rotation": `${1080 + Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id)) * 31}deg`, "--wheel-spin-duration": `${Math.max(5, (ceremony?.spinDurationMs ?? 6500) / 1000)}s` } as CSSProperties;
+  const candidateCount = Math.max(1, candidates.length);
+  const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
+  const sliceDegrees = 360 / candidateCount;
+  const resultCenterAngle = resultIndex * sliceDegrees + sliceDegrees / 2;
+  const sliceColors = ["#67e8f9", "#0284c7", "#e0fbff", "#0ea5e9"];
+  const sliceBackground = candidates.length > 0 ? `conic-gradient(from -90deg, ${candidates.map((_, index) => `${sliceColors[index % sliceColors.length]} ${index * sliceDegrees}deg ${(index + 1) * sliceDegrees}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
+  const wheelStyle = {
+    "--wheel-final-rotation": `${1440 - resultCenterAngle}deg`,
+    "--wheel-spin-duration": `${Math.max(5, (ceremony?.spinDurationMs ?? 6500) / 1000)}s`,
+    "--wheel-slice-count": candidateCount,
+    "--wheel-slice-background": sliceBackground,
+    "--wheel-name-size": candidates.length > 10 ? "1.04vmin" : candidates.length > 6 ? "1.28vmin" : "1.58vmin",
+  } as CSSProperties;
+  const labelMaxLength = candidates.length > 10 ? 12 : candidates.length > 6 ? 15 : 20;
 
   return (
     <div className={`live-overlay-wheel-scene ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`}>
-      <div className="live-overlay-wheel-copy">
+      <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
-        <h1>{scene.title}</h1>
-        {scene.subtitle && <h2>{scene.subtitle}</h2>}
-        <p className="live-overlay-message">{scene.message}</p>
+        <h1>{scene.subtitle || scene.title}</h1>
       </div>
+
       <div className="live-overlay-wheel-wrap">
         <div className="live-overlay-wheel-pointer" aria-hidden="true" />
         <div className="live-overlay-wheel" style={wheelStyle}>
-          {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => (
-            <span key={candidate.id} className="live-overlay-wheel-name" style={{ transform: `rotate(${(360 / candidates.length) * index}deg) translateY(-21vmin)` }}>
-              {candidate.artistName}
-            </span>
-          ))}
+          <div className="live-overlay-wheel-slices" aria-hidden="true" />
+          {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
+            const angle = index * sliceDegrees + sliceDegrees / 2;
+            const label = shortWheelLabel(candidate.artistName, labelMaxLength);
+            const labelStyle = { "--wheel-label-angle": `${angle}deg` } as CSSProperties;
+            return (
+              <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>
+                <span>{label}</span>
+              </span>
+            );
+          })}
           <div className="live-overlay-wheel-core"><span>10K</span><small>TAP WHEEL</small></div>
         </div>
       </div>
-      <div className="live-overlay-wheel-roster">
-        {candidates.slice(0, 5).map((candidate) => <span key={candidate.id}>{candidate.artistName} — {candidate.trackTitle}</span>)}
-        {(ceremony?.hiddenCandidateCount ?? 0) > 0 && <span>+ {ceremony?.hiddenCandidateCount} more signals</span>}
-      </div>
-      {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-result"><span>{ceremony.status === "confirmed" ? "LOCKED" : "RESULT"}</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em></div>}
+
+      {(scene.message || result) && <div className="live-overlay-wheel-status">
+        {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") ? <><span>{ceremony.status === "confirmed" ? "SIGNAL LOCKED" : "RESULT PENDING"}</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em></> : <><span>{scene.title}</span>{scene.message && <strong>{scene.message}</strong>}</>}
+      </div>}
     </div>
   );
 }
@@ -209,7 +232,7 @@ export function LiveOverlayReceiver() {
 
   return (
     <div className="live-overlay-shell" aria-label="BARCODE Radio live overlay receiver">
-      <section className={`live-overlay-stage ${frameTone(scene.mode)} ${youtubeVisible ? "live-overlay-stage--youtube" : ""}`}>
+      <section className={`live-overlay-stage ${frameTone(scene.mode)} ${youtubeVisible ? "live-overlay-stage--youtube" : ""} ${wheelVisible ? "live-overlay-stage--wheel-ceremony" : ""}`}>
         <div className="live-overlay-noise" aria-hidden="true" />
         <div className="live-overlay-corners" aria-hidden="true" />
         <div className="live-overlay-header">
@@ -256,10 +279,10 @@ export function LiveOverlayReceiver() {
           )}
         </main>
 
-        <div className="live-overlay-footer">
+        {!wheelVisible && <div className="live-overlay-footer">
           <span>{scene.automatic ? "AUTO LIVE SOURCE" : "OVERRIDE LIVE SOURCE"} / 1:1</span>
           <span>{new Date(scene.updatedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
-        </div>
+        </div>}
       </section>
     </div>
   );

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -68,11 +68,13 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
 
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { maxLength: 30, width: "44vmin", distance: "3.4vmin", size: "2.85vmin" };
-  if (count <= 8) return { maxLength: 24, width: "38vmin", distance: "5.6vmin", size: "2.2vmin" };
-  if (count <= 14) return { maxLength: 20, width: "32vmin", distance: "8.2vmin", size: "1.55vmin" };
-  if (count <= 24) return { maxLength: 16, width: "27vmin", distance: "10.3vmin", size: "1.08vmin" };
-  return { maxLength: 12, width: "21vmin", distance: "12.7vmin", size: "0.82vmin" };
+  if (count <= 4) return { maxLength: 42, width: "58vmin", distance: "-4.8vmin", size: "4.3vmin", tracking: "0.04em", rail: "34vmin" };
+  if (count <= 6) return { maxLength: 36, width: "52vmin", distance: "-1.2vmin", size: "3.45vmin", tracking: "0.045em", rail: "31vmin" };
+  if (count <= 8) return { maxLength: 31, width: "47vmin", distance: "1.8vmin", size: "2.75vmin", tracking: "0.05em", rail: "28vmin" };
+  if (count <= 12) return { maxLength: 25, width: "40vmin", distance: "5.4vmin", size: "2.05vmin", tracking: "0.055em", rail: "24vmin" };
+  if (count <= 16) return { maxLength: 21, width: "35vmin", distance: "7.8vmin", size: "1.58vmin", tracking: "0.06em", rail: "21vmin" };
+  if (count <= 24) return { maxLength: 18, width: "30vmin", distance: "9.8vmin", size: "1.18vmin", tracking: "0.065em", rail: "18vmin" };
+  return { maxLength: 14, width: "24vmin", distance: "11.8vmin", size: "0.94vmin", tracking: "0.055em", rail: "14vmin" };
 }
 
 function shortWheelLabel(value: string, maxLength: number): string {
@@ -101,6 +103,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-name-size": labelMetrics.size,
     "--wheel-label-width": labelMetrics.width,
     "--wheel-label-distance": labelMetrics.distance,
+    "--wheel-letter-spacing": labelMetrics.tracking,
+    "--wheel-rail-length": labelMetrics.rail,
   } as CSSProperties;
   const labelMaxLength = labelMetrics.maxLength;
 

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -44,6 +44,7 @@ function modeLabel(mode: ResolvedLiveOverlayScene["mode"]): string {
   if (mode === "now_playing") return "NOW PLAYING";
   if (mode === "artist_card") return "ARTIST CARD";
   if (mode === "wheel_ready") return "WHEEL READY";
+  if (mode === "wheel_reencrypting") return "RE-ENCRYPTING";
   if (mode === "wheel_spinning") return "WHEEL SPINNING";
   if (mode === "wheel_result") return "WHEEL RESULT";
   if (mode === "wheel_confirmed") return "WHEEL CHOSEN";
@@ -55,7 +56,7 @@ function modeLabel(mode: ResolvedLiveOverlayScene["mode"]): string {
 }
 
 function frameTone(mode: ResolvedLiveOverlayScene["mode"]): string {
-  if (mode === "wheel_ready" || mode === "wheel_spinning" || mode === "wheel_result" || mode === "wheel_confirmed") return "live-overlay-stage--wheel";
+  if (mode === "wheel_ready" || mode === "wheel_reencrypting" || mode === "wheel_spinning" || mode === "wheel_result" || mode === "wheel_confirmed") return "live-overlay-stage--wheel";
   if (mode === "sponsor" || mode === "system_message") return "live-overlay-stage--message";
   if (mode === "video_placeholder") return "live-overlay-stage--video";
   return "";
@@ -65,6 +66,14 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
   return Boolean((scene.mode === "now_playing" || scene.mode === "artist_card") && scene.track);
 }
 
+
+function wheelLabelMetrics(count: number) {
+  if (count <= 4) return { maxLength: 30, width: "44vmin", distance: "3.4vmin", size: "2.85vmin" };
+  if (count <= 8) return { maxLength: 24, width: "38vmin", distance: "5.6vmin", size: "2.2vmin" };
+  if (count <= 14) return { maxLength: 20, width: "32vmin", distance: "8.2vmin", size: "1.55vmin" };
+  if (count <= 24) return { maxLength: 16, width: "27vmin", distance: "10.3vmin", size: "1.08vmin" };
+  return { maxLength: 12, width: "21vmin", distance: "12.7vmin", size: "0.82vmin" };
+}
 
 function shortWheelLabel(value: string, maxLength: number): string {
   const cleaned = value.replace(/\s+/g, " ").trim();
@@ -81,19 +90,23 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
   const sliceDegrees = 360 / candidateCount;
   const resultCenterAngle = resultIndex * sliceDegrees + sliceDegrees / 2;
-  const sliceColors = ["#67e8f9", "#0284c7", "#e0fbff", "#0ea5e9"];
+  const sliceColors = ["#67e8f9", "#0ea5e9", "#2563eb", "#7c3aed", "#c026d3", "#ff2b6d", "#ef4444", "#f97316", "#facc15", "#22c55e", "#e5e7eb", "#071426"];
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from -90deg, ${candidates.map((_, index) => `${sliceColors[index % sliceColors.length]} ${index * sliceDegrees}deg ${(index + 1) * sliceDegrees}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
+  const labelMetrics = wheelLabelMetrics(candidates.length);
   const wheelStyle = {
     "--wheel-final-rotation": `${1440 - resultCenterAngle}deg`,
     "--wheel-spin-duration": `${Math.max(5, (ceremony?.spinDurationMs ?? 6500) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
-    "--wheel-name-size": candidates.length > 10 ? "1.04vmin" : candidates.length > 6 ? "1.28vmin" : "1.58vmin",
+    "--wheel-name-size": labelMetrics.size,
+    "--wheel-label-width": labelMetrics.width,
+    "--wheel-label-distance": labelMetrics.distance,
   } as CSSProperties;
-  const labelMaxLength = candidates.length > 10 ? 12 : candidates.length > 6 ? 15 : 20;
+  const labelMaxLength = labelMetrics.maxLength;
 
   return (
-    <div className={`live-overlay-wheel-scene ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`}>
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`}>
+      {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
         <h1>{scene.subtitle || scene.title}</h1>

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -1,8 +1,8 @@
 import type { QueueSourceType, SponsorBreakStatus } from "./queue-types";
 
-export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_ready" | "wheel_spinning" | "wheel_result" | "wheel_confirmed" | "sponsor" | "video_placeholder" | "system_message" | "session_active";
+export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_ready" | "wheel_reencrypting" | "wheel_spinning" | "wheel_result" | "wheel_confirmed" | "sponsor" | "video_placeholder" | "system_message" | "session_active";
 export type WheelOverlayStatus = "ready" | "intro" | "active" | "complete";
-export type WheelCeremonyStatus = "idle" | "ready" | "spinning" | "result_pending" | "confirmed" | "cancelled";
+export type WheelCeremonyStatus = "idle" | "ready" | "reencrypting" | "spinning" | "result_pending" | "confirmed" | "cancelled";
 
 export interface LiveOverlayTrackInput {
   id?: string;
@@ -149,8 +149,9 @@ export interface ResolvedLiveOverlayScene {
 const MAX_URL_LENGTH = 600;
 const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit.ly", "tinyurl.com", "t.co", "goo.gl", "private.blob.vercel-storage.com"];
 const WHEEL_SPIN_DURATION_MS = 6500;
+const WHEEL_REENCRYPTING_MS = 2500;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
-const MAX_WHEEL_DISPLAY_CANDIDATES = 12;
+const MAX_WHEEL_DISPLAY_CANDIDATES = 32;
 
 export function safeLiveOverlayUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -212,7 +213,7 @@ function safeWheelCandidate(candidate: LiveOverlayWheelCandidateInput): Resolved
 }
 
 function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
-  return value === "ready" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
+  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
 }
 
 function timeMs(value?: string): number | null {
@@ -229,9 +230,12 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   const resultTrackId = cleanDisplay(overlayState?.wheelCeremonyResultTrackId);
   const resultTrack = candidates.find((candidate) => candidate.id === resultTrackId) ?? (resultTrackId ? { id: resultTrackId, artistName: cleanDisplay(overlayState?.artistName) || "Selected artist", trackTitle: cleanDisplay(overlayState?.trackTitle) || "Selected transmission" } : null);
   let status = storedStatus;
-  if (storedStatus === "spinning") {
+  if (storedStatus === "reencrypting" || storedStatus === "spinning") {
     const spinStartedMs = timeMs(overlayState?.wheelCeremonySpinStartedAt) ?? now.getTime();
-    if (now.getTime() - spinStartedMs >= WHEEL_SPIN_DURATION_MS) status = "result_pending";
+    const elapsedMs = now.getTime() - spinStartedMs;
+    if (storedStatus === "reencrypting" && elapsedMs < WHEEL_REENCRYPTING_MS) status = "reencrypting";
+    else if (elapsedMs < WHEEL_SPIN_DURATION_MS) status = "spinning";
+    else status = "result_pending";
   }
   if (storedStatus === "confirmed") {
     const confirmedAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
@@ -276,13 +280,13 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
 
   if (wheelCeremony) {
     const result = wheelCeremony.resultTrack;
-    const mode: OverlayMode = wheelCeremony.status === "spinning" ? "wheel_spinning" : wheelCeremony.status === "result_pending" ? "wheel_result" : wheelCeremony.status === "confirmed" ? "wheel_confirmed" : "wheel_ready";
+    const mode: OverlayMode = wheelCeremony.status === "reencrypting" ? "wheel_reencrypting" : wheelCeremony.status === "spinning" ? "wheel_spinning" : wheelCeremony.status === "result_pending" ? "wheel_result" : wheelCeremony.status === "confirmed" ? "wheel_confirmed" : "wheel_ready";
     return scene({
       mode,
-      reason: wheelCeremony.status === "ready" ? "Wheel ceremony was launched by the host." : wheelCeremony.status === "spinning" ? "Wheel spin is running under host control." : wheelCeremony.status === "confirmed" ? "Wheel result was confirmed through the queue admin path." : "Wheel result is waiting for host confirmation.",
+      reason: wheelCeremony.status === "ready" ? "Wheel ceremony was launched by the host." : wheelCeremony.status === "reencrypting" ? "Wheel result is being re-encrypted before host confirmation." : wheelCeremony.status === "spinning" ? "Wheel spin is running under host control." : wheelCeremony.status === "confirmed" ? "Wheel result was confirmed through the queue admin path." : "Wheel result is waiting for host confirmation.",
       title: wheelCeremony.status === "confirmed" ? "WHEEL CHOSEN" : "10K TAP WHEEL",
-      subtitle: wheelCeremony.status === "ready" ? "READY" : wheelCeremony.status === "spinning" ? "SPINNING" : wheelCeremony.status === "confirmed" ? "LOCKED IN" : "RESULT PENDING",
-      message: wheelCeremony.status === "ready" ? `Candidates: ${wheelCeremony.candidateCount}. Awaiting host spin.` : wheelCeremony.status === "spinning" ? "Result incoming." : result ? `${result.artistName} — ${result.trackTitle}` : "Awaiting host confirmation.",
+      subtitle: wheelCeremony.status === "ready" ? "READY" : wheelCeremony.status === "reencrypting" ? "RE-ENCRYPTING SIGNAL" : wheelCeremony.status === "spinning" ? "SPINNING" : wheelCeremony.status === "confirmed" ? "LOCKED IN" : "RESULT PENDING",
+      message: wheelCeremony.status === "ready" ? `Candidates: ${wheelCeremony.candidateCount}. Awaiting host spin.` : wheelCeremony.status === "reencrypting" ? "Signal scramble in progress." : wheelCeremony.status === "spinning" ? "Result incoming." : result ? `${result.artistName} — ${result.trackTitle}` : "Awaiting host confirmation.",
       wheelCeremony,
       priority: 100,
       automatic: false,

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -1,7 +1,8 @@
 import type { QueueSourceType, SponsorBreakStatus } from "./queue-types";
 
-export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_ready" | "sponsor" | "video_placeholder" | "system_message" | "session_active";
+export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_ready" | "wheel_spinning" | "wheel_result" | "wheel_confirmed" | "sponsor" | "video_placeholder" | "system_message" | "session_active";
 export type WheelOverlayStatus = "ready" | "intro" | "active" | "complete";
+export type WheelCeremonyStatus = "idle" | "ready" | "spinning" | "result_pending" | "confirmed" | "cancelled";
 
 export interface LiveOverlayTrackInput {
   id?: string;
@@ -18,11 +19,25 @@ export interface LiveOverlayTrackInput {
   youtubeVideoId?: string | null;
 }
 
+export interface LiveOverlayWheelCandidateInput {
+  id?: string;
+  artistName?: string;
+  trackTitle?: string;
+  artist?: string;
+  title?: string;
+  submittedArtistName?: string;
+  submittedSongTitle?: string;
+  detectedArtistName?: string | null;
+  detectedSongTitle?: string | null;
+}
+
 export interface LiveOverlayStateInput {
   mode?: OverlayMode;
   title?: string;
   subtitle?: string;
   message?: string;
+  artistName?: string;
+  trackTitle?: string;
   artworkUrl?: string | null;
   sourceUrl?: string | null;
   sponsorLabel?: string;
@@ -34,6 +49,13 @@ export interface LiveOverlayStateInput {
   wheelOverlayActive?: boolean;
   wheelOverlayLaunchedAt?: string;
   wheelOverlayStatus?: WheelOverlayStatus;
+  wheelCeremonyStatus?: WheelCeremonyStatus;
+  wheelCeremonyStartedAt?: string;
+  wheelCeremonySpinStartedAt?: string;
+  wheelCeremonyResultTrackId?: string;
+  wheelCeremonyResultSelectedAt?: string;
+  wheelCeremonySeed?: string;
+  wheelCeremonyJingleKey?: string;
   updatedAt?: string;
 }
 
@@ -65,10 +87,12 @@ export interface ResolveLiveOverlaySceneInput {
   nowPlaying?: LiveOverlayTrackInput | null;
   upNext?: LiveOverlayTrackInput | null;
   playerSync?: LiveOverlayYouTubeSync | null;
+  wheelCandidates?: LiveOverlayWheelCandidateInput[];
   wheelSpinsOwed?: number;
   sponsorBreakStatus?: SponsorBreakStatus;
   broadcastPhase?: string;
   queueOpen?: boolean;
+  now?: Date;
 }
 
 export interface ResolvedLiveOverlayTrack {
@@ -77,6 +101,28 @@ export interface ResolvedLiveOverlayTrack {
   trackTitle: string;
   sourceType: QueueSourceType | "unknown";
   durationLabel?: string;
+}
+
+export interface ResolvedWheelCeremonyTrack {
+  id: string;
+  artistName: string;
+  trackTitle: string;
+}
+
+export interface ResolvedWheelCeremonyScene {
+  status: WheelCeremonyStatus;
+  storedStatus: WheelCeremonyStatus;
+  candidateCount: number;
+  displayCandidates: ResolvedWheelCeremonyTrack[];
+  hiddenCandidateCount: number;
+  resultTrack?: ResolvedWheelCeremonyTrack | null;
+  resultTrackId?: string;
+  startedAt?: string;
+  spinStartedAt?: string;
+  resultSelectedAt?: string;
+  seed?: string;
+  jingleKey?: string;
+  spinDurationMs: number;
 }
 
 export interface ResolvedLiveOverlayScene {
@@ -91,6 +137,7 @@ export interface ResolvedLiveOverlayScene {
   sourceUrl?: string | null;
   videoUrl?: string;
   youtube?: LiveOverlayYouTubeSync;
+  wheelCeremony?: ResolvedWheelCeremonyScene;
   priority: number;
   automatic: boolean;
   overrideActive: boolean;
@@ -101,6 +148,9 @@ export interface ResolvedLiveOverlayScene {
 
 const MAX_URL_LENGTH = 600;
 const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit.ly", "tinyurl.com", "t.co", "goo.gl", "private.blob.vercel-storage.com"];
+const WHEEL_SPIN_DURATION_MS = 6500;
+const WHEEL_CONFIRMED_RETURN_MS = 2200;
+const MAX_WHEEL_DISPLAY_CANDIDATES = 12;
 
 export function safeLiveOverlayUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -122,12 +172,12 @@ function cleanDisplay(value: string | null | undefined): string | undefined {
   return cleaned || undefined;
 }
 
-function displayArtist(track: LiveOverlayTrackInput): string {
-  return cleanDisplay(track.detectedArtistName) || cleanDisplay(track.submittedArtistName) || cleanDisplay(track.artist) || "Unknown artist";
+function displayArtist(track: LiveOverlayTrackInput | LiveOverlayWheelCandidateInput): string {
+  return cleanDisplay(track.detectedArtistName) || cleanDisplay(track.submittedArtistName) || cleanDisplay("artistName" in track ? track.artistName : undefined) || cleanDisplay(track.artist) || "Unknown artist";
 }
 
-function displayTitle(track: LiveOverlayTrackInput): string {
-  return cleanDisplay(track.detectedSongTitle) || cleanDisplay(track.submittedSongTitle) || cleanDisplay(track.title) || "Untitled transmission";
+function displayTitle(track: LiveOverlayTrackInput | LiveOverlayWheelCandidateInput): string {
+  return cleanDisplay(track.detectedSongTitle) || cleanDisplay(track.submittedSongTitle) || cleanDisplay("trackTitle" in track ? track.trackTitle : undefined) || cleanDisplay(track.title) || "Untitled transmission";
 }
 
 function youtubeSyncForTrack(track: LiveOverlayTrackInput, playerSync?: LiveOverlayYouTubeSync | null): LiveOverlayYouTubeSync | undefined {
@@ -155,35 +205,89 @@ function safeTrack(track: LiveOverlayTrackInput): { track: ResolvedLiveOverlayTr
   };
 }
 
-function scene(input: Omit<ResolvedLiveOverlayScene, "resolvedMode" | "updatedAt" | "wheelSpinsOwed" | "wheelOverlayActive">, overlayState: LiveOverlayStateInput | null | undefined, wheelSpinsOwed: number): ResolvedLiveOverlayScene {
+function safeWheelCandidate(candidate: LiveOverlayWheelCandidateInput): ResolvedWheelCeremonyTrack | null {
+  const id = cleanDisplay(candidate.id);
+  if (!id) return null;
+  return { id, artistName: displayArtist(candidate), trackTitle: displayTitle(candidate) };
+}
+
+function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
+  return value === "ready" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
+}
+
+function timeMs(value?: string): number | null {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): ResolvedWheelCeremonyScene | null {
+  const overlayState = input.overlayState ?? null;
+  const storedStatus = normalizeWheelCeremonyStatus(overlayState?.wheelCeremonyStatus ?? (overlayState?.wheelOverlayActive ? "ready" : "idle"));
+  if (storedStatus === "idle" || storedStatus === "cancelled") return null;
+  const candidates = (input.wheelCandidates ?? []).map(safeWheelCandidate).filter((candidate): candidate is ResolvedWheelCeremonyTrack => Boolean(candidate));
+  const resultTrackId = cleanDisplay(overlayState?.wheelCeremonyResultTrackId);
+  const resultTrack = candidates.find((candidate) => candidate.id === resultTrackId) ?? (resultTrackId ? { id: resultTrackId, artistName: cleanDisplay(overlayState?.artistName) || "Selected artist", trackTitle: cleanDisplay(overlayState?.trackTitle) || "Selected transmission" } : null);
+  let status = storedStatus;
+  if (storedStatus === "spinning") {
+    const spinStartedMs = timeMs(overlayState?.wheelCeremonySpinStartedAt) ?? now.getTime();
+    if (now.getTime() - spinStartedMs >= WHEEL_SPIN_DURATION_MS) status = "result_pending";
+  }
+  if (storedStatus === "confirmed") {
+    const confirmedAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
+    if (now.getTime() - confirmedAtMs > WHEEL_CONFIRMED_RETURN_MS) return null;
+  }
+  return {
+    status,
+    storedStatus,
+    candidateCount: candidates.length,
+    displayCandidates: candidates.slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
+    hiddenCandidateCount: Math.max(0, candidates.length - MAX_WHEEL_DISPLAY_CANDIDATES),
+    resultTrack,
+    resultTrackId,
+    startedAt: overlayState?.wheelCeremonyStartedAt ?? overlayState?.wheelOverlayLaunchedAt,
+    spinStartedAt: overlayState?.wheelCeremonySpinStartedAt,
+    resultSelectedAt: overlayState?.wheelCeremonyResultSelectedAt,
+    seed: cleanDisplay(overlayState?.wheelCeremonySeed),
+    jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
+    spinDurationMs: WHEEL_SPIN_DURATION_MS,
+  };
+}
+
+function scene(input: Omit<ResolvedLiveOverlayScene, "resolvedMode" | "updatedAt" | "wheelSpinsOwed" | "wheelOverlayActive">, overlayState: LiveOverlayStateInput | null | undefined, wheelSpinsOwed: number, wheelOverlayActive?: boolean): ResolvedLiveOverlayScene {
   return {
     ...input,
     resolvedMode: input.mode,
     updatedAt: overlayState?.updatedAt ?? new Date().toISOString(),
     wheelSpinsOwed,
-    wheelOverlayActive: overlayState?.wheelOverlayActive === true,
+    wheelOverlayActive: wheelOverlayActive ?? overlayState?.wheelOverlayActive === true,
   };
 }
 
 export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): ResolvedLiveOverlayScene {
   const overlayState = input.overlayState ?? null;
   const currentSession = input.currentSession ?? null;
+  const now = input.now ?? new Date();
   const wheelSpinsOwed = Math.max(0, Math.floor(input.wheelSpinsOwed ?? currentSession?.wheelSpinsOwed ?? 0));
   const sponsorBreakStatus = input.sponsorBreakStatus ?? currentSession?.sponsorBreakStatus;
   const queueOpen = input.queueOpen ?? currentSession?.queueOpen ?? false;
   const broadcastPhase = input.broadcastPhase ?? currentSession?.broadcastPhase;
+  const wheelCeremony = resolveWheelCeremony(input, now);
 
-  if (overlayState?.wheelOverlayActive) {
+  if (wheelCeremony) {
+    const result = wheelCeremony.resultTrack;
+    const mode: OverlayMode = wheelCeremony.status === "spinning" ? "wheel_spinning" : wheelCeremony.status === "result_pending" ? "wheel_result" : wheelCeremony.status === "confirmed" ? "wheel_confirmed" : "wheel_ready";
     return scene({
-      mode: "wheel_ready",
-      reason: "Wheel overlay was launched by the host.",
-      title: "10K TAP WHEEL",
-      subtitle: "READY",
-      message: "Awaiting host spin.",
+      mode,
+      reason: wheelCeremony.status === "ready" ? "Wheel ceremony was launched by the host." : wheelCeremony.status === "spinning" ? "Wheel spin is running under host control." : wheelCeremony.status === "confirmed" ? "Wheel result was confirmed through the queue admin path." : "Wheel result is waiting for host confirmation.",
+      title: wheelCeremony.status === "confirmed" ? "WHEEL CHOSEN" : "10K TAP WHEEL",
+      subtitle: wheelCeremony.status === "ready" ? "READY" : wheelCeremony.status === "spinning" ? "SPINNING" : wheelCeremony.status === "confirmed" ? "LOCKED IN" : "RESULT PENDING",
+      message: wheelCeremony.status === "ready" ? `Candidates: ${wheelCeremony.candidateCount}. Awaiting host spin.` : wheelCeremony.status === "spinning" ? "Result incoming." : result ? `${result.artistName} — ${result.trackTitle}` : "Awaiting host confirmation.",
+      wheelCeremony,
       priority: 100,
       automatic: false,
       overrideActive: true,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, true);
   }
 
   if (sponsorBreakStatus === "running") {
@@ -196,7 +300,7 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
       priority: 90,
       automatic: true,
       overrideActive: false,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, false);
   }
 
   if (overlayState?.systemMessageActive) {
@@ -209,7 +313,7 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
       priority: 80,
       automatic: false,
       overrideActive: true,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, false);
   }
 
   if (overlayState?.videoPlaceholderActive) {
@@ -223,7 +327,7 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
       priority: 70,
       automatic: false,
       overrideActive: true,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, false);
   }
 
   if (input.nowPlaying) {
@@ -241,7 +345,7 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
       priority: youtube ? 60 : 50,
       automatic: true,
       overrideActive: false,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, false);
   }
 
   if (currentSession && currentSession.status !== "archived") {
@@ -254,7 +358,7 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
       priority: 20,
       automatic: true,
       overrideActive: false,
-    }, overlayState, wheelSpinsOwed);
+    }, overlayState, wheelSpinsOwed, false);
   }
 
   return scene({
@@ -266,5 +370,5 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
     priority: 0,
     automatic: true,
     overrideActive: false,
-  }, overlayState, wheelSpinsOwed);
+  }, overlayState, wheelSpinsOwed, false);
 }

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -40,7 +40,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
 }
 
 export interface LiveOverlayPayload {
-  action?: "launchWheel" | "spinWheel" | "confirmWheel" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
+  action?: "launchWheel" | "spinWheel" | "reencryptWheel" | "confirmWheel" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
   mode?: OverlayMode;
   title?: unknown;
   subtitle?: unknown;
@@ -143,18 +143,19 @@ function randomSeed(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
-function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[]): ResolvedWheelCeremonyTrack | null {
-  if (candidates.length === 0) return null;
-  const index = Math.floor(Math.random() * candidates.length);
-  return candidates[Math.max(0, Math.min(candidates.length - 1, index))] ?? null;
+function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[], excludeId?: string): ResolvedWheelCeremonyTrack | null {
+  const pool = excludeId && candidates.length > 1 ? candidates.filter((candidate) => candidate.id !== excludeId) : candidates;
+  if (pool.length === 0) return null;
+  const index = Math.floor(Math.random() * pool.length);
+  return pool[Math.max(0, Math.min(pool.length - 1, index))] ?? null;
 }
 
 function isActiveCeremony(status?: WheelCeremonyStatus): boolean {
-  return status === "ready" || status === "spinning" || status === "result_pending";
+  return status === "ready" || status === "reencrypting" || status === "spinning" || status === "result_pending";
 }
 
 function normalizeMode(value: unknown): OverlayMode {
-  const modes: OverlayMode[] = ["standby", "now_playing", "artist_card", "wheel_ready", "wheel_spinning", "wheel_result", "wheel_confirmed", "sponsor", "video_placeholder", "system_message", "session_active"];
+  const modes: OverlayMode[] = ["standby", "now_playing", "artist_card", "wheel_ready", "wheel_reencrypting", "wheel_spinning", "wheel_result", "wheel_confirmed", "sponsor", "video_placeholder", "system_message", "session_active"];
   return modes.includes(value as OverlayMode) ? value as OverlayMode : "standby";
 }
 
@@ -168,7 +169,7 @@ function normalizeWheelStatus(value: unknown): WheelOverlayStatus {
 }
 
 function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
-  return value === "ready" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
+  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
 }
 
 
@@ -222,7 +223,7 @@ function normalizeState(input: unknown): LiveOverlayState {
     systemMessageTitle: cleanText(raw.systemMessageTitle),
     systemMessage: cleanText(raw.systemMessage),
     videoPlaceholderActive: raw.videoPlaceholderActive === true,
-    wheelOverlayActive: raw.wheelOverlayActive === true || raw.mode === "wheel_ready" || raw.mode === "wheel_spinning" || raw.mode === "wheel_result" || raw.mode === "wheel_confirmed",
+    wheelOverlayActive: raw.wheelOverlayActive === true || raw.mode === "wheel_ready" || raw.mode === "wheel_reencrypting" || raw.mode === "wheel_spinning" || raw.mode === "wheel_result" || raw.mode === "wheel_confirmed",
     wheelOverlayLaunchedAt: typeof raw.wheelOverlayLaunchedAt === "string" ? raw.wheelOverlayLaunchedAt : undefined,
     wheelOverlayStatus: normalizeWheelStatus(raw.wheelOverlayStatus),
     wheelCeremonyStatus: normalizeWheelCeremonyStatus(raw.wheelCeremonyStatus ?? (raw.wheelOverlayActive ? "ready" : "idle")),
@@ -334,20 +335,22 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyJingleKey: "silent",
       updatedAt: now,
     };
-  } else if (payload.action === "spinWheel") {
+  } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
     const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
-    if (!isActiveCeremony(currentStatus)) throw new Error("Launch the wheel before spinning.");
+    if (payload.action === "spinWheel" && !isActiveCeremony(currentStatus)) throw new Error("Launch the wheel before spinning.");
+    if (payload.action === "reencryptWheel" && currentStatus !== "result_pending" && currentStatus !== "spinning") throw new Error("Re-encrypt is only available before confirming a pending result.");
     const queueState = await getRadioQueueState();
     if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
-    const selected = pickRandomCandidate(candidates);
+    const selected = pickRandomCandidate(candidates, payload.action === "reencryptWheel" ? current.wheelCeremonyResultTrackId : undefined);
     if (!selected) throw new Error("No eligible Wheel Chosen candidates are available.");
+    const reencrypting = payload.action === "reencryptWheel";
     next = {
       ...current,
-      mode: "wheel_spinning",
+      mode: reencrypting ? "wheel_reencrypting" : "wheel_spinning",
       wheelOverlayActive: true,
       wheelOverlayStatus: "active",
-      wheelCeremonyStatus: "spinning",
+      wheelCeremonyStatus: reencrypting ? "reencrypting" : "spinning",
       wheelCeremonySpinStartedAt: now,
       wheelCeremonyResultTrackId: selected.id,
       wheelCeremonyResultSelectedAt: now,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -1,12 +1,12 @@
 import { Redis } from "@upstash/redis";
-import { getRadioQueueState } from "./queue";
+import { getRadioQueueState, isWheelEligibleTrack, updateRadioTrack } from "./queue";
 import { getTrackArtworkUrl, getTrackDurationLabel } from "./queue-types";
 import { resolveLiveOverlayScene, safeLiveOverlayUrl } from "./live-overlay-resolver";
 import { parseYouTubeVideoId } from "./track-duration";
 import type { QueueEntry, QueueSourceType } from "./queue-types";
-import type { LiveOverlayPlaybackState, LiveOverlayStateInput, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, WheelOverlayStatus } from "./live-overlay-resolver";
+import type { LiveOverlayPlaybackState, LiveOverlayStateInput, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, ResolvedWheelCeremonyTrack, WheelCeremonyStatus, WheelOverlayStatus } from "./live-overlay-resolver";
 
-export type { LiveOverlayPlaybackState, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, WheelOverlayStatus } from "./live-overlay-resolver";
+export type { LiveOverlayPlaybackState, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, ResolvedWheelCeremonyTrack, WheelCeremonyStatus, WheelOverlayStatus } from "./live-overlay-resolver";
 
 export interface LiveOverlayState extends LiveOverlayStateInput {
   mode: OverlayMode;
@@ -29,11 +29,18 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelOverlayActive?: boolean;
   wheelOverlayLaunchedAt?: string;
   wheelOverlayStatus?: WheelOverlayStatus;
+  wheelCeremonyStatus?: WheelCeremonyStatus;
+  wheelCeremonyStartedAt?: string;
+  wheelCeremonySpinStartedAt?: string;
+  wheelCeremonyResultTrackId?: string;
+  wheelCeremonyResultSelectedAt?: string;
+  wheelCeremonySeed?: string;
+  wheelCeremonyJingleKey?: string;
   updatedAt: string;
 }
 
 export interface LiveOverlayPayload {
-  action?: "launchWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
+  action?: "launchWheel" | "spinWheel" | "confirmWheel" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
   mode?: OverlayMode;
   title?: unknown;
   subtitle?: unknown;
@@ -51,6 +58,7 @@ export interface LiveOverlayAdminSnapshot {
   overlayState: LiveOverlayState;
   scene: ResolvedLiveOverlayScene;
   playerSync: LiveOverlayYouTubeSync | null;
+  wheelCandidates: ResolvedWheelCeremonyTrack[];
 }
 
 const OVERLAY_STATE_KEY = "barcode:live-overlay:state";
@@ -79,6 +87,8 @@ export function defaultLiveOverlayState(): LiveOverlayState {
     videoPlaceholderActive: false,
     wheelOverlayActive: false,
     wheelOverlayStatus: "ready",
+    wheelCeremonyStatus: "idle",
+    wheelCeremonyJingleKey: "silent",
     updatedAt: new Date().toISOString(),
   };
 }
@@ -118,8 +128,33 @@ function overlayTrackInput(entry: QueueEntry) {
   };
 }
 
+
+function wheelCandidateFromEntry(entry: QueueEntry): ResolvedWheelCeremonyTrack {
+  return { id: entry.id, artistName: displayArtist(entry), trackTitle: displayTitle(entry) };
+}
+
+function getWheelCandidatesFromQueue(queue: QueueEntry[]): ResolvedWheelCeremonyTrack[] {
+  return queue.filter(isWheelEligibleTrack).map(wheelCandidateFromEntry);
+}
+
+function randomSeed(): string {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) return cryptoApi.randomUUID();
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[]): ResolvedWheelCeremonyTrack | null {
+  if (candidates.length === 0) return null;
+  const index = Math.floor(Math.random() * candidates.length);
+  return candidates[Math.max(0, Math.min(candidates.length - 1, index))] ?? null;
+}
+
+function isActiveCeremony(status?: WheelCeremonyStatus): boolean {
+  return status === "ready" || status === "spinning" || status === "result_pending";
+}
+
 function normalizeMode(value: unknown): OverlayMode {
-  const modes: OverlayMode[] = ["standby", "now_playing", "artist_card", "wheel_ready", "sponsor", "video_placeholder", "system_message", "session_active"];
+  const modes: OverlayMode[] = ["standby", "now_playing", "artist_card", "wheel_ready", "wheel_spinning", "wheel_result", "wheel_confirmed", "sponsor", "video_placeholder", "system_message", "session_active"];
   return modes.includes(value as OverlayMode) ? value as OverlayMode : "standby";
 }
 
@@ -130,6 +165,10 @@ function normalizeSourceType(value: unknown): LiveOverlayState["sourceType"] {
 
 function normalizeWheelStatus(value: unknown): WheelOverlayStatus {
   return value === "intro" || value === "active" || value === "complete" || value === "ready" ? value : "ready";
+}
+
+function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
+  return value === "ready" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
 }
 
 
@@ -183,9 +222,16 @@ function normalizeState(input: unknown): LiveOverlayState {
     systemMessageTitle: cleanText(raw.systemMessageTitle),
     systemMessage: cleanText(raw.systemMessage),
     videoPlaceholderActive: raw.videoPlaceholderActive === true,
-    wheelOverlayActive: raw.wheelOverlayActive === true || raw.mode === "wheel_ready",
+    wheelOverlayActive: raw.wheelOverlayActive === true || raw.mode === "wheel_ready" || raw.mode === "wheel_spinning" || raw.mode === "wheel_result" || raw.mode === "wheel_confirmed",
     wheelOverlayLaunchedAt: typeof raw.wheelOverlayLaunchedAt === "string" ? raw.wheelOverlayLaunchedAt : undefined,
     wheelOverlayStatus: normalizeWheelStatus(raw.wheelOverlayStatus),
+    wheelCeremonyStatus: normalizeWheelCeremonyStatus(raw.wheelCeremonyStatus ?? (raw.wheelOverlayActive ? "ready" : "idle")),
+    wheelCeremonyStartedAt: typeof raw.wheelCeremonyStartedAt === "string" ? raw.wheelCeremonyStartedAt : undefined,
+    wheelCeremonySpinStartedAt: typeof raw.wheelCeremonySpinStartedAt === "string" ? raw.wheelCeremonySpinStartedAt : undefined,
+    wheelCeremonyResultTrackId: cleanText(raw.wheelCeremonyResultTrackId),
+    wheelCeremonyResultSelectedAt: typeof raw.wheelCeremonyResultSelectedAt === "string" ? raw.wheelCeremonyResultSelectedAt : undefined,
+    wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
+    wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
   };
 }
@@ -235,6 +281,7 @@ export async function getStoredLiveOverlayState(): Promise<LiveOverlayState> {
 
 export async function getResolvedLiveOverlayScene(): Promise<ResolvedLiveOverlayScene> {
   const [overlayState, queueState, playerSync] = await Promise.all([getStoredLiveOverlayState(), getRadioQueueState(), getLiveOverlayPlayerSync()]);
+  const wheelCandidates = getWheelCandidatesFromQueue(queueState.queue);
   const session = queueState.session ?? null;
   return resolveLiveOverlayScene({
     overlayState,
@@ -250,6 +297,7 @@ export async function getResolvedLiveOverlayScene(): Promise<ResolvedLiveOverlay
     nowPlaying: queueState.nowPlaying ? overlayTrackInput(queueState.nowPlaying) : null,
     upNext: queueState.nextInLine ? overlayTrackInput(queueState.nextInLine) : null,
     playerSync,
+    wheelCandidates,
     wheelSpinsOwed: session?.wheelSpinsOwed ?? 0,
     sponsorBreakStatus: session?.sponsorBreakStatus,
     broadcastPhase: session?.broadcastPhase,
@@ -258,8 +306,8 @@ export async function getResolvedLiveOverlayScene(): Promise<ResolvedLiveOverlay
 }
 
 export async function getLiveOverlayAdminSnapshot(): Promise<LiveOverlayAdminSnapshot> {
-  const [overlayState, scene, playerSync] = await Promise.all([getStoredLiveOverlayState(), getResolvedLiveOverlayScene(), getLiveOverlayPlayerSync()]);
-  return { overlayState, scene, playerSync };
+  const [overlayState, scene, playerSync, queueState] = await Promise.all([getStoredLiveOverlayState(), getResolvedLiveOverlayScene(), getLiveOverlayPlayerSync(), getRadioQueueState()]);
+  return { overlayState, scene, playerSync, wheelCandidates: getWheelCandidatesFromQueue(queueState.queue) };
 }
 
 export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<LiveOverlayAdminSnapshot> {
@@ -270,10 +318,82 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
   if (payload.action === "launchWheel") {
     const queueState = await getRadioQueueState();
     const wheelSpinsOwed = queueState.session?.wheelSpinsOwed ?? 0;
-    if (wheelSpinsOwed <= 0) return getLiveOverlayAdminSnapshot();
-    next = { ...current, mode: "wheel_ready", wheelOverlayActive: true, wheelOverlayLaunchedAt: now, wheelOverlayStatus: "ready", updatedAt: now };
-  } else if (payload.action === "clearWheel") {
-    next = { ...current, mode: "standby", wheelOverlayActive: false, wheelOverlayLaunchedAt: undefined, wheelOverlayStatus: "ready", updatedAt: now };
+    if (wheelSpinsOwed <= 0) throw new Error("No wheel spins are owed.");
+    next = {
+      ...current,
+      mode: "wheel_ready",
+      wheelOverlayActive: true,
+      wheelOverlayLaunchedAt: now,
+      wheelOverlayStatus: "ready",
+      wheelCeremonyStatus: "ready",
+      wheelCeremonyStartedAt: now,
+      wheelCeremonySpinStartedAt: undefined,
+      wheelCeremonyResultTrackId: undefined,
+      wheelCeremonyResultSelectedAt: undefined,
+      wheelCeremonySeed: randomSeed(),
+      wheelCeremonyJingleKey: "silent",
+      updatedAt: now,
+    };
+  } else if (payload.action === "spinWheel") {
+    const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
+    if (!isActiveCeremony(currentStatus)) throw new Error("Launch the wheel before spinning.");
+    const queueState = await getRadioQueueState();
+    if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
+    const candidates = getWheelCandidatesFromQueue(queueState.queue);
+    const selected = pickRandomCandidate(candidates);
+    if (!selected) throw new Error("No eligible Wheel Chosen candidates are available.");
+    next = {
+      ...current,
+      mode: "wheel_spinning",
+      wheelOverlayActive: true,
+      wheelOverlayStatus: "active",
+      wheelCeremonyStatus: "spinning",
+      wheelCeremonySpinStartedAt: now,
+      wheelCeremonyResultTrackId: selected.id,
+      wheelCeremonyResultSelectedAt: now,
+      wheelCeremonySeed: randomSeed(),
+      wheelCeremonyJingleKey: "silent",
+      artistName: selected.artistName,
+      trackTitle: selected.trackTitle,
+      updatedAt: now,
+    };
+  } else if (payload.action === "confirmWheel") {
+    const resultTrackId = cleanText(current.wheelCeremonyResultTrackId);
+    if (!resultTrackId) throw new Error("No wheel result is ready to confirm.");
+    const queueState = await getRadioQueueState();
+    const candidates = getWheelCandidatesFromQueue(queueState.queue);
+    const selected = candidates.find((candidate) => candidate.id === resultTrackId);
+    if (!selected) throw new Error("The selected wheel result is no longer eligible. Reroll or cancel the ceremony.");
+    await updateRadioTrack(resultTrackId, "wheel");
+    next = {
+      ...current,
+      mode: "wheel_confirmed",
+      wheelOverlayActive: true,
+      wheelOverlayStatus: "complete",
+      wheelCeremonyStatus: "confirmed",
+      wheelCeremonyResultSelectedAt: now,
+      artistName: selected.artistName,
+      trackTitle: selected.trackTitle,
+      updatedAt: now,
+    };
+  } else if (payload.action === "cancelWheel" || payload.action === "clearWheel") {
+    next = {
+      ...current,
+      mode: "standby",
+      wheelOverlayActive: false,
+      wheelOverlayLaunchedAt: undefined,
+      wheelOverlayStatus: "ready",
+      wheelCeremonyStatus: payload.action === "cancelWheel" ? "cancelled" : "idle",
+      wheelCeremonyStartedAt: undefined,
+      wheelCeremonySpinStartedAt: undefined,
+      wheelCeremonyResultTrackId: undefined,
+      wheelCeremonyResultSelectedAt: undefined,
+      wheelCeremonySeed: undefined,
+      wheelCeremonyJingleKey: "silent",
+      artistName: undefined,
+      trackTitle: undefined,
+      updatedAt: now,
+    };
   } else if (payload.action === "setSystemMessage") {
     next = { ...current, mode: "system_message", systemMessageActive: true, systemMessageTitle: cleanText(payload.title, "BARCODE SYSTEM MESSAGE"), systemMessage: cleanText(payload.message, "Stand by."), updatedAt: now };
   } else if (payload.action === "clearSystemMessage") {

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -194,7 +194,7 @@ function isActivePriorityTrack(entry: QueueEntry | null | undefined): boolean {
   return entry.priorityUpgradeStatus === "paid" || entry.priorityUpgradeStatus === "manual";
 }
 
-function isWheelEligibleTrack(entry: QueueEntry | null | undefined): boolean {
+export function isWheelEligibleTrack(entry: QueueEntry | null | undefined): boolean {
   if (!entry) return false;
   return (!entry.lane || entry.lane === "regular") && entry.status === "queued" && (entry.priorityUpgradeStatus ?? "none") === "none" && !entry.priorityPausedAt;
 }

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -48,7 +48,11 @@ assert.equal(receiver.includes("ctrl+enter"), false, "public wheel overlay does 
 assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public wheel overlay does not render the previous bottom roster/control clutter");
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
+assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-distance"), true, "wheel artist labels use dynamic sizing variables");
+assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(91.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
+assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");
 
 const eligibleCandidates = [
   { id: "free-1", submittedArtistName: "Free Artist", submittedSongTitle: "Free Track" },
@@ -70,6 +74,13 @@ assert.equal(spinning.wheelCeremony?.resultTrack?.id, "free-2", "server-selected
 const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
+
+const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+assert.equal(reencrypting.mode, "wheel_reencrypting", "re-encrypting ceremony shows re-encryption scene first");
+assert.equal(reencrypting.subtitle, "RE-ENCRYPTING SIGNAL", "re-encrypting scene uses BARCODE-controlled copy");
+
+const reencryptedPending = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
+assert.equal(reencryptedPending.mode, "wheel_result", "re-encrypting ceremony returns to result pending after the visual sequence");
 
 const confirmedFresh = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 0 }, overlayState: { wheelCeremonyStatus: "confirmed", wheelOverlayActive: true, wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(confirmedFresh.mode, "wheel_confirmed", "fresh confirmed result shows lock-in scene");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -41,7 +41,14 @@ const adminPanel = readFileSync("src/components/AdminLiveOverlayControl.tsx", "u
 assert.equal(adminPanel.includes("Show Now Playing"), false, "admin panel does not expose normal manual scene picker");
 assert.equal(adminPanel.includes("Temporary System Message") && adminPanel.indexOf("Temporary System Message") > adminPanel.indexOf("<details"), true, "temporary system message is inside collapsed emergency details");
 
-console.log("live overlay resolver tests passed");
+const receiver = readFileSync("src/components/LiveOverlayReceiver.tsx", "utf8");
+const overlayCss = readFileSync("src/app/overlay/live/overlay-live.css", "utf8");
+assert.equal(receiver.includes("Click to spin"), false, "public wheel overlay does not include stock click-to-spin text");
+assert.equal(receiver.includes("ctrl+enter"), false, "public wheel overlay does not include stock keyboard shortcut text");
+assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public wheel overlay does not render the previous bottom roster/control clutter");
+assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
+assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
+assert.equal(overlayCss.includes("width: min(91.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 
 const eligibleCandidates = [
   { id: "free-1", submittedArtistName: "Free Artist", submittedSongTitle: "Free Track" },
@@ -72,3 +79,5 @@ assert.equal(confirmedExpired.mode, "now_playing", "confirmed scene automaticall
 
 const cancelled = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "cancelled", wheelOverlayActive: false }, wheelCandidates: eligibleCandidates, nowPlaying: spotifyTrack });
 assert.equal(cancelled.mode, "now_playing", "cancelled wheel returns to automatic overlay mode without a wheel scene");
+
+console.log("live overlay resolver tests passed");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -49,10 +49,11 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-distance"), true, "wheel artist labels use dynamic sizing variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-distance") && receiver.includes("--wheel-rail-length"), true, "wheel artist labels use dynamic sizing variables");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
-assert.equal(overlayCss.includes("width: min(91.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
+assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");
+assert.equal(overlayCss.includes("IBM Plex Mono") && overlayCss.includes("live-overlay-wheel::before") && overlayCss.includes("live-overlay-wheel-slice-label::before"), true, "wheel CSS includes BARCODE-style typography, rim detailing, and label rails");
 
 const eligibleCandidates = [
   { id: "free-1", submittedArtistName: "Free Artist", submittedSongTitle: "Free Track" },

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -42,3 +42,33 @@ assert.equal(adminPanel.includes("Show Now Playing"), false, "admin panel does n
 assert.equal(adminPanel.includes("Temporary System Message") && adminPanel.indexOf("Temporary System Message") > adminPanel.indexOf("<details"), true, "temporary system message is inside collapsed emergency details");
 
 console.log("live overlay resolver tests passed");
+
+const eligibleCandidates = [
+  { id: "free-1", submittedArtistName: "Free Artist", submittedSongTitle: "Free Track" },
+  { id: "free-2", submittedArtistName: "Second Artist", submittedSongTitle: "Second Track" },
+];
+const notLaunched = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, nowPlaying: spotifyTrack, wheelCandidates: eligibleCandidates });
+assert.equal(notLaunched.mode, "now_playing", "wheel owed with candidates still does not auto-spin before launch");
+assert.equal(notLaunched.wheelCeremony, undefined, "wheel ceremony state is absent until host launch");
+
+const launched = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonyStartedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, nowPlaying: spotifyTrack });
+assert.equal(launched.mode, "wheel_ready", "launched wheel resolves to ready scene");
+assert.equal(launched.wheelCeremony?.candidateCount, 2, "ready scene exposes safe eligible candidate count");
+assert.equal(launched.automatic, false, "launched wheel is host-controlled visual state");
+
+const spinning = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:03.000Z") });
+assert.equal(spinning.mode, "wheel_spinning", "spin scene stays spinning during the visual spin window");
+assert.equal(spinning.wheelCeremony?.resultTrack?.id, "free-2", "server-selected result is stored while visual spin runs");
+
+const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
+assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
+assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
+
+const confirmedFresh = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 0 }, overlayState: { wheelCeremonyStatus: "confirmed", wheelOverlayActive: true, wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+assert.equal(confirmedFresh.mode, "wheel_confirmed", "fresh confirmed result shows lock-in scene");
+
+const confirmedExpired = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 0 }, overlayState: { wheelCeremonyStatus: "confirmed", wheelOverlayActive: true, wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, nowPlaying: spotifyTrack, now: new Date("2026-05-14T00:00:04.000Z") });
+assert.equal(confirmedExpired.mode, "now_playing", "confirmed scene automatically returns to normal resolver after lock-in window");
+
+const cancelled = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "cancelled", wheelOverlayActive: false }, wheelCandidates: eligibleCandidates, nowPlaying: spotifyTrack });
+assert.equal(cancelled.mode, "now_playing", "cancelled wheel returns to automatic overlay mode without a wheel scene");

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -966,3 +966,15 @@ test("priority can claim Next In Line after failed wheel removal hold", async ()
   assert.equal(state.nextInLine?.lane, "priority");
   assert.equal(state.session.wheelSpinsOwed, 1, "owed Wheel remains underneath Priority");
 });
+
+test("wheel ceremony eligibility helper excludes unsafe queue states", () => {
+  const base = { id: "base", artist: "Artist", title: "Track", link: "https://example.com/base", tier: "free", lane: "regular", amount: 0, stripeSessionId: null, status: "queued", createdAt: new Date().toISOString(), playedAt: null, priorityUpgradeStatus: "none" };
+  assert.equal(queue.isWheelEligibleTrack(base), true, "regular queued track with no priority upgrade is eligible");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "priority", lane: "priority", priorityUpgradeStatus: "paid" }), false, "paid priority is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "checkout", priorityUpgradeStatus: "checkout_pending" }), false, "checkout pending/payment processing is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "wheel", lane: "wheel" }), false, "already Wheel Chosen is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "playing", status: "playing" }), false, "playing/Now Playing is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "next", status: "next" }), false, "Next In Line is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "completed", status: "completed" }), false, "completed is excluded");
+  assert.equal(queue.isWheelEligibleTrack({ ...base, id: "removed", status: "removed" }), false, "removed is excluded");
+});

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -33,6 +33,7 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 
 const require = createRequire(import.meta.url);
 const queue = require("../src/lib/queue.ts");
+const overlay = require("../src/lib/live-overlay.ts");
 
 let trackSequence = 0;
 async function freshOpenSession(label, options = {}) {
@@ -977,4 +978,49 @@ test("wheel ceremony eligibility helper excludes unsafe queue states", () => {
   assert.equal(queue.isWheelEligibleTrack({ ...base, id: "next", status: "next" }), false, "Next In Line is excluded");
   assert.equal(queue.isWheelEligibleTrack({ ...base, id: "completed", status: "completed" }), false, "completed is excluded");
   assert.equal(queue.isWheelEligibleTrack({ ...base, id: "removed", status: "removed" }), false, "removed is excluded");
+});
+
+
+test("wheel re-encrypt rerolls visually without consuming owed spin or marking Wheel Chosen", async () => {
+  await freshOpenSession("wheel reencrypt", { showStarted: true });
+  const first = await addTrack("Reencrypt One");
+  const second = await addTrack("Reencrypt Two");
+  await queue.updateRadioTrack("", "addWheelSpinOwed");
+
+  await overlay.setLiveOverlayState({ action: "launchWheel" });
+  await overlay.setLiveOverlayState({ action: "spinWheel" });
+  const pending = await overlay.getLiveOverlayAdminSnapshot();
+  const firstResult = pending.overlayState.wheelCeremonyResultTrackId;
+  assert.ok(firstResult === first.id || firstResult === second.id, "spin stores a pending eligible result");
+
+  const afterSpin = await queue.getRadioQueueState();
+  assert.equal(afterSpin.session.wheelSpinsOwed, 1, "visual spin does not consume the owed wheel");
+  assert.equal(afterSpin.queue.some((entry) => entry.lane === "wheel"), false, "visual spin does not mark Wheel Chosen");
+
+  await overlay.setLiveOverlayState({ action: "reencryptWheel" });
+  const reencrypted = await overlay.getLiveOverlayAdminSnapshot();
+  assert.equal(reencrypted.overlayState.wheelCeremonyStatus, "reencrypting", "re-encrypt enters ceremony effect state");
+  assert.ok(reencrypted.overlayState.wheelCeremonyResultTrackId === first.id || reencrypted.overlayState.wheelCeremonyResultTrackId === second.id, "re-encrypt stores a pending eligible result");
+
+  const afterReencrypt = await queue.getRadioQueueState();
+  assert.equal(afterReencrypt.session.wheelSpinsOwed, 1, "re-encrypt does not consume the owed wheel");
+  assert.equal(afterReencrypt.queue.some((entry) => entry.lane === "wheel"), false, "re-encrypt does not mark Wheel Chosen");
+});
+
+test("wheel ceremony spin and stale confirm errors do not mutate queue", async () => {
+  await freshOpenSession("wheel ceremony errors", { showStarted: true });
+  await queue.updateRadioTrack("", "addWheelSpinOwed");
+  await overlay.setLiveOverlayState({ action: "launchWheel" });
+  await assert.rejects(() => overlay.setLiveOverlayState({ action: "spinWheel" }), /No eligible Wheel Chosen candidates/);
+  let state = await queue.getRadioQueueState();
+  assert.equal(state.session.wheelSpinsOwed, 1, "failed spin keeps owed wheel");
+  assert.equal(state.queue.some((entry) => entry.lane === "wheel"), false, "failed spin does not mark Wheel Chosen");
+
+  const stale = await addTrack("Stale Ceremony Result");
+  await overlay.setLiveOverlayState({ action: "spinWheel" });
+  await queue.updateRadioTrack(stale.id, "remove");
+  await assert.rejects(() => overlay.setLiveOverlayState({ action: "confirmWheel" }), /no longer eligible/);
+  state = await queue.getRadioQueueState();
+  assert.equal(state.session.wheelSpinsOwed, 1, "stale confirm keeps owed wheel");
+  assert.equal(state.queue.some((entry) => entry.lane === "wheel"), false, "stale confirm does not mark Wheel Chosen");
 });


### PR DESCRIPTION
### Motivation
- Provide a controlled, admin-driven wheel ceremony flow (launch → spin → reveal → confirm) that uses the existing overlay foundation without changing resolver/queue mechanics automatically. 
- Surface eligible candidates and a safe visual spin experience on the square/live overlay while preserving backend enforcement of eligibility and queue state changes.

### Description
- Add minimal wheel ceremony state, types, and resolver logic (`idle|ready|spinning|result_pending|confirmed|cancelled`) and compute a wheel ceremony scene that the overlay can render (server-selected result, candidate lists, spin timing, silent `jingleKey`).
- Add admin overlay actions and payload handling: `launchWheel`, `spinWheel` (server selects candidate, visual-only), `confirmWheel` (calls existing `updateRadioTrack(id, "wheel")` to mark Wheel Chosen), and `cancelWheel`/`clearWheel`; launch/spin do not mutate queue state, only confirmation affects queue via existing path.
- Expose eligible candidates using the safe helper (`isWheelEligibleTrack`) so paid/held/checkout/playing/next/completed/removed/wheel tracks are excluded; build candidate list from the active queue for display and server selection.
- Add overlay UI and CSS for ready / spinning / result / confirmed scenes plus admin controls in the admin panel with candidate roster, Spin, Confirm, Reroll, and Cancel buttons; add API error handling to surface invalid/stale actions.
- Files changed (key): `src/lib/live-overlay-resolver.ts`, `src/lib/live-overlay.ts`, `src/lib/queue.ts` (export helper), `src/components/AdminLiveOverlayControl.tsx`, `src/components/LiveOverlayReceiver.tsx`, `src/app/overlay/live/overlay-live.css`, `src/app/api/admin/overlay/live/route.ts`, and tests `tests/live-overlay-resolver.test.mjs`, `tests/queue-playback.test.mjs`.

### Testing
- `git diff --check` — passed.
- `npx tsc --noEmit --pretty false` — passed (existing npm warning about `http-proxy` only).
- `npx eslint` (targeted files) — passed (same existing npm warning only).
- Unit/runtime tests: `node tests/live-overlay-resolver.test.mjs` and `node tests/queue-playback.test.mjs` — both passed (all new and existing assertions green).
- Summary: overlay resolver tests and queue playback tests passed; type-check and lint passed; admin route now returns helpful errors for invalid ceremony actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053f0b8718832199172fac50dfc25d)