### PR TITLE
Fix wheel ceremony overlay follow-up: labels, spin duration, re-encrypt behavior, and local audio

### DIFF
--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -480,7 +480,10 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label > span {
-  animation: live-wheel-label-scramble 0.32s steps(2, end) infinite;
+  color: transparent;
+  text-shadow: 0 0 0.8vmin rgba(255,255,255,0.9), 0.5vmin 0 rgba(255,43,109,0.7), -0.5vmin 0 rgba(103,232,249,0.7);
+  filter: blur(0.35vmin) contrast(1.8);
+  animation: live-wheel-label-scramble 0.24s steps(2, end) infinite;
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(2n) > span {
@@ -633,11 +636,12 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel {
-  animation: live-wheel-reencrypt-brew 1.85s ease-in-out both;
+  animation: live-wheel-reencrypt-brew 2.2s ease-in-out both;
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slices {
-  filter: blur(0.48vmin) saturate(0.62) contrast(1.46);
+  filter: blur(0.9vmin) saturate(0.45) contrast(1.9);
+  opacity: 0.72;
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel::before {
@@ -671,11 +675,53 @@ body > div:last-of-type {
   animation: live-wheel-reencrypt-sweep 0.42s steps(3, end) infinite;
 }
 
+.live-overlay-wheel-glitch-stack {
+  position: absolute;
+  inset: 0;
+  z-index: 11;
+  pointer-events: none;
+  overflow: hidden;
+  animation: live-wheel-glitch-stack-pop 2.2s steps(2, end) both;
+}
+
+.live-overlay-wheel-static {
+  position: absolute;
+  inset: -8%;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255, 43, 109, 0.44), transparent 16%),
+    radial-gradient(circle at 82% 68%, rgba(103, 232, 249, 0.5), transparent 20%),
+    repeating-linear-gradient(90deg, rgba(255,255,255,0.22) 0 0.18vmin, transparent 0.2vmin 0.62vmin),
+    repeating-linear-gradient(0deg, rgba(15,23,42,0) 0 0.7vmin, rgba(255,255,255,0.16) 0.74vmin 0.96vmin);
+  mix-blend-mode: screen;
+  opacity: 0.82;
+  filter: blur(0.22vmin) contrast(1.6);
+  animation: live-wheel-static-surge 0.2s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-corrupt-labels {
+  position: absolute;
+  left: 50%;
+  bottom: 17%;
+  z-index: 12;
+  border: 0.18vmin solid rgba(255, 43, 109, 0.7);
+  background: rgba(2, 6, 23, 0.82);
+  color: #f0f9ff;
+  font-family: var(--font-geist-mono), "IBM Plex Mono", monospace;
+  font-size: clamp(0.64rem, 1.8vmin, 1.2rem);
+  font-weight: 950;
+  letter-spacing: 0.2em;
+  padding: 0.7vmin 1.1vmin;
+  text-transform: uppercase;
+  transform: translateX(-50%);
+  text-shadow: 0.3vmin 0 #ff2b6d, -0.3vmin 0 #67e8f9;
+  animation: live-wheel-corrupt-labels 0.28s steps(2, end) infinite;
+}
+
 .live-overlay-wheel-glitch {
   position: absolute;
   top: 45%;
   left: 50%;
-  z-index: 10;
+  z-index: 12;
   border: 0.28vmin solid rgba(255, 255, 255, 0.82);
   background: rgba(2, 6, 23, 0.9);
   padding: 1vmin 1.6vmin;
@@ -863,9 +909,10 @@ body > div:last-of-type {
 
 @keyframes live-wheel-reencrypt-brew {
   0% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1) rotate(0deg); }
-  18% { filter: blur(0.3vmin) hue-rotate(95deg) saturate(0.58) contrast(1.5); transform: scale(1.018) rotate(-0.55deg); }
-  42% { filter: blur(0.62vmin) hue-rotate(-130deg) saturate(1.7) contrast(0.82); transform: scale(0.986) rotate(0.7deg); }
-  70% { filter: blur(0.38vmin) hue-rotate(180deg) saturate(0.86) contrast(1.62); transform: scale(1.01) rotate(-0.28deg); }
+  12% { filter: blur(1.1vmin) hue-rotate(95deg) saturate(0.45) contrast(1.9); transform: scale(1.035) rotate(-1.1deg) translateX(-0.6vmin); }
+  36% { filter: blur(1.55vmin) hue-rotate(-130deg) saturate(2.2) contrast(0.72); transform: scale(0.97) rotate(1.4deg) translateX(0.7vmin); }
+  58% { filter: blur(1.25vmin) hue-rotate(180deg) saturate(0.62) contrast(2.1); transform: scale(1.026) rotate(-0.8deg) translateY(-0.5vmin); }
+  78% { filter: blur(0.55vmin) hue-rotate(-45deg) saturate(1.4) contrast(1.5); transform: scale(1.008) rotate(0.3deg); }
   100% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1) rotate(0deg); }
 }
 
@@ -921,6 +968,25 @@ body > div:last-of-type {
   0%, 100% { clip-path: inset(0 0 0 0); transform: translate(-50%, -50%) skewX(0deg); }
   35% { clip-path: inset(10% 0 18% 0); transform: translate(-49%, -51%) skewX(-6deg); }
   70% { clip-path: inset(18% 0 8% 0); transform: translate(-51%, -49%) skewX(5deg); }
+}
+
+
+@keyframes live-wheel-glitch-stack-pop {
+  0% { opacity: 0; filter: brightness(2.4); }
+  4% { opacity: 1; filter: brightness(1.7); }
+  72% { opacity: 0.96; filter: brightness(1.35); }
+  100% { opacity: 0; filter: brightness(1); }
+}
+
+@keyframes live-wheel-static-surge {
+  0%, 100% { transform: translate3d(-1.2vmin, 0, 0) skewX(-2deg); opacity: 0.62; }
+  50% { transform: translate3d(1.4vmin, -0.8vmin, 0) skewX(3deg); opacity: 0.92; }
+}
+
+@keyframes live-wheel-corrupt-labels {
+  0%, 100% { clip-path: inset(0 0 0 0); transform: translateX(-50%) skewX(0deg); }
+  35% { clip-path: inset(22% 0 18% 0); transform: translateX(calc(-50% - 0.8vmin)) skewX(-8deg); }
+  70% { clip-path: inset(8% 0 34% 0); transform: translateX(calc(-50% + 0.7vmin)) skewX(7deg); }
 }
 
 @keyframes live-wheel-result-pop {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -470,6 +470,11 @@ body > div:last-of-type {
   animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
 }
 
+.live-overlay-wheel-scene--result_pending .live-overlay-wheel,
+.live-overlay-wheel-scene--confirmed .live-overlay-wheel {
+  transform: rotate(var(--wheel-final-rotation, 1260deg));
+}
+
 
 .live-overlay-wheel-scene--ready .live-overlay-wheel-slices {
   animation: live-wheel-ready-shimmer 5.4s ease-in-out infinite;

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -526,10 +526,10 @@ body > div:last-of-type {
   overflow: visible;
   color: #f8fdff;
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
-  font-size: clamp(0.68rem, calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-scale, 1)), 4.35vmin);
+  font-size: clamp(0.68rem, var(--wheel-name-size, 1.45vmin), 5.95vmin);
   font-weight: 950;
   letter-spacing: var(--wheel-letter-spacing, 0.01em);
-  line-height: 0.86;
+  line-height: var(--wheel-label-line-height, 0.86);
   text-align: center;
   text-transform: uppercase;
   hyphens: auto;

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -494,18 +494,18 @@ body > div:last-of-type {
   min-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.08);
   place-items: center;
   pointer-events: none;
-  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 32vmin))) translate(-50%, -50%);
+  transform: translate(calc(-50% + var(--wheel-label-x, 0vmin)), calc(-50% + var(--wheel-label-y, -32vmin))) rotate(var(--wheel-label-rotation, 0deg));
   transform-origin: center;
 }
 
 .live-overlay-wheel-slice-label::before {
   position: absolute;
-  inset: 10% 4%;
+  inset: 2% -3%;
   content: "";
   border-radius: 999px;
-  background: radial-gradient(ellipse at center, rgba(2, 6, 23, 0.16), transparent 72%);
-  filter: blur(0.22vmin);
-  opacity: 0.34;
+  background: radial-gradient(ellipse at center, rgba(2, 6, 23, 0.24), transparent 74%);
+  filter: blur(0.2vmin);
+  opacity: 0.42;
 }
 
 .live-overlay-wheel-slice-label > span {
@@ -517,21 +517,22 @@ body > div:last-of-type {
   overflow: visible;
   color: #f8fdff;
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
-  font-size: clamp(0.68rem, calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-scale, 1)), 4.1vmin);
+  font-size: clamp(0.68rem, calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-scale, 1)), 4.35vmin);
   font-weight: 950;
   letter-spacing: var(--wheel-letter-spacing, 0.01em);
-  line-height: 0.9;
+  line-height: 0.86;
   text-align: center;
   text-transform: uppercase;
-  overflow-wrap: break-word;
+  hyphens: auto;
+  overflow-wrap: anywhere;
   word-break: normal;
   white-space: normal;
-  transform: rotate(var(--wheel-label-text-flip, 0deg));
   text-shadow:
-    0.14vmin 0.14vmin 0 rgba(2, 6, 23, 0.96),
-    -0.1vmin -0.08vmin 0 rgba(2, 6, 23, 0.9),
-    0 0 0.65vmin rgba(2, 6, 23, 0.95),
-    0 0 1.25vmin rgba(255, 255, 255, 0.42);
+    0.16vmin 0.16vmin 0 rgba(2, 6, 23, 0.98),
+    -0.12vmin -0.1vmin 0 rgba(2, 6, 23, 0.92),
+    0.08vmin -0.12vmin 0 rgba(2, 6, 23, 0.88),
+    0 0 0.72vmin rgba(2, 6, 23, 0.98),
+    0 0 1.18vmin rgba(255, 255, 255, 0.36);
 }
 
 .live-overlay-wheel-core {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -472,6 +472,15 @@ body > div:last-of-type {
   animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
 }
 
+
+.live-overlay-wheel-scene--ready .live-overlay-wheel-slices {
+  animation: live-wheel-ready-shimmer 5.4s ease-in-out infinite;
+}
+
+.live-overlay-wheel-scene--ready .live-overlay-wheel-pointer {
+  animation: live-wheel-pointer-idle 2.8s ease-in-out infinite;
+}
+
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label > span {
   animation: live-wheel-label-scramble 0.32s steps(2, end) infinite;
 }
@@ -594,6 +603,14 @@ body > div:last-of-type {
 .live-overlay-wheel-scene--spinning .live-overlay-wheel-slices,
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slices {
   animation: live-wheel-slice-glow 0.7s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel {
+  animation: live-wheel-reencrypt-brew 1.6s ease-in-out both;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slices {
+  filter: blur(0.35vmin) saturate(0.75) contrast(1.25);
 }
 
 .live-overlay-wheel-scene--spinning .live-overlay-wheel-pointer,
@@ -750,6 +767,17 @@ body > div:last-of-type {
   text-transform: uppercase;
 }
 
+.live-overlay-wheel-result-card p::after {
+  display: block;
+  width: min(32vmin, 100%);
+  height: 0.36vmin;
+  margin: 0.9vmin auto 0;
+  content: "";
+  background: linear-gradient(90deg, #67e8f9, #ff2b6d);
+  box-shadow: 0 0 1.3vmin rgba(103, 232, 249, 0.65);
+  animation: live-wheel-claim-countdown 20s linear both;
+}
+
 .live-overlay-wheel-result-card strong {
   color: #fff;
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
@@ -786,6 +814,23 @@ body > div:last-of-type {
   font-weight: 950;
   text-shadow: 0 0 1vmin rgba(103, 232, 249, 0.75);
   animation: live-binary-confetti var(--bit-duration, 2.8s) linear var(--bit-delay, 0s) infinite;
+}
+
+@keyframes live-wheel-ready-shimmer {
+  0%, 100% { filter: brightness(1) saturate(1.02); }
+  50% { filter: brightness(1.08) saturate(1.16); }
+}
+
+@keyframes live-wheel-pointer-idle {
+  0%, 100% { filter: drop-shadow(0 0 1.4vmin rgba(34, 211, 238, 0.75)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9)); }
+  50% { filter: drop-shadow(0 0 2vmin rgba(255, 255, 255, 0.9)) drop-shadow(0 0 0.9vmin rgba(34, 211, 238, 0.9)); }
+}
+
+@keyframes live-wheel-reencrypt-brew {
+  0% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1); }
+  25% { filter: blur(0.22vmin) hue-rotate(80deg) saturate(0.7) contrast(1.35); transform: scale(1.012) rotate(-0.35deg); }
+  58% { filter: blur(0.44vmin) hue-rotate(-95deg) saturate(1.55) contrast(0.92); transform: scale(0.992) rotate(0.42deg); }
+  100% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1); }
 }
 
 @keyframes live-wheel-slice-glow {
@@ -830,6 +875,11 @@ body > div:last-of-type {
   0% { transform: translate3d(0, -8vh, 0) rotate(0deg); opacity: 0; }
   12% { opacity: 1; }
   100% { transform: translate3d(var(--bit-drift, 0), 112vh, 0) rotate(140deg); opacity: 0; }
+}
+
+@keyframes live-wheel-claim-countdown {
+  0% { transform: scaleX(1); transform-origin: left; }
+  100% { transform: scaleX(0); transform-origin: left; }
 }
 
 @keyframes live-wheel-result-lock {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -396,13 +396,15 @@ body > div:last-of-type {
 
 .live-overlay-wheel-pointer {
   position: absolute;
-  top: -0.15vmin;
+  top: 50%;
+  right: -0.3vmin;
   z-index: 9;
   width: 0;
   height: 0;
-  border-right: 3.1vmin solid transparent;
-  border-left: 3.1vmin solid transparent;
-  border-top: 7.2vmin solid #fff;
+  border-top: 3.1vmin solid transparent;
+  border-bottom: 3.1vmin solid transparent;
+  border-right: 7.2vmin solid #fff;
+  transform: translateY(-50%);
   filter: drop-shadow(0 0 1.5vmin rgba(34, 211, 238, 0.95)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9));
 }
 
@@ -489,10 +491,10 @@ body > div:last-of-type {
   left: 50%;
   display: grid;
   width: var(--wheel-label-width, 24vmin);
-  min-height: calc(var(--wheel-name-size, 1.45vmin) * 2.35);
+  min-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.05);
   place-items: center;
   pointer-events: none;
-  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 38vmin))) rotate(var(--wheel-label-counter-angle)) translate(-50%, -50%);
+  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 38vmin))) translate(-50%, -50%);
   transform-origin: center;
 }
 
@@ -511,13 +513,13 @@ body > div:last-of-type {
   z-index: 1;
   display: -webkit-box;
   width: 100%;
-  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.3);
+  max-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.08);
   overflow: hidden;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: var(--wheel-label-lines, 2);
   color: #f8fdff;
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
-  font-size: clamp(0.72rem, var(--wheel-name-size, 1.45vmin), 4.5vmin);
+  font-size: clamp(0.68rem, calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-scale, 1)), 4.1vmin);
   font-weight: 950;
   letter-spacing: var(--wheel-letter-spacing, 0.01em);
   line-height: 0.96;
@@ -525,6 +527,7 @@ body > div:last-of-type {
   text-transform: uppercase;
   overflow-wrap: anywhere;
   white-space: normal;
+  transform: rotate(var(--wheel-label-text-flip, 0deg));
   text-shadow:
     0.14vmin 0.14vmin 0 rgba(2, 6, 23, 0.96),
     -0.1vmin -0.08vmin 0 rgba(2, 6, 23, 0.9),
@@ -635,7 +638,61 @@ body > div:last-of-type {
 }
 
 
-.live-overlay-wheel-audio-arm,
+.live-overlay-wheel-audio-modal {
+  position: absolute;
+  inset: 0;
+  z-index: 14;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle, rgba(2, 6, 23, 0.34), rgba(2, 6, 23, 0.72));
+}
+
+.live-overlay-wheel-audio-modal > div {
+  display: grid;
+  gap: 1vmin;
+  min-width: min(58vmin, 88%);
+  border: 0.2vmin solid rgba(103, 232, 249, 0.78);
+  background: rgba(2, 6, 23, 0.92);
+  padding: 2.2vmin;
+  text-align: center;
+  box-shadow: 0 0 5vmin rgba(103, 232, 249, 0.28), inset 0 0 2.5vmin rgba(103, 232, 249, 0.1);
+}
+
+.live-overlay-wheel-audio-modal span,
+.live-overlay-wheel-audio-notice,
+.live-overlay-wheel-audio-armed {
+  color: #a5f3fc;
+  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
+  font-size: clamp(0.58rem, 1.15vmin, 0.82rem);
+  font-weight: 950;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-audio-modal strong {
+  color: #fff;
+  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
+  font-size: clamp(1.5rem, 4vmin, 3.4rem);
+  line-height: 0.95;
+  text-transform: uppercase;
+  text-shadow: 0 0 1.4vmin rgba(103, 232, 249, 0.42);
+}
+
+.live-overlay-wheel-audio-modal button {
+  justify-self: center;
+  border: 1px solid rgba(103, 232, 249, 0.92);
+  background: #67e8f9;
+  color: #020617;
+  cursor: pointer;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: clamp(0.72rem, 1.35vmin, 1rem);
+  font-weight: 950;
+  letter-spacing: 0.16em;
+  padding: 0.9vmin 1.35vmin;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-audio-notice,
 .live-overlay-wheel-audio-armed {
   position: absolute;
   top: 4.8vmin;
@@ -643,24 +700,13 @@ body > div:last-of-type {
   z-index: 12;
   border: 1px solid rgba(103, 232, 249, 0.58);
   background: rgba(2, 6, 23, 0.76);
-  color: #dffbff;
-  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
-  font-size: clamp(0.58rem, 1.1vmin, 0.82rem);
-  font-weight: 950;
-  letter-spacing: 0.18em;
   padding: 0.72vmin 0.95vmin;
-  text-transform: uppercase;
   box-shadow: 0 0 2vmin rgba(103, 232, 249, 0.2);
 }
 
-.live-overlay-wheel-audio-arm {
-  cursor: pointer;
-}
-
-.live-overlay-wheel-audio-arm:hover,
-.live-overlay-wheel-audio-arm:focus-visible {
-  background: rgba(8, 47, 73, 0.86);
-  outline: 0.16vmin solid rgba(255, 255, 255, 0.72);
+.live-overlay-wheel-audio-notice {
+  border-color: rgba(255, 170, 0, 0.65);
+  color: #ffd166;
 }
 
 .live-overlay-wheel-audio-armed {
@@ -705,14 +751,84 @@ body > div:last-of-type {
 }
 
 
+.live-overlay-wheel-result-reveal {
+  position: absolute;
+  inset: 0;
+  z-index: 11;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.live-overlay-wheel-result-card {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: 0.55vmin;
+  max-width: 78vmin;
+  border: 0.24vmin solid rgba(255, 255, 255, 0.88);
+  background: radial-gradient(circle at top, rgba(103, 232, 249, 0.24), rgba(2, 6, 23, 0.95) 62%);
+  padding: 2.2vmin 3vmin;
+  text-align: center;
+  box-shadow: 0 0 7vmin rgba(103, 232, 249, 0.44), 0 0 12vmin rgba(255, 43, 109, 0.18);
+  animation: live-wheel-result-pop 0.62s cubic-bezier(0.2, 1.35, 0.22, 1) both;
+}
+
+.live-overlay-wheel-result-card span,
+.live-overlay-wheel-result-card p {
+  margin: 0;
+  color: #67e8f9;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: clamp(0.68rem, 1.6vmin, 1.08rem);
+  font-weight: 950;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-result-card strong {
+  color: #fff;
+  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
+  font-size: clamp(2.1rem, 7vmin, 6.2rem);
+  line-height: 0.92;
+  overflow-wrap: anywhere;
+  text-transform: uppercase;
+  text-shadow: 0.18vmin 0.18vmin 0 rgba(2, 6, 23, 0.95), 0 0 2.2vmin rgba(103, 232, 249, 0.58);
+}
+
+.live-overlay-wheel-result-card em {
+  color: #dffbff;
+  font-size: clamp(0.9rem, 2.4vmin, 1.8rem);
+  font-style: normal;
+  font-weight: 850;
+  overflow-wrap: anywhere;
+}
+
+.live-overlay-binary-confetti {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.live-overlay-binary-confetti span {
+  position: absolute;
+  top: -8%;
+  left: var(--bit-left);
+  color: rgba(219, 252, 255, 0.86);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: clamp(0.85rem, 2.2vmin, 1.5rem);
+  font-weight: 950;
+  text-shadow: 0 0 1vmin rgba(103, 232, 249, 0.75);
+  animation: live-binary-confetti var(--bit-duration, 2.8s) linear var(--bit-delay, 0s) infinite;
+}
+
 @keyframes live-wheel-slice-glow {
   0%, 100% { filter: saturate(1.1) brightness(1); }
   50% { filter: saturate(1.45) brightness(1.18); }
 }
 
 @keyframes live-wheel-pointer-pulse {
-  0%, 100% { transform: translateY(0); filter: drop-shadow(0 0 1.5vmin rgba(34, 211, 238, 0.95)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9)); }
-  50% { transform: translateY(0.55vmin); filter: drop-shadow(0 0 2.6vmin rgba(255, 255, 255, 1)) drop-shadow(0 0 1.2vmin rgba(34, 211, 238, 1)); }
+  0%, 100% { transform: translateY(-50%); filter: drop-shadow(0 0 1.5vmin rgba(34, 211, 238, 0.95)) drop-shadow(0 0 0.4vmin rgba(0, 0, 0, 0.9)); }
+  50% { transform: translateY(calc(-50% + 0.55vmin)); filter: drop-shadow(0 0 2.6vmin rgba(255, 255, 255, 1)) drop-shadow(0 0 1.2vmin rgba(34, 211, 238, 1)); }
 }
 
 @keyframes live-wheel-core-glow {
@@ -738,6 +854,17 @@ body > div:last-of-type {
   70% { clip-path: inset(18% 0 8% 0); transform: translate(-51%, -49%) skewX(5deg); }
 }
 
+@keyframes live-wheel-result-pop {
+  0% { opacity: 0; transform: scale(0.72) translateY(3vmin); filter: brightness(1.8); }
+  100% { opacity: 1; transform: scale(1) translateY(0); filter: brightness(1); }
+}
+
+@keyframes live-binary-confetti {
+  0% { transform: translate3d(0, -8vh, 0) rotate(0deg); opacity: 0; }
+  12% { opacity: 1; }
+  100% { transform: translate3d(var(--bit-drift, 0), 112vh, 0) rotate(140deg); opacity: 0; }
+}
+
 @keyframes live-wheel-result-lock {
   0% { transform: scale(0.96); filter: brightness(1.8); }
   100% { transform: scale(1); filter: brightness(1); }
@@ -756,11 +883,6 @@ body > div:last-of-type {
 
   .live-overlay-wheel {
     width: min(90.5vmin, 100%);
-  }
-
-  .live-overlay-wheel-slice-label > span {
-    right: var(--wheel-label-distance, 9.4vmin);
-    width: var(--wheel-label-width, 26vmin);
   }
 
   .live-overlay-wheel-status {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -441,9 +441,7 @@ body > div:last-of-type {
   inset: 0;
   content: "";
   border-radius: inherit;
-  background:
-    repeating-conic-gradient(from -90deg, rgba(2, 6, 23, 0.72) 0deg 0.38deg, transparent 0.38deg calc(360deg / var(--wheel-slice-count, 8))),
-    radial-gradient(circle, transparent 0 49%, rgba(255, 255, 255, 0.12) 50% 50.4%, transparent 51% 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.46) 100%);
+  background: radial-gradient(circle, transparent 0 49%, rgba(255, 255, 255, 0.12) 50% 50.4%, transparent 51% 58%, rgba(2, 6, 23, 0.18) 78%, rgba(2, 6, 23, 0.46) 100%);
 }
 
 .live-overlay-wheel::before,
@@ -544,6 +542,35 @@ body > div:last-of-type {
     0 0 1.18vmin rgba(255, 255, 255, 0.36);
 }
 
+
+.live-overlay-wheel-winning-segment {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  pointer-events: none;
+  background: conic-gradient(from 0deg, transparent 0deg var(--wheel-winning-start, 0deg), rgba(255, 255, 255, 0.5) var(--wheel-winning-start, 0deg) var(--wheel-winning-end, 0deg), transparent var(--wheel-winning-end, 0deg) 360deg);
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 0 1.6vmin rgba(255, 255, 255, 0.8)) drop-shadow(0 0 3.2vmin rgba(103, 232, 249, 0.65));
+  animation: live-wheel-winning-segment-lock 1.15s ease-in-out infinite;
+}
+
+.live-overlay-wheel-scene--result_pending .live-overlay-wheel-pointer::after,
+.live-overlay-wheel-scene--confirmed .live-overlay-wheel-pointer::after {
+  position: absolute;
+  top: 50%;
+  right: -3.7vmin;
+  content: "SIGNAL LOCKED";
+  color: #fff;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: clamp(0.48rem, 0.95vmin, 0.72rem);
+  font-weight: 950;
+  letter-spacing: 0.16em;
+  text-shadow: 0 0 1vmin rgba(103, 232, 249, 0.9), 0 0 0.7vmin rgba(2, 6, 23, 1);
+  transform: translate(100%, -50%);
+  animation: live-wheel-pointer-lock-flash 0.84s ease-in-out infinite;
+}
+
 .live-overlay-wheel-core {
   position: absolute;
   z-index: 5;
@@ -606,11 +633,19 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel {
-  animation: live-wheel-reencrypt-brew 1.6s ease-in-out both;
+  animation: live-wheel-reencrypt-brew 1.85s ease-in-out both;
 }
 
 .live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slices {
-  filter: blur(0.35vmin) saturate(0.75) contrast(1.25);
+  filter: blur(0.48vmin) saturate(0.62) contrast(1.46);
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel::before {
+  animation: live-wheel-rgb-ghost 0.28s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel::after {
+  animation: live-wheel-radial-jitter 0.34s steps(2, end) infinite;
 }
 
 .live-overlay-wheel-scene--spinning .live-overlay-wheel-pointer,
@@ -827,10 +862,32 @@ body > div:last-of-type {
 }
 
 @keyframes live-wheel-reencrypt-brew {
-  0% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1); }
-  25% { filter: blur(0.22vmin) hue-rotate(80deg) saturate(0.7) contrast(1.35); transform: scale(1.012) rotate(-0.35deg); }
-  58% { filter: blur(0.44vmin) hue-rotate(-95deg) saturate(1.55) contrast(0.92); transform: scale(0.992) rotate(0.42deg); }
-  100% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1); }
+  0% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1) rotate(0deg); }
+  18% { filter: blur(0.3vmin) hue-rotate(95deg) saturate(0.58) contrast(1.5); transform: scale(1.018) rotate(-0.55deg); }
+  42% { filter: blur(0.62vmin) hue-rotate(-130deg) saturate(1.7) contrast(0.82); transform: scale(0.986) rotate(0.7deg); }
+  70% { filter: blur(0.38vmin) hue-rotate(180deg) saturate(0.86) contrast(1.62); transform: scale(1.01) rotate(-0.28deg); }
+  100% { filter: blur(0) hue-rotate(0deg) saturate(1); transform: scale(1) rotate(0deg); }
+}
+
+@keyframes live-wheel-rgb-ghost {
+  0%, 100% { transform: translate(0, 0); opacity: 0.64; filter: hue-rotate(0deg); }
+  45% { transform: translate(0.7vmin, -0.45vmin); opacity: 0.96; filter: hue-rotate(110deg); }
+  72% { transform: translate(-0.55vmin, 0.38vmin); opacity: 0.72; filter: hue-rotate(-120deg); }
+}
+
+@keyframes live-wheel-radial-jitter {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.026) rotate(0.65deg); opacity: 0.58; }
+}
+
+@keyframes live-wheel-winning-segment-lock {
+  0%, 100% { opacity: 0.28; filter: drop-shadow(0 0 1.2vmin rgba(255, 255, 255, 0.65)) drop-shadow(0 0 2.2vmin rgba(103, 232, 249, 0.42)); }
+  50% { opacity: 0.72; filter: drop-shadow(0 0 2.2vmin rgba(255, 255, 255, 0.96)) drop-shadow(0 0 4.6vmin rgba(103, 232, 249, 0.86)); }
+}
+
+@keyframes live-wheel-pointer-lock-flash {
+  0%, 100% { opacity: 0.62; }
+  50% { opacity: 1; }
 }
 
 @keyframes live-wheel-slice-glow {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -489,21 +489,21 @@ body > div:last-of-type {
   left: 50%;
   display: grid;
   width: var(--wheel-label-width, 24vmin);
-  min-height: calc(var(--wheel-name-size, 1.45vmin) * 2.25);
+  min-height: calc(var(--wheel-name-size, 1.45vmin) * 2.35);
   place-items: center;
   pointer-events: none;
-  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 36vmin))) rotate(var(--wheel-label-counter-angle)) translate(-50%, -50%);
+  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 38vmin))) rotate(var(--wheel-label-counter-angle)) translate(-50%, -50%);
   transform-origin: center;
 }
 
 .live-overlay-wheel-slice-label::before {
   position: absolute;
-  inset: -0.28vmin -0.7vmin;
+  inset: 10% 4%;
   content: "";
   border-radius: 999px;
-  background: radial-gradient(ellipse at center, rgba(2, 6, 23, 0.2), transparent 68%);
-  filter: blur(0.18vmin);
-  opacity: 0.42;
+  background: radial-gradient(ellipse at center, rgba(2, 6, 23, 0.16), transparent 72%);
+  filter: blur(0.22vmin);
+  opacity: 0.34;
 }
 
 .live-overlay-wheel-slice-label > span {
@@ -511,34 +511,32 @@ body > div:last-of-type {
   z-index: 1;
   display: -webkit-box;
   width: 100%;
-  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.18);
+  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.3);
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   color: #f8fdff;
-  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", Rajdhani, Orbitron, var(--font-geist-mono), monospace;
+  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
   font-size: clamp(0.72rem, var(--wheel-name-size, 1.45vmin), 4.5vmin);
   font-weight: 950;
-  letter-spacing: var(--wheel-letter-spacing, 0.016em);
-  line-height: 0.88;
+  letter-spacing: var(--wheel-letter-spacing, 0.01em);
+  line-height: 0.96;
   text-align: center;
   text-transform: uppercase;
   overflow-wrap: anywhere;
   white-space: normal;
-  -webkit-text-stroke: 0.075vmin rgba(2, 6, 23, 0.92);
   text-shadow:
-    0 0 0.16vmin rgba(2, 6, 23, 1),
-    0.18vmin 0.18vmin 0 rgba(2, 6, 23, 0.95),
-    -0.12vmin -0.08vmin 0 rgba(2, 6, 23, 0.85),
-    0 0 1.2vmin rgba(255, 255, 255, 0.58),
-    0 0 2.2vmin rgba(103, 232, 249, 0.45);
+    0.14vmin 0.14vmin 0 rgba(2, 6, 23, 0.96),
+    -0.1vmin -0.08vmin 0 rgba(2, 6, 23, 0.9),
+    0 0 0.65vmin rgba(2, 6, 23, 0.95),
+    0 0 1.25vmin rgba(255, 255, 255, 0.42);
 }
 
 .live-overlay-wheel-core {
   position: absolute;
   z-index: 5;
   display: grid;
-  width: 16vmin;
+  width: 14.5vmin;
   aspect-ratio: 1 / 1;
   place-items: center;
   border: 0.5vmin solid rgba(255,255,255,0.92);
@@ -552,14 +550,14 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-core span {
-  font-size: clamp(1.35rem, 4.85vmin, 3.45rem);
+  font-size: clamp(1.2rem, 4.35vmin, 3.1rem);
   font-weight: 950;
   line-height: 0.75;
 }
 
 .live-overlay-wheel-core small {
   color: rgba(255,255,255,0.82);
-  font-size: clamp(0.42rem, 0.98vmin, 0.7rem);
+  font-size: clamp(0.38rem, 0.86vmin, 0.62rem);
   letter-spacing: 0.22em;
 }
 

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -466,9 +466,20 @@ body > div:last-of-type {
   box-shadow: inset 0 0 2.8vmin rgba(2, 6, 23, 0.32), 0 0 2.2vmin rgba(255, 255, 255, 0.1);
 }
 
-.live-overlay-wheel-scene--spinning .live-overlay-wheel,
-.live-overlay-wheel-scene--reencrypting .live-overlay-wheel {
-  animation: live-wheel-spin var(--wheel-spin-duration, 6.5s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
+.live-overlay-wheel-scene--spinning .live-overlay-wheel {
+  animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label {
+  animation: live-wheel-label-scramble 0.32s steps(2, end) infinite;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(2n) {
+  animation-direction: reverse;
+}
+
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(3n) {
+  animation-duration: 0.46s;
 }
 
 .live-overlay-wheel-slice-label {
@@ -496,9 +507,12 @@ body > div:last-of-type {
 .live-overlay-wheel-slice-label > span {
   position: absolute;
   right: var(--wheel-label-distance, 10.4vmin);
-  display: block;
+  display: -webkit-box;
   width: var(--wheel-label-width, 28vmin);
+  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.15);
   overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   border: 0.14vmin solid rgba(2, 6, 23, 0.46);
   border-radius: 0.7vmin;
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(219, 252, 255, 0.72), rgba(255, 255, 255, 0.5));
@@ -507,12 +521,12 @@ body > div:last-of-type {
   font-size: clamp(0.72rem, var(--wheel-name-size, 1.45vmin), 4.5vmin);
   font-weight: 950;
   letter-spacing: var(--wheel-letter-spacing, 0.06em);
-  line-height: 0.88;
+  line-height: 0.92;
   text-align: center;
-  text-overflow: ellipsis;
   text-shadow: 0.08vmin 0 rgba(255, 255, 255, 0.72), 0 0 0.75vmin rgba(255, 255, 255, 0.55);
   text-transform: uppercase;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
   transform: translateY(-50%);
   box-shadow: 0.35vmin 0.35vmin 0 rgba(2, 6, 23, 0.35), inset 0 0 1.2vmin rgba(103, 232, 249, 0.14);
 }
@@ -521,7 +535,7 @@ body > div:last-of-type {
   position: absolute;
   z-index: 5;
   display: grid;
-  width: 21.5vmin;
+  width: 18.5vmin;
   aspect-ratio: 1 / 1;
   place-items: center;
   border: 0.5vmin solid rgba(255,255,255,0.92);
@@ -535,14 +549,14 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-core span {
-  font-size: clamp(1.9rem, 6.3vmin, 4.5rem);
+  font-size: clamp(1.55rem, 5.45vmin, 3.9rem);
   font-weight: 950;
   line-height: 0.75;
 }
 
 .live-overlay-wheel-core small {
   color: rgba(255,255,255,0.82);
-  font-size: clamp(0.5rem, 1.35vmin, 0.9rem);
+  font-size: clamp(0.46rem, 1.12vmin, 0.78rem);
   letter-spacing: 0.22em;
 }
 
@@ -637,14 +651,13 @@ body > div:last-of-type {
 .live-overlay-wheel-status strong {
   display: block;
   max-width: 82vmin;
-  overflow: hidden;
   color: #fff;
   font-size: clamp(1.1rem, 3.45vmin, 2.95rem);
   font-weight: 950;
   line-height: 0.92;
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
   text-shadow: 0.12vmin 0 rgba(103, 232, 249, 0.55), -0.08vmin 0 rgba(255, 43, 109, 0.36);
 }
 
@@ -662,6 +675,12 @@ body > div:last-of-type {
 @keyframes live-wheel-core-glow {
   0%, 100% { box-shadow: 0 0 3.5vmin rgba(0,0,0,0.85), inset 0 0 2.5vmin rgba(103, 232, 249, 0.2); }
   50% { box-shadow: 0 0 5vmin rgba(103, 232, 249, 0.58), inset 0 0 3.4vmin rgba(103, 232, 249, 0.35); }
+}
+
+@keyframes live-wheel-label-scramble {
+  0%, 100% { transform: translateY(-50%) translateX(0) skewX(0deg); filter: hue-rotate(0deg) contrast(1); }
+  34% { transform: translateY(-50%) translateX(-1.2vmin) skewX(-8deg); filter: hue-rotate(105deg) contrast(1.35); }
+  68% { transform: translateY(-50%) translateX(1vmin) skewX(7deg); filter: hue-rotate(-80deg) contrast(1.2); }
 }
 
 @keyframes live-wheel-reencrypt-sweep {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -470,15 +470,15 @@ body > div:last-of-type {
   animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
 }
 
-.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label {
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label > span {
   animation: live-wheel-label-scramble 0.32s steps(2, end) infinite;
 }
 
-.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(2n) {
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(2n) > span {
   animation-direction: reverse;
 }
 
-.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(3n) {
+.live-overlay-wheel-scene--reencrypting .live-overlay-wheel-slice-label:nth-of-type(3n) > span {
   animation-duration: 0.46s;
 }
 
@@ -487,55 +487,58 @@ body > div:last-of-type {
   z-index: 2;
   top: 50%;
   left: 50%;
-  width: 50%;
-  height: 0;
-  transform: rotate(calc(var(--wheel-label-angle) - 90deg));
-  transform-origin: 0 0;
+  display: grid;
+  width: var(--wheel-label-width, 24vmin);
+  min-height: calc(var(--wheel-name-size, 1.45vmin) * 2.25);
+  place-items: center;
+  pointer-events: none;
+  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 36vmin))) rotate(var(--wheel-label-counter-angle)) translate(-50%, -50%);
+  transform-origin: center;
 }
 
 .live-overlay-wheel-slice-label::before {
   position: absolute;
-  right: calc(var(--wheel-label-distance, 10.4vmin) + 1vmin);
-  width: var(--wheel-rail-length, 20vmin);
-  height: 0.24vmin;
+  inset: -0.28vmin -0.7vmin;
   content: "";
-  background: linear-gradient(90deg, transparent, rgba(2, 6, 23, 0.46), rgba(255, 255, 255, 0.5));
-  transform: translateY(-50%);
-  opacity: 0.66;
+  border-radius: 999px;
+  background: radial-gradient(ellipse at center, rgba(2, 6, 23, 0.2), transparent 68%);
+  filter: blur(0.18vmin);
+  opacity: 0.42;
 }
 
 .live-overlay-wheel-slice-label > span {
-  position: absolute;
-  right: var(--wheel-label-distance, 10.4vmin);
+  position: relative;
+  z-index: 1;
   display: -webkit-box;
-  width: var(--wheel-label-width, 28vmin);
-  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.15);
+  width: 100%;
+  max-height: calc(var(--wheel-name-size, 1.45vmin) * 2.18);
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-  border: 0.14vmin solid rgba(2, 6, 23, 0.46);
-  border-radius: 0.7vmin;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(219, 252, 255, 0.72), rgba(255, 255, 255, 0.5));
-  padding: 0.62vmin 1.05vmin 0.68vmin;
-  color: #020617;
+  color: #f8fdff;
+  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", Rajdhani, Orbitron, var(--font-geist-mono), monospace;
   font-size: clamp(0.72rem, var(--wheel-name-size, 1.45vmin), 4.5vmin);
   font-weight: 950;
-  letter-spacing: var(--wheel-letter-spacing, 0.06em);
-  line-height: 0.92;
+  letter-spacing: var(--wheel-letter-spacing, 0.016em);
+  line-height: 0.88;
   text-align: center;
-  text-shadow: 0.08vmin 0 rgba(255, 255, 255, 0.72), 0 0 0.75vmin rgba(255, 255, 255, 0.55);
   text-transform: uppercase;
   overflow-wrap: anywhere;
   white-space: normal;
-  transform: translateY(-50%);
-  box-shadow: 0.35vmin 0.35vmin 0 rgba(2, 6, 23, 0.35), inset 0 0 1.2vmin rgba(103, 232, 249, 0.14);
+  -webkit-text-stroke: 0.075vmin rgba(2, 6, 23, 0.92);
+  text-shadow:
+    0 0 0.16vmin rgba(2, 6, 23, 1),
+    0.18vmin 0.18vmin 0 rgba(2, 6, 23, 0.95),
+    -0.12vmin -0.08vmin 0 rgba(2, 6, 23, 0.85),
+    0 0 1.2vmin rgba(255, 255, 255, 0.58),
+    0 0 2.2vmin rgba(103, 232, 249, 0.45);
 }
 
 .live-overlay-wheel-core {
   position: absolute;
   z-index: 5;
   display: grid;
-  width: 18.5vmin;
+  width: 16vmin;
   aspect-ratio: 1 / 1;
   place-items: center;
   border: 0.5vmin solid rgba(255,255,255,0.92);
@@ -549,14 +552,14 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-core span {
-  font-size: clamp(1.55rem, 5.45vmin, 3.9rem);
+  font-size: clamp(1.35rem, 4.85vmin, 3.45rem);
   font-weight: 950;
   line-height: 0.75;
 }
 
 .live-overlay-wheel-core small {
   color: rgba(255,255,255,0.82);
-  font-size: clamp(0.46rem, 1.12vmin, 0.78rem);
+  font-size: clamp(0.42rem, 0.98vmin, 0.7rem);
   letter-spacing: 0.22em;
 }
 
@@ -633,6 +636,40 @@ body > div:last-of-type {
   animation: live-wheel-glitch-card 0.5s steps(2, end) infinite;
 }
 
+
+.live-overlay-wheel-audio-arm,
+.live-overlay-wheel-audio-armed {
+  position: absolute;
+  top: 4.8vmin;
+  right: 4.8vmin;
+  z-index: 12;
+  border: 1px solid rgba(103, 232, 249, 0.58);
+  background: rgba(2, 6, 23, 0.76);
+  color: #dffbff;
+  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
+  font-size: clamp(0.58rem, 1.1vmin, 0.82rem);
+  font-weight: 950;
+  letter-spacing: 0.18em;
+  padding: 0.72vmin 0.95vmin;
+  text-transform: uppercase;
+  box-shadow: 0 0 2vmin rgba(103, 232, 249, 0.2);
+}
+
+.live-overlay-wheel-audio-arm {
+  cursor: pointer;
+}
+
+.live-overlay-wheel-audio-arm:hover,
+.live-overlay-wheel-audio-arm:focus-visible {
+  background: rgba(8, 47, 73, 0.86);
+  outline: 0.16vmin solid rgba(255, 255, 255, 0.72);
+}
+
+.live-overlay-wheel-audio-armed {
+  border-color: rgba(34, 197, 94, 0.62);
+  color: #bbf7d0;
+}
+
 .live-overlay-wheel-scene--confirmed .live-overlay-wheel-status {
   animation: live-wheel-result-lock 0.9s ease-out both;
 }
@@ -646,6 +683,14 @@ body > div:last-of-type {
   font-weight: 850;
   letter-spacing: 0.28em;
   text-transform: uppercase;
+}
+
+.live-overlay-wheel-status em {
+  max-width: 84vmin;
+  margin-top: 0.3vmin;
+  letter-spacing: 0.06em;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .live-overlay-wheel-status strong {
@@ -678,9 +723,9 @@ body > div:last-of-type {
 }
 
 @keyframes live-wheel-label-scramble {
-  0%, 100% { transform: translateY(-50%) translateX(0) skewX(0deg); filter: hue-rotate(0deg) contrast(1); }
-  34% { transform: translateY(-50%) translateX(-1.2vmin) skewX(-8deg); filter: hue-rotate(105deg) contrast(1.35); }
-  68% { transform: translateY(-50%) translateX(1vmin) skewX(7deg); filter: hue-rotate(-80deg) contrast(1.2); }
+  0%, 100% { transform: translateX(0) skewX(0deg); filter: hue-rotate(0deg) contrast(1); }
+  34% { transform: translateX(-0.9vmin) skewX(-8deg); filter: hue-rotate(105deg) contrast(1.35); }
+  68% { transform: translateX(0.8vmin) skewX(7deg); filter: hue-rotate(-80deg) contrast(1.2); }
 }
 
 @keyframes live-wheel-reencrypt-sweep {

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -303,7 +303,7 @@ body > div:last-of-type {
 .live-overlay-youtube-lower h1 {
   font-size: clamp(1.5rem, 4.8vmin, 4rem);
   font-weight: 900;
-  line-height: 0.96;
+  line-height: 0.9;
 }
 
 .live-overlay-youtube-lower h2 {
@@ -491,10 +491,10 @@ body > div:last-of-type {
   left: 50%;
   display: grid;
   width: var(--wheel-label-width, 24vmin);
-  min-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.05);
+  min-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.08);
   place-items: center;
   pointer-events: none;
-  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 38vmin))) translate(-50%, -50%);
+  transform: rotate(var(--wheel-label-angle)) translateY(calc(0vmin - var(--wheel-label-radius, 32vmin))) translate(-50%, -50%);
   transform-origin: center;
 }
 
@@ -511,21 +511,20 @@ body > div:last-of-type {
 .live-overlay-wheel-slice-label > span {
   position: relative;
   z-index: 1;
-  display: -webkit-box;
+  display: block;
   width: 100%;
-  max-height: calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-lines, 2) * 1.08);
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: var(--wheel-label-lines, 2);
+  max-height: none;
+  overflow: visible;
   color: #f8fdff;
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
   font-size: clamp(0.68rem, calc(var(--wheel-name-size, 1.45vmin) * var(--wheel-label-scale, 1)), 4.1vmin);
   font-weight: 950;
   letter-spacing: var(--wheel-letter-spacing, 0.01em);
-  line-height: 0.96;
+  line-height: 0.9;
   text-align: center;
   text-transform: uppercase;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   white-space: normal;
   transform: rotate(var(--wheel-label-text-flip, 0deg));
   text-shadow:
@@ -638,60 +637,7 @@ body > div:last-of-type {
 }
 
 
-.live-overlay-wheel-audio-modal {
-  position: absolute;
-  inset: 0;
-  z-index: 14;
-  display: grid;
-  place-items: center;
-  background: radial-gradient(circle, rgba(2, 6, 23, 0.34), rgba(2, 6, 23, 0.72));
-}
-
-.live-overlay-wheel-audio-modal > div {
-  display: grid;
-  gap: 1vmin;
-  min-width: min(58vmin, 88%);
-  border: 0.2vmin solid rgba(103, 232, 249, 0.78);
-  background: rgba(2, 6, 23, 0.92);
-  padding: 2.2vmin;
-  text-align: center;
-  box-shadow: 0 0 5vmin rgba(103, 232, 249, 0.28), inset 0 0 2.5vmin rgba(103, 232, 249, 0.1);
-}
-
-.live-overlay-wheel-audio-modal span,
-.live-overlay-wheel-audio-notice,
-.live-overlay-wheel-audio-armed {
-  color: #a5f3fc;
-  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
-  font-size: clamp(0.58rem, 1.15vmin, 0.82rem);
-  font-weight: 950;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
-.live-overlay-wheel-audio-modal strong {
-  color: #fff;
-  font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
-  font-size: clamp(1.5rem, 4vmin, 3.4rem);
-  line-height: 0.95;
-  text-transform: uppercase;
-  text-shadow: 0 0 1.4vmin rgba(103, 232, 249, 0.42);
-}
-
-.live-overlay-wheel-audio-modal button {
-  justify-self: center;
-  border: 1px solid rgba(103, 232, 249, 0.92);
-  background: #67e8f9;
-  color: #020617;
-  cursor: pointer;
-  font-family: var(--font-geist-mono), monospace;
-  font-size: clamp(0.72rem, 1.35vmin, 1rem);
-  font-weight: 950;
-  letter-spacing: 0.16em;
-  padding: 0.9vmin 1.35vmin;
-  text-transform: uppercase;
-}
-
+.live-overlay-wheel-audio-arm,
 .live-overlay-wheel-audio-notice,
 .live-overlay-wheel-audio-armed {
   position: absolute;
@@ -700,8 +646,24 @@ body > div:last-of-type {
   z-index: 12;
   border: 1px solid rgba(103, 232, 249, 0.58);
   background: rgba(2, 6, 23, 0.76);
+  color: #a5f3fc;
+  font-family: var(--font-geist-mono), "IBM Plex Mono", "Share Tech Mono", monospace;
+  font-size: clamp(0.58rem, 1.1vmin, 0.82rem);
+  font-weight: 950;
+  letter-spacing: 0.14em;
   padding: 0.72vmin 0.95vmin;
+  text-transform: uppercase;
   box-shadow: 0 0 2vmin rgba(103, 232, 249, 0.2);
+}
+
+.live-overlay-wheel-audio-arm {
+  cursor: pointer;
+}
+
+.live-overlay-wheel-audio-arm:hover,
+.live-overlay-wheel-audio-arm:focus-visible {
+  background: rgba(8, 47, 73, 0.86);
+  outline: 0.16vmin solid rgba(255, 255, 255, 0.72);
 }
 
 .live-overlay-wheel-audio-notice {
@@ -733,7 +695,8 @@ body > div:last-of-type {
   max-width: 84vmin;
   margin-top: 0.3vmin;
   letter-spacing: 0.06em;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   white-space: normal;
 }
 
@@ -745,7 +708,8 @@ body > div:last-of-type {
   font-weight: 950;
   line-height: 0.92;
   text-transform: uppercase;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   white-space: normal;
   text-shadow: 0.12vmin 0 rgba(103, 232, 249, 0.55), -0.08vmin 0 rgba(255, 43, 109, 0.36);
 }
@@ -790,7 +754,8 @@ body > div:last-of-type {
   font-family: "Arial Black", Impact, "Franklin Gothic Heavy", system-ui, sans-serif;
   font-size: clamp(2.1rem, 7vmin, 6.2rem);
   line-height: 0.92;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   text-transform: uppercase;
   text-shadow: 0.18vmin 0.18vmin 0 rgba(2, 6, 23, 0.95), 0 0 2.2vmin rgba(103, 232, 249, 0.58);
 }
@@ -800,7 +765,8 @@ body > div:last-of-type {
   font-size: clamp(0.9rem, 2.4vmin, 1.8rem);
   font-style: normal;
   font-weight: 850;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 .live-overlay-binary-confetti {

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -53,6 +53,7 @@ export function AdminLiveOverlayControl() {
   const result = ceremony?.resultTrack;
   const canLaunch = wheelOwed > 0 && !wheelActive;
   const canSpin = wheelOwed > 0 && ceremony?.status === "ready" && candidates.length > 0;
+  const canReencrypt = canSpin && !ceremony?.resultTrackId;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;
   const wheelAttention = wheelOwed > 0 || wheelActive;
 
@@ -80,8 +81,9 @@ export function AdminLiveOverlayControl() {
             <p className="mt-1 text-sm text-muted">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</p>
             {!wheelActive && wheelOwed > 0 && <p className="mt-1 text-sm text-muted">Launch when you are ready to show the wheel on air. Launch does not choose a winner, consume spins, or change queue state.</p>}
             {ceremony?.status === "ready" && <p className="mt-1 text-sm text-muted">Candidates: {ceremony.candidateCount}. Awaiting host spin.</p>}
-            {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting signal before the next reveal…</p>}
+            {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting candidates before the spin…</p>}
             {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
+            {ceremony?.status === "signal_lost" && <p className="mt-1 text-sm text-cyan-100">SIGNAL LOST — winner not present. Wheel still owed; spin again when ready.</p>}
             {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
             {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
             {wheelActive && candidates.length === 0 && <p className="mt-2 border border-danger/40 bg-danger/10 p-2 text-sm text-danger">No eligible Free/Regular queued tracks are available for Wheel Chosen.</p>}
@@ -89,12 +91,13 @@ export function AdminLiveOverlayControl() {
           <div className="flex flex-wrap gap-2">
             {canLaunch && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel ceremony launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel</button>}
             {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
+            {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={!canReencrypt} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
             {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel" }, "Wheel Chosen confirmed through queue admin.")} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background">Confirm Wheel Chosen</button>}
-            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={candidates.length === 0} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
-            {wheelActive && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
+            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "wheelWinnerNotHere" }, "Winner removed; wheel still owed. Spin again.")} className="border border-danger/70 px-4 py-2 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background">Winner Not Here</button>}
+            {wheelActive && ceremony?.status !== "spinning" && ceremony?.status !== "reencrypting" && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
-        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Scramble and spin again before confirmation.</p>}
+        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm the winner, remove an absent winner without fulfilling the owed wheel, or cancel back to automatic.</p>}
         {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
       </section>
 

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -12,6 +12,7 @@ export function AdminLiveOverlayControl() {
   const [snapshot, setSnapshot] = useState<LiveOverlayAdminSnapshot | null>(null);
   const [systemTitle, setSystemTitle] = useState("");
   const [systemMessage, setSystemMessage] = useState("");
+  const [selectedWheelTrackId, setSelectedWheelTrackId] = useState("");
   const [status, setStatus] = useState<string | null>(null);
 
   async function load() {
@@ -51,12 +52,27 @@ export function AdminLiveOverlayControl() {
   const ceremony = scene?.wheelCeremony;
   const candidates = snapshot?.wheelCandidates ?? [];
   const result = ceremony?.resultTrack;
+  const resultTracks = result?.tracks ?? [];
+  const resultNeedsTrackChoice = ceremony?.status === "result_pending" && resultTracks.length > 1;
+  const canConfirmWheel = ceremony?.status === "result_pending" && (!resultNeedsTrackChoice || Boolean(selectedWheelTrackId));
   const canLaunch = wheelOwed > 0 && !wheelActive;
   const wheelReadyForAction = ceremony?.status === "ready";
   const canSpin = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0;
   const canReencrypt = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && !ceremony?.resultTrackId;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;
   const wheelAttention = wheelOwed > 0 || wheelActive;
+
+  useEffect(() => {
+    if (ceremony?.status !== "result_pending" || !result) {
+      setSelectedWheelTrackId("");
+      return;
+    }
+    if ((result.tracks?.length ?? 0) === 1) {
+      setSelectedWheelTrackId(result.tracks?.[0]?.id ?? "");
+      return;
+    }
+    setSelectedWheelTrackId((current) => result.tracks?.some((track) => track.id === current) ? current : "");
+  }, [ceremony?.status, result]);
 
   return (
     <section className="space-y-4 border border-accent/40 bg-background/50 p-5">
@@ -85,7 +101,7 @@ export function AdminLiveOverlayControl() {
             {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting candidates before the spin…</p>}
             {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
             {ceremony?.status === "signal_lost" && <p className="mt-1 text-sm text-cyan-100">SIGNAL LOST — winner not present. Wheel still owed; spin again when ready.</p>}
-            {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
+            {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName}</span>{resultTracks.length > 1 ? <span> — choose 1 of {resultTracks.length} tracks below</span> : <span> — {result.trackTitle}</span>}</p>}
             {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
             {wheelActive && candidates.length === 0 && <p className="mt-2 border border-danger/40 bg-danger/10 p-2 text-sm text-danger">No eligible Free/Regular queued tracks are available for Wheel Chosen.</p>}
           </div>
@@ -93,14 +109,15 @@ export function AdminLiveOverlayControl() {
             {canLaunch && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel ceremony launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel</button>}
             {wheelReadyForAction && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
             {wheelReadyForAction && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={!canReencrypt} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
-            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel" }, "Wheel Chosen confirmed through queue admin.")} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background">Confirm Wheel Chosen</button>}
+            {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel", selectedTrackId: selectedWheelTrackId }, "Wheel Chosen confirmed through queue admin.")} disabled={!canConfirmWheel} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Confirm Wheel Chosen</button>}
             {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "wheelWinnerNotHere" }, "Winner removed; wheel still owed. Spin again.")} className="border border-danger/70 px-4 py-2 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background">Winner Not Here</button>}
             {wheelActive && ceremony?.status !== "spinning" && ceremony?.status !== "reencrypting" && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
         {wheelReadyForAction && <p className="text-xs uppercase tracking-widest text-muted">Cancel / Return to Auto closes wheel mode without choosing a winner, fulfilling the owed wheel, or changing queue order.</p>}
-        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm chooses this track. Winner Not Here removes this artist and keeps the wheel owed. Cancel exits wheel mode without choosing a winner.</p>}
-        {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
+        {ceremony?.status === "result_pending" && resultNeedsTrackChoice && <label className="block max-w-xl space-y-1 text-xs uppercase tracking-widest text-cyan-100"><span>Choose winning track for {result?.artistName}</span><select value={selectedWheelTrackId} onChange={(event) => setSelectedWheelTrackId(event.target.value)} className="w-full border border-cyan-300/40 bg-background px-3 py-2 text-sm normal-case tracking-normal text-foreground"><option value="">Select the Wheel Chosen track…</option>{resultTracks.map((track) => <option key={track.id} value={track.id}>{track.trackTitle}</option>)}</select></label>}
+        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm marks the selected song from the winning person as Wheel Chosen. Winner Not Here removes that winning person from the active wheel pool and keeps the wheel owed. Cancel exits wheel mode without choosing a winner.</p>}
+        {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {(candidate.trackCount ?? 1) > 1 ? `${candidate.trackCount} tracks` : candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more grouped signals</p>}</div>}
       </section>
 
       <details className="border border-border bg-background/40 p-4">

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -4,17 +4,6 @@
 import { useEffect, useState } from "react";
 import type { LiveOverlayAdminSnapshot } from "@/lib/live-overlay";
 
-const WHEEL_AUDIO_ARMED_STORAGE_KEY = "barcode-wheel-audio-armed";
-
-function readWheelAudioArmed(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(WHEEL_AUDIO_ARMED_STORAGE_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
 function sceneLabel(mode?: string): string {
   return mode ? mode.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "Syncing";
 }
@@ -24,7 +13,6 @@ export function AdminLiveOverlayControl() {
   const [systemTitle, setSystemTitle] = useState("");
   const [systemMessage, setSystemMessage] = useState("");
   const [status, setStatus] = useState<string | null>(null);
-  const [overlayAudioArmed, setOverlayAudioArmed] = useState(() => readWheelAudioArmed());
 
   async function load() {
     const res = await fetch("/api/admin/overlay/live", { cache: "no-store" });
@@ -37,10 +25,7 @@ export function AdminLiveOverlayControl() {
 
   useEffect(() => {
     load();
-    const interval = window.setInterval(() => {
-      load();
-      setOverlayAudioArmed(readWheelAudioArmed());
-    }, 5_000);
+    const interval = window.setInterval(load, 5_000);
     return () => window.clearInterval(interval);
   }, []);
 
@@ -68,7 +53,7 @@ export function AdminLiveOverlayControl() {
   const result = ceremony?.resultTrack;
   const canLaunch = wheelOwed > 0 && !wheelActive;
   const wheelReadyForAction = ceremony?.status === "ready" || ceremony?.status === "signal_lost";
-  const canSpin = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && overlayAudioArmed;
+  const canSpin = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0;
   const canReencrypt = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && !ceremony?.resultTrackId;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;
   const wheelAttention = wheelOwed > 0 || wheelActive;
@@ -96,11 +81,10 @@ export function AdminLiveOverlayControl() {
             <h3 className="mt-1 text-lg font-bold text-foreground">{wheelActive ? sceneLabel(ceremony?.status) : wheelOwed > 0 ? "Wheel Spin Waiting" : "No Wheel Spin Waiting"}</h3>
             <p className="mt-1 text-sm text-muted">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</p>
             {!wheelActive && wheelOwed > 0 && <p className="mt-1 text-sm text-muted">Launch when you are ready to show the wheel on air. Launch does not choose a winner, consume spins, or change queue state.</p>}
-            {wheelReadyForAction && <p className="mt-1 text-sm text-muted">Candidates: {ceremony?.candidateCount ?? 0}. Spin Wheel chooses the winner. Re-encrypt Signal reshuffles the wheel before the spin.</p>}
+            {wheelReadyForAction && <p className="mt-1 text-sm text-muted">Candidates: {ceremony?.candidateCount ?? 0}. Spin Wheel chooses the winner. Re-encrypt Signal reshuffles/remaps the wheel before the spin without touching the queue.</p>}
             {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting candidates before the spin…</p>}
             {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
             {ceremony?.status === "signal_lost" && <p className="mt-1 text-sm text-cyan-100">SIGNAL LOST — winner not present. Wheel still owed; spin again when ready.</p>}
-            {wheelReadyForAction && !overlayAudioArmed && <p className="mt-2 border border-[#ffaa00]/50 bg-[#ffaa00]/10 p-2 text-sm text-[#ffaa00]">Overlay audio must be enabled before first spin. Open the overlay and click ENABLE WHEEL AUDIO.</p>}
             {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
             {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
             {wheelActive && candidates.length === 0 && <p className="mt-2 border border-danger/40 bg-danger/10 p-2 text-sm text-danger">No eligible Free/Regular queued tracks are available for Wheel Chosen.</p>}
@@ -114,7 +98,7 @@ export function AdminLiveOverlayControl() {
             {wheelActive && ceremony?.status !== "spinning" && ceremony?.status !== "reencrypting" && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
-        {wheelReadyForAction && <p className="text-xs uppercase tracking-widest text-muted">Cancel / Return to Auto closes wheel mode without choosing a winner or fulfilling the owed wheel.</p>}
+        {wheelReadyForAction && <p className="text-xs uppercase tracking-widest text-muted">Cancel / Return to Auto closes wheel mode without choosing a winner, fulfilling the owed wheel, or changing queue order.</p>}
         {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm chooses this track. Winner Not Here removes this artist and keeps the wheel owed. Cancel exits wheel mode without choosing a winner.</p>}
         {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
       </section>

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -52,7 +52,7 @@ export function AdminLiveOverlayControl() {
   const candidates = snapshot?.wheelCandidates ?? [];
   const result = ceremony?.resultTrack;
   const canLaunch = wheelOwed > 0 && !wheelActive;
-  const wheelReadyForAction = ceremony?.status === "ready" || ceremony?.status === "signal_lost";
+  const wheelReadyForAction = ceremony?.status === "ready";
   const canSpin = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0;
   const canReencrypt = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && !ceremony?.resultTrackId;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;

--- a/src/components/AdminLiveOverlayControl.tsx
+++ b/src/components/AdminLiveOverlayControl.tsx
@@ -4,6 +4,17 @@
 import { useEffect, useState } from "react";
 import type { LiveOverlayAdminSnapshot } from "@/lib/live-overlay";
 
+const WHEEL_AUDIO_ARMED_STORAGE_KEY = "barcode-wheel-audio-armed";
+
+function readWheelAudioArmed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(WHEEL_AUDIO_ARMED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 function sceneLabel(mode?: string): string {
   return mode ? mode.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "Syncing";
 }
@@ -13,6 +24,7 @@ export function AdminLiveOverlayControl() {
   const [systemTitle, setSystemTitle] = useState("");
   const [systemMessage, setSystemMessage] = useState("");
   const [status, setStatus] = useState<string | null>(null);
+  const [overlayAudioArmed, setOverlayAudioArmed] = useState(() => readWheelAudioArmed());
 
   async function load() {
     const res = await fetch("/api/admin/overlay/live", { cache: "no-store" });
@@ -25,7 +37,10 @@ export function AdminLiveOverlayControl() {
 
   useEffect(() => {
     load();
-    const interval = window.setInterval(load, 5_000);
+    const interval = window.setInterval(() => {
+      load();
+      setOverlayAudioArmed(readWheelAudioArmed());
+    }, 5_000);
     return () => window.clearInterval(interval);
   }, []);
 
@@ -52,8 +67,9 @@ export function AdminLiveOverlayControl() {
   const candidates = snapshot?.wheelCandidates ?? [];
   const result = ceremony?.resultTrack;
   const canLaunch = wheelOwed > 0 && !wheelActive;
-  const canSpin = wheelOwed > 0 && ceremony?.status === "ready" && candidates.length > 0;
-  const canReencrypt = canSpin && !ceremony?.resultTrackId;
+  const wheelReadyForAction = ceremony?.status === "ready" || ceremony?.status === "signal_lost";
+  const canSpin = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && overlayAudioArmed;
+  const canReencrypt = wheelOwed > 0 && wheelReadyForAction && candidates.length > 0 && !ceremony?.resultTrackId;
   const systemActive = snapshot?.overlayState.systemMessageActive === true;
   const wheelAttention = wheelOwed > 0 || wheelActive;
 
@@ -80,24 +96,26 @@ export function AdminLiveOverlayControl() {
             <h3 className="mt-1 text-lg font-bold text-foreground">{wheelActive ? sceneLabel(ceremony?.status) : wheelOwed > 0 ? "Wheel Spin Waiting" : "No Wheel Spin Waiting"}</h3>
             <p className="mt-1 text-sm text-muted">{wheelOwed} wheel spin{wheelOwed === 1 ? "" : "s"} owed.</p>
             {!wheelActive && wheelOwed > 0 && <p className="mt-1 text-sm text-muted">Launch when you are ready to show the wheel on air. Launch does not choose a winner, consume spins, or change queue state.</p>}
-            {ceremony?.status === "ready" && <p className="mt-1 text-sm text-muted">Candidates: {ceremony.candidateCount}. Awaiting host spin.</p>}
+            {wheelReadyForAction && <p className="mt-1 text-sm text-muted">Candidates: {ceremony?.candidateCount ?? 0}. Spin Wheel chooses the winner. Re-encrypt Signal reshuffles the wheel before the spin.</p>}
             {ceremony?.status === "reencrypting" && <p className="mt-1 text-sm text-cyan-100">Re-encrypting candidates before the spin…</p>}
             {ceremony?.status === "spinning" && <p className="mt-1 text-sm text-cyan-100">Result incoming…</p>}
             {ceremony?.status === "signal_lost" && <p className="mt-1 text-sm text-cyan-100">SIGNAL LOST — winner not present. Wheel still owed; spin again when ready.</p>}
+            {wheelReadyForAction && !overlayAudioArmed && <p className="mt-2 border border-[#ffaa00]/50 bg-[#ffaa00]/10 p-2 text-sm text-[#ffaa00]">Overlay audio must be enabled before first spin. Open the overlay and click ENABLE WHEEL AUDIO.</p>}
             {ceremony?.status === "result_pending" && result && <p className="mt-1 text-sm text-cyan-100">Winner: <span className="font-bold text-foreground">{result.artistName} — {result.trackTitle}</span></p>}
             {ceremony?.status === "confirmed" && result && <p className="mt-1 text-sm text-cyan-100">Confirmed: {result.artistName} — {result.trackTitle}. Overlay will return to automatic mode.</p>}
             {wheelActive && candidates.length === 0 && <p className="mt-2 border border-danger/40 bg-danger/10 p-2 text-sm text-danger">No eligible Free/Regular queued tracks are available for Wheel Chosen.</p>}
           </div>
           <div className="flex flex-wrap gap-2">
             {canLaunch && <button type="button" onClick={() => post({ action: "launchWheel" }, "Wheel ceremony launched.")} className="border border-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 hover:bg-cyan-300 hover:text-background">Launch Wheel</button>}
-            {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
-            {ceremony?.status === "ready" && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={!canReencrypt} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
+            {wheelReadyForAction && <button type="button" onClick={() => post({ action: "spinWheel" }, "Wheel spin started.")} disabled={!canSpin} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background disabled:cursor-not-allowed disabled:opacity-40">Spin Wheel</button>}
+            {wheelReadyForAction && <button type="button" onClick={() => post({ action: "reencryptWheel" }, "Signal re-encryption started.")} disabled={!canReencrypt} className="border border-cyan-300/70 px-4 py-2 text-xs uppercase tracking-widest text-cyan-200 disabled:cursor-not-allowed disabled:opacity-40">Re-encrypt Signal</button>}
             {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "confirmWheel" }, "Wheel Chosen confirmed through queue admin.")} className="border border-cyan-300 bg-cyan-300 px-4 py-2 text-xs uppercase tracking-widest text-background">Confirm Wheel Chosen</button>}
             {ceremony?.status === "result_pending" && <button type="button" onClick={() => post({ action: "wheelWinnerNotHere" }, "Winner removed; wheel still owed. Spin again.")} className="border border-danger/70 px-4 py-2 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background">Winner Not Here</button>}
             {wheelActive && ceremony?.status !== "spinning" && ceremony?.status !== "reencrypting" && <button type="button" onClick={() => post({ action: "cancelWheel" }, "Wheel ceremony cancelled; returning to auto.")} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Cancel / Return to Auto</button>}
           </div>
         </div>
-        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm the winner, remove an absent winner without fulfilling the owed wheel, or cancel back to automatic.</p>}
+        {wheelReadyForAction && <p className="text-xs uppercase tracking-widest text-muted">Cancel / Return to Auto closes wheel mode without choosing a winner or fulfilling the owed wheel.</p>}
+        {ceremony?.status === "result_pending" && <p className="text-xs uppercase tracking-widest text-muted">Confirm chooses this track. Winner Not Here removes this artist and keeps the wheel owed. Cancel exits wheel mode without choosing a winner.</p>}
         {wheelActive && candidates.length > 0 && <div className="grid gap-2 text-xs text-muted md:grid-cols-2 lg:grid-cols-3">{candidates.slice(0, 6).map((candidate) => <p key={candidate.id} className="border border-cyan-300/20 bg-background/40 p-2"><span className="text-cyan-100">{candidate.artistName}</span> — {candidate.trackTitle}</p>)}{candidates.length > 6 && <p className="border border-cyan-300/20 bg-background/40 p-2 text-cyan-100">+ {candidates.length - 6} more eligible signals</p>}</div>}
       </section>
 

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { wheelFinalRotationForSlice } from "@/lib/live-overlay-resolver";
+import { buildWheelSegments, wheelFinalRotationForSegment } from "@/lib/live-overlay-resolver";
 import type { LiveOverlayYouTubeSync, ResolvedLiveOverlayScene } from "@/lib/live-overlay";
 
 type YTPlayer = {
@@ -207,11 +207,11 @@ function wheelLabelMetrics(count: number) {
   return { width: 12.4, radius: 36.7, size: 0.98, tracking: "0", lines: 2 };
 }
 
-function wheelLabelFit(value: string, count: number) {
+function wheelLabelFit(value: string, count: number, segmentAngle: number) {
   const cleaned = value.replace(/\s+/g, " ").trim();
   const length = cleaned.length;
   const words = cleaned.split(" ").filter(Boolean).length;
-  const sliceDegrees = 360 / Math.max(1, count);
+  const sliceDegrees = Math.max(1, segmentAngle);
   const base = wheelLabelMetrics(count);
   const shortNameBoost = length <= 7 ? 1.32 : length <= 14 ? 1.18 : length <= 24 ? 1.06 : 1;
   const lines = length <= 12 && words <= 2 ? 1 : length > 34 || words > 3 ? 3 : 2;
@@ -252,13 +252,13 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const candidateCount = Math.max(1, candidates.length);
-  const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
-  const sliceDegrees = 360 / candidateCount;
+  const wheelSegments = buildWheelSegments(candidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
+  const resultSegment = wheelSegments.find((segment) => segment.candidateId === result?.id) ?? wheelSegments[0];
   const sliceColors = ["#67e8f9", "#0ea5e9", "#2563eb", "#7c3aed", "#c026d3", "#ff2b6d", "#ef4444", "#f97316", "#facc15", "#22c55e", "#e5e7eb", "#071426"];
-  const sliceBackground = candidates.length > 0 ? `conic-gradient(from -90deg, ${candidates.map((_, index) => `${sliceColors[index % sliceColors.length]} ${index * sliceDegrees}deg ${(index + 1) * sliceDegrees}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
+  const sliceBackground = candidates.length > 0 ? `conic-gradient(from 0deg, ${wheelSegments.map((segment, index) => `${sliceColors[index % sliceColors.length]} ${segment.startAngle}deg ${segment.endAngle}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
   const wheelStyle = {
-    "--wheel-final-rotation": `${wheelFinalRotationForSlice(candidateCount, resultIndex)}deg`,
+    "--wheel-final-rotation": `${wheelFinalRotationForSegment(resultSegment)}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
@@ -267,6 +267,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-label-radius": `${labelMetrics.radius}vmin`,
     "--wheel-letter-spacing": labelMetrics.tracking,
     "--wheel-label-lines": labelMetrics.lines,
+    "--wheel-winning-start": `${resultSegment.startAngle}deg`,
+    "--wheel-winning-end": `${resultSegment.endAngle}deg`,
   } as CSSProperties;
   useEffect(() => {
     if (!audioJustArmed) return undefined;
@@ -362,10 +364,12 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
         <div className="live-overlay-wheel-pointer" aria-hidden="true" />
         <div className="live-overlay-wheel" style={wheelStyle}>
           <div className="live-overlay-wheel-slices" aria-hidden="true" />
+          {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-winning-segment" aria-hidden="true" />}
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
-            const angle = index * sliceDegrees + sliceDegrees / 2;
+            const segment = wheelSegments[index] ?? resultSegment;
+            const angle = segment.centerAngle;
             const label = candidate.artistName.replace(/\s+/g, " ").trim();
-            const labelFit = wheelLabelFit(label, candidateCount);
+            const labelFit = wheelLabelFit(label, candidateCount, segment.angleSize);
             const position = wheelLabelPosition(angle, labelFit.radius);
             // Wheel labels are visual only. Winner selection is based on slice geometry and the right-side pointer.
             const labelStyle = {

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -66,7 +66,41 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
   return Boolean((scene.mode === "now_playing" || scene.mode === "artist_card") && scene.track);
 }
 
+const WHEEL_AUDIO_ARMED_STORAGE_KEY = "barcode-wheel-audio-armed";
+
 const FALLBACK_WHEEL_AUDIO_FILES = [
+  "/audio/wheel/142.mp3",
+  "/audio/wheel/77.mp3",
+  "/audio/wheel/150.mp3",
+  "/audio/wheel/49.mp3",
+  "/audio/wheel/103.mp3",
+  "/audio/wheel/56.mp3",
+  "/audio/wheel/58.mp3",
+  "/audio/wheel/84.mp3",
+  "/audio/wheel/147.mp3",
+  "/audio/wheel/102.mp3",
+  "/audio/wheel/92.mp3",
+  "/audio/wheel/76.mp3",
+  "/audio/wheel/111.mp3",
+  "/audio/wheel/74.mp3",
+  "/audio/wheel/139.mp3",
+  "/audio/wheel/110.mp3",
+  "/audio/wheel/126.mp3",
+  "/audio/wheel/148.mp3",
+  "/audio/wheel/162.mp3",
+  "/audio/wheel/104.mp3",
+  "/audio/wheel/32%20(1).mp3",
+  "/audio/wheel/140.mp3",
+  "/audio/wheel/81.mp3",
+  "/audio/wheel/75.mp3",
+  "/audio/wheel/129.mp3",
+  "/audio/wheel/78.mp3",
+  "/audio/wheel/36.mp3",
+  "/audio/wheel/154.mp3",
+  "/audio/wheel/24.mp3",
+  "/audio/wheel/41.mp3",
+  "/audio/wheel/130.mp3",
+  "/audio/wheel/70.mp3",
   "/audio/wheel/wheel-spin-01-creepy-circus-astronautflute.mp3",
   "/audio/wheel/wheel-spin-02-dark-circus-top-sue.mp3",
   "/audio/wheel/wheel-spin-03-comedy-circus-top-sue.mp3",
@@ -89,7 +123,7 @@ const FALLBACK_WHEEL_AUDIO_FILES = [
 
 function safeWheelAudioPath(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  const cleaned = value.trim();
+  const cleaned = value.trim().replace(/\s/g, "%20");
   if (!/^[a-zA-Z0-9._~!$&'()*+,;=:@/%-]+\.mp3(?:\?.*)?$/i.test(cleaned)) return null;
   if (/^https?:\/\//i.test(cleaned) || cleaned.includes("..")) return null;
   if (cleaned.startsWith("/") && !cleaned.startsWith("/audio/wheel/")) return null;
@@ -112,21 +146,52 @@ async function loadWheelAudioFiles(): Promise<string[]> {
   }
 }
 
+function shuffledAudioPaths(paths: string[]): string[] {
+  const shuffled = [...paths];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled;
+}
+
+function audioPlayWasBlocked(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
+
 function stopWheelAudio(audio: HTMLAudioElement | null): void {
   if (!audio) return;
   audio.pause();
   audio.currentTime = 0;
 }
 
+function readWheelAudioArmed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(WHEEL_AUDIO_ARMED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function rememberWheelAudioArmed(armed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (armed) window.localStorage.setItem(WHEEL_AUDIO_ARMED_STORAGE_KEY, "true");
+    else window.localStorage.removeItem(WHEEL_AUDIO_ARMED_STORAGE_KEY);
+  } catch {
+    // localStorage can be unavailable in private or embedded preview contexts.
+  }
+}
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { maxLength: 64, width: "38vmin", distance: "2.2vmin", size: "4.8vmin", tracking: "0.025em", rail: "34vmin" };
-  if (count <= 6) return { maxLength: 56, width: "34vmin", distance: "3.8vmin", size: "3.95vmin", tracking: "0.03em", rail: "31vmin" };
-  if (count <= 8) return { maxLength: 48, width: "30vmin", distance: "5.5vmin", size: "3.15vmin", tracking: "0.035em", rail: "28vmin" };
-  if (count <= 12) return { maxLength: 40, width: "26vmin", distance: "7.4vmin", size: "2.35vmin", tracking: "0.04em", rail: "24vmin" };
-  if (count <= 16) return { maxLength: 34, width: "22vmin", distance: "9.6vmin", size: "1.8vmin", tracking: "0.045em", rail: "21vmin" };
-  if (count <= 24) return { maxLength: 28, width: "18vmin", distance: "11.4vmin", size: "1.3vmin", tracking: "0.05em", rail: "18vmin" };
-  return { maxLength: 22, width: "15vmin", distance: "13vmin", size: "1vmin", tracking: "0.045em", rail: "14vmin" };
+  if (count <= 4) return { maxLength: 64, width: "30vmin", radius: "34vmin", size: "4.6vmin", tracking: "0.01em" };
+  if (count <= 6) return { maxLength: 56, width: "27vmin", radius: "35vmin", size: "3.75vmin", tracking: "0.012em" };
+  if (count <= 8) return { maxLength: 48, width: "24vmin", radius: "36vmin", size: "2.95vmin", tracking: "0.014em" };
+  if (count <= 12) return { maxLength: 40, width: "20vmin", radius: "36.8vmin", size: "2.18vmin", tracking: "0.016em" };
+  if (count <= 16) return { maxLength: 34, width: "17vmin", radius: "37.5vmin", size: "1.66vmin", tracking: "0.018em" };
+  if (count <= 24) return { maxLength: 28, width: "14vmin", radius: "38.2vmin", size: "1.18vmin", tracking: "0.02em" };
+  return { maxLength: 22, width: "11.5vmin", radius: "39vmin", size: "0.92vmin", tracking: "0.015em" };
 }
 
 function shortWheelLabel(value: string, maxLength: number): string {
@@ -141,6 +206,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const result = ceremony?.resultTrack;
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [audioArmed, setAudioArmed] = useState(() => readWheelAudioArmed());
+  const [audioJustArmed, setAudioJustArmed] = useState(false);
   const candidateCount = Math.max(1, candidates.length);
   const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
   const sliceDegrees = 360 / candidateCount;
@@ -155,34 +222,49 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-slice-background": sliceBackground,
     "--wheel-name-size": labelMetrics.size,
     "--wheel-label-width": labelMetrics.width,
-    "--wheel-label-distance": labelMetrics.distance,
+    "--wheel-label-radius": labelMetrics.radius,
     "--wheel-letter-spacing": labelMetrics.tracking,
-    "--wheel-rail-length": labelMetrics.rail,
   } as CSSProperties;
   const labelMaxLength = labelMetrics.maxLength;
 
   useEffect(() => {
+    if (!audioJustArmed) return undefined;
+    const timeout = window.setTimeout(() => setAudioJustArmed(false), 2200);
+    return () => window.clearTimeout(timeout);
+  }, [audioJustArmed]);
+
+  useEffect(() => {
     const existingAudio = audioRef.current;
-    if (!spinning) {
+    if (!spinning || !audioArmed) {
       stopWheelAudio(existingAudio);
       audioRef.current = null;
       return undefined;
     }
 
     let cancelled = false;
-    loadWheelAudioFiles().then((files) => {
-      if (cancelled || files.length === 0) return;
-      const audioPath = files[Math.floor(Math.random() * files.length)] ?? files[0];
-      if (!audioPath) return;
-      const audio = new Audio(audioPath);
-      audio.loop = true;
-      audio.preload = "auto";
-      audio.volume = 0.72;
-      audioRef.current = audio;
-      audio.play().catch(() => {
-        stopWheelAudio(audio);
-        if (audioRef.current === audio) audioRef.current = null;
-      });
+    loadWheelAudioFiles().then(async (files) => {
+      const storedPath = safeWheelAudioPath(ceremony?.audioPath);
+      const candidatePaths = [storedPath, ...shuffledAudioPaths(files)].filter((path, index, paths): path is string => Boolean(path) && paths.indexOf(path) === index);
+      for (const audioPath of candidatePaths) {
+        if (cancelled) return;
+        const audio = new Audio(audioPath);
+        audio.loop = true;
+        audio.preload = "auto";
+        audio.volume = 0.72;
+        audioRef.current = audio;
+        try {
+          await audio.play();
+          return;
+        } catch (error) {
+          stopWheelAudio(audio);
+          if (audioRef.current === audio) audioRef.current = null;
+          if (audioPlayWasBlocked(error)) {
+            setAudioArmed(false);
+            rememberWheelAudioArmed(false);
+            return;
+          }
+        }
+      }
     });
 
     return () => {
@@ -190,10 +272,24 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       stopWheelAudio(audioRef.current);
       audioRef.current = null;
     };
-  }, [spinning, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
+  }, [audioArmed, spinning, ceremony?.audioPath, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
+
+  function enableWheelAudio() {
+    const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
+    const unlockAudio = new Audio(unlockPath);
+    unlockAudio.muted = true;
+    unlockAudio.volume = 0;
+    unlockAudio.play().catch(() => undefined).finally(() => {
+      stopWheelAudio(unlockAudio);
+      setAudioArmed(true);
+      setAudioJustArmed(true);
+      rememberWheelAudioArmed(true);
+    });
+  }
 
   return (
     <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
+      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
@@ -207,7 +303,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
             const angle = index * sliceDegrees + sliceDegrees / 2;
             const label = shortWheelLabel(candidate.artistName, labelMaxLength);
-            const labelStyle = { "--wheel-label-angle": `${angle}deg` } as CSSProperties;
+            const labelStyle = { "--wheel-label-angle": `${angle}deg`, "--wheel-label-counter-angle": `${-angle}deg` } as CSSProperties;
             return (
               <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>
                 <span>{label}</span>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -246,6 +246,10 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const ceremony = scene.wheelCeremony;
   const candidates = ceremony?.displayCandidates ?? [];
   const result = ceremony?.resultTrack;
+  const reencryptNonce = ceremony?.reencryptNonce ?? ceremony?.reencryptCycleId;
+  const [visibleReencryptNonce, setVisibleReencryptNonce] = useState<string | null>(null);
+  const lastSeenReencryptNonceRef = useRef<string | undefined>(undefined);
+  const reencryptVisualActive = ceremony?.status === "reencrypting" || Boolean(reencryptNonce && visibleReencryptNonce === reencryptNonce);
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [audioArmed, setAudioArmed] = useState(() => readWheelAudioArmed());
@@ -257,7 +261,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const sliceColors = ["#67e8f9", "#0ea5e9", "#2563eb", "#7c3aed", "#c026d3", "#ff2b6d", "#ef4444", "#f97316", "#facc15", "#22c55e", "#e5e7eb", "#071426"];
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from 0deg, ${wheelSegments.map((segment, index) => `${sliceColors[index % sliceColors.length]} ${segment.startAngle}deg ${segment.endAngle}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
-  const animationKey = ceremony?.status === "reencrypting" ? ceremony.reencryptCycleId ?? ceremony.seed ?? "reencrypting" : ceremony?.seed ?? ceremony?.status ?? "wheel";
+  const animationKey = reencryptVisualActive ? reencryptNonce ?? ceremony?.seed ?? "reencrypting" : ceremony?.seed ?? ceremony?.status ?? "wheel";
   const wheelStyle = {
     "--wheel-final-rotation": `${wheelFinalRotationForSegment(resultSegment)}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
@@ -271,6 +275,17 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-winning-start": `${resultSegment.startAngle}deg`,
     "--wheel-winning-end": `${resultSegment.endAngle}deg`,
   } as CSSProperties;
+
+  useEffect(() => {
+    if (!reencryptNonce || lastSeenReencryptNonceRef.current === reencryptNonce) return undefined;
+    lastSeenReencryptNonceRef.current = reencryptNonce;
+    setVisibleReencryptNonce(reencryptNonce);
+    const timeout = window.setTimeout(() => {
+      setVisibleReencryptNonce((current) => current === reencryptNonce ? null : current);
+    }, 2200);
+    return () => window.clearTimeout(timeout);
+  }, [reencryptNonce]);
+
   useEffect(() => {
     if (!audioJustArmed) return undefined;
     const timeout = window.setTimeout(() => setAudioJustArmed(false), 2200);
@@ -352,10 +367,10 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }
 
   return (
-    <div key={animationKey} className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
       {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE OPTIONAL WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">OPTIONAL AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
-      {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
+      {reencryptVisualActive && <div key={`glitch-${animationKey}`} className="live-overlay-wheel-glitch-stack" aria-hidden="true"><div className="live-overlay-wheel-static" /><div className="live-overlay-wheel-glitch">RE-ENCRYPTING SIGNAL</div><div className="live-overlay-wheel-corrupt-labels">010010 // SIGNAL MUTATING // 101101</div></div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
         <h1>{scene.subtitle || scene.title}</h1>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -193,24 +193,27 @@ function rememberWheelAudioArmed(armed: boolean): void {
 }
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { width: "34vmin", radius: 26.4, size: "4.35vmin", tracking: "0.001em", lines: 3 };
-  if (count <= 6) return { width: "30vmin", radius: 27.8, size: "3.55vmin", tracking: "0.001em", lines: 3 };
-  if (count <= 8) return { width: "26vmin", radius: 29.5, size: "2.85vmin", tracking: "0.002em", lines: 3 };
-  if (count <= 12) return { width: "21vmin", radius: 31.5, size: "2.08vmin", tracking: "0.002em", lines: 3 };
+  if (count <= 4) return { width: "35vmin", radius: 26.4, size: "4.65vmin", tracking: "0.001em", lines: 3 };
+  if (count <= 6) return { width: "31vmin", radius: 27.8, size: "3.88vmin", tracking: "0.001em", lines: 3 };
+  if (count <= 8) return { width: "27vmin", radius: 29.5, size: "3.12vmin", tracking: "0.002em", lines: 3 };
+  if (count <= 12) return { width: "22vmin", radius: 31.5, size: "2.28vmin", tracking: "0.002em", lines: 3 };
   if (count <= 16) return { width: "17vmin", radius: 33.5, size: "1.55vmin", tracking: "0.002em", lines: 2 };
   if (count <= 24) return { width: "13.2vmin", radius: 35.5, size: "1.12vmin", tracking: "0.001em", lines: 2 };
   return { width: "10.8vmin", radius: 37, size: "0.88vmin", tracking: "0", lines: 2 };
 }
 
-function wheelLabelScale(value: string, count: number): string {
-  const length = value.replace(/\s+/g, " ").trim().length;
+function wheelLabelFit(value: string, count: number) {
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  const length = cleaned.length;
+  const words = cleaned.split(" ").filter(Boolean).length;
   const generousSlice = count <= 8;
-  if (length > 72) return generousSlice ? "0.62" : "0.54";
-  if (length > 58) return generousSlice ? "0.7" : "0.6";
-  if (length > 44) return generousSlice ? "0.78" : "0.68";
-  if (length > 32) return generousSlice ? "0.88" : "0.78";
-  if (length > 24) return generousSlice ? "0.96" : "0.88";
-  return "1";
+  const lines = generousSlice && (words > 2 || length > 30) ? 3 : 2;
+  if (length > 72) return { scale: generousSlice ? "0.64" : "0.54", lines };
+  if (length > 58) return { scale: generousSlice ? "0.72" : "0.6", lines };
+  if (length > 44) return { scale: generousSlice ? "0.82" : "0.68", lines };
+  if (length > 32) return { scale: generousSlice ? "0.93" : "0.78", lines };
+  if (length > 24) return { scale: generousSlice ? "1.04" : "0.9", lines };
+  return { scale: generousSlice ? "1.08" : "1", lines: 2 };
 }
 
 function wheelLabelPosition(angle: number, radius: number) {
@@ -348,11 +351,13 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
             const angle = index * sliceDegrees + sliceDegrees / 2;
             const label = candidate.artistName.replace(/\s+/g, " ").trim();
             const position = wheelLabelPosition(angle, labelMetrics.radius);
+            const labelFit = wheelLabelFit(label, candidateCount);
             const labelStyle = {
               "--wheel-label-x": position.x,
               "--wheel-label-y": position.y,
               "--wheel-label-rotation": position.rotation,
-              "--wheel-label-scale": wheelLabelScale(label, candidateCount),
+              "--wheel-label-scale": labelFit.scale,
+              "--wheel-label-lines": labelFit.lines,
             } as CSSProperties;
             return (
               <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -193,22 +193,34 @@ function rememberWheelAudioArmed(armed: boolean): void {
 }
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { width: "36vmin", radius: "28.5vmin", size: "4.1vmin", tracking: "0.002em", lines: 3 };
-  if (count <= 6) return { width: "31vmin", radius: "30vmin", size: "3.3vmin", tracking: "0.003em", lines: 3 };
-  if (count <= 8) return { width: "27vmin", radius: "31.8vmin", size: "2.62vmin", tracking: "0.004em", lines: 3 };
-  if (count <= 12) return { width: "22vmin", radius: "33.7vmin", size: "1.98vmin", tracking: "0.005em", lines: 3 };
-  if (count <= 16) return { width: "18vmin", radius: "35.2vmin", size: "1.5vmin", tracking: "0.006em", lines: 2 };
-  if (count <= 24) return { width: "14vmin", radius: "36.8vmin", size: "1.1vmin", tracking: "0.006em", lines: 2 };
-  return { width: "11.4vmin", radius: "38vmin", size: "0.86vmin", tracking: "0.003em", lines: 2 };
+  if (count <= 4) return { width: "34vmin", radius: 26.4, size: "4.35vmin", tracking: "0.001em", lines: 3 };
+  if (count <= 6) return { width: "30vmin", radius: 27.8, size: "3.55vmin", tracking: "0.001em", lines: 3 };
+  if (count <= 8) return { width: "26vmin", radius: 29.5, size: "2.85vmin", tracking: "0.002em", lines: 3 };
+  if (count <= 12) return { width: "21vmin", radius: 31.5, size: "2.08vmin", tracking: "0.002em", lines: 3 };
+  if (count <= 16) return { width: "17vmin", radius: 33.5, size: "1.55vmin", tracking: "0.002em", lines: 2 };
+  if (count <= 24) return { width: "13.2vmin", radius: 35.5, size: "1.12vmin", tracking: "0.001em", lines: 2 };
+  return { width: "10.8vmin", radius: 37, size: "0.88vmin", tracking: "0", lines: 2 };
 }
 
-function wheelLabelScale(value: string): string {
+function wheelLabelScale(value: string, count: number): string {
   const length = value.replace(/\s+/g, " ").trim().length;
-  if (length > 60) return "0.58";
-  if (length > 48) return "0.66";
-  if (length > 36) return "0.76";
-  if (length > 26) return "0.88";
+  const generousSlice = count <= 8;
+  if (length > 72) return generousSlice ? "0.62" : "0.54";
+  if (length > 58) return generousSlice ? "0.7" : "0.6";
+  if (length > 44) return generousSlice ? "0.78" : "0.68";
+  if (length > 32) return generousSlice ? "0.88" : "0.78";
+  if (length > 24) return generousSlice ? "0.96" : "0.88";
   return "1";
+}
+
+function wheelLabelPosition(angle: number, radius: number) {
+  const radians = (angle * Math.PI) / 180;
+  const x = Math.sin(radians) * radius;
+  const y = Math.cos(radians) * -radius;
+  let rotation = angle - 90;
+  if (rotation > 90 && rotation < 270) rotation += 180;
+  if (rotation > 180) rotation -= 360;
+  return { x: `${x.toFixed(3)}vmin`, y: `${y.toFixed(3)}vmin`, rotation: `${rotation.toFixed(3)}deg` };
 }
 
 function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
@@ -234,7 +246,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-slice-background": sliceBackground,
     "--wheel-name-size": labelMetrics.size,
     "--wheel-label-width": labelMetrics.width,
-    "--wheel-label-radius": labelMetrics.radius,
+    "--wheel-label-radius": `${labelMetrics.radius}vmin`,
     "--wheel-letter-spacing": labelMetrics.tracking,
     "--wheel-label-lines": labelMetrics.lines,
   } as CSSProperties;
@@ -281,12 +293,12 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           if (audioPlayWasBlocked(error)) {
             setAudioArmed(false);
             rememberWheelAudioArmed(false);
-            setAudioNotice("AUDIO FAILED TO START");
+            setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
             return;
           }
         }
       }
-      if (!cancelled) setAudioNotice("AUDIO FAILED TO START");
+      if (!cancelled) setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
     });
 
     return () => {
@@ -312,7 +324,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       rememberWheelAudioArmed(true);
     }).catch(() => {
       stopWheelAudio(unlockAudio);
-      setAudioNotice("AUDIO FAILED TO START");
+      setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
       setAudioArmed(false);
       rememberWheelAudioArmed(false);
     });
@@ -320,7 +332,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
   return (
     <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
-      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE OPTIONAL WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">OPTIONAL AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
@@ -335,7 +347,13 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
             const angle = index * sliceDegrees + sliceDegrees / 2;
             const label = candidate.artistName.replace(/\s+/g, " ").trim();
-            const labelStyle = { "--wheel-label-angle": `${angle}deg`, "--wheel-label-text-flip": angle > 90 && angle < 270 ? "180deg" : "0deg", "--wheel-label-scale": wheelLabelScale(label) } as CSSProperties;
+            const position = wheelLabelPosition(angle, labelMetrics.radius);
+            const labelStyle = {
+              "--wheel-label-x": position.x,
+              "--wheel-label-y": position.y,
+              "--wheel-label-rotation": position.rotation,
+              "--wheel-label-scale": wheelLabelScale(label, candidateCount),
+            } as CSSProperties;
             return (
               <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>
                 <span>{label}</span>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -66,15 +66,67 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
   return Boolean((scene.mode === "now_playing" || scene.mode === "artist_card") && scene.track);
 }
 
+const FALLBACK_WHEEL_AUDIO_FILES = [
+  "/audio/wheel/wheel-spin-01-creepy-circus-astronautflute.mp3",
+  "/audio/wheel/wheel-spin-02-dark-circus-top-sue.mp3",
+  "/audio/wheel/wheel-spin-03-comedy-circus-top-sue.mp3",
+  "/audio/wheel/wheel-spin-04-circus-fast-andorios.mp3",
+  "/audio/wheel/wheel-spin-05-carousel-circus-chakong.mp3",
+  "/audio/wheel/wheel-spin-06-circus-bear-studiokolomna.mp3",
+  "/audio/wheel/wheel-spin-07-upbeat-corporate-kornevmusic.mp3",
+  "/audio/wheel/wheel-spin-08-corporate-music-absolutesound.mp3",
+  "/audio/wheel/wheel-spin-09-corporate-music-2-absolutesound.mp3",
+  "/audio/wheel/wheel-spin-10-this-heavy-metal-mrclaps.mp3",
+  "/audio/wheel/wheel-spin-11-metal-dark-matter-alexgrohl.mp3",
+  "/audio/wheel/wheel-spin-12-burn-it-down-alexgrohl.mp3",
+  "/audio/wheel/wheel-spin-13-8bit-retro-the-mountain.mp3",
+  "/audio/wheel/wheel-spin-14-retro-swing-the-mountain.mp3",
+  "/audio/wheel/wheel-spin-15-retro-arcade-mondamusic.mp3",
+  "/audio/wheel/wheel-spin-16-synthwave-retro-80s-monume.mp3",
+  "/audio/wheel/wheel-spin-17-retro-game-arcade-moodmode.mp3",
+  "/audio/wheel/wheel-spin-18-retro-surf-rock-tunetank.mp3",
+];
+
+function safeWheelAudioPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value.trim();
+  if (!/^[a-zA-Z0-9._~!$&'()*+,;=:@/%-]+\.mp3(?:\?.*)?$/i.test(cleaned)) return null;
+  if (/^https?:\/\//i.test(cleaned) || cleaned.includes("..")) return null;
+  if (cleaned.startsWith("/") && !cleaned.startsWith("/audio/wheel/")) return null;
+  return cleaned.startsWith("/") ? cleaned : `/audio/wheel/${cleaned.replace(/^audio\/wheel\//, "")}`;
+}
+
+function normalizeWheelAudioManifest(input: unknown): string[] {
+  const rawFiles = Array.isArray(input) ? input : Array.isArray((input as { files?: unknown } | null)?.files) ? (input as { files: unknown[] }).files : [];
+  return Array.from(new Set(rawFiles.map(safeWheelAudioPath).filter((file): file is string => Boolean(file))));
+}
+
+async function loadWheelAudioFiles(): Promise<string[]> {
+  try {
+    const response = await fetch("/audio/wheel/manifest.json", { cache: "no-store" });
+    if (!response.ok) return FALLBACK_WHEEL_AUDIO_FILES;
+    const files = normalizeWheelAudioManifest(await response.json());
+    return files.length > 0 ? files : FALLBACK_WHEEL_AUDIO_FILES;
+  } catch {
+    return FALLBACK_WHEEL_AUDIO_FILES;
+  }
+}
+
+function stopWheelAudio(audio: HTMLAudioElement | null): void {
+  if (!audio) return;
+  audio.pause();
+  audio.currentTime = 0;
+}
+
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { maxLength: 42, width: "58vmin", distance: "-4.8vmin", size: "4.3vmin", tracking: "0.04em", rail: "34vmin" };
-  if (count <= 6) return { maxLength: 36, width: "52vmin", distance: "-1.2vmin", size: "3.45vmin", tracking: "0.045em", rail: "31vmin" };
-  if (count <= 8) return { maxLength: 31, width: "47vmin", distance: "1.8vmin", size: "2.75vmin", tracking: "0.05em", rail: "28vmin" };
-  if (count <= 12) return { maxLength: 25, width: "40vmin", distance: "5.4vmin", size: "2.05vmin", tracking: "0.055em", rail: "24vmin" };
-  if (count <= 16) return { maxLength: 21, width: "35vmin", distance: "7.8vmin", size: "1.58vmin", tracking: "0.06em", rail: "21vmin" };
-  if (count <= 24) return { maxLength: 18, width: "30vmin", distance: "9.8vmin", size: "1.18vmin", tracking: "0.065em", rail: "18vmin" };
-  return { maxLength: 14, width: "24vmin", distance: "11.8vmin", size: "0.94vmin", tracking: "0.055em", rail: "14vmin" };
+  if (count <= 4) return { maxLength: 64, width: "38vmin", distance: "2.2vmin", size: "4.8vmin", tracking: "0.025em", rail: "34vmin" };
+  if (count <= 6) return { maxLength: 56, width: "34vmin", distance: "3.8vmin", size: "3.95vmin", tracking: "0.03em", rail: "31vmin" };
+  if (count <= 8) return { maxLength: 48, width: "30vmin", distance: "5.5vmin", size: "3.15vmin", tracking: "0.035em", rail: "28vmin" };
+  if (count <= 12) return { maxLength: 40, width: "26vmin", distance: "7.4vmin", size: "2.35vmin", tracking: "0.04em", rail: "24vmin" };
+  if (count <= 16) return { maxLength: 34, width: "22vmin", distance: "9.6vmin", size: "1.8vmin", tracking: "0.045em", rail: "21vmin" };
+  if (count <= 24) return { maxLength: 28, width: "18vmin", distance: "11.4vmin", size: "1.3vmin", tracking: "0.05em", rail: "18vmin" };
+  return { maxLength: 22, width: "15vmin", distance: "13vmin", size: "1vmin", tracking: "0.045em", rail: "14vmin" };
 }
 
 function shortWheelLabel(value: string, maxLength: number): string {
@@ -88,6 +140,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const candidates = ceremony?.displayCandidates ?? [];
   const result = ceremony?.resultTrack;
   const spinning = ceremony?.status === "spinning";
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const candidateCount = Math.max(1, candidates.length);
   const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
   const sliceDegrees = 360 / candidateCount;
@@ -97,7 +150,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const labelMetrics = wheelLabelMetrics(candidates.length);
   const wheelStyle = {
     "--wheel-final-rotation": `${1440 - resultCenterAngle}deg`,
-    "--wheel-spin-duration": `${Math.max(5, (ceremony?.spinDurationMs ?? 6500) / 1000)}s`,
+    "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
     "--wheel-name-size": labelMetrics.size,
@@ -108,8 +161,39 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   } as CSSProperties;
   const labelMaxLength = labelMetrics.maxLength;
 
+  useEffect(() => {
+    const existingAudio = audioRef.current;
+    if (!spinning) {
+      stopWheelAudio(existingAudio);
+      audioRef.current = null;
+      return undefined;
+    }
+
+    let cancelled = false;
+    loadWheelAudioFiles().then((files) => {
+      if (cancelled || files.length === 0) return;
+      const audioPath = files[Math.floor(Math.random() * files.length)] ?? files[0];
+      if (!audioPath) return;
+      const audio = new Audio(audioPath);
+      audio.loop = true;
+      audio.preload = "auto";
+      audio.volume = 0.72;
+      audioRef.current = audio;
+      audio.play().catch(() => {
+        stopWheelAudio(audio);
+        if (audioRef.current === audio) audioRef.current = null;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      stopWheelAudio(audioRef.current);
+      audioRef.current = null;
+    };
+  }, [spinning, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
+
   return (
-    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`}>
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { buildWheelSegments, wheelFinalRotationForSegment } from "@/lib/live-overlay-resolver";
+import { buildWheelSegments, wheelFinalRotationForSegment, wheelUprightLabelRotationDegrees } from "@/lib/live-overlay-resolver";
 import type { LiveOverlayYouTubeSync, ResolvedLiveOverlayScene } from "@/lib/live-overlay";
 
 type YTPlayer = {
@@ -236,9 +236,7 @@ function wheelLabelPosition(angle: number, radius: number) {
   const radians = (angle * Math.PI) / 180;
   const x = Math.sin(radians) * radius;
   const y = Math.cos(radians) * -radius;
-  let rotation = angle - 90;
-  if (rotation > 90 && rotation < 270) rotation += 180;
-  if (rotation > 180) rotation -= 360;
+  const rotation = wheelUprightLabelRotationDegrees(angle);
   return { x: `${x.toFixed(3)}vmin`, y: `${y.toFixed(3)}vmin`, rotation: `${rotation.toFixed(3)}deg` };
 }
 
@@ -262,8 +260,9 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from 0deg, ${wheelSegments.map((segment, index) => `${sliceColors[index % sliceColors.length]} ${segment.startAngle}deg ${segment.endAngle}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
   const animationKey = reencryptVisualActive ? reencryptNonce ?? ceremony?.seed ?? "reencrypting" : ceremony?.seed ?? ceremony?.status ?? "wheel";
+  const finalRotationDeg = typeof ceremony?.finalRotationDeg === "number" ? ceremony.finalRotationDeg : wheelFinalRotationForSegment(resultSegment);
   const wheelStyle = {
-    "--wheel-final-rotation": `${wheelFinalRotationForSegment(resultSegment)}deg`,
+    "--wheel-final-rotation": `${finalRotationDeg}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -121,6 +121,14 @@ const FALLBACK_WHEEL_AUDIO_FILES = [
   "/audio/wheel/wheel-spin-18-retro-surf-rock-tunetank.mp3",
 ];
 
+const BINARY_CONFETTI = Array.from({ length: 44 }, (_, index) => ({
+  bit: index % 3 === 0 ? "0" : "1",
+  left: `${(index * 19) % 100}%`,
+  delay: `${(index % 11) * 0.17}s`,
+  drift: `${((index % 9) - 4) * 1.25}vmin`,
+  duration: `${2.4 + (index % 7) * 0.18}s`,
+}));
+
 function safeWheelAudioPath(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const cleaned = value.trim().replace(/\s/g, "%20");
@@ -185,19 +193,21 @@ function rememberWheelAudioArmed(armed: boolean): void {
 }
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { maxLength: 64, width: "28vmin", radius: "36vmin", size: "4.25vmin", tracking: "0.005em" };
-  if (count <= 6) return { maxLength: 58, width: "25vmin", radius: "37vmin", size: "3.35vmin", tracking: "0.006em" };
-  if (count <= 8) return { maxLength: 52, width: "22vmin", radius: "38vmin", size: "2.65vmin", tracking: "0.008em" };
-  if (count <= 12) return { maxLength: 42, width: "18vmin", radius: "39vmin", size: "2.02vmin", tracking: "0.01em" };
-  if (count <= 16) return { maxLength: 34, width: "15.5vmin", radius: "39.6vmin", size: "1.52vmin", tracking: "0.01em" };
-  if (count <= 24) return { maxLength: 28, width: "12.8vmin", radius: "40vmin", size: "1.12vmin", tracking: "0.01em" };
-  return { maxLength: 22, width: "10.8vmin", radius: "40.4vmin", size: "0.88vmin", tracking: "0.006em" };
+  if (count <= 4) return { width: "34vmin", radius: "30vmin", size: "4vmin", tracking: "0.004em", lines: 3 };
+  if (count <= 6) return { width: "30vmin", radius: "31.5vmin", size: "3.25vmin", tracking: "0.005em", lines: 3 };
+  if (count <= 8) return { width: "26vmin", radius: "33vmin", size: "2.55vmin", tracking: "0.006em", lines: 3 };
+  if (count <= 12) return { width: "21vmin", radius: "35vmin", size: "1.95vmin", tracking: "0.008em", lines: 2 };
+  if (count <= 16) return { width: "17vmin", radius: "36.5vmin", size: "1.48vmin", tracking: "0.008em", lines: 2 };
+  if (count <= 24) return { width: "13.5vmin", radius: "38vmin", size: "1.1vmin", tracking: "0.008em", lines: 2 };
+  return { width: "11vmin", radius: "39vmin", size: "0.86vmin", tracking: "0.004em", lines: 2 };
 }
 
-function shortWheelLabel(value: string, maxLength: number): string {
-  const cleaned = value.replace(/\s+/g, " ").trim();
-  if (cleaned.length <= maxLength) return cleaned;
-  return `${cleaned.slice(0, Math.max(1, maxLength - 1)).trim()}…`;
+function wheelLabelScale(value: string): string {
+  const length = value.replace(/\s+/g, " ").trim().length;
+  if (length > 54) return "0.68";
+  if (length > 40) return "0.76";
+  if (length > 28) return "0.86";
+  return "1";
 }
 
 function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
@@ -207,6 +217,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [audioArmed, setAudioArmed] = useState(() => readWheelAudioArmed());
+  const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const candidateCount = Math.max(1, candidates.length);
   const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
@@ -216,7 +227,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from -90deg, ${candidates.map((_, index) => `${sliceColors[index % sliceColors.length]} ${index * sliceDegrees}deg ${(index + 1) * sliceDegrees}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
   const wheelStyle = {
-    "--wheel-final-rotation": `${1440 - resultCenterAngle}deg`,
+    "--wheel-final-rotation": `${1530 - resultCenterAngle}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
@@ -224,9 +235,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-label-width": labelMetrics.width,
     "--wheel-label-radius": labelMetrics.radius,
     "--wheel-letter-spacing": labelMetrics.tracking,
+    "--wheel-label-lines": labelMetrics.lines,
   } as CSSProperties;
-  const labelMaxLength = labelMetrics.maxLength;
-
   useEffect(() => {
     if (!audioJustArmed) return undefined;
     const timeout = window.setTimeout(() => setAudioJustArmed(false), 2200);
@@ -234,10 +244,16 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }, [audioJustArmed]);
 
   useEffect(() => {
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+      audioRef.current.preload = "auto";
+    }
+  }, []);
+
+  useEffect(() => {
     const existingAudio = audioRef.current;
     if (!spinning || !audioArmed) {
       stopWheelAudio(existingAudio);
-      audioRef.current = null;
       return undefined;
     }
 
@@ -245,51 +261,66 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     loadWheelAudioFiles().then(async (files) => {
       const storedPath = safeWheelAudioPath(ceremony?.audioPath);
       const candidatePaths = [storedPath, ...shuffledAudioPaths(files)].filter((path, index, paths): path is string => Boolean(path) && paths.indexOf(path) === index);
+      const audio = audioRef.current ?? new Audio();
+      audioRef.current = audio;
+      audio.loop = true;
+      audio.preload = "auto";
+      audio.volume = 0.82;
       for (const audioPath of candidatePaths) {
         if (cancelled) return;
-        const audio = new Audio(audioPath);
-        audio.loop = true;
-        audio.preload = "auto";
-        audio.volume = 0.72;
-        audioRef.current = audio;
         try {
+          stopWheelAudio(audio);
+          audio.src = audioPath;
+          audio.load();
           await audio.play();
+          if (!cancelled) setAudioNotice(null);
           return;
         } catch (error) {
           stopWheelAudio(audio);
-          if (audioRef.current === audio) audioRef.current = null;
           if (audioPlayWasBlocked(error)) {
             setAudioArmed(false);
             rememberWheelAudioArmed(false);
+            setAudioNotice("AUDIO FAILED TO START");
             return;
           }
         }
       }
+      if (!cancelled) setAudioNotice("AUDIO FAILED TO START");
     });
 
     return () => {
       cancelled = true;
       stopWheelAudio(audioRef.current);
-      audioRef.current = null;
     };
   }, [audioArmed, spinning, ceremony?.audioPath, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
 
   function enableWheelAudio() {
     const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
     const unlockAudio = new Audio(unlockPath);
-    unlockAudio.muted = true;
-    unlockAudio.volume = 0;
-    unlockAudio.play().catch(() => undefined).finally(() => {
-      stopWheelAudio(unlockAudio);
+    unlockAudio.loop = false;
+    unlockAudio.muted = false;
+    unlockAudio.volume = 0.04;
+    unlockAudio.preload = "auto";
+    unlockAudio.load();
+    audioRef.current = unlockAudio;
+    unlockAudio.play().then(() => {
+      window.setTimeout(() => stopWheelAudio(unlockAudio), 280);
       setAudioArmed(true);
       setAudioJustArmed(true);
+      setAudioNotice(null);
       rememberWheelAudioArmed(true);
+    }).catch(() => {
+      stopWheelAudio(unlockAudio);
+      setAudioNotice("AUDIO FAILED TO START");
+      setAudioArmed(false);
+      rememberWheelAudioArmed(false);
     });
   }
 
   return (
     <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
-      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+      {!audioArmed ? <div className="live-overlay-wheel-audio-modal"><div><span>Required before first spin</span><strong>ENABLE WHEEL AUDIO</strong><button type="button" onClick={enableWheelAudio}>Arm Wheel Audio</button></div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+      {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
         <p className="live-overlay-mode">{modeLabel(scene.mode)}</p>
@@ -302,8 +333,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           <div className="live-overlay-wheel-slices" aria-hidden="true" />
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
             const angle = index * sliceDegrees + sliceDegrees / 2;
-            const label = shortWheelLabel(candidate.artistName, labelMaxLength);
-            const labelStyle = { "--wheel-label-angle": `${angle}deg`, "--wheel-label-counter-angle": `${-angle}deg` } as CSSProperties;
+            const label = candidate.artistName.replace(/\s+/g, " ").trim();
+            const labelStyle = { "--wheel-label-angle": `${angle}deg`, "--wheel-label-text-flip": angle > 90 && angle < 270 ? "180deg" : "0deg", "--wheel-label-scale": wheelLabelScale(label) } as CSSProperties;
             return (
               <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>
                 <span>{label}</span>
@@ -313,6 +344,11 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           <div className="live-overlay-wheel-core"><span>10K</span><small>TAP WHEEL</small></div>
         </div>
       </div>
+
+      {result && ceremony?.status === "result_pending" && <div className="live-overlay-wheel-result-reveal" aria-live="assertive">
+        <div className="live-overlay-binary-confetti" aria-hidden="true">{BINARY_CONFETTI.map((bit, index) => <span key={`${bit.bit}-${index}`} style={{ "--bit-left": bit.left, "--bit-delay": bit.delay, "--bit-drift": bit.drift, "--bit-duration": bit.duration } as CSSProperties}>{bit.bit}</span>)}</div>
+        <div className="live-overlay-wheel-result-card"><span>WHEEL WINNER</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em><p>20 SECONDS TO CLAIM YOUR WINNINGS</p></div>
+      </div>}
 
       {(scene.message || result) && <div className="live-overlay-wheel-status">
         {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") ? <><span>{ceremony.status === "confirmed" ? "SIGNAL LOCKED" : "RESULT PENDING"}</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em></> : <><span>{scene.title}</span>{scene.message && <strong>{scene.message}</strong>}</>}

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -257,6 +257,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const sliceColors = ["#67e8f9", "#0ea5e9", "#2563eb", "#7c3aed", "#c026d3", "#ff2b6d", "#ef4444", "#f97316", "#facc15", "#22c55e", "#e5e7eb", "#071426"];
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from 0deg, ${wheelSegments.map((segment, index) => `${sliceColors[index % sliceColors.length]} ${segment.startAngle}deg ${segment.endAngle}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
+  const animationKey = ceremony?.status === "reencrypting" ? ceremony.reencryptCycleId ?? ceremony.seed ?? "reencrypting" : ceremony?.seed ?? ceremony?.status ?? "wheel";
   const wheelStyle = {
     "--wheel-final-rotation": `${wheelFinalRotationForSegment(resultSegment)}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
@@ -351,7 +352,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }
 
   return (
-    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
+    <div key={animationKey} className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
       {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE OPTIONAL WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">OPTIONAL AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
@@ -498,7 +499,7 @@ export function LiveOverlayReceiver() {
       }
     }
     load();
-    const interval = window.setInterval(load, 3_000);
+    const interval = window.setInterval(load, 650);
     return () => {
       cancelled = true;
       window.clearInterval(interval);

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
+import { wheelFinalRotationForSlice } from "@/lib/live-overlay-resolver";
 import type { LiveOverlayYouTubeSync, ResolvedLiveOverlayScene } from "@/lib/live-overlay";
 
 type YTPlayer = {
@@ -192,28 +193,43 @@ function rememberWheelAudioArmed(armed: boolean): void {
   }
 }
 
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { width: "35vmin", radius: 26.4, size: "4.65vmin", tracking: "0.001em", lines: 3 };
-  if (count <= 6) return { width: "31vmin", radius: 27.8, size: "3.88vmin", tracking: "0.001em", lines: 3 };
-  if (count <= 8) return { width: "27vmin", radius: 29.5, size: "3.12vmin", tracking: "0.002em", lines: 3 };
-  if (count <= 12) return { width: "22vmin", radius: 31.5, size: "2.28vmin", tracking: "0.002em", lines: 3 };
-  if (count <= 16) return { width: "17vmin", radius: 33.5, size: "1.55vmin", tracking: "0.002em", lines: 2 };
-  if (count <= 24) return { width: "13.2vmin", radius: 35.5, size: "1.12vmin", tracking: "0.001em", lines: 2 };
-  return { width: "10.8vmin", radius: 37, size: "0.88vmin", tracking: "0", lines: 2 };
+  if (count <= 4) return { width: 35, radius: 26.4, size: 4.65, tracking: "0.001em", lines: 3 };
+  if (count <= 6) return { width: 31, radius: 27.8, size: 3.88, tracking: "0.001em", lines: 3 };
+  if (count <= 8) return { width: 27, radius: 29.5, size: 3.12, tracking: "0.002em", lines: 3 };
+  if (count <= 12) return { width: 22, radius: 31.5, size: 2.28, tracking: "0.002em", lines: 3 };
+  if (count <= 16) return { width: 18.4, radius: 33.2, size: 1.72, tracking: "0.001em", lines: 2 };
+  if (count <= 24) return { width: 15.2, radius: 35.1, size: 1.28, tracking: "0", lines: 2 };
+  return { width: 12.4, radius: 36.7, size: 0.98, tracking: "0", lines: 2 };
 }
 
 function wheelLabelFit(value: string, count: number) {
   const cleaned = value.replace(/\s+/g, " ").trim();
   const length = cleaned.length;
   const words = cleaned.split(" ").filter(Boolean).length;
-  const generousSlice = count <= 8;
-  const lines = generousSlice && (words > 2 || length > 30) ? 3 : 2;
-  if (length > 72) return { scale: generousSlice ? "0.64" : "0.54", lines };
-  if (length > 58) return { scale: generousSlice ? "0.72" : "0.6", lines };
-  if (length > 44) return { scale: generousSlice ? "0.82" : "0.68", lines };
-  if (length > 32) return { scale: generousSlice ? "0.93" : "0.78", lines };
-  if (length > 24) return { scale: generousSlice ? "1.04" : "0.9", lines };
-  return { scale: generousSlice ? "1.08" : "1", lines: 2 };
+  const sliceDegrees = 360 / Math.max(1, count);
+  const base = wheelLabelMetrics(count);
+  const shortNameBoost = length <= 7 ? 1.32 : length <= 14 ? 1.18 : length <= 24 ? 1.06 : 1;
+  const lines = length <= 12 && words <= 2 ? 1 : length > 34 || words > 3 ? 3 : 2;
+  const radius = clampNumber(base.radius + (length > 34 ? 1.2 : length <= 10 ? -0.7 : 0), 24.8, 38.2);
+  const tangentWidth = 2 * radius * Math.sin((sliceDegrees * Math.PI) / 360);
+  const minWidth = count <= 8 ? 17 : count <= 16 ? 11 : count <= 24 ? 8 : 6.2;
+  const width = clampNumber(Math.min(base.width * shortNameBoost, tangentWidth * 0.98), minWidth, base.width * 1.22);
+  const maxLineLength = Math.max(4, Math.ceil(length / lines));
+  const fitSize = (width * (lines === 1 ? 1.72 : 1.58)) / Math.max(5, maxLineLength);
+  const size = clampNumber(Math.min(base.size * shortNameBoost, fitSize), count <= 16 ? 0.92 : 0.72, base.size * 1.28);
+  return {
+    width: `${width.toFixed(2)}vmin`,
+    radius,
+    size: `${size.toFixed(2)}vmin`,
+    lines,
+    tracking: length <= 12 ? "0.002em" : base.tracking,
+    lineHeight: lines === 1 ? "0.92" : lines === 2 ? "0.86" : "0.8",
+  };
 }
 
 function wheelLabelPosition(angle: number, radius: number) {
@@ -238,17 +254,16 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const candidateCount = Math.max(1, candidates.length);
   const resultIndex = Math.max(0, candidates.findIndex((candidate) => candidate.id === result?.id));
   const sliceDegrees = 360 / candidateCount;
-  const resultCenterAngle = resultIndex * sliceDegrees + sliceDegrees / 2;
   const sliceColors = ["#67e8f9", "#0ea5e9", "#2563eb", "#7c3aed", "#c026d3", "#ff2b6d", "#ef4444", "#f97316", "#facc15", "#22c55e", "#e5e7eb", "#071426"];
   const sliceBackground = candidates.length > 0 ? `conic-gradient(from -90deg, ${candidates.map((_, index) => `${sliceColors[index % sliceColors.length]} ${index * sliceDegrees}deg ${(index + 1) * sliceDegrees}deg`).join(", ")})` : "radial-gradient(circle, #67e8f9, #0284c7)";
   const labelMetrics = wheelLabelMetrics(candidates.length);
   const wheelStyle = {
-    "--wheel-final-rotation": `${1530 - resultCenterAngle}deg`,
+    "--wheel-final-rotation": `${wheelFinalRotationForSlice(candidateCount, resultIndex)}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
-    "--wheel-name-size": labelMetrics.size,
-    "--wheel-label-width": labelMetrics.width,
+    "--wheel-name-size": `${labelMetrics.size}vmin`,
+    "--wheel-label-width": `${labelMetrics.width}vmin`,
     "--wheel-label-radius": `${labelMetrics.radius}vmin`,
     "--wheel-letter-spacing": labelMetrics.tracking,
     "--wheel-label-lines": labelMetrics.lines,
@@ -350,14 +365,18 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
             const angle = index * sliceDegrees + sliceDegrees / 2;
             const label = candidate.artistName.replace(/\s+/g, " ").trim();
-            const position = wheelLabelPosition(angle, labelMetrics.radius);
             const labelFit = wheelLabelFit(label, candidateCount);
+            const position = wheelLabelPosition(angle, labelFit.radius);
+            // Wheel labels are visual only. Winner selection is based on slice geometry and the right-side pointer.
             const labelStyle = {
               "--wheel-label-x": position.x,
               "--wheel-label-y": position.y,
               "--wheel-label-rotation": position.rotation,
-              "--wheel-label-scale": labelFit.scale,
+              "--wheel-label-width": labelFit.width,
+              "--wheel-name-size": labelFit.size,
+              "--wheel-letter-spacing": labelFit.tracking,
               "--wheel-label-lines": labelFit.lines,
+              "--wheel-label-line-height": labelFit.lineHeight,
             } as CSSProperties;
             return (
               <span key={candidate.id} className="live-overlay-wheel-slice-label" style={labelStyle} title={`${candidate.artistName} — ${candidate.trackTitle}`}>

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -185,13 +185,13 @@ function rememberWheelAudioArmed(armed: boolean): void {
 }
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { maxLength: 64, width: "30vmin", radius: "34vmin", size: "4.6vmin", tracking: "0.01em" };
-  if (count <= 6) return { maxLength: 56, width: "27vmin", radius: "35vmin", size: "3.75vmin", tracking: "0.012em" };
-  if (count <= 8) return { maxLength: 48, width: "24vmin", radius: "36vmin", size: "2.95vmin", tracking: "0.014em" };
-  if (count <= 12) return { maxLength: 40, width: "20vmin", radius: "36.8vmin", size: "2.18vmin", tracking: "0.016em" };
-  if (count <= 16) return { maxLength: 34, width: "17vmin", radius: "37.5vmin", size: "1.66vmin", tracking: "0.018em" };
-  if (count <= 24) return { maxLength: 28, width: "14vmin", radius: "38.2vmin", size: "1.18vmin", tracking: "0.02em" };
-  return { maxLength: 22, width: "11.5vmin", radius: "39vmin", size: "0.92vmin", tracking: "0.015em" };
+  if (count <= 4) return { maxLength: 64, width: "28vmin", radius: "36vmin", size: "4.25vmin", tracking: "0.005em" };
+  if (count <= 6) return { maxLength: 58, width: "25vmin", radius: "37vmin", size: "3.35vmin", tracking: "0.006em" };
+  if (count <= 8) return { maxLength: 52, width: "22vmin", radius: "38vmin", size: "2.65vmin", tracking: "0.008em" };
+  if (count <= 12) return { maxLength: 42, width: "18vmin", radius: "39vmin", size: "2.02vmin", tracking: "0.01em" };
+  if (count <= 16) return { maxLength: 34, width: "15.5vmin", radius: "39.6vmin", size: "1.52vmin", tracking: "0.01em" };
+  if (count <= 24) return { maxLength: 28, width: "12.8vmin", radius: "40vmin", size: "1.12vmin", tracking: "0.01em" };
+  return { maxLength: 22, width: "10.8vmin", radius: "40.4vmin", size: "0.88vmin", tracking: "0.006em" };
 }
 
 function shortWheelLabel(value: string, maxLength: number): string {

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -193,20 +193,21 @@ function rememberWheelAudioArmed(armed: boolean): void {
 }
 
 function wheelLabelMetrics(count: number) {
-  if (count <= 4) return { width: "34vmin", radius: "30vmin", size: "4vmin", tracking: "0.004em", lines: 3 };
-  if (count <= 6) return { width: "30vmin", radius: "31.5vmin", size: "3.25vmin", tracking: "0.005em", lines: 3 };
-  if (count <= 8) return { width: "26vmin", radius: "33vmin", size: "2.55vmin", tracking: "0.006em", lines: 3 };
-  if (count <= 12) return { width: "21vmin", radius: "35vmin", size: "1.95vmin", tracking: "0.008em", lines: 2 };
-  if (count <= 16) return { width: "17vmin", radius: "36.5vmin", size: "1.48vmin", tracking: "0.008em", lines: 2 };
-  if (count <= 24) return { width: "13.5vmin", radius: "38vmin", size: "1.1vmin", tracking: "0.008em", lines: 2 };
-  return { width: "11vmin", radius: "39vmin", size: "0.86vmin", tracking: "0.004em", lines: 2 };
+  if (count <= 4) return { width: "36vmin", radius: "28.5vmin", size: "4.1vmin", tracking: "0.002em", lines: 3 };
+  if (count <= 6) return { width: "31vmin", radius: "30vmin", size: "3.3vmin", tracking: "0.003em", lines: 3 };
+  if (count <= 8) return { width: "27vmin", radius: "31.8vmin", size: "2.62vmin", tracking: "0.004em", lines: 3 };
+  if (count <= 12) return { width: "22vmin", radius: "33.7vmin", size: "1.98vmin", tracking: "0.005em", lines: 3 };
+  if (count <= 16) return { width: "18vmin", radius: "35.2vmin", size: "1.5vmin", tracking: "0.006em", lines: 2 };
+  if (count <= 24) return { width: "14vmin", radius: "36.8vmin", size: "1.1vmin", tracking: "0.006em", lines: 2 };
+  return { width: "11.4vmin", radius: "38vmin", size: "0.86vmin", tracking: "0.003em", lines: 2 };
 }
 
 function wheelLabelScale(value: string): string {
   const length = value.replace(/\s+/g, " ").trim().length;
-  if (length > 54) return "0.68";
-  if (length > 40) return "0.76";
-  if (length > 28) return "0.86";
+  if (length > 60) return "0.58";
+  if (length > 48) return "0.66";
+  if (length > 36) return "0.76";
+  if (length > 26) return "0.88";
   return "1";
 }
 
@@ -319,7 +320,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
   return (
     <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed}>
-      {!audioArmed ? <div className="live-overlay-wheel-audio-modal"><div><span>Required before first spin</span><strong>ENABLE WHEEL AUDIO</strong><button type="button" onClick={enableWheelAudio}>Arm Wheel Audio</button></div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {ceremony?.status === "reencrypting" && <div className="live-overlay-wheel-glitch" aria-hidden="true">RE-ENCRYPTING SIGNAL</div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -4,6 +4,33 @@ export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_rea
 export type WheelOverlayStatus = "ready" | "intro" | "active" | "complete";
 export type WheelCeremonyStatus = "idle" | "ready" | "reencrypting" | "spinning" | "result_pending" | "confirmed" | "cancelled" | "signal_lost";
 
+export const WHEEL_RIGHT_POINTER_ANGLE_DEGREES = 90;
+
+export function normalizeWheelAngle(degrees: number): number {
+  if (!Number.isFinite(degrees)) return 0;
+  return ((degrees % 360) + 360) % 360;
+}
+
+export function wheelSliceIndexAtPointer(entryCount: number, finalRotationDegrees: number, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
+  const count = Math.max(1, Math.floor(entryCount));
+  const sliceSize = 360 / count;
+  // Winner selection is based only on slice geometry. Labels are visual only and must not affect this math.
+  // Boundary rule: each slice owns [startAngle, endAngle), so an exact boundary belongs to the next slice.
+  const pointerLocalAngle = normalizeWheelAngle(pointerAngleDegrees - normalizeWheelAngle(finalRotationDegrees));
+  return Math.min(count - 1, Math.floor(pointerLocalAngle / sliceSize));
+}
+
+export function wheelSliceCenterAngle(entryCount: number, index: number): number {
+  const count = Math.max(1, Math.floor(entryCount));
+  const safeIndex = Math.max(0, Math.min(count - 1, Math.floor(index)));
+  const sliceSize = 360 / count;
+  return safeIndex * sliceSize + sliceSize / 2;
+}
+
+export function wheelFinalRotationForSlice(entryCount: number, index: number, fullTurns = 4, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
+  return (Math.max(0, Math.floor(fullTurns)) * 360) + pointerAngleDegrees - wheelSliceCenterAngle(entryCount, index);
+}
+
 export interface LiveOverlayTrackInput {
   id?: string;
   artist?: string;

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -57,6 +57,7 @@ export interface LiveOverlayStateInput {
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
+  wheelCeremonyAudioPath?: string;
   updatedAt?: string;
 }
 
@@ -124,6 +125,7 @@ export interface ResolvedWheelCeremonyScene {
   seed?: string;
   jingleKey?: string;
   spinDurationMs: number;
+  audioPath?: string;
 }
 
 export interface ResolvedLiveOverlayScene {
@@ -283,6 +285,7 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     seed: cleanDisplay(overlayState?.wheelCeremonySeed),
     jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
     spinDurationMs,
+    audioPath: cleanDisplay(overlayState?.wheelCeremonyAudioPath),
   };
 }
 

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -150,6 +150,8 @@ export interface LiveOverlayStateInput {
   wheelCeremonyChosenTrackId?: string;
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
+  wheelCeremonyPreviousSeed?: string;
+  wheelCeremonyReencryptCycleId?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
   wheelCeremonyAudioPath?: string;
@@ -223,6 +225,8 @@ export interface ResolvedWheelCeremonyScene {
   spinStartedAt?: string;
   resultSelectedAt?: string;
   seed?: string;
+  previousSeed?: string;
+  reencryptCycleId?: string;
   jingleKey?: string;
   spinDurationMs: number;
   audioPath?: string;
@@ -254,7 +258,8 @@ const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit
 const DEFAULT_WHEEL_SPIN_DURATION_MS = 24000;
 const MIN_WHEEL_SPIN_DURATION_MS = 16000;
 const MAX_WHEEL_SPIN_DURATION_MS = 32000;
-const WHEEL_REENCRYPTING_MS = 1600;
+const WHEEL_REENCRYPTING_MS = 1850;
+const WHEEL_REENCRYPT_REMAP_MS = 750;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
 const WHEEL_SIGNAL_LOST_MS = 3500;
 const MAX_WHEEL_DISPLAY_CANDIDATES = 32;
@@ -378,11 +383,14 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   const resultTrack = rawResultTrack && chosenTrackTitle ? { ...rawResultTrack, trackTitle: chosenTrackTitle } : rawResultTrack;
   let status = storedStatus;
   const spinDurationMs = normalizeWheelSpinDurationMs(overlayState?.wheelCeremonySpinDurationMs);
+  let reencryptElapsedMs = 0;
   if (storedStatus === "reencrypting" || storedStatus === "spinning") {
     const spinStartedMs = timeMs(overlayState?.wheelCeremonySpinStartedAt) ?? now.getTime();
     const elapsedMs = now.getTime() - spinStartedMs;
-    if (storedStatus === "reencrypting") status = elapsedMs < WHEEL_REENCRYPTING_MS ? "reencrypting" : "ready";
-    else status = elapsedMs < spinDurationMs ? "spinning" : "result_pending";
+    if (storedStatus === "reencrypting") {
+      reencryptElapsedMs = elapsedMs;
+      status = elapsedMs < WHEEL_REENCRYPTING_MS ? "reencrypting" : "ready";
+    } else status = elapsedMs < spinDurationMs ? "spinning" : "result_pending";
   }
   if (storedStatus === "signal_lost") {
     const signalLostAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
@@ -392,11 +400,14 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     const confirmedAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
     if (now.getTime() - confirmedAtMs > WHEEL_CONFIRMED_RETURN_MS) return null;
   }
+  const currentSeed = cleanDisplay(overlayState?.wheelCeremonySeed);
+  const previousSeed = cleanDisplay(overlayState?.wheelCeremonyPreviousSeed);
+  const displaySeed = storedStatus === "reencrypting" && status === "reencrypting" && reencryptElapsedMs < WHEEL_REENCRYPT_REMAP_MS ? previousSeed ?? currentSeed : currentSeed;
   return {
     status,
     storedStatus,
     candidateCount: candidates.length,
-    displayCandidates: shuffledWheelCandidates(candidates, cleanDisplay(overlayState?.wheelCeremonySeed)).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
+    displayCandidates: shuffledWheelCandidates(candidates, displaySeed).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
     hiddenCandidateCount: Math.max(0, candidates.length - MAX_WHEEL_DISPLAY_CANDIDATES),
     resultTrack,
     resultTrackId,
@@ -404,7 +415,9 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     startedAt: overlayState?.wheelCeremonyStartedAt ?? overlayState?.wheelOverlayLaunchedAt,
     spinStartedAt: overlayState?.wheelCeremonySpinStartedAt,
     resultSelectedAt: overlayState?.wheelCeremonyResultSelectedAt,
-    seed: cleanDisplay(overlayState?.wheelCeremonySeed),
+    seed: currentSeed,
+    previousSeed,
+    reencryptCycleId: cleanDisplay(overlayState?.wheelCeremonyReencryptCycleId),
     jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
     spinDurationMs,
     audioPath: cleanDisplay(overlayState?.wheelCeremonyAudioPath),

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -151,6 +151,9 @@ export interface LiveOverlayStateInput {
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyPreviousSeed?: string;
+  wheelCeremonyCandidateOrder?: string[];
+  wheelCeremonyPreviousCandidateOrder?: string[];
+  wheelCeremonyReencryptNonce?: string;
   wheelCeremonyReencryptCycleId?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
@@ -226,6 +229,9 @@ export interface ResolvedWheelCeremonyScene {
   resultSelectedAt?: string;
   seed?: string;
   previousSeed?: string;
+  candidateOrder?: string[];
+  previousCandidateOrder?: string[];
+  reencryptNonce?: string;
   reencryptCycleId?: string;
   jingleKey?: string;
   spinDurationMs: number;
@@ -258,7 +264,7 @@ const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit
 const DEFAULT_WHEEL_SPIN_DURATION_MS = 24000;
 const MIN_WHEEL_SPIN_DURATION_MS = 16000;
 const MAX_WHEEL_SPIN_DURATION_MS = 32000;
-const WHEEL_REENCRYPTING_MS = 1850;
+const WHEEL_REENCRYPTING_MS = 2200;
 const WHEEL_REENCRYPT_REMAP_MS = 750;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
 const WHEEL_SIGNAL_LOST_MS = 3500;
@@ -371,6 +377,54 @@ function shuffledWheelCandidates(candidates: ResolvedWheelCeremonyTrack[], seed?
   return shuffled;
 }
 
+function cleanStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const cleaned = value.map(cleanDisplay).filter((entry): entry is string => Boolean(entry));
+  return cleaned.length > 0 ? [...new Set(cleaned)] : undefined;
+}
+
+export function orderedWheelCandidateIds(candidates: Pick<ResolvedWheelCeremonyTrack, "id">[], order?: string[], seed?: string): string[] {
+  const candidateIds = candidates.map((candidate) => candidate.id).filter(Boolean);
+  const candidateIdSet = new Set(candidateIds);
+  const ordered = (order ?? []).filter((candidateId) => candidateIdSet.has(candidateId));
+  const missing = candidateIds.filter((candidateId) => !ordered.includes(candidateId));
+  if (ordered.length > 0) return [...ordered, ...missing];
+  return shuffledWheelCandidates(candidates as ResolvedWheelCeremonyTrack[], seed).map((candidate) => candidate.id);
+}
+
+function orderWheelCandidates(candidates: ResolvedWheelCeremonyTrack[], order?: string[], seed?: string): ResolvedWheelCeremonyTrack[] {
+  const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  return orderedWheelCandidateIds(candidates, order, seed).map((candidateId) => byId.get(candidateId)).filter((candidate): candidate is ResolvedWheelCeremonyTrack => Boolean(candidate));
+}
+
+function rotateWheelOrder(order: string[], amount: number): string[] {
+  if (order.length === 0) return order;
+  const safeAmount = ((amount % order.length) + order.length) % order.length;
+  return [...order.slice(safeAmount), ...order.slice(0, safeAmount)];
+}
+
+export function derangedWheelCandidateOrder(candidates: Pick<ResolvedWheelCeremonyTrack, "id">[], previousOrder?: string[], seed?: string): string[] {
+  const baseline = orderedWheelCandidateIds(candidates, previousOrder, seed);
+  if (baseline.length <= 1) return baseline;
+  if (baseline.length === 2) return [baseline[1], baseline[0]];
+
+  const shuffled = [...baseline];
+  let state = seededHash(seed || `barcode-wheel-derange:${baseline.join("|")}`);
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const swapIndex = state % (index + 1);
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+
+  for (let rotation = 0; rotation < shuffled.length; rotation += 1) {
+    const rotated = rotateWheelOrder(shuffled, rotation);
+    if (rotated.every((candidateId, index) => candidateId !== baseline[index])) return rotated;
+  }
+
+  const fallbackShift = (seededHash(`${seed ?? "fallback"}:${baseline.join("|")}`) % (baseline.length - 1)) + 1;
+  return rotateWheelOrder(baseline, fallbackShift);
+}
+
 function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): ResolvedWheelCeremonyScene | null {
   const overlayState = input.overlayState ?? null;
   const storedStatus = normalizeWheelCeremonyStatus(overlayState?.wheelCeremonyStatus ?? (overlayState?.wheelOverlayActive ? "ready" : "idle"));
@@ -402,12 +456,16 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   }
   const currentSeed = cleanDisplay(overlayState?.wheelCeremonySeed);
   const previousSeed = cleanDisplay(overlayState?.wheelCeremonyPreviousSeed);
-  const displaySeed = storedStatus === "reencrypting" && status === "reencrypting" && reencryptElapsedMs < WHEEL_REENCRYPT_REMAP_MS ? previousSeed ?? currentSeed : currentSeed;
+  const currentOrder = cleanStringList(overlayState?.wheelCeremonyCandidateOrder);
+  const previousOrder = cleanStringList(overlayState?.wheelCeremonyPreviousCandidateOrder);
+  const usePreviousMapping = storedStatus === "reencrypting" && status === "reencrypting" && reencryptElapsedMs < WHEEL_REENCRYPT_REMAP_MS;
+  const displaySeed = usePreviousMapping ? previousSeed ?? currentSeed : currentSeed;
+  const displayOrder = usePreviousMapping ? previousOrder ?? currentOrder : currentOrder;
   return {
     status,
     storedStatus,
     candidateCount: candidates.length,
-    displayCandidates: shuffledWheelCandidates(candidates, displaySeed).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
+    displayCandidates: orderWheelCandidates(candidates, displayOrder, displaySeed).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
     hiddenCandidateCount: Math.max(0, candidates.length - MAX_WHEEL_DISPLAY_CANDIDATES),
     resultTrack,
     resultTrackId,
@@ -417,6 +475,9 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     resultSelectedAt: overlayState?.wheelCeremonyResultSelectedAt,
     seed: currentSeed,
     previousSeed,
+    candidateOrder: currentOrder,
+    previousCandidateOrder: previousOrder,
+    reencryptNonce: cleanDisplay(overlayState?.wheelCeremonyReencryptNonce) ?? cleanDisplay(overlayState?.wheelCeremonyReencryptCycleId),
     reencryptCycleId: cleanDisplay(overlayState?.wheelCeremonyReencryptCycleId),
     jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
     spinDurationMs,

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -2,7 +2,7 @@ import type { QueueSourceType, SponsorBreakStatus } from "./queue-types";
 
 export type OverlayMode = "standby" | "now_playing" | "artist_card" | "wheel_ready" | "wheel_reencrypting" | "wheel_spinning" | "wheel_result" | "wheel_confirmed" | "sponsor" | "video_placeholder" | "system_message" | "session_active";
 export type WheelOverlayStatus = "ready" | "intro" | "active" | "complete";
-export type WheelCeremonyStatus = "idle" | "ready" | "reencrypting" | "spinning" | "result_pending" | "confirmed" | "cancelled";
+export type WheelCeremonyStatus = "idle" | "ready" | "reencrypting" | "spinning" | "result_pending" | "confirmed" | "cancelled" | "signal_lost";
 
 export interface LiveOverlayTrackInput {
   id?: string;
@@ -156,6 +156,7 @@ const MIN_WHEEL_SPIN_DURATION_MS = 16000;
 const MAX_WHEEL_SPIN_DURATION_MS = 32000;
 const WHEEL_REENCRYPTING_MS = 2500;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
+const WHEEL_SIGNAL_LOST_MS = 3500;
 const MAX_WHEEL_DISPLAY_CANDIDATES = 32;
 
 export function safeLiveOverlayUrl(value: unknown): string | undefined {
@@ -218,7 +219,7 @@ function safeWheelCandidate(candidate: LiveOverlayWheelCandidateInput): Resolved
 }
 
 function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
-  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
+  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "signal_lost" || value === "idle" ? value : "idle";
 }
 
 function timeMs(value?: string): number | null {
@@ -264,8 +265,12 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   if (storedStatus === "reencrypting" || storedStatus === "spinning") {
     const spinStartedMs = timeMs(overlayState?.wheelCeremonySpinStartedAt) ?? now.getTime();
     const elapsedMs = now.getTime() - spinStartedMs;
-    if (storedStatus === "reencrypting") status = elapsedMs < WHEEL_REENCRYPTING_MS ? "reencrypting" : "result_pending";
+    if (storedStatus === "reencrypting") status = elapsedMs < WHEEL_REENCRYPTING_MS ? "reencrypting" : "ready";
     else status = elapsedMs < spinDurationMs ? "spinning" : "result_pending";
+  }
+  if (storedStatus === "signal_lost") {
+    const signalLostAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
+    status = now.getTime() - signalLostAtMs < WHEEL_SIGNAL_LOST_MS ? "signal_lost" : "ready";
   }
   if (storedStatus === "confirmed") {
     const confirmedAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
@@ -314,10 +319,10 @@ export function resolveLiveOverlayScene(input: ResolveLiveOverlaySceneInput): Re
     const mode: OverlayMode = wheelCeremony.status === "reencrypting" ? "wheel_reencrypting" : wheelCeremony.status === "spinning" ? "wheel_spinning" : wheelCeremony.status === "result_pending" ? "wheel_result" : wheelCeremony.status === "confirmed" ? "wheel_confirmed" : "wheel_ready";
     return scene({
       mode,
-      reason: wheelCeremony.status === "ready" ? "Wheel ceremony was launched by the host." : wheelCeremony.status === "reencrypting" ? "Wheel result is being re-encrypted before host confirmation." : wheelCeremony.status === "spinning" ? "Wheel spin is running under host control." : wheelCeremony.status === "confirmed" ? "Wheel result was confirmed through the queue admin path." : "Wheel result is waiting for host confirmation.",
+      reason: wheelCeremony.status === "ready" ? "Wheel ceremony was launched by the host." : wheelCeremony.status === "reencrypting" ? "Wheel candidates are being re-encrypted before the spin." : wheelCeremony.status === "signal_lost" ? "Wheel winner was removed because the signal was not present." : wheelCeremony.status === "spinning" ? "Wheel spin is running under host control." : wheelCeremony.status === "confirmed" ? "Wheel result was confirmed through the queue admin path." : "Wheel result is waiting for host confirmation.",
       title: wheelCeremony.status === "confirmed" ? "WHEEL CHOSEN" : "10K TAP WHEEL",
-      subtitle: wheelCeremony.status === "ready" ? "READY" : wheelCeremony.status === "reencrypting" ? "RE-ENCRYPTING SIGNAL" : wheelCeremony.status === "spinning" ? "SPINNING" : wheelCeremony.status === "confirmed" ? "LOCKED IN" : "RESULT PENDING",
-      message: wheelCeremony.status === "ready" ? `Candidates: ${wheelCeremony.candidateCount}. Awaiting host spin.` : wheelCeremony.status === "reencrypting" ? "Signal scramble in progress." : wheelCeremony.status === "spinning" ? "Result incoming." : result ? `${result.artistName} — ${result.trackTitle}` : "Awaiting host confirmation.",
+      subtitle: wheelCeremony.status === "ready" ? "READY" : wheelCeremony.status === "reencrypting" ? "RE-ENCRYPTING SIGNAL" : wheelCeremony.status === "signal_lost" ? "SIGNAL LOST" : wheelCeremony.status === "spinning" ? "SPINNING" : wheelCeremony.status === "confirmed" ? "LOCKED IN" : "RESULT PENDING",
+      message: wheelCeremony.status === "ready" ? `Candidates: ${wheelCeremony.candidateCount}. Awaiting host spin.` : wheelCeremony.status === "reencrypting" ? "Signal scramble in progress." : wheelCeremony.status === "signal_lost" ? "WINNER NOT PRESENT — WHEEL STILL OWED" : wheelCeremony.status === "spinning" ? "Result incoming." : result ? `${result.artistName} — ${result.trackTitle}` : "Awaiting host confirmation.",
       wheelCeremony,
       priority: 100,
       automatic: false,

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -56,6 +56,7 @@ export interface LiveOverlayStateInput {
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
+  wheelCeremonySpinDurationMs?: number;
   updatedAt?: string;
 }
 
@@ -148,7 +149,9 @@ export interface ResolvedLiveOverlayScene {
 
 const MAX_URL_LENGTH = 600;
 const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit.ly", "tinyurl.com", "t.co", "goo.gl", "private.blob.vercel-storage.com"];
-const WHEEL_SPIN_DURATION_MS = 6500;
+const DEFAULT_WHEEL_SPIN_DURATION_MS = 24000;
+const MIN_WHEEL_SPIN_DURATION_MS = 16000;
+const MAX_WHEEL_SPIN_DURATION_MS = 32000;
 const WHEEL_REENCRYPTING_MS = 2500;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
 const MAX_WHEEL_DISPLAY_CANDIDATES = 32;
@@ -222,6 +225,31 @@ function timeMs(value?: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function normalizeWheelSpinDurationMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_WHEEL_SPIN_DURATION_MS;
+  return Math.max(MIN_WHEEL_SPIN_DURATION_MS, Math.min(MAX_WHEEL_SPIN_DURATION_MS, Math.round(value)));
+}
+
+function seededHash(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function shuffledWheelCandidates(candidates: ResolvedWheelCeremonyTrack[], seed?: string): ResolvedWheelCeremonyTrack[] {
+  const shuffled = [...candidates];
+  let state = seededHash(seed || "barcode-wheel");
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const swapIndex = state % (index + 1);
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled;
+}
+
 function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): ResolvedWheelCeremonyScene | null {
   const overlayState = input.overlayState ?? null;
   const storedStatus = normalizeWheelCeremonyStatus(overlayState?.wheelCeremonyStatus ?? (overlayState?.wheelOverlayActive ? "ready" : "idle"));
@@ -230,12 +258,12 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   const resultTrackId = cleanDisplay(overlayState?.wheelCeremonyResultTrackId);
   const resultTrack = candidates.find((candidate) => candidate.id === resultTrackId) ?? (resultTrackId ? { id: resultTrackId, artistName: cleanDisplay(overlayState?.artistName) || "Selected artist", trackTitle: cleanDisplay(overlayState?.trackTitle) || "Selected transmission" } : null);
   let status = storedStatus;
+  const spinDurationMs = normalizeWheelSpinDurationMs(overlayState?.wheelCeremonySpinDurationMs);
   if (storedStatus === "reencrypting" || storedStatus === "spinning") {
     const spinStartedMs = timeMs(overlayState?.wheelCeremonySpinStartedAt) ?? now.getTime();
     const elapsedMs = now.getTime() - spinStartedMs;
-    if (storedStatus === "reencrypting" && elapsedMs < WHEEL_REENCRYPTING_MS) status = "reencrypting";
-    else if (elapsedMs < WHEEL_SPIN_DURATION_MS) status = "spinning";
-    else status = "result_pending";
+    if (storedStatus === "reencrypting") status = elapsedMs < WHEEL_REENCRYPTING_MS ? "reencrypting" : "result_pending";
+    else status = elapsedMs < spinDurationMs ? "spinning" : "result_pending";
   }
   if (storedStatus === "confirmed") {
     const confirmedAtMs = timeMs(overlayState?.wheelCeremonyResultSelectedAt) ?? timeMs(overlayState?.updatedAt) ?? now.getTime();
@@ -245,7 +273,7 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     status,
     storedStatus,
     candidateCount: candidates.length,
-    displayCandidates: candidates.slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
+    displayCandidates: (storedStatus === "reencrypting" ? shuffledWheelCandidates(candidates, cleanDisplay(overlayState?.wheelCeremonySeed)) : candidates).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
     hiddenCandidateCount: Math.max(0, candidates.length - MAX_WHEEL_DISPLAY_CANDIDATES),
     resultTrack,
     resultTrackId,
@@ -254,7 +282,7 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     resultSelectedAt: overlayState?.wheelCeremonyResultSelectedAt,
     seed: cleanDisplay(overlayState?.wheelCeremonySeed),
     jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
-    spinDurationMs: WHEEL_SPIN_DURATION_MS,
+    spinDurationMs,
   };
 }
 

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -29,6 +29,9 @@ export interface LiveOverlayWheelCandidateInput {
   submittedSongTitle?: string;
   detectedArtistName?: string | null;
   detectedSongTitle?: string | null;
+  trackIds?: string[];
+  trackCount?: number;
+  tracks?: ResolvedWheelCeremonyTrack[];
 }
 
 export interface LiveOverlayStateInput {
@@ -53,6 +56,7 @@ export interface LiveOverlayStateInput {
   wheelCeremonyStartedAt?: string;
   wheelCeremonySpinStartedAt?: string;
   wheelCeremonyResultTrackId?: string;
+  wheelCeremonyChosenTrackId?: string;
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
@@ -109,6 +113,9 @@ export interface ResolvedWheelCeremonyTrack {
   id: string;
   artistName: string;
   trackTitle: string;
+  trackIds?: string[];
+  trackCount?: number;
+  tracks?: ResolvedWheelCeremonyTrack[];
 }
 
 export interface ResolvedWheelCeremonyScene {
@@ -119,6 +126,7 @@ export interface ResolvedWheelCeremonyScene {
   hiddenCandidateCount: number;
   resultTrack?: ResolvedWheelCeremonyTrack | null;
   resultTrackId?: string;
+  chosenTrackId?: string;
   startedAt?: string;
   spinStartedAt?: string;
   resultSelectedAt?: string;
@@ -154,7 +162,7 @@ const BLOCKED_HOSTS = ["drive.google.com", "dropbox.com", "wetransfer.com", "bit
 const DEFAULT_WHEEL_SPIN_DURATION_MS = 24000;
 const MIN_WHEEL_SPIN_DURATION_MS = 16000;
 const MAX_WHEEL_SPIN_DURATION_MS = 32000;
-const WHEEL_REENCRYPTING_MS = 2500;
+const WHEEL_REENCRYPTING_MS = 1600;
 const WHEEL_CONFIRMED_RETURN_MS = 2200;
 const WHEEL_SIGNAL_LOST_MS = 3500;
 const MAX_WHEEL_DISPLAY_CANDIDATES = 32;
@@ -215,7 +223,19 @@ function safeTrack(track: LiveOverlayTrackInput): { track: ResolvedLiveOverlayTr
 function safeWheelCandidate(candidate: LiveOverlayWheelCandidateInput): ResolvedWheelCeremonyTrack | null {
   const id = cleanDisplay(candidate.id);
   if (!id) return null;
-  return { id, artistName: displayArtist(candidate), trackTitle: displayTitle(candidate) };
+  const tracks = Array.isArray(candidate.tracks)
+    ? candidate.tracks.map((track) => ({ id: cleanDisplay(track.id) ?? "", artistName: cleanDisplay(track.artistName) || displayArtist(candidate), trackTitle: cleanDisplay(track.trackTitle) || "Untitled transmission" })).filter((track) => Boolean(track.id))
+    : undefined;
+  const trackIds = Array.isArray(candidate.trackIds) ? candidate.trackIds.map(cleanDisplay).filter((trackId): trackId is string => Boolean(trackId)) : tracks?.map((track) => track.id);
+  const trackCount = Math.max(1, Math.floor(candidate.trackCount ?? trackIds?.length ?? tracks?.length ?? 1));
+  return {
+    id,
+    artistName: displayArtist(candidate),
+    trackTitle: trackCount > 1 ? `${trackCount} eligible tracks` : displayTitle(candidate),
+    trackIds,
+    trackCount,
+    tracks,
+  };
 }
 
 function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
@@ -259,7 +279,10 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
   if (storedStatus === "idle" || storedStatus === "cancelled") return null;
   const candidates = (input.wheelCandidates ?? []).map(safeWheelCandidate).filter((candidate): candidate is ResolvedWheelCeremonyTrack => Boolean(candidate));
   const resultTrackId = cleanDisplay(overlayState?.wheelCeremonyResultTrackId);
-  const resultTrack = candidates.find((candidate) => candidate.id === resultTrackId) ?? (resultTrackId ? { id: resultTrackId, artistName: cleanDisplay(overlayState?.artistName) || "Selected artist", trackTitle: cleanDisplay(overlayState?.trackTitle) || "Selected transmission" } : null);
+  const chosenTrackId = cleanDisplay(overlayState?.wheelCeremonyChosenTrackId);
+  const rawResultTrack = candidates.find((candidate) => candidate.id === resultTrackId) ?? (resultTrackId ? { id: resultTrackId, artistName: cleanDisplay(overlayState?.artistName) || "Selected artist", trackTitle: cleanDisplay(overlayState?.trackTitle) || "Selected transmission" } : null);
+  const chosenTrackTitle = chosenTrackId ? rawResultTrack?.tracks?.find((track) => track.id === chosenTrackId)?.trackTitle ?? cleanDisplay(overlayState?.trackTitle) : undefined;
+  const resultTrack = rawResultTrack && chosenTrackTitle ? { ...rawResultTrack, trackTitle: chosenTrackTitle } : rawResultTrack;
   let status = storedStatus;
   const spinDurationMs = normalizeWheelSpinDurationMs(overlayState?.wheelCeremonySpinDurationMs);
   if (storedStatus === "reencrypting" || storedStatus === "spinning") {
@@ -280,10 +303,11 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     status,
     storedStatus,
     candidateCount: candidates.length,
-    displayCandidates: (storedStatus === "reencrypting" ? shuffledWheelCandidates(candidates, cleanDisplay(overlayState?.wheelCeremonySeed)) : candidates).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
+    displayCandidates: shuffledWheelCandidates(candidates, cleanDisplay(overlayState?.wheelCeremonySeed)).slice(0, MAX_WHEEL_DISPLAY_CANDIDATES),
     hiddenCandidateCount: Math.max(0, candidates.length - MAX_WHEEL_DISPLAY_CANDIDATES),
     resultTrack,
     resultTrackId,
+    chosenTrackId,
     startedAt: overlayState?.wheelCeremonyStartedAt ?? overlayState?.wheelOverlayLaunchedAt,
     spinStartedAt: overlayState?.wheelCeremonySpinStartedAt,
     resultSelectedAt: overlayState?.wheelCeremonyResultSelectedAt,

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -94,6 +94,14 @@ export function wheelFinalRotationForSlice(entryCount: number, index: number, fu
   return wheelFinalRotationForSegment(segment ?? buildWheelSegments([])[0], fullTurns, pointerAngleDegrees);
 }
 
+export function wheelUprightLabelRotationDegrees(angle: number): number {
+  let rotation = normalizeWheelAngle(angle) - 90;
+  if (rotation > 180) rotation -= 360;
+  if (rotation > 90) rotation -= 180;
+  if (rotation < -90) rotation += 180;
+  return rotation;
+}
+
 export interface LiveOverlayTrackInput {
   id?: string;
   artist?: string;
@@ -155,6 +163,10 @@ export interface LiveOverlayStateInput {
   wheelCeremonyPreviousCandidateOrder?: string[];
   wheelCeremonyReencryptNonce?: string;
   wheelCeremonyReencryptCycleId?: string;
+  wheelCeremonyFinalRotationDeg?: number;
+  wheelCeremonyLandingAngleDeg?: number;
+  wheelCeremonyWinningSegmentId?: string;
+  wheelCeremonyWinningSegmentIndex?: number;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
   wheelCeremonyAudioPath?: string;
@@ -233,6 +245,10 @@ export interface ResolvedWheelCeremonyScene {
   previousCandidateOrder?: string[];
   reencryptNonce?: string;
   reencryptCycleId?: string;
+  finalRotationDeg?: number;
+  landingAngleDeg?: number;
+  winningSegmentId?: string;
+  winningSegmentIndex?: number;
   jingleKey?: string;
   spinDurationMs: number;
   audioPath?: string;
@@ -383,6 +399,16 @@ function cleanStringList(value: unknown): string[] | undefined {
   return cleaned.length > 0 ? [...new Set(cleaned)] : undefined;
 }
 
+function cleanNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value;
+}
+
+function cleanInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.floor(value);
+}
+
 export function orderedWheelCandidateIds(candidates: Pick<ResolvedWheelCeremonyTrack, "id">[], order?: string[], seed?: string): string[] {
   const candidateIds = candidates.map((candidate) => candidate.id).filter(Boolean);
   const candidateIdSet = new Set(candidateIds);
@@ -479,6 +505,10 @@ function resolveWheelCeremony(input: ResolveLiveOverlaySceneInput, now: Date): R
     previousCandidateOrder: previousOrder,
     reencryptNonce: cleanDisplay(overlayState?.wheelCeremonyReencryptNonce) ?? cleanDisplay(overlayState?.wheelCeremonyReencryptCycleId),
     reencryptCycleId: cleanDisplay(overlayState?.wheelCeremonyReencryptCycleId),
+    finalRotationDeg: cleanNumber(overlayState?.wheelCeremonyFinalRotationDeg),
+    landingAngleDeg: cleanNumber(overlayState?.wheelCeremonyLandingAngleDeg),
+    winningSegmentId: cleanDisplay(overlayState?.wheelCeremonyWinningSegmentId),
+    winningSegmentIndex: cleanInteger(overlayState?.wheelCeremonyWinningSegmentIndex),
     jingleKey: cleanDisplay(overlayState?.wheelCeremonyJingleKey) || "silent",
     spinDurationMs,
     audioPath: cleanDisplay(overlayState?.wheelCeremonyAudioPath),

--- a/src/lib/live-overlay-resolver.ts
+++ b/src/lib/live-overlay-resolver.ts
@@ -6,29 +6,92 @@ export type WheelCeremonyStatus = "idle" | "ready" | "reencrypting" | "spinning"
 
 export const WHEEL_RIGHT_POINTER_ANGLE_DEGREES = 90;
 
+export interface WheelSegmentInput {
+  id: string;
+  label: string;
+  weight?: number;
+}
+
+export interface WheelSegment {
+  id: string;
+  candidateId: string;
+  displayLabel: string;
+  startAngle: number;
+  endAngle: number;
+  centerAngle: number;
+  angleSize: number;
+  weight: number;
+  index: number;
+}
+
 export function normalizeWheelAngle(degrees: number): number {
   if (!Number.isFinite(degrees)) return 0;
   return ((degrees % 360) + 360) % 360;
 }
 
+function normalizeWheelWeight(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+export function buildWheelSegments(entries: WheelSegmentInput[]): WheelSegment[] {
+  const safeEntries = entries.length > 0 ? entries : [{ id: "empty", label: "NO CANDIDATES", weight: 1 }];
+  const weights = safeEntries.map((entry) => normalizeWheelWeight(entry.weight));
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0) || 1;
+  let cursor = 0;
+
+  return safeEntries.map((entry, index) => {
+    const weight = weights[index] ?? 1;
+    const startAngle = cursor;
+    const angleSize = index === safeEntries.length - 1 ? 360 - startAngle : 360 * weight / totalWeight;
+    const endAngle = index === safeEntries.length - 1 ? 360 : startAngle + angleSize;
+    cursor = endAngle;
+    return {
+      id: `segment:${entry.id}`,
+      candidateId: entry.id,
+      displayLabel: entry.label,
+      startAngle,
+      endAngle,
+      centerAngle: startAngle + angleSize / 2,
+      angleSize,
+      weight,
+      index,
+    };
+  });
+}
+
+export function wheelPointerLocalAngle(finalRotationDegrees: number, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
+  return normalizeWheelAngle(pointerAngleDegrees - normalizeWheelAngle(finalRotationDegrees));
+}
+
+export function wheelSegmentAtPointer(segments: WheelSegment[], finalRotationDegrees: number, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): WheelSegment {
+  const safeSegments = segments.length > 0 ? segments : buildWheelSegments([]);
+  // Wheel labels are visual only. Winner selection is based exclusively on segment geometry under the right-side pointer.
+  // Boundary rule: each segment owns [startAngle, endAngle), so an exact boundary belongs to the next clockwise segment.
+  const pointerLocalAngle = wheelPointerLocalAngle(finalRotationDegrees, pointerAngleDegrees);
+  return safeSegments.find((segment, index) => pointerLocalAngle >= segment.startAngle && (pointerLocalAngle < segment.endAngle || index === safeSegments.length - 1 && pointerLocalAngle < 360)) ?? safeSegments[0];
+}
+
 export function wheelSliceIndexAtPointer(entryCount: number, finalRotationDegrees: number, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
   const count = Math.max(1, Math.floor(entryCount));
-  const sliceSize = 360 / count;
-  // Winner selection is based only on slice geometry. Labels are visual only and must not affect this math.
-  // Boundary rule: each slice owns [startAngle, endAngle), so an exact boundary belongs to the next slice.
-  const pointerLocalAngle = normalizeWheelAngle(pointerAngleDegrees - normalizeWheelAngle(finalRotationDegrees));
-  return Math.min(count - 1, Math.floor(pointerLocalAngle / sliceSize));
+  const segments = buildWheelSegments(Array.from({ length: count }, (_, index) => ({ id: `slice-${index}`, label: `Slice ${index + 1}` })));
+  return wheelSegmentAtPointer(segments, finalRotationDegrees, pointerAngleDegrees).index;
 }
 
 export function wheelSliceCenterAngle(entryCount: number, index: number): number {
   const count = Math.max(1, Math.floor(entryCount));
   const safeIndex = Math.max(0, Math.min(count - 1, Math.floor(index)));
-  const sliceSize = 360 / count;
-  return safeIndex * sliceSize + sliceSize / 2;
+  return buildWheelSegments(Array.from({ length: count }, (_, segmentIndex) => ({ id: `slice-${segmentIndex}`, label: `Slice ${segmentIndex + 1}` })))[safeIndex]?.centerAngle ?? 0;
+}
+
+export function wheelFinalRotationForSegment(segment: WheelSegment, fullTurns = 4, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
+  return (Math.max(0, Math.floor(fullTurns)) * 360) + pointerAngleDegrees - segment.centerAngle;
 }
 
 export function wheelFinalRotationForSlice(entryCount: number, index: number, fullTurns = 4, pointerAngleDegrees = WHEEL_RIGHT_POINTER_ANGLE_DEGREES): number {
-  return (Math.max(0, Math.floor(fullTurns)) * 360) + pointerAngleDegrees - wheelSliceCenterAngle(entryCount, index);
+  const count = Math.max(1, Math.floor(entryCount));
+  const safeIndex = Math.max(0, Math.min(count - 1, Math.floor(index)));
+  const segment = buildWheelSegments(Array.from({ length: count }, (_, segmentIndex) => ({ id: `slice-${segmentIndex}`, label: `Slice ${segmentIndex + 1}` })))[safeIndex];
+  return wheelFinalRotationForSegment(segment ?? buildWheelSegments([])[0], fullTurns, pointerAngleDegrees);
 }
 
 export interface LiveOverlayTrackInput {
@@ -59,6 +122,7 @@ export interface LiveOverlayWheelCandidateInput {
   trackIds?: string[];
   trackCount?: number;
   tracks?: ResolvedWheelCeremonyTrack[];
+  weight?: number;
 }
 
 export interface LiveOverlayStateInput {
@@ -143,6 +207,7 @@ export interface ResolvedWheelCeremonyTrack {
   trackIds?: string[];
   trackCount?: number;
   tracks?: ResolvedWheelCeremonyTrack[];
+  weight?: number;
 }
 
 export interface ResolvedWheelCeremonyScene {
@@ -262,6 +327,7 @@ function safeWheelCandidate(candidate: LiveOverlayWheelCandidateInput): Resolved
     trackIds,
     trackCount,
     tracks,
+    weight: normalizeWheelWeight(candidate.weight),
   };
 }
 

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -387,8 +387,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
     };
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
     const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
-    if (payload.action === "spinWheel" && (currentStatus !== "ready" && currentStatus !== "signal_lost" && currentStatus !== "reencrypting")) throw new Error("Launch the wheel before spinning.");
-    if (payload.action === "reencryptWheel" && ((currentStatus !== "ready" && currentStatus !== "reencrypting" && currentStatus !== "signal_lost") || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
+    if (payload.action === "spinWheel" && currentStatus !== "ready" && currentStatus !== "signal_lost") throw new Error("Launch the wheel before spinning.");
+    if (payload.action === "reencryptWheel" && (currentStatus !== "ready" || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
     const queueState = await getRadioQueueState();
     if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
@@ -427,7 +427,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       mode: "wheel_ready",
       wheelOverlayActive: true,
       wheelOverlayStatus: "ready",
-      wheelCeremonyStatus: "signal_lost",
+      wheelCeremonyStatus: "ready",
       wheelCeremonySpinStartedAt: undefined,
       wheelCeremonyResultTrackId: undefined,
       wheelCeremonyResultSelectedAt: now,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -36,6 +36,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
+  wheelCeremonySpinDurationMs?: number;
   updatedAt: string;
 }
 
@@ -143,6 +144,15 @@ function randomSeed(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
+function randomSpinDurationMs(): number {
+  return 16_000 + Math.floor(Math.random() * 16_001);
+}
+
+function normalizeSpinDurationMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(16_000, Math.min(32_000, Math.round(value)));
+}
+
 function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[], excludeId?: string): ResolvedWheelCeremonyTrack | null {
   const pool = excludeId && candidates.length > 1 ? candidates.filter((candidate) => candidate.id !== excludeId) : candidates;
   if (pool.length === 0) return null;
@@ -233,6 +243,7 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonyResultSelectedAt: typeof raw.wheelCeremonyResultSelectedAt === "string" ? raw.wheelCeremonyResultSelectedAt : undefined,
     wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
+    wheelCeremonySpinDurationMs: normalizeSpinDurationMs(raw.wheelCeremonySpinDurationMs),
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
   };
 }
@@ -333,12 +344,13 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
+      wheelCeremonySpinDurationMs: undefined,
       updatedAt: now,
     };
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
     const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
     if (payload.action === "spinWheel" && !isActiveCeremony(currentStatus)) throw new Error("Launch the wheel before spinning.");
-    if (payload.action === "reencryptWheel" && currentStatus !== "result_pending" && currentStatus !== "spinning") throw new Error("Re-encrypt is only available before confirming a pending result.");
+    if (payload.action === "reencryptWheel" && currentStatus !== "result_pending" && currentStatus !== "spinning" && currentStatus !== "reencrypting") throw new Error("Re-encrypt is only available before confirming a pending result.");
     const queueState = await getRadioQueueState();
     if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
@@ -356,6 +368,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: now,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
+      wheelCeremonySpinDurationMs: reencrypting ? current.wheelCeremonySpinDurationMs : randomSpinDurationMs(),
       artistName: selected.artistName,
       trackTitle: selected.trackTitle,
       updatedAt: now,
@@ -393,6 +406,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: undefined,
       wheelCeremonyJingleKey: "silent",
+      wheelCeremonySpinDurationMs: undefined,
       artistName: undefined,
       trackTitle: undefined,
       updatedAt: now,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -42,7 +42,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
 }
 
 export interface LiveOverlayPayload {
-  action?: "launchWheel" | "spinWheel" | "reencryptWheel" | "confirmWheel" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
+  action?: "launchWheel" | "spinWheel" | "reencryptWheel" | "confirmWheel" | "wheelWinnerNotHere" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
   mode?: OverlayMode;
   title?: unknown;
   subtitle?: unknown;
@@ -199,9 +199,6 @@ function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[], excludeId
   return pool[Math.max(0, Math.min(pool.length - 1, index))] ?? null;
 }
 
-function isActiveCeremony(status?: WheelCeremonyStatus): boolean {
-  return status === "ready" || status === "reencrypting" || status === "spinning" || status === "result_pending";
-}
 
 function normalizeMode(value: unknown): OverlayMode {
   const modes: OverlayMode[] = ["standby", "now_playing", "artist_card", "wheel_ready", "wheel_reencrypting", "wheel_spinning", "wheel_result", "wheel_confirmed", "sponsor", "video_placeholder", "system_message", "session_active"];
@@ -218,7 +215,7 @@ function normalizeWheelStatus(value: unknown): WheelOverlayStatus {
 }
 
 function normalizeWheelCeremonyStatus(value: unknown): WheelCeremonyStatus {
-  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "idle" ? value : "idle";
+  return value === "ready" || value === "reencrypting" || value === "spinning" || value === "result_pending" || value === "confirmed" || value === "cancelled" || value === "signal_lost" || value === "idle" ? value : "idle";
 }
 
 
@@ -390,14 +387,15 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
     };
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
     const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
-    if (payload.action === "spinWheel" && !isActiveCeremony(currentStatus)) throw new Error("Launch the wheel before spinning.");
-    if (payload.action === "reencryptWheel" && currentStatus !== "result_pending" && currentStatus !== "spinning" && currentStatus !== "reencrypting") throw new Error("Re-encrypt is only available before confirming a pending result.");
+    if (payload.action === "spinWheel" && (currentStatus !== "ready" && currentStatus !== "signal_lost" && currentStatus !== "reencrypting")) throw new Error("Launch the wheel before spinning.");
+    if (payload.action === "reencryptWheel" && ((currentStatus !== "ready" && currentStatus !== "reencrypting" && currentStatus !== "signal_lost") || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
     const queueState = await getRadioQueueState();
     if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
-    const selected = pickRandomCandidate(candidates, payload.action === "reencryptWheel" ? current.wheelCeremonyResultTrackId : undefined);
-    if (!selected) throw new Error("No eligible Wheel Chosen candidates are available.");
+    if (candidates.length === 0) throw new Error("No eligible Wheel Chosen candidates are available.");
     const reencrypting = payload.action === "reencryptWheel";
+    const selected = reencrypting ? null : pickRandomCandidate(candidates);
+    if (!reencrypting && !selected) throw new Error("No eligible Wheel Chosen candidates are available.");
     next = {
       ...current,
       mode: reencrypting ? "wheel_reencrypting" : "wheel_spinning",
@@ -405,14 +403,40 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelOverlayStatus: "active",
       wheelCeremonyStatus: reencrypting ? "reencrypting" : "spinning",
       wheelCeremonySpinStartedAt: now,
-      wheelCeremonyResultTrackId: selected.id,
+      wheelCeremonyResultTrackId: selected?.id,
+      wheelCeremonyResultSelectedAt: selected ? now : undefined,
+      wheelCeremonySeed: randomSeed(),
+      wheelCeremonyJingleKey: "silent",
+      wheelCeremonySpinDurationMs: reencrypting ? undefined : randomSpinDurationMs(),
+      wheelCeremonyAudioPath: reencrypting ? undefined : randomWheelAudioPath(),
+      artistName: selected?.artistName,
+      trackTitle: selected?.trackTitle,
+      updatedAt: now,
+    };
+  } else if (payload.action === "wheelWinnerNotHere") {
+    const resultTrackId = cleanText(current.wheelCeremonyResultTrackId);
+    if (!resultTrackId) throw new Error("No wheel result is ready to remove.");
+    const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
+    if (currentStatus !== "result_pending") throw new Error("Winner Not Here is only available for a pending wheel result.");
+    const queueState = await getRadioQueueState();
+    const selected = getWheelCandidatesFromQueue(queueState.queue).find((candidate) => candidate.id === resultTrackId);
+    if (!selected) throw new Error("The selected wheel result is no longer removable from the active queue.");
+    await updateRadioTrack(resultTrackId, "remove");
+    next = {
+      ...current,
+      mode: "wheel_ready",
+      wheelOverlayActive: true,
+      wheelOverlayStatus: "ready",
+      wheelCeremonyStatus: "signal_lost",
+      wheelCeremonySpinStartedAt: undefined,
+      wheelCeremonyResultTrackId: undefined,
       wheelCeremonyResultSelectedAt: now,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
-      wheelCeremonySpinDurationMs: reencrypting ? current.wheelCeremonySpinDurationMs : randomSpinDurationMs(),
-      wheelCeremonyAudioPath: reencrypting ? current.wheelCeremonyAudioPath : randomWheelAudioPath(),
-      artistName: selected.artistName,
-      trackTitle: selected.trackTitle,
+      wheelCeremonySpinDurationMs: undefined,
+      wheelCeremonyAudioPath: undefined,
+      artistName: undefined,
+      trackTitle: undefined,
       updatedAt: now,
     };
   } else if (payload.action === "confirmWheel") {

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -37,6 +37,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
+  wheelCeremonyAudioPath?: string;
   updatedAt: string;
 }
 
@@ -65,6 +66,40 @@ export interface LiveOverlayAdminSnapshot {
 const OVERLAY_STATE_KEY = "barcode:live-overlay:state";
 const PLAYER_SYNC_KEY = "barcode:live-overlay:player-sync";
 const MAX_TEXT_LENGTH = 180;
+const WHEEL_AUDIO_FILES = [
+  "/audio/wheel/142.mp3",
+  "/audio/wheel/77.mp3",
+  "/audio/wheel/150.mp3",
+  "/audio/wheel/49.mp3",
+  "/audio/wheel/103.mp3",
+  "/audio/wheel/56.mp3",
+  "/audio/wheel/58.mp3",
+  "/audio/wheel/84.mp3",
+  "/audio/wheel/147.mp3",
+  "/audio/wheel/102.mp3",
+  "/audio/wheel/92.mp3",
+  "/audio/wheel/76.mp3",
+  "/audio/wheel/111.mp3",
+  "/audio/wheel/74.mp3",
+  "/audio/wheel/139.mp3",
+  "/audio/wheel/110.mp3",
+  "/audio/wheel/126.mp3",
+  "/audio/wheel/148.mp3",
+  "/audio/wheel/162.mp3",
+  "/audio/wheel/104.mp3",
+  "/audio/wheel/32%20(1).mp3",
+  "/audio/wheel/140.mp3",
+  "/audio/wheel/81.mp3",
+  "/audio/wheel/75.mp3",
+  "/audio/wheel/129.mp3",
+  "/audio/wheel/78.mp3",
+  "/audio/wheel/36.mp3",
+  "/audio/wheel/154.mp3",
+  "/audio/wheel/24.mp3",
+  "/audio/wheel/41.mp3",
+  "/audio/wheel/130.mp3",
+  "/audio/wheel/70.mp3",
+];
 
 let memoryOverlayState: LiveOverlayState = defaultLiveOverlayState();
 let memoryPlayerSync: LiveOverlayYouTubeSync | null = null;
@@ -146,6 +181,10 @@ function randomSeed(): string {
 
 function randomSpinDurationMs(): number {
   return 16_000 + Math.floor(Math.random() * 16_001);
+}
+
+function randomWheelAudioPath(): string {
+  return WHEEL_AUDIO_FILES[Math.floor(Math.random() * WHEEL_AUDIO_FILES.length)] ?? WHEEL_AUDIO_FILES[0];
 }
 
 function normalizeSpinDurationMs(value: unknown): number | undefined {
@@ -244,6 +283,7 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
     wheelCeremonySpinDurationMs: normalizeSpinDurationMs(raw.wheelCeremonySpinDurationMs),
+    wheelCeremonyAudioPath: cleanText(raw.wheelCeremonyAudioPath),
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
   };
 }
@@ -345,6 +385,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
+      wheelCeremonyAudioPath: undefined,
       updatedAt: now,
     };
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
@@ -369,6 +410,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: reencrypting ? current.wheelCeremonySpinDurationMs : randomSpinDurationMs(),
+      wheelCeremonyAudioPath: reencrypting ? current.wheelCeremonyAudioPath : randomWheelAudioPath(),
       artistName: selected.artistName,
       trackTitle: selected.trackTitle,
       updatedAt: now,
@@ -407,6 +449,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonySeed: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
+      wheelCeremonyAudioPath: undefined,
       artistName: undefined,
       trackTitle: undefined,
       updatedAt: now,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -33,6 +33,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonyStartedAt?: string;
   wheelCeremonySpinStartedAt?: string;
   wheelCeremonyResultTrackId?: string;
+  wheelCeremonyChosenTrackId?: string;
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyJingleKey?: string;
@@ -43,6 +44,7 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
 
 export interface LiveOverlayPayload {
   action?: "launchWheel" | "spinWheel" | "reencryptWheel" | "confirmWheel" | "wheelWinnerNotHere" | "cancelWheel" | "clearWheel" | "setSystemMessage" | "clearSystemMessage" | "launchVideoPlaceholder" | "clearVideoPlaceholder" | "clearAllOverrides" | "updatePlayerSync" | "clearPlayerSync";
+  selectedTrackId?: unknown;
   mode?: OverlayMode;
   title?: unknown;
   subtitle?: unknown;
@@ -166,11 +168,62 @@ function overlayTrackInput(entry: QueueEntry) {
 
 
 function wheelCandidateFromEntry(entry: QueueEntry): ResolvedWheelCeremonyTrack {
-  return { id: entry.id, artistName: displayArtist(entry), trackTitle: displayTitle(entry) };
+  return { id: entry.id, artistName: displayArtist(entry), trackTitle: displayTitle(entry), trackIds: [entry.id], trackCount: 1 };
+}
+
+function normalizePersonIdentity(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().normalize("NFKD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+}
+
+function hashWheelIdentity(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function submitterIdentityKeys(entry: QueueEntry): string[] {
+  const keys = [
+    entry.submitterToken ? `token:${entry.submitterToken.trim()}` : null,
+    entry.normalizedTikTokHandle ? `handle:${entry.normalizedTikTokHandle.trim().toLowerCase().replace(/^@/, "")}` : null,
+    entry.contactEmail ? `email:${entry.contactEmail.trim().toLowerCase()}` : null,
+    normalizePersonIdentity(entry.submitterArtistName ?? entry.submittedArtistName ?? entry.artist) ? `artist:${normalizePersonIdentity(entry.submitterArtistName ?? entry.submittedArtistName ?? entry.artist)}` : null,
+  ].filter((key): key is string => Boolean(key));
+  return keys.length > 0 ? keys : [`track:${entry.id}`];
 }
 
 function getWheelCandidatesFromQueue(queue: QueueEntry[]): ResolvedWheelCeremonyTrack[] {
-  return queue.filter(isWheelEligibleTrack).map(wheelCandidateFromEntry);
+  const groups: ResolvedWheelCeremonyTrack[] = [];
+  const groupByKey = new Map<string, ResolvedWheelCeremonyTrack>();
+
+  for (const entry of queue.filter(isWheelEligibleTrack)) {
+    const track = wheelCandidateFromEntry(entry);
+    const keys = submitterIdentityKeys(entry);
+    const existing = keys.map((key) => groupByKey.get(key)).find((group): group is ResolvedWheelCeremonyTrack => Boolean(group));
+    if (existing) {
+      existing.tracks = [...(existing.tracks ?? []), track];
+      existing.trackIds = [...(existing.trackIds ?? []), entry.id];
+      existing.trackCount = existing.trackIds.length;
+      existing.trackTitle = `${existing.trackCount} eligible tracks`;
+      keys.forEach((key) => groupByKey.set(key, existing));
+      continue;
+    }
+
+    const group: ResolvedWheelCeremonyTrack = {
+      id: `person:${hashWheelIdentity(keys.join("|"))}`,
+      artistName: displayArtist(entry),
+      trackTitle: displayTitle(entry),
+      trackIds: [entry.id],
+      trackCount: 1,
+      tracks: [track],
+    };
+    groups.push(group);
+    keys.forEach((key) => groupByKey.set(key, group));
+  }
+
+  return groups.map((group) => ({ ...group, trackTitle: (group.trackCount ?? 1) > 1 ? `${group.trackCount} eligible tracks` : group.trackTitle }));
 }
 
 function randomSeed(): string {
@@ -197,6 +250,22 @@ function pickRandomCandidate(candidates: ResolvedWheelCeremonyTrack[], excludeId
   if (pool.length === 0) return null;
   const index = Math.floor(Math.random() * pool.length);
   return pool[Math.max(0, Math.min(pool.length - 1, index))] ?? null;
+}
+
+function effectiveWheelCeremonyStatus(state: LiveOverlayState, nowMs: number): WheelCeremonyStatus {
+  const status = normalizeWheelCeremonyStatus(state.wheelCeremonyStatus);
+  if (status !== "reencrypting" && status !== "spinning") return status;
+  const startedMs = typeof state.wheelCeremonySpinStartedAt === "string" ? new Date(state.wheelCeremonySpinStartedAt).getTime() : nowMs;
+  if (!Number.isFinite(startedMs)) return status;
+  const elapsedMs = nowMs - startedMs;
+  if (status === "reencrypting") return elapsedMs >= 1600 ? "ready" : "reencrypting";
+  return elapsedMs >= (normalizeSpinDurationMs(state.wheelCeremonySpinDurationMs) ?? 24_000) ? "result_pending" : "spinning";
+}
+
+function findTrackInWinnerGroup(group: ResolvedWheelCeremonyTrack, selectedTrackId?: string): ResolvedWheelCeremonyTrack | null {
+  const tracks = group.tracks ?? [];
+  if (selectedTrackId) return tracks.find((track) => track.id === selectedTrackId) ?? null;
+  return tracks.length === 1 ? tracks[0] ?? null : null;
 }
 
 
@@ -276,6 +345,7 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonyStartedAt: typeof raw.wheelCeremonyStartedAt === "string" ? raw.wheelCeremonyStartedAt : undefined,
     wheelCeremonySpinStartedAt: typeof raw.wheelCeremonySpinStartedAt === "string" ? raw.wheelCeremonySpinStartedAt : undefined,
     wheelCeremonyResultTrackId: cleanText(raw.wheelCeremonyResultTrackId),
+    wheelCeremonyChosenTrackId: cleanText(raw.wheelCeremonyChosenTrackId),
     wheelCeremonyResultSelectedAt: typeof raw.wheelCeremonyResultSelectedAt === "string" ? raw.wheelCeremonyResultSelectedAt : undefined,
     wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
@@ -378,6 +448,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyStartedAt: now,
       wheelCeremonySpinStartedAt: undefined,
       wheelCeremonyResultTrackId: undefined,
+      wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
@@ -386,7 +457,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       updatedAt: now,
     };
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
-    const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
+    const currentStatus = effectiveWheelCeremonyStatus(current, new Date(now).getTime());
     if (payload.action === "spinWheel" && currentStatus !== "ready" && currentStatus !== "signal_lost") throw new Error("Launch the wheel before spinning.");
     if (payload.action === "reencryptWheel" && (currentStatus !== "ready" || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
     const queueState = await getRadioQueueState();
@@ -404,6 +475,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyStatus: reencrypting ? "reencrypting" : "spinning",
       wheelCeremonySpinStartedAt: now,
       wheelCeremonyResultTrackId: selected?.id,
+      wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: selected ? now : undefined,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
@@ -416,12 +488,13 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
   } else if (payload.action === "wheelWinnerNotHere") {
     const resultTrackId = cleanText(current.wheelCeremonyResultTrackId);
     if (!resultTrackId) throw new Error("No wheel result is ready to remove.");
-    const currentStatus = normalizeWheelCeremonyStatus(current.wheelCeremonyStatus);
+    const currentStatus = effectiveWheelCeremonyStatus(current, new Date(now).getTime());
     if (currentStatus !== "result_pending") throw new Error("Winner Not Here is only available for a pending wheel result.");
     const queueState = await getRadioQueueState();
     const selected = getWheelCandidatesFromQueue(queueState.queue).find((candidate) => candidate.id === resultTrackId);
     if (!selected) throw new Error("The selected wheel result is no longer removable from the active queue.");
-    await updateRadioTrack(resultTrackId, "remove");
+    const trackIdsToRemove = selected.trackIds?.length ? selected.trackIds : [resultTrackId];
+    for (const trackId of trackIdsToRemove) await updateRadioTrack(trackId, "remove");
     next = {
       ...current,
       mode: "wheel_ready",
@@ -430,6 +503,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyStatus: "ready",
       wheelCeremonySpinStartedAt: undefined,
       wheelCeremonyResultTrackId: undefined,
+      wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: now,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyJingleKey: "silent",
@@ -440,21 +514,27 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       updatedAt: now,
     };
   } else if (payload.action === "confirmWheel") {
+    const currentStatus = effectiveWheelCeremonyStatus(current, new Date(now).getTime());
+    if (currentStatus !== "result_pending") throw new Error("Wheel result is not ready to confirm yet.");
     const resultTrackId = cleanText(current.wheelCeremonyResultTrackId);
     if (!resultTrackId) throw new Error("No wheel result is ready to confirm.");
     const queueState = await getRadioQueueState();
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
-    const selected = candidates.find((candidate) => candidate.id === resultTrackId);
-    if (!selected) throw new Error("The selected wheel result is no longer eligible. Reroll or cancel the ceremony.");
-    await updateRadioTrack(resultTrackId, "wheel");
+    const winnerGroup = candidates.find((candidate) => candidate.id === resultTrackId);
+    if (!winnerGroup) throw new Error("The selected wheel result is no longer eligible. Reroll or cancel the ceremony.");
+    const selectedTrackId = cleanText(payload.selectedTrackId) ?? cleanText(current.wheelCeremonyChosenTrackId);
+    const selected = findTrackInWinnerGroup(winnerGroup, selectedTrackId);
+    if (!selected) throw new Error("Choose one eligible track from the winning artist before confirming Wheel Chosen.");
+    await updateRadioTrack(selected.id, "wheel");
     next = {
       ...current,
       mode: "wheel_confirmed",
       wheelOverlayActive: true,
       wheelOverlayStatus: "complete",
       wheelCeremonyStatus: "confirmed",
+      wheelCeremonyChosenTrackId: selected.id,
       wheelCeremonyResultSelectedAt: now,
-      artistName: selected.artistName,
+      artistName: winnerGroup.artistName,
       trackTitle: selected.trackTitle,
       updatedAt: now,
     };
@@ -469,6 +549,7 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyStartedAt: undefined,
       wheelCeremonySpinStartedAt: undefined,
       wheelCeremonyResultTrackId: undefined,
+      wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: undefined,
       wheelCeremonyJingleKey: "silent",

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -36,6 +36,8 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonyChosenTrackId?: string;
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
+  wheelCeremonyPreviousSeed?: string;
+  wheelCeremonyReencryptCycleId?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
   wheelCeremonyAudioPath?: string;
@@ -185,16 +187,22 @@ function hashWheelIdentity(value: string): string {
 }
 
 function submitterIdentityKeys(entry: QueueEntry): string[] {
+  const identityEntry = entry as QueueEntry & { submitterId?: string | null; accountId?: string | null };
+  const normalizedHandle = (entry.normalizedTikTokHandle ?? entry.tiktokHandle)?.trim().toLowerCase().replace(/^@/, "").replace(/[^a-z0-9_.]+/g, "");
+  const normalizedEmail = entry.contactEmail?.trim().toLowerCase();
+  const normalizedName = normalizePersonIdentity(entry.submitterArtistName ?? entry.submittedArtistName ?? entry.artist);
   const keys = [
     entry.submitterToken ? `token:${entry.submitterToken.trim()}` : null,
-    entry.normalizedTikTokHandle ? `handle:${entry.normalizedTikTokHandle.trim().toLowerCase().replace(/^@/, "")}` : null,
-    entry.contactEmail ? `email:${entry.contactEmail.trim().toLowerCase()}` : null,
-    normalizePersonIdentity(entry.submitterArtistName ?? entry.submittedArtistName ?? entry.artist) ? `artist:${normalizePersonIdentity(entry.submitterArtistName ?? entry.submittedArtistName ?? entry.artist)}` : null,
+    identityEntry.submitterId ? `submitter:${identityEntry.submitterId.trim()}` : null,
+    identityEntry.accountId ? `account:${identityEntry.accountId.trim()}` : null,
+    normalizedHandle ? `handle:${normalizedHandle}` : null,
+    normalizedEmail ? `email:${normalizedEmail}` : null,
+    normalizedName ? `artist:${normalizedName}` : null,
   ].filter((key): key is string => Boolean(key));
   return keys.length > 0 ? keys : [`track:${entry.id}`];
 }
 
-function getWheelCandidatesFromQueue(queue: QueueEntry[]): ResolvedWheelCeremonyTrack[] {
+export function getWheelCandidatesFromQueue(queue: QueueEntry[]): ResolvedWheelCeremonyTrack[] {
   const groups: ResolvedWheelCeremonyTrack[] = [];
   const groupByKey = new Map<string, ResolvedWheelCeremonyTrack>();
 
@@ -258,7 +266,7 @@ function effectiveWheelCeremonyStatus(state: LiveOverlayState, nowMs: number): W
   const startedMs = typeof state.wheelCeremonySpinStartedAt === "string" ? new Date(state.wheelCeremonySpinStartedAt).getTime() : nowMs;
   if (!Number.isFinite(startedMs)) return status;
   const elapsedMs = nowMs - startedMs;
-  if (status === "reencrypting") return elapsedMs >= 1600 ? "ready" : "reencrypting";
+  if (status === "reencrypting") return elapsedMs >= 1850 ? "ready" : "reencrypting";
   return elapsedMs >= (normalizeSpinDurationMs(state.wheelCeremonySpinDurationMs) ?? 24_000) ? "result_pending" : "spinning";
 }
 
@@ -348,6 +356,8 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonyChosenTrackId: cleanText(raw.wheelCeremonyChosenTrackId),
     wheelCeremonyResultSelectedAt: typeof raw.wheelCeremonyResultSelectedAt === "string" ? raw.wheelCeremonyResultSelectedAt : undefined,
     wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
+    wheelCeremonyPreviousSeed: cleanText(raw.wheelCeremonyPreviousSeed),
+    wheelCeremonyReencryptCycleId: cleanText(raw.wheelCeremonyReencryptCycleId),
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
     wheelCeremonySpinDurationMs: normalizeSpinDurationMs(raw.wheelCeremonySpinDurationMs),
     wheelCeremonyAudioPath: cleanText(raw.wheelCeremonyAudioPath),
@@ -451,6 +461,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: randomSeed(),
+      wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,
@@ -478,6 +490,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: selected ? now : undefined,
       wheelCeremonySeed: randomSeed(),
+      wheelCeremonyPreviousSeed: reencrypting ? current.wheelCeremonySeed : undefined,
+      wheelCeremonyReencryptCycleId: reencrypting ? randomSeed() : undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: reencrypting ? undefined : randomSpinDurationMs(),
       wheelCeremonyAudioPath: reencrypting ? undefined : randomWheelAudioPath(),
@@ -506,6 +520,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: now,
       wheelCeremonySeed: randomSeed(),
+      wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,
@@ -552,6 +568,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: undefined,
+      wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -1,7 +1,7 @@
 import { Redis } from "@upstash/redis";
 import { getRadioQueueState, isWheelEligibleTrack, updateRadioTrack } from "./queue";
 import { getTrackArtworkUrl, getTrackDurationLabel } from "./queue-types";
-import { resolveLiveOverlayScene, safeLiveOverlayUrl } from "./live-overlay-resolver";
+import { derangedWheelCandidateOrder, orderedWheelCandidateIds, resolveLiveOverlayScene, safeLiveOverlayUrl } from "./live-overlay-resolver";
 import { parseYouTubeVideoId } from "./track-duration";
 import type { QueueEntry, QueueSourceType } from "./queue-types";
 import type { LiveOverlayPlaybackState, LiveOverlayStateInput, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, ResolvedWheelCeremonyTrack, WheelCeremonyStatus, WheelOverlayStatus } from "./live-overlay-resolver";
@@ -37,6 +37,9 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonyResultSelectedAt?: string;
   wheelCeremonySeed?: string;
   wheelCeremonyPreviousSeed?: string;
+  wheelCeremonyCandidateOrder?: string[];
+  wheelCeremonyPreviousCandidateOrder?: string[];
+  wheelCeremonyReencryptNonce?: string;
   wheelCeremonyReencryptCycleId?: string;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
@@ -266,7 +269,7 @@ function effectiveWheelCeremonyStatus(state: LiveOverlayState, nowMs: number): W
   const startedMs = typeof state.wheelCeremonySpinStartedAt === "string" ? new Date(state.wheelCeremonySpinStartedAt).getTime() : nowMs;
   if (!Number.isFinite(startedMs)) return status;
   const elapsedMs = nowMs - startedMs;
-  if (status === "reencrypting") return elapsedMs >= 1850 ? "ready" : "reencrypting";
+  if (status === "reencrypting") return elapsedMs >= 2200 ? "ready" : "reencrypting";
   return elapsedMs >= (normalizeSpinDurationMs(state.wheelCeremonySpinDurationMs) ?? 24_000) ? "result_pending" : "spinning";
 }
 
@@ -357,6 +360,9 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonyResultSelectedAt: typeof raw.wheelCeremonyResultSelectedAt === "string" ? raw.wheelCeremonyResultSelectedAt : undefined,
     wheelCeremonySeed: cleanText(raw.wheelCeremonySeed),
     wheelCeremonyPreviousSeed: cleanText(raw.wheelCeremonyPreviousSeed),
+    wheelCeremonyCandidateOrder: Array.isArray(raw.wheelCeremonyCandidateOrder) ? raw.wheelCeremonyCandidateOrder.map((entry) => cleanText(entry)).filter((entry): entry is string => Boolean(entry)) : undefined,
+    wheelCeremonyPreviousCandidateOrder: Array.isArray(raw.wheelCeremonyPreviousCandidateOrder) ? raw.wheelCeremonyPreviousCandidateOrder.map((entry) => cleanText(entry)).filter((entry): entry is string => Boolean(entry)) : undefined,
+    wheelCeremonyReencryptNonce: cleanText(raw.wheelCeremonyReencryptNonce),
     wheelCeremonyReencryptCycleId: cleanText(raw.wheelCeremonyReencryptCycleId),
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
     wheelCeremonySpinDurationMs: normalizeSpinDurationMs(raw.wheelCeremonySpinDurationMs),
@@ -447,6 +453,8 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
   if (payload.action === "launchWheel") {
     const queueState = await getRadioQueueState();
     const wheelSpinsOwed = queueState.session?.wheelSpinsOwed ?? 0;
+    const candidates = getWheelCandidatesFromQueue(queueState.queue);
+    const launchSeed = randomSeed();
     if (wheelSpinsOwed <= 0) throw new Error("No wheel spins are owed.");
     next = {
       ...current,
@@ -460,8 +468,11 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultTrackId: undefined,
       wheelCeremonyChosenTrackId: undefined,
       wheelCeremonyResultSelectedAt: undefined,
-      wheelCeremonySeed: randomSeed(),
+      wheelCeremonySeed: launchSeed,
       wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyCandidateOrder: orderedWheelCandidateIds(candidates, undefined, launchSeed),
+      wheelCeremonyPreviousCandidateOrder: undefined,
+      wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
@@ -471,12 +482,15 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
   } else if (payload.action === "spinWheel" || payload.action === "reencryptWheel") {
     const currentStatus = effectiveWheelCeremonyStatus(current, new Date(now).getTime());
     if (payload.action === "spinWheel" && currentStatus !== "ready" && currentStatus !== "signal_lost") throw new Error("Launch the wheel before spinning.");
-    if (payload.action === "reencryptWheel" && (currentStatus !== "ready" || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
+    if (payload.action === "reencryptWheel" && ((currentStatus !== "ready" && currentStatus !== "reencrypting") || current.wheelCeremonyResultTrackId)) throw new Error("Re-encryption is only available before the wheel spin.");
     const queueState = await getRadioQueueState();
     if ((queueState.session?.wheelSpinsOwed ?? 0) <= 0) throw new Error("No wheel spins are owed.");
     const candidates = getWheelCandidatesFromQueue(queueState.queue);
     if (candidates.length === 0) throw new Error("No eligible Wheel Chosen candidates are available.");
     const reencrypting = payload.action === "reencryptWheel";
+    const nonce = reencrypting ? randomSeed() : undefined;
+    const previousOrder = orderedWheelCandidateIds(candidates, current.wheelCeremonyCandidateOrder, current.wheelCeremonySeed);
+    const candidateOrder = reencrypting ? derangedWheelCandidateOrder(candidates, previousOrder, nonce) : previousOrder;
     const selected = reencrypting ? null : pickRandomCandidate(candidates);
     if (!reencrypting && !selected) throw new Error("No eligible Wheel Chosen candidates are available.");
     next = {
@@ -491,7 +505,10 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: selected ? now : undefined,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyPreviousSeed: reencrypting ? current.wheelCeremonySeed : undefined,
-      wheelCeremonyReencryptCycleId: reencrypting ? randomSeed() : undefined,
+      wheelCeremonyCandidateOrder: candidateOrder,
+      wheelCeremonyPreviousCandidateOrder: reencrypting ? previousOrder : undefined,
+      wheelCeremonyReencryptNonce: nonce,
+      wheelCeremonyReencryptCycleId: nonce,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: reencrypting ? undefined : randomSpinDurationMs(),
       wheelCeremonyAudioPath: reencrypting ? undefined : randomWheelAudioPath(),
@@ -521,6 +538,9 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: now,
       wheelCeremonySeed: randomSeed(),
       wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyCandidateOrder: undefined,
+      wheelCeremonyPreviousCandidateOrder: undefined,
+      wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
@@ -569,6 +589,9 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyResultSelectedAt: undefined,
       wheelCeremonySeed: undefined,
       wheelCeremonyPreviousSeed: undefined,
+      wheelCeremonyCandidateOrder: undefined,
+      wheelCeremonyPreviousCandidateOrder: undefined,
+      wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -1,7 +1,7 @@
 import { Redis } from "@upstash/redis";
 import { getRadioQueueState, isWheelEligibleTrack, updateRadioTrack } from "./queue";
 import { getTrackArtworkUrl, getTrackDurationLabel } from "./queue-types";
-import { derangedWheelCandidateOrder, orderedWheelCandidateIds, resolveLiveOverlayScene, safeLiveOverlayUrl } from "./live-overlay-resolver";
+import { buildWheelSegments, derangedWheelCandidateOrder, orderedWheelCandidateIds, resolveLiveOverlayScene, safeLiveOverlayUrl, wheelFinalRotationForSegment } from "./live-overlay-resolver";
 import { parseYouTubeVideoId } from "./track-duration";
 import type { QueueEntry, QueueSourceType } from "./queue-types";
 import type { LiveOverlayPlaybackState, LiveOverlayStateInput, LiveOverlayYouTubeSync, OverlayMode, ResolvedLiveOverlayScene, ResolvedWheelCeremonyTrack, WheelCeremonyStatus, WheelOverlayStatus } from "./live-overlay-resolver";
@@ -41,6 +41,10 @@ export interface LiveOverlayState extends LiveOverlayStateInput {
   wheelCeremonyPreviousCandidateOrder?: string[];
   wheelCeremonyReencryptNonce?: string;
   wheelCeremonyReencryptCycleId?: string;
+  wheelCeremonyFinalRotationDeg?: number;
+  wheelCeremonyLandingAngleDeg?: number;
+  wheelCeremonyWinningSegmentId?: string;
+  wheelCeremonyWinningSegmentIndex?: number;
   wheelCeremonyJingleKey?: string;
   wheelCeremonySpinDurationMs?: number;
   wheelCeremonyAudioPath?: string;
@@ -364,6 +368,10 @@ function normalizeState(input: unknown): LiveOverlayState {
     wheelCeremonyPreviousCandidateOrder: Array.isArray(raw.wheelCeremonyPreviousCandidateOrder) ? raw.wheelCeremonyPreviousCandidateOrder.map((entry) => cleanText(entry)).filter((entry): entry is string => Boolean(entry)) : undefined,
     wheelCeremonyReencryptNonce: cleanText(raw.wheelCeremonyReencryptNonce),
     wheelCeremonyReencryptCycleId: cleanText(raw.wheelCeremonyReencryptCycleId),
+    wheelCeremonyFinalRotationDeg: typeof raw.wheelCeremonyFinalRotationDeg === "number" && Number.isFinite(raw.wheelCeremonyFinalRotationDeg) ? raw.wheelCeremonyFinalRotationDeg : undefined,
+    wheelCeremonyLandingAngleDeg: typeof raw.wheelCeremonyLandingAngleDeg === "number" && Number.isFinite(raw.wheelCeremonyLandingAngleDeg) ? raw.wheelCeremonyLandingAngleDeg : undefined,
+    wheelCeremonyWinningSegmentId: cleanText(raw.wheelCeremonyWinningSegmentId),
+    wheelCeremonyWinningSegmentIndex: typeof raw.wheelCeremonyWinningSegmentIndex === "number" && Number.isFinite(raw.wheelCeremonyWinningSegmentIndex) ? Math.floor(raw.wheelCeremonyWinningSegmentIndex) : undefined,
     wheelCeremonyJingleKey: cleanText(raw.wheelCeremonyJingleKey, "silent"),
     wheelCeremonySpinDurationMs: normalizeSpinDurationMs(raw.wheelCeremonySpinDurationMs),
     wheelCeremonyAudioPath: cleanText(raw.wheelCeremonyAudioPath),
@@ -474,6 +482,10 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyPreviousCandidateOrder: undefined,
       wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
+      wheelCeremonyFinalRotationDeg: undefined,
+      wheelCeremonyLandingAngleDeg: undefined,
+      wheelCeremonyWinningSegmentId: undefined,
+      wheelCeremonyWinningSegmentIndex: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,
@@ -491,8 +503,12 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
     const nonce = reencrypting ? randomSeed() : undefined;
     const previousOrder = orderedWheelCandidateIds(candidates, current.wheelCeremonyCandidateOrder, current.wheelCeremonySeed);
     const candidateOrder = reencrypting ? derangedWheelCandidateOrder(candidates, previousOrder, nonce) : previousOrder;
-    const selected = reencrypting ? null : pickRandomCandidate(candidates);
-    if (!reencrypting && !selected) throw new Error("No eligible Wheel Chosen candidates are available.");
+    const orderedCandidates = candidateOrder.map((candidateId) => candidates.find((candidate) => candidate.id === candidateId)).filter((candidate): candidate is ResolvedWheelCeremonyTrack => Boolean(candidate));
+    const selected = reencrypting ? null : pickRandomCandidate(orderedCandidates);
+    const wheelSegments = buildWheelSegments(orderedCandidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
+    const selectedSegment = selected ? wheelSegments.find((segment) => segment.candidateId === selected.id) : undefined;
+    const finalRotationDeg = selectedSegment ? wheelFinalRotationForSegment(selectedSegment) : undefined;
+    if (!reencrypting && (!selected || !selectedSegment || typeof finalRotationDeg !== "number")) throw new Error("No eligible Wheel Chosen candidates are available.");
     next = {
       ...current,
       mode: reencrypting ? "wheel_reencrypting" : "wheel_spinning",
@@ -509,6 +525,10 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyPreviousCandidateOrder: reencrypting ? previousOrder : undefined,
       wheelCeremonyReencryptNonce: nonce,
       wheelCeremonyReencryptCycleId: nonce,
+      wheelCeremonyFinalRotationDeg: reencrypting ? undefined : finalRotationDeg,
+      wheelCeremonyLandingAngleDeg: reencrypting ? undefined : selectedSegment?.centerAngle,
+      wheelCeremonyWinningSegmentId: reencrypting ? undefined : selectedSegment?.id,
+      wheelCeremonyWinningSegmentIndex: reencrypting ? undefined : selectedSegment?.index,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: reencrypting ? undefined : randomSpinDurationMs(),
       wheelCeremonyAudioPath: reencrypting ? undefined : randomWheelAudioPath(),
@@ -542,6 +562,10 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyPreviousCandidateOrder: undefined,
       wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
+      wheelCeremonyFinalRotationDeg: undefined,
+      wheelCeremonyLandingAngleDeg: undefined,
+      wheelCeremonyWinningSegmentId: undefined,
+      wheelCeremonyWinningSegmentIndex: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,
@@ -593,6 +617,10 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
       wheelCeremonyPreviousCandidateOrder: undefined,
       wheelCeremonyReencryptNonce: undefined,
       wheelCeremonyReencryptCycleId: undefined,
+      wheelCeremonyFinalRotationDeg: undefined,
+      wheelCeremonyLandingAngleDeg: undefined,
+      wheelCeremonyWinningSegmentId: undefined,
+      wheelCeremonyWinningSegmentIndex: undefined,
       wheelCeremonyJingleKey: "silent",
       wheelCeremonySpinDurationMs: undefined,
       wheelCeremonyAudioPath: undefined,

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { resolveLiveOverlayScene } from "../src/lib/live-overlay-resolver.ts";
+import { resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSlice, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
 
 const session = { sessionId: "s1", status: "open", queueOpen: true, wheelSpinsOwed: 0, sponsorBreakStatus: "not_due", broadcastPhase: "broadcast_active" };
 const youtubeTrack = { id: "yt1", submittedArtistName: "Artist Name", submittedSongTitle: "Video Track", sourceType: "youtube", sourceArtworkUrl: "https://img.youtube.com/vi/abcdefghijk/hqdefault.jpg", link: "https://youtube.com/watch?v=abcdefghijk", durationLabel: "3:30", youtubeVideoId: "abcdefghijk" };
 const spotifyTrack = { id: "sp1", submittedArtistName: "Spotify Artist", submittedSongTitle: "Audio Track", sourceType: "spotify", sourceArtworkUrl: "https://i.scdn.co/image/example", link: "https://open.spotify.com/track/abc123", durationLabel: "2:45" };
+
+
+function finalRotationForPointerLocalAngle(localAngle, pointerAngle = WHEEL_RIGHT_POINTER_ANGLE_DEGREES) {
+  return 1080 + pointerAngle - localAngle;
+}
+
+assert.equal(wheelSliceIndexAtPointer(4, finalRotationForPointerLocalAngle(44)), 0, "4 candidates: right pointer inside slice 0 selects candidate 0");
+assert.equal(wheelSliceIndexAtPointer(4, finalRotationForPointerLocalAngle(91)), 1, "4 candidates: right pointer inside slice 1 selects candidate 1");
+assert.equal(wheelSliceIndexAtPointer(8, finalRotationForPointerLocalAngle(44.999)), 0, "8 candidates: just before boundary keeps previous slice");
+assert.equal(wheelSliceIndexAtPointer(8, finalRotationForPointerLocalAngle(45.001)), 1, "8 candidates: just after boundary selects next slice");
+assert.equal(wheelSliceIndexAtPointer(13, finalRotationForPointerLocalAngle(201.4)), 7, "13 candidates: arbitrary angle uses floor boundary math");
+assert.equal(wheelSliceIndexAtPointer(8, finalRotationForPointerLocalAngle(45.001) + 360 * 9), 1, "final rotation wrapping past multiple turns still normalizes to the correct slice");
+assert.equal(wheelSliceIndexAtPointer(4, 0, WHEEL_RIGHT_POINTER_ANGLE_DEGREES), 1, "right-side pointer uses 3 o'clock selector rather than top selector");
+assert.equal(wheelSliceIndexAtPointer(8, wheelFinalRotationForSlice(8, 6)), 6, "final rotation helper lands the stored winner slice under the right pointer");
 
 assert.equal(resolveLiveOverlayScene({}).mode, "standby", "no session resolves to standby");
 assert.equal(resolveLiveOverlayScene({ currentSession: session }).mode, "session_active", "open session with no track resolves to intake/session scene");
@@ -52,7 +66,8 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-name-size") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
+assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSlice"), true, "wheel receiver documents labels as visual-only and lands stored winners with slice geometry");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-reencrypt-brew") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes brewing re-encryption and pointer polish effects");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -49,7 +49,7 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-radius") && receiver.includes("--wheel-label-counter-angle"), true, "wheel artist labels use dynamic sizing variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-radius") && receiver.includes("--wheel-label-text-flip"), true, "wheel artist labels use dynamic sizing variables");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { buildWheelSegments, derangedWheelCandidateOrder, resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSegment, wheelFinalRotationForSlice, wheelSegmentAtPointer, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
+import { buildWheelSegments, derangedWheelCandidateOrder, resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSegment, wheelFinalRotationForSlice, wheelSegmentAtPointer, wheelSliceIndexAtPointer, wheelUprightLabelRotationDegrees } from "../src/lib/live-overlay-resolver.ts";
 
 const session = { sessionId: "s1", status: "open", queueOpen: true, wheelSpinsOwed: 0, sponsorBreakStatus: "not_due", broadcastPhase: "broadcast_active" };
 const youtubeTrack = { id: "yt1", submittedArtistName: "Artist Name", submittedSongTitle: "Video Track", sourceType: "youtube", sourceArtworkUrl: "https://img.youtube.com/vi/abcdefghijk/hqdefault.jpg", link: "https://youtube.com/watch?v=abcdefghijk", durationLabel: "3:30", youtubeVideoId: "abcdefghijk" };
@@ -26,6 +26,13 @@ assert.equal(wheelSegmentAtPointer(weightedSegments, finalRotationForPointerLoca
 assert.equal(wheelSegmentAtPointer(weightedSegments, wheelFinalRotationForSegment(weightedSegments[2])).candidateId, "small-b", "weighted final rotation helper lands the stored segment under the right pointer");
 const relabeledWeightedSegments = buildWheelSegments([{ id: "small-a", label: "Tiny", weight: 1 }, { id: "large", label: "Very Long Label That Wraps", weight: 2 }, { id: "small-b", label: "Six", weight: 1 }]);
 assert.equal(wheelSegmentAtPointer(relabeledWeightedSegments, finalRotationForPointerLocalAngle(180)).candidateId, "large", "label text changes do not affect segment geometry winner result");
+
+const rightSideSegments = buildWheelSegments([{ id: "top", label: "Top" }, { id: "right", label: "Right pointer" }, { id: "bottom", label: "Bottom" }, { id: "left", label: "Left" }]);
+const rightSideFinalRotation = wheelFinalRotationForSegment(rightSideSegments[1]);
+assert.equal(wheelSegmentAtPointer(rightSideSegments, rightSideFinalRotation, WHEEL_RIGHT_POINTER_ANGLE_DEGREES).candidateId, "right", "stored final rotation lands the selected segment under the visual right-side pointer");
+assert.equal(Math.abs(wheelUprightLabelRotationDegrees(90)) <= 90, true, "label near right-side pointer remains upright");
+assert.equal(Math.abs(wheelUprightLabelRotationDegrees(270)) <= 90, true, "label on opposite side is flipped out of upside-down orientation");
+assert.equal([0, 45, 90, 135, 180, 225, 270, 315].every((angle) => Math.abs(wheelUprightLabelRotationDegrees(angle)) <= 90), true, "wheel label rotation helper never returns upside-down text orientation");
 
 assert.equal(resolveLiveOverlayScene({}).mode, "standby", "no session resolves to standby");
 assert.equal(resolveLiveOverlayScene({ currentSession: session }).mode, "session_active", "open session with no track resolves to intake/session scene");
@@ -74,10 +81,12 @@ assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-fo
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
 assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-name-size") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
-assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSegment") && receiver.includes("live-overlay-wheel-winning-segment"), true, "wheel receiver documents labels as visual-only, lands stored winners with segment geometry, and renders a segment highlight");
+assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("finalRotationDeg") && receiver.includes("live-overlay-wheel-winning-segment"), true, "wheel receiver documents labels as visual-only, uses stored landing rotation, and renders a segment highlight");
+assert.equal(overlayCss.includes("live-overlay-wheel-scene--result_pending .live-overlay-wheel") && overlayCss.includes("transform: rotate(var(--wheel-final-rotation"), true, "result state preserves the stored wheel rotation instead of snapping after spin");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(receiver.includes("data-wheel-animation-key") && receiver.includes("reencryptNonce") && receiver.includes("key={`glitch-${animationKey}`}"), true, "receiver keys the glitch animation layer by nonce so re-encryption visibly remounts and replays every time");
 assert.equal(liveOverlayController.includes("wheelCeremonyPreviousCandidateOrder") && liveOverlayController.includes("wheelCeremonyReencryptNonce") && liveOverlayController.includes("derangedWheelCandidateOrder"), true, "wheel controller persists previous order plus a fresh re-encryption nonce and deranged order on each re-encrypt click");
+assert.equal(liveOverlayController.includes("wheelCeremonyFinalRotationDeg") && liveOverlayController.includes("wheelCeremonyLandingAngleDeg") && liveOverlayController.includes("wheelCeremonyWinningSegmentIndex") && liveOverlayController.includes("wheelFinalRotationForSegment"), true, "spin action stores one final landing rotation contract with segment metadata before the overlay spins");
 const submitterIdentitySource = liveOverlayController.slice(liveOverlayController.indexOf("function submitterIdentityKeys"), liveOverlayController.indexOf("export function getWheelCandidatesFromQueue"));
 assert.equal(submitterIdentitySource.includes("submitterToken") && submitterIdentitySource.includes("submitterId") && submitterIdentitySource.includes("accountId") && submitterIdentitySource.includes("normalizedTikTokHandle") && submitterIdentitySource.includes("contactEmail"), true, "wheel controller groups by stable submitter identity before falling back to name");
 assert.equal(submitterIdentitySource.includes("submittedSongTitle"), false, "submitter identity grouping does not use song titles as grouping keys");
@@ -110,6 +119,18 @@ assert.equal(spinning.wheelCeremony?.resultTrack?.id, "free-2", "server-selected
 const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:25.000Z") });
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
+
+const frozenSpinOrder = ["free-2", "free-1"];
+const frozenSegments = buildWheelSegments(frozenSpinOrder.map((candidateId) => ({ id: candidateId, label: candidateId })));
+const frozenWinnerSegment = frozenSegments.find((segment) => segment.candidateId === "free-2");
+const frozenFinalRotation = wheelFinalRotationForSegment(frozenWinnerSegment);
+const storedRotationSpin = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyCandidateOrder: frozenSpinOrder, wheelCeremonyFinalRotationDeg: frozenFinalRotation, wheelCeremonyLandingAngleDeg: frozenWinnerSegment.centerAngle, wheelCeremonyWinningSegmentId: frozenWinnerSegment.id, wheelCeremonyWinningSegmentIndex: frozenWinnerSegment.index }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:03.000Z") });
+const storedRotationResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyCandidateOrder: frozenSpinOrder, wheelCeremonyFinalRotationDeg: frozenFinalRotation, wheelCeremonyLandingAngleDeg: frozenWinnerSegment.centerAngle, wheelCeremonyWinningSegmentId: frozenWinnerSegment.id, wheelCeremonyWinningSegmentIndex: frozenWinnerSegment.index }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:25.000Z") });
+assert.deepEqual(storedRotationSpin.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), frozenSpinOrder, "spinning scene draws the frozen display order used for winner math");
+assert.deepEqual(storedRotationResult.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), frozenSpinOrder, "result scene keeps the same frozen display order after the spin");
+assert.equal(storedRotationResult.wheelCeremony?.finalRotationDeg, frozenFinalRotation, "result pending keeps the stored final rotation without recomputing after spin");
+assert.equal(wheelSegmentAtPointer(frozenSegments, storedRotationResult.wheelCeremony?.finalRotationDeg, WHEEL_RIGHT_POINTER_ANGLE_DEGREES).candidateId, "free-2", "stored final rotation still places the selected frozen segment under the right-side pointer");
+assert.equal(storedRotationResult.wheelCeremony?.winningSegmentIndex, frozenWinnerSegment.index, "spin/result contract exposes the winning segment index used to calculate landing rotation");
 
 const derangedTwo = derangedWheelCandidateOrder([{ id: "a" }, { id: "b" }], ["a", "b"], "nonce-2");
 assert.deepEqual(derangedTwo, ["b", "a"], "two wheel candidates swap positions during re-encrypt");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -49,7 +49,7 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-radius") && receiver.includes("--wheel-label-text-flip"), true, "wheel artist labels use dynamic sizing variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use dynamic sizing and slice-body placement variables");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");
@@ -85,8 +85,12 @@ assert.equal(reencryptedReady.mode, "wheel_ready", "re-encrypting ceremony retur
 assert.equal(reencryptedReady.wheelCeremony?.resultTrackId, undefined, "re-encrypting does not produce a final winner");
 
 const signalLost = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "signal_lost", wheelOverlayActive: true, wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
-assert.equal(signalLost.mode, "wheel_ready", "winner-not-here recovery stays in the wheel-ready scene");
-assert.equal(signalLost.subtitle, "SIGNAL LOST", "winner-not-here recovery shows signal-lost copy");
+assert.equal(signalLost.mode, "wheel_ready", "legacy winner-not-here recovery stays in the wheel-ready scene");
+assert.equal(signalLost.subtitle, "SIGNAL LOST", "legacy winner-not-here recovery can still show signal-lost copy");
+
+const winnerNotHereReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+assert.equal(winnerNotHereReady.mode, "wheel_ready", "winner-not-here recovery returns the ceremony to ready state");
+assert.equal(winnerNotHereReady.subtitle, "READY", "winner-not-here recovery exposes ready controls again");
 
 const confirmedFresh = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 0 }, overlayState: { wheelCeremonyStatus: "confirmed", wheelOverlayActive: true, wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(confirmedFresh.mode, "wheel_confirmed", "fresh confirmed result shows lock-in scene");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -49,11 +49,11 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-distance") && receiver.includes("--wheel-rail-length"), true, "wheel artist labels use dynamic sizing variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-radius") && receiver.includes("--wheel-label-counter-angle"), true, "wheel artist labels use dynamic sizing variables");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");
-assert.equal(overlayCss.includes("IBM Plex Mono") && overlayCss.includes("live-overlay-wheel::before") && overlayCss.includes("live-overlay-wheel-slice-label::before"), true, "wheel CSS includes BARCODE-style typography, rim detailing, and label rails");
+assert.equal(overlayCss.includes("\"Arial Black\"") && overlayCss.includes("live-overlay-wheel::before") && overlayCss.includes("radial-gradient(ellipse at center"), true, "wheel CSS includes BARCODE-style typography, rim detailing, and integrated label glow");
 
 const eligibleCandidates = [
   { id: "free-1", submittedArtistName: "Free Artist", submittedSongTitle: "Free Track" },
@@ -72,7 +72,7 @@ const spinning = resolveLiveOverlayScene({ currentSession: { ...session, wheelSp
 assert.equal(spinning.mode, "wheel_spinning", "spin scene stays spinning during the visual spin window");
 assert.equal(spinning.wheelCeremony?.resultTrack?.id, "free-2", "server-selected result is stored while visual spin runs");
 
-const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
+const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:25.000Z") });
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
 

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSlice, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
+import { buildWheelSegments, resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSegment, wheelFinalRotationForSlice, wheelSegmentAtPointer, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
 
 const session = { sessionId: "s1", status: "open", queueOpen: true, wheelSpinsOwed: 0, sponsorBreakStatus: "not_due", broadcastPhase: "broadcast_active" };
 const youtubeTrack = { id: "yt1", submittedArtistName: "Artist Name", submittedSongTitle: "Video Track", sourceType: "youtube", sourceArtworkUrl: "https://img.youtube.com/vi/abcdefghijk/hqdefault.jpg", link: "https://youtube.com/watch?v=abcdefghijk", durationLabel: "3:30", youtubeVideoId: "abcdefghijk" };
@@ -19,6 +19,13 @@ assert.equal(wheelSliceIndexAtPointer(13, finalRotationForPointerLocalAngle(201.
 assert.equal(wheelSliceIndexAtPointer(8, finalRotationForPointerLocalAngle(45.001) + 360 * 9), 1, "final rotation wrapping past multiple turns still normalizes to the correct slice");
 assert.equal(wheelSliceIndexAtPointer(4, 0, WHEEL_RIGHT_POINTER_ANGLE_DEGREES), 1, "right-side pointer uses 3 o'clock selector rather than top selector");
 assert.equal(wheelSliceIndexAtPointer(8, wheelFinalRotationForSlice(8, 6)), 6, "final rotation helper lands the stored winner slice under the right pointer");
+const weightedSegments = buildWheelSegments([{ id: "small-a", label: "Small A", weight: 1 }, { id: "large", label: "Large", weight: 2 }, { id: "small-b", label: "Small B", weight: 1 }]);
+assert.deepEqual(weightedSegments.map((segment) => [segment.startAngle, segment.endAngle]), [[0, 90], [90, 270], [270, 360]], "weighted segments expose variable section boundaries");
+assert.equal(wheelSegmentAtPointer(weightedSegments, finalRotationForPointerLocalAngle(180)).candidateId, "large", "weighted hit test resolves inside larger segment");
+assert.equal(wheelSegmentAtPointer(weightedSegments, finalRotationForPointerLocalAngle(90)).candidateId, "large", "exact boundary belongs to next clockwise segment");
+assert.equal(wheelSegmentAtPointer(weightedSegments, wheelFinalRotationForSegment(weightedSegments[2])).candidateId, "small-b", "weighted final rotation helper lands the stored segment under the right pointer");
+const relabeledWeightedSegments = buildWheelSegments([{ id: "small-a", label: "Tiny", weight: 1 }, { id: "large", label: "Very Long Label That Wraps", weight: 2 }, { id: "small-b", label: "Six", weight: 1 }]);
+assert.equal(wheelSegmentAtPointer(relabeledWeightedSegments, finalRotationForPointerLocalAngle(180)).candidateId, "large", "label text changes do not affect segment geometry winner result");
 
 assert.equal(resolveLiveOverlayScene({}).mode, "standby", "no session resolves to standby");
 assert.equal(resolveLiveOverlayScene({ currentSession: session }).mode, "session_active", "open session with no track resolves to intake/session scene");
@@ -67,7 +74,7 @@ assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-fo
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
 assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-name-size") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
-assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSlice"), true, "wheel receiver documents labels as visual-only and lands stored winners with slice geometry");
+assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSegment") && receiver.includes("live-overlay-wheel-winning-segment"), true, "wheel receiver documents labels as visual-only, lands stored winners with segment geometry, and renders a segment highlight");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-reencrypt-brew") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes brewing re-encryption and pointer polish effects");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -76,6 +76,12 @@ assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && rec
 assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-name-size") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
 assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSegment") && receiver.includes("live-overlay-wheel-winning-segment"), true, "wheel receiver documents labels as visual-only, lands stored winners with segment geometry, and renders a segment highlight");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
+assert.equal(receiver.includes("data-wheel-animation-key") && receiver.includes("reencryptCycleId") && receiver.includes("key={animationKey}"), true, "receiver keys re-encryption cycles so CSS animation remounts and replays every time");
+assert.equal(liveOverlayController.includes("wheelCeremonyPreviousSeed") && liveOverlayController.includes("wheelCeremonyReencryptCycleId") && liveOverlayController.includes("payload.action === \"reencryptWheel\""), true, "wheel controller persists previous seed plus a fresh re-encryption cycle id on each re-encrypt click");
+const submitterIdentitySource = liveOverlayController.slice(liveOverlayController.indexOf("function submitterIdentityKeys"), liveOverlayController.indexOf("export function getWheelCandidatesFromQueue"));
+assert.equal(submitterIdentitySource.includes("submitterToken") && submitterIdentitySource.includes("submitterId") && submitterIdentitySource.includes("accountId") && submitterIdentitySource.includes("normalizedTikTokHandle") && submitterIdentitySource.includes("contactEmail"), true, "wheel controller groups by stable submitter identity before falling back to name");
+assert.equal(submitterIdentitySource.includes("submittedSongTitle"), false, "submitter identity grouping does not use song titles as grouping keys");
+assert.equal(liveOverlayController.includes("queue.filter(isWheelEligibleTrack)") && liveOverlayController.includes("trackCount") && liveOverlayController.includes("tracks: [track]"), true, "wheel grouping starts from eligible regular tracks and preserves one grouped person entry with track choices");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
 assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-reencrypt-brew") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes brewing re-encryption and pointer polish effects");
 assert.equal(overlayCss.includes("\"Arial Black\"") && overlayCss.includes("live-overlay-wheel::before") && overlayCss.includes("radial-gradient(ellipse at center"), true, "wheel CSS includes BARCODE-style typography, rim detailing, and integrated label glow");
@@ -105,13 +111,33 @@ const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wh
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
 
-const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+const timingCandidates = [
+  { id: "alpha", submittedArtistName: "Alpha", submittedSongTitle: "One" },
+  { id: "bravo", submittedArtistName: "Bravo", submittedSongTitle: "Two" },
+  { id: "charlie", submittedArtistName: "Charlie", submittedSongTitle: "Three" },
+];
+const previousSeedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonySeed: "prev" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
+const currentSeedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonySeed: "new" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
+assert.notDeepEqual(previousSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "test seeds produce visibly different wheel mappings");
+
+const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.300Z") });
 assert.equal(reencrypting.mode, "wheel_reencrypting", "re-encrypting ceremony shows re-encryption scene first");
 assert.equal(reencrypting.subtitle, "RE-ENCRYPTING SIGNAL", "re-encrypting scene uses BARCODE-controlled copy");
+assert.equal(reencrypting.wheelCeremony?.reencryptCycleId, "cycle-1", "first re-encrypt exposes animation cycle id to the overlay");
+assert.deepEqual(reencrypting.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), previousSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "early re-encrypt keeps the previous clean mapping visible before the obscured remap point");
 
-const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:02.000Z") });
+const secondReencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:10.000Z", wheelCeremonySeed: "prev", wheelCeremonyPreviousSeed: "new", wheelCeremonyReencryptCycleId: "cycle-2" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:10.300Z") });
+assert.equal(secondReencrypting.wheelCeremony?.reencryptCycleId, "cycle-2", "second re-encrypt exposes a different cycle id so animation can replay");
+assert.notEqual(secondReencrypting.wheelCeremony?.reencryptCycleId, reencrypting.wheelCeremony?.reencryptCycleId, "successive re-encrypt cycles are distinguishable by the receiver");
+
+const remappedDuringGlitch = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+assert.equal(remappedDuringGlitch.mode, "wheel_reencrypting", "re-encrypt remains visually glitching after the remap point");
+assert.deepEqual(remappedDuringGlitch.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "re-encrypt switches to the new mapping while the glitch state is still active");
+
+const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:02.000Z") });
 assert.equal(reencryptedReady.mode, "wheel_ready", "re-encrypting ceremony returns to ready without selecting a winner");
 assert.equal(reencryptedReady.wheelCeremony?.resultTrackId, undefined, "re-encrypting does not produce a final winner");
+assert.deepEqual(reencryptedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "ready state resolves with the remapped names after the glitch clears");
 
 const signalLost = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "signal_lost", wheelOverlayActive: true, wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(signalLost.mode, "wheel_ready", "legacy winner-not-here recovery stays in the wheel-ready scene");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { buildWheelSegments, resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSegment, wheelFinalRotationForSlice, wheelSegmentAtPointer, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
+import { buildWheelSegments, derangedWheelCandidateOrder, resolveLiveOverlayScene, WHEEL_RIGHT_POINTER_ANGLE_DEGREES, wheelFinalRotationForSegment, wheelFinalRotationForSlice, wheelSegmentAtPointer, wheelSliceIndexAtPointer } from "../src/lib/live-overlay-resolver.ts";
 
 const session = { sessionId: "s1", status: "open", queueOpen: true, wheelSpinsOwed: 0, sponsorBreakStatus: "not_due", broadcastPhase: "broadcast_active" };
 const youtubeTrack = { id: "yt1", submittedArtistName: "Artist Name", submittedSongTitle: "Video Track", sourceType: "youtube", sourceArtworkUrl: "https://img.youtube.com/vi/abcdefghijk/hqdefault.jpg", link: "https://youtube.com/watch?v=abcdefghijk", durationLabel: "3:30", youtubeVideoId: "abcdefghijk" };
@@ -76,8 +76,8 @@ assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && rec
 assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-name-size") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
 assert.equal(receiver.includes("Winner selection is based on slice geometry") && receiver.includes("wheelFinalRotationForSegment") && receiver.includes("live-overlay-wheel-winning-segment"), true, "wheel receiver documents labels as visual-only, lands stored winners with segment geometry, and renders a segment highlight");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
-assert.equal(receiver.includes("data-wheel-animation-key") && receiver.includes("reencryptCycleId") && receiver.includes("key={animationKey}"), true, "receiver keys re-encryption cycles so CSS animation remounts and replays every time");
-assert.equal(liveOverlayController.includes("wheelCeremonyPreviousSeed") && liveOverlayController.includes("wheelCeremonyReencryptCycleId") && liveOverlayController.includes("payload.action === \"reencryptWheel\""), true, "wheel controller persists previous seed plus a fresh re-encryption cycle id on each re-encrypt click");
+assert.equal(receiver.includes("data-wheel-animation-key") && receiver.includes("reencryptNonce") && receiver.includes("key={`glitch-${animationKey}`}"), true, "receiver keys the glitch animation layer by nonce so re-encryption visibly remounts and replays every time");
+assert.equal(liveOverlayController.includes("wheelCeremonyPreviousCandidateOrder") && liveOverlayController.includes("wheelCeremonyReencryptNonce") && liveOverlayController.includes("derangedWheelCandidateOrder"), true, "wheel controller persists previous order plus a fresh re-encryption nonce and deranged order on each re-encrypt click");
 const submitterIdentitySource = liveOverlayController.slice(liveOverlayController.indexOf("function submitterIdentityKeys"), liveOverlayController.indexOf("export function getWheelCandidatesFromQueue"));
 assert.equal(submitterIdentitySource.includes("submitterToken") && submitterIdentitySource.includes("submitterId") && submitterIdentitySource.includes("accountId") && submitterIdentitySource.includes("normalizedTikTokHandle") && submitterIdentitySource.includes("contactEmail"), true, "wheel controller groups by stable submitter identity before falling back to name");
 assert.equal(submitterIdentitySource.includes("submittedSongTitle"), false, "submitter identity grouping does not use song titles as grouping keys");
@@ -111,33 +111,47 @@ const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wh
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
 
+const derangedTwo = derangedWheelCandidateOrder([{ id: "a" }, { id: "b" }], ["a", "b"], "nonce-2");
+assert.deepEqual(derangedTwo, ["b", "a"], "two wheel candidates swap positions during re-encrypt");
+for (const count of [5, 10]) {
+  const previousOrder = Array.from({ length: count }, (_, index) => `candidate-${index}`);
+  const derangedOrder = derangedWheelCandidateOrder(previousOrder.map((id) => ({ id })), previousOrder, `nonce-${count}`);
+  assert.equal(derangedOrder.length, previousOrder.length, `${count} candidate derangement preserves candidate count`);
+  assert.equal(derangedOrder.every((candidateId, index) => candidateId !== previousOrder[index]), true, `${count} candidate derangement moves every candidate to a new index`);
+}
+assert.deepEqual(derangedWheelCandidateOrder([{ id: "solo" }], ["solo"], "nonce-1"), ["solo"], "single candidate remains in place but can still receive an animation nonce");
+
 const timingCandidates = [
   { id: "alpha", submittedArtistName: "Alpha", submittedSongTitle: "One" },
   { id: "bravo", submittedArtistName: "Bravo", submittedSongTitle: "Two" },
   { id: "charlie", submittedArtistName: "Charlie", submittedSongTitle: "Three" },
 ];
-const previousSeedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonySeed: "prev" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
-const currentSeedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonySeed: "new" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
-assert.notDeepEqual(previousSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "test seeds produce visibly different wheel mappings");
+const previousOrder = ["alpha", "bravo", "charlie"];
+const currentOrder = derangedWheelCandidateOrder(timingCandidates, previousOrder, "nonce-a");
+assert.equal(currentOrder.every((candidateId, index) => candidateId !== previousOrder[index]), true, "test re-encrypt order visibly moves every candidate");
 
-const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.300Z") });
+const previousOrderReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonyCandidateOrder: previousOrder }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
+const currentOrderReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonyCandidateOrder: currentOrder }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.000Z") });
+
+const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyCandidateOrder: currentOrder, wheelCeremonyPreviousCandidateOrder: previousOrder, wheelCeremonyReencryptNonce: "nonce-a" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:00.300Z") });
 assert.equal(reencrypting.mode, "wheel_reencrypting", "re-encrypting ceremony shows re-encryption scene first");
 assert.equal(reencrypting.subtitle, "RE-ENCRYPTING SIGNAL", "re-encrypting scene uses BARCODE-controlled copy");
-assert.equal(reencrypting.wheelCeremony?.reencryptCycleId, "cycle-1", "first re-encrypt exposes animation cycle id to the overlay");
-assert.deepEqual(reencrypting.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), previousSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "early re-encrypt keeps the previous clean mapping visible before the obscured remap point");
+assert.equal(reencrypting.wheelCeremony?.reencryptNonce, "nonce-a", "first re-encrypt exposes animation nonce to the overlay");
+assert.deepEqual(reencrypting.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), previousOrderReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "early re-encrypt keeps the previous clean mapping visible before the obscured remap point");
 
-const secondReencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:10.000Z", wheelCeremonySeed: "prev", wheelCeremonyPreviousSeed: "new", wheelCeremonyReencryptCycleId: "cycle-2" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:10.300Z") });
-assert.equal(secondReencrypting.wheelCeremony?.reencryptCycleId, "cycle-2", "second re-encrypt exposes a different cycle id so animation can replay");
-assert.notEqual(secondReencrypting.wheelCeremony?.reencryptCycleId, reencrypting.wheelCeremony?.reencryptCycleId, "successive re-encrypt cycles are distinguishable by the receiver");
+const secondReencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:10.000Z", wheelCeremonyCandidateOrder: previousOrder, wheelCeremonyPreviousCandidateOrder: currentOrder, wheelCeremonyReencryptNonce: "nonce-b" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:10.300Z") });
+const thirdReencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:20.000Z", wheelCeremonyCandidateOrder: currentOrder, wheelCeremonyPreviousCandidateOrder: previousOrder, wheelCeremonyReencryptNonce: "nonce-c" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:20.300Z") });
+assert.deepEqual(new Set([reencrypting.wheelCeremony?.reencryptNonce, secondReencrypting.wheelCeremony?.reencryptNonce, thirdReencrypting.wheelCeremony?.reencryptNonce]).size, 3, "first, second, and third re-encrypt nonces are all unique");
 
-const remappedDuringGlitch = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+const remappedDuringGlitch = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyCandidateOrder: currentOrder, wheelCeremonyPreviousCandidateOrder: previousOrder, wheelCeremonyReencryptNonce: "nonce-a" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(remappedDuringGlitch.mode, "wheel_reencrypting", "re-encrypt remains visually glitching after the remap point");
-assert.deepEqual(remappedDuringGlitch.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "re-encrypt switches to the new mapping while the glitch state is still active");
+assert.deepEqual(remappedDuringGlitch.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentOrderReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "re-encrypt switches to the new mapping while the glitch state is still active");
 
-const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "new", wheelCeremonyPreviousSeed: "prev", wheelCeremonyReencryptCycleId: "cycle-1" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:02.000Z") });
+const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyCandidateOrder: currentOrder, wheelCeremonyPreviousCandidateOrder: previousOrder, wheelCeremonyReencryptNonce: "nonce-a" }, wheelCandidates: timingCandidates, now: new Date("2026-05-14T00:00:02.300Z") });
 assert.equal(reencryptedReady.mode, "wheel_ready", "re-encrypting ceremony returns to ready without selecting a winner");
 assert.equal(reencryptedReady.wheelCeremony?.resultTrackId, undefined, "re-encrypting does not produce a final winner");
-assert.deepEqual(reencryptedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentSeedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "ready state resolves with the remapped names after the glitch clears");
+assert.equal(reencryptedReady.wheelSpinsOwed, 1, "re-encrypting does not consume the owed wheel spin");
+assert.deepEqual(reencryptedReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), currentOrderReady.wheelCeremony?.displayCandidates.map((candidate) => candidate.id), "ready state resolves with the remapped names after the glitch clears");
 
 const signalLost = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "signal_lost", wheelOverlayActive: true, wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(signalLost.mode, "wheel_ready", "legacy winner-not-here recovery stays in the wheel-ready scene");

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -38,8 +38,11 @@ assert.equal(unsafe.sourceUrl, null, "unsafe link is not exposed");
 assert.equal(unsafe.artworkUrl, null, "private blob artwork is not exposed");
 
 const adminPanel = readFileSync("src/components/AdminLiveOverlayControl.tsx", "utf8");
+const liveOverlayController = readFileSync("src/lib/live-overlay.ts", "utf8");
 assert.equal(adminPanel.includes("Show Now Playing"), false, "admin panel does not expose normal manual scene picker");
 assert.equal(adminPanel.includes("Temporary System Message") && adminPanel.indexOf("Temporary System Message") > adminPanel.indexOf("<details"), true, "temporary system message is inside collapsed emergency details");
+assert.equal(adminPanel.includes("selectedWheelTrackId") && adminPanel.includes("Choose winning track") && adminPanel.includes("selectedTrackId"), true, "admin panel provides a grouped winner track picker before confirming Wheel Chosen");
+assert.equal(liveOverlayController.includes("submitterIdentityKeys") && liveOverlayController.includes("trackCount") && liveOverlayController.includes("findTrackInWinnerGroup"), true, "wheel controller groups candidates by submitter identity and resolves grouped winners to a selected track");
 
 const receiver = readFileSync("src/components/LiveOverlayReceiver.tsx", "utf8");
 const overlayCss = readFileSync("src/app/overlay/live/overlay-live.css", "utf8");
@@ -49,10 +52,10 @@ assert.equal(receiver.includes("live-overlay-wheel-roster"), false, "public whee
 assert.equal(receiver.includes(`!wheelVisible && <div className="live-overlay-footer"`), true, "public wheel ceremony hides the generic overlay footer");
 assert.equal(receiver.includes("live-overlay-wheel-slice-label"), true, "public wheel overlay renders candidate names as slice labels");
 assert.equal(receiver.includes("#7c3aed") && receiver.includes("#facc15") && receiver.includes("#22c55e"), true, "wheel slice palette includes expanded BARCODE colors");
-assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use dynamic sizing and slice-body placement variables");
+assert.equal(receiver.includes("wheelLabelMetrics") && receiver.includes("wheelLabelFit") && receiver.includes("--wheel-label-width") && receiver.includes("--wheel-label-x") && receiver.includes("--wheel-label-rotation"), true, "wheel artist labels use per-name dynamic sizing and slice-body placement variables");
 assert.equal(receiver.includes("Re-encrypting Signal") || receiver.includes("RE-ENCRYPTING"), true, "receiver has re-encryption ceremony copy");
 assert.equal(overlayCss.includes("width: min(92.5vmin, 100%)"), true, "wheel is sized to dominate the square overlay");
-assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes re-encryption and pointer polish effects");
+assert.equal(overlayCss.includes("live-wheel-reencrypt-sweep") && overlayCss.includes("live-wheel-reencrypt-brew") && overlayCss.includes("live-wheel-pointer-pulse"), true, "wheel ceremony CSS includes brewing re-encryption and pointer polish effects");
 assert.equal(overlayCss.includes("\"Arial Black\"") && overlayCss.includes("live-overlay-wheel::before") && overlayCss.includes("radial-gradient(ellipse at center"), true, "wheel CSS includes BARCODE-style typography, rim detailing, and integrated label glow");
 
 const eligibleCandidates = [
@@ -68,6 +71,10 @@ assert.equal(launched.mode, "wheel_ready", "launched wheel resolves to ready sce
 assert.equal(launched.wheelCeremony?.candidateCount, 2, "ready scene exposes safe eligible candidate count");
 assert.equal(launched.automatic, false, "launched wheel is host-controlled visual state");
 
+const groupedCandidate = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "ready", wheelOverlayActive: true, wheelCeremonySeed: "grouped-a" }, wheelCandidates: [{ id: "person:melanie", artistName: "Melanie", trackTitle: "3 eligible tracks", trackIds: ["m1", "m2", "m3"], trackCount: 3, tracks: [{ id: "m1", artistName: "Melanie", trackTitle: "First" }, { id: "m2", artistName: "Melanie", trackTitle: "Second" }, { id: "m3", artistName: "Melanie", trackTitle: "Third" }] }], nowPlaying: spotifyTrack });
+assert.equal(groupedCandidate.wheelCeremony?.candidateCount, 1, "grouped person appears once on the wheel");
+assert.equal(groupedCandidate.wheelCeremony?.displayCandidates[0]?.trackCount, 3, "grouped wheel entry preserves eligible track count");
+
 const spinning = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "spinning", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-2", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:03.000Z") });
 assert.equal(spinning.mode, "wheel_spinning", "spin scene stays spinning during the visual spin window");
 assert.equal(spinning.wheelCeremony?.resultTrack?.id, "free-2", "server-selected result is stored while visual spin runs");
@@ -80,7 +87,7 @@ const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, whe
 assert.equal(reencrypting.mode, "wheel_reencrypting", "re-encrypting ceremony shows re-encryption scene first");
 assert.equal(reencrypting.subtitle, "RE-ENCRYPTING SIGNAL", "re-encrypting scene uses BARCODE-controlled copy");
 
-const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
+const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:02.000Z") });
 assert.equal(reencryptedReady.mode, "wheel_ready", "re-encrypting ceremony returns to ready without selecting a winner");
 assert.equal(reencryptedReady.wheelCeremony?.resultTrackId, undefined, "re-encrypting does not produce a final winner");
 

--- a/tests/live-overlay-resolver.test.mjs
+++ b/tests/live-overlay-resolver.test.mjs
@@ -76,12 +76,17 @@ const pendingResult = resolveLiveOverlayScene({ currentSession: { ...session, wh
 assert.equal(pendingResult.mode, "wheel_result", "spinning ceremony becomes result pending after spin duration");
 assert.equal(pendingResult.wheelCeremony?.status, "result_pending", "computed ceremony status waits for host confirmation");
 
-const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+const reencrypting = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(reencrypting.mode, "wheel_reencrypting", "re-encrypting ceremony shows re-encryption scene first");
 assert.equal(reencrypting.subtitle, "RE-ENCRYPTING SIGNAL", "re-encrypting scene uses BARCODE-controlled copy");
 
-const reencryptedPending = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
-assert.equal(reencryptedPending.mode, "wheel_result", "re-encrypting ceremony returns to result pending after the visual sequence");
+const reencryptedReady = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "reencrypting", wheelOverlayActive: true, wheelCeremonySpinStartedAt: "2026-05-14T00:00:00.000Z", wheelCeremonySeed: "shuffle-a" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:08.000Z") });
+assert.equal(reencryptedReady.mode, "wheel_ready", "re-encrypting ceremony returns to ready without selecting a winner");
+assert.equal(reencryptedReady.wheelCeremony?.resultTrackId, undefined, "re-encrypting does not produce a final winner");
+
+const signalLost = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 1 }, overlayState: { wheelCeremonyStatus: "signal_lost", wheelOverlayActive: true, wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
+assert.equal(signalLost.mode, "wheel_ready", "winner-not-here recovery stays in the wheel-ready scene");
+assert.equal(signalLost.subtitle, "SIGNAL LOST", "winner-not-here recovery shows signal-lost copy");
 
 const confirmedFresh = resolveLiveOverlayScene({ currentSession: { ...session, wheelSpinsOwed: 0 }, overlayState: { wheelCeremonyStatus: "confirmed", wheelOverlayActive: true, wheelCeremonyResultTrackId: "free-1", wheelCeremonyResultSelectedAt: "2026-05-14T00:00:00.000Z" }, wheelCandidates: eligibleCandidates, now: new Date("2026-05-14T00:00:01.000Z") });
 assert.equal(confirmedFresh.mode, "wheel_confirmed", "fresh confirmed result shows lock-in scene");


### PR DESCRIPTION
### Motivation

- Finish resolving UX and behavior issues for the wheel ceremony overlay so artist labels are legible, the spin timing is realistic and variable, re-encryption visually scrambles without mutating queue state, and local wheel audio files are usable.
- Keep all queue/resolver/payment semantics unchanged so only overlay behavior and stored overlay state are affected.

### Description

- Adaptive labels & hub: allow artist names to wrap up to 2 lines, move labels farther outward, increase label sizing when candidate counts are low, and reduce the center hub size to avoid cutting off names; label metrics are computed dynamically in `LiveOverlayReceiver`. (changed `src/components/LiveOverlayReceiver.tsx`, `src/app/overlay/live/overlay-live.css`)
- Random spin duration: when `Spin Wheel` is triggered the backend now stores a random `wheelCeremonySpinDurationMs` between 16000–32000ms and the resolver/overlay use that value for the CSS animation duration rather than the old fixed 6.5s. (changed `src/lib/live-overlay.ts`, `src/lib/live-overlay-resolver.ts`, `src/components/LiveOverlayReceiver.tsx`)
- Re-encryption behavior: `Re-encrypt Signal` no longer runs the wheel spin animation or confirm logic; it shuffles/scrambles the displayed candidate labels (deterministic shuffle using the ceremony seed) and may pick a new pending result while not calling `updateRadioTrack`, not consuming owed spins, and not changing queue state. (changed `src/lib/live-overlay.ts`, `src/lib/live-overlay-resolver.ts`, `src/app/overlay/live/overlay-live.css`)
- Local wheel audio: overlay looks for `/audio/wheel/manifest.json` or falls back to bundled numeric MP3 filenames in `public/audio/wheel/`; audio file paths are sanitized, one file is chosen randomly per spin, audio plays while spinning and stops when the result appears / cancel / confirm / clear; failures are caught so missing/unplayable audio cannot crash the overlay. (changed `src/components/LiveOverlayReceiver.tsx`)

Files changed: `src/components/LiveOverlayReceiver.tsx`, `src/app/overlay/live/overlay-live.css`, `src/lib/live-overlay.ts`, `src/lib/live-overlay-resolver.ts`.

### Testing

- Type-check: ran `npx tsc --noEmit --pretty false`, which completed without type errors.
- Lint: ran `npx eslint src/components/LiveOverlayReceiver.tsx src/lib/live-overlay.ts src/lib/live-overlay-resolver.ts`, which produced no blocking lint failures for the changed files.
- Formatting / diff checks: ran `git diff --check` to ensure no whitespace/diff-check issues.

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05562d45948321be95e50188f59941)