### PR TITLE
Wheel ceremony polish pass: label orientation, spin/audio sync, fadeout, and new-session reset

### DIFF
--- a/src/app/api/admin/queue/route.ts
+++ b/src/app/api/admin/queue/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
+import { resetWheelCeremonyStateForNewSession } from "@/lib/live-overlay";
 import { archiveCurrentQueueSession, getRadioQueueState, setQueueOpen, startNewQueueSession, activateQueueSession, updatePriorityUpgradeSettings, updateRadioTrack, updateSponsorBreakState, updateSubmissionCooldownSettings } from "@/lib/queue";
 
 export const dynamic = "force-dynamic";
@@ -32,7 +33,7 @@ export async function POST(req: Request) {
     const safePriorityPriceCents = Number.isFinite(priorityPriceCents) ? Math.max(0, Math.round(priorityPriceCents)) : undefined;
     const priorityPaidRequested = body.priorityUpgradesEnabled === true || body.priorityUpgradePaymentsEnabled === true;
     const priorityPaidEnabled = priorityPaidRequested && (safePriorityPriceCents ?? 0) > 0;
-    return NextResponse.json(await startNewQueueSession({
+    const state = await startNewQueueSession({
       title: typeof body.title === "string" ? body.title : undefined,
       showDate: typeof body.showDate === "string" ? body.showDate : undefined,
       description: typeof body.description === "string" ? body.description : undefined,
@@ -46,7 +47,9 @@ export async function POST(req: Request) {
       priorityUpgradePriceCents: safePriorityPriceCents,
       priorityUpgradeCurrency: typeof body.priorityUpgradeCurrency === "string" ? body.priorityUpgradeCurrency : undefined,
       priorityUpgradePaymentsEnabled: priorityPaidEnabled,
-    }));
+    });
+    await resetWheelCeremonyStateForNewSession();
+    return NextResponse.json(state);
   }
   if (body.action === "updateSubmissionCooldownSettings") {
     const submissionCooldownSeconds = Number(body.submissionCooldownSeconds);

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -467,13 +467,7 @@ body > div:last-of-type {
 }
 
 .live-overlay-wheel-scene--spinning.live-overlay-wheel-scene--spin-armed .live-overlay-wheel {
-  animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
-  animation-delay: var(--wheel-spin-delay, 0.85s);
-}
-
-.live-overlay-wheel-scene--result_pending .live-overlay-wheel,
-.live-overlay-wheel-scene--confirmed .live-overlay-wheel {
-  transform: rotate(var(--wheel-final-rotation, 1260deg));
+  /* Rotation is JS-controlled to avoid post-spin snap/hop. */
 }
 
 

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -761,6 +761,51 @@ body > div:last-of-type {
   box-shadow: 0 0 2vmin rgba(103, 232, 249, 0.2);
 }
 
+.live-overlay-wheel-audio-modal {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  background: rgba(2, 6, 23, 0.66);
+  backdrop-filter: blur(0.4vmin);
+}
+
+.live-overlay-wheel-audio-modal-card {
+  width: min(76vmin, 92vw);
+  border: 0.2vmin solid rgba(103, 232, 249, 0.62);
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.96), rgba(8, 47, 73, 0.92));
+  padding: 3vmin;
+  text-align: center;
+  box-shadow: 0 0 4vmin rgba(34, 211, 238, 0.32), inset 0 0 2vmin rgba(103, 232, 249, 0.18);
+}
+
+.live-overlay-wheel-audio-modal-card p {
+  margin: 0;
+  color: #f8fdff;
+  font-size: clamp(1rem, 3vmin, 2rem);
+  font-weight: 950;
+  letter-spacing: 0.12em;
+}
+
+.live-overlay-wheel-audio-modal-card span {
+  display: block;
+  margin-top: 1.1vmin;
+  color: #a5f3fc;
+  font-size: clamp(0.7rem, 1.5vmin, 1rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.live-overlay-wheel-audio-modal-card em {
+  display: block;
+  margin-top: 1.2vmin;
+  color: #fda4af;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
 .live-overlay-wheel-audio-arm {
   cursor: pointer;
 }

--- a/src/app/overlay/live/overlay-live.css
+++ b/src/app/overlay/live/overlay-live.css
@@ -466,8 +466,9 @@ body > div:last-of-type {
   box-shadow: inset 0 0 2.8vmin rgba(2, 6, 23, 0.32), 0 0 2.2vmin rgba(255, 255, 255, 0.1);
 }
 
-.live-overlay-wheel-scene--spinning .live-overlay-wheel {
+.live-overlay-wheel-scene--spinning.live-overlay-wheel-scene--spin-armed .live-overlay-wheel {
   animation: live-wheel-spin var(--wheel-spin-duration, 24s) cubic-bezier(0.11, 0.78, 0.18, 1) both;
+  animation-delay: var(--wheel-spin-delay, 0.85s);
 }
 
 .live-overlay-wheel-scene--result_pending .live-overlay-wheel,

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -68,6 +68,8 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
 }
 
 const WHEEL_AUDIO_ARMED_STORAGE_KEY = "barcode-wheel-audio-armed";
+const WHEEL_SPIN_START_DELAY_MS = 850;
+const WHEEL_AUDIO_FADE_OUT_MS = 10_000;
 
 const FALLBACK_WHEEL_AUDIO_FILES = [
   "/audio/wheel/142.mp3",
@@ -236,7 +238,9 @@ function wheelLabelPosition(angle: number, radius: number) {
   const radians = (angle * Math.PI) / 180;
   const x = Math.sin(radians) * radius;
   const y = Math.cos(radians) * -radius;
-  const rotation = wheelUprightLabelRotationDegrees(angle);
+  const normalizedAngle = ((angle % 360) + 360) % 360;
+  const inRightSelectorZone = normalizedAngle >= 60 && normalizedAngle <= 120;
+  const rotation = inRightSelectorZone ? 0 : wheelUprightLabelRotationDegrees(angle);
   return { x: `${x.toFixed(3)}vmin`, y: `${y.toFixed(3)}vmin`, rotation: `${rotation.toFixed(3)}deg` };
 }
 
@@ -250,6 +254,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const reencryptVisualActive = ceremony?.status === "reencrypting" || Boolean(reencryptNonce && visibleReencryptNonce === reencryptNonce);
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioFadeFrameRef = useRef<number | null>(null);
   const [audioArmed, setAudioArmed] = useState(() => readWheelAudioArmed());
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
@@ -264,6 +269,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const wheelStyle = {
     "--wheel-final-rotation": `${finalRotationDeg}deg`,
     "--wheel-spin-duration": `${Math.max(16, (ceremony?.spinDurationMs ?? 24000) / 1000)}s`,
+    "--wheel-spin-delay": `${WHEEL_SPIN_START_DELAY_MS / 1000}s`,
     "--wheel-slice-count": candidateCount,
     "--wheel-slice-background": sliceBackground,
     "--wheel-name-size": `${labelMetrics.size}vmin`,
@@ -299,6 +305,10 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }, []);
 
   useEffect(() => {
+    if (audioFadeFrameRef.current !== null) {
+      window.cancelAnimationFrame(audioFadeFrameRef.current);
+      audioFadeFrameRef.current = null;
+    }
     const existingAudio = audioRef.current;
     if (!spinning || !audioArmed) {
       stopWheelAudio(existingAudio);
@@ -338,9 +348,39 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
     return () => {
       cancelled = true;
-      stopWheelAudio(audioRef.current);
     };
   }, [audioArmed, spinning, ceremony?.audioPath, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || spinning || ceremony?.status === "reencrypting") return undefined;
+    if (audio.paused || audio.currentTime <= 0) return undefined;
+    const startVolume = audio.volume;
+    if (startVolume <= 0.001) {
+      stopWheelAudio(audio);
+      return undefined;
+    }
+    const startedAt = performance.now();
+    const fade = (now: number) => {
+      const elapsed = now - startedAt;
+      const progress = Math.max(0, Math.min(1, elapsed / WHEEL_AUDIO_FADE_OUT_MS));
+      audio.volume = startVolume * (1 - progress);
+      if (progress >= 1) {
+        stopWheelAudio(audio);
+        audio.volume = startVolume;
+        audioFadeFrameRef.current = null;
+        return;
+      }
+      audioFadeFrameRef.current = window.requestAnimationFrame(fade);
+    };
+    audioFadeFrameRef.current = window.requestAnimationFrame(fade);
+    return () => {
+      if (audioFadeFrameRef.current !== null) {
+        window.cancelAnimationFrame(audioFadeFrameRef.current);
+        audioFadeFrameRef.current = null;
+      }
+    };
+  }, [ceremony?.status, spinning]);
 
   function enableWheelAudio() {
     const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
@@ -366,7 +406,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }
 
   return (
-    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinning ? "live-overlay-wheel-scene--spinning" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinning ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
       {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE OPTIONAL WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">OPTIONAL AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {reencryptVisualActive && <div key={`glitch-${animationKey}`} className="live-overlay-wheel-glitch-stack" aria-hidden="true"><div className="live-overlay-wheel-static" /><div className="live-overlay-wheel-glitch">RE-ENCRYPTING SIGNAL</div><div className="live-overlay-wheel-corrupt-labels">010010 // SIGNAL MUTATING // 101101</div></div>}

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -178,6 +178,29 @@ function stopWheelAudio(audio: HTMLAudioElement | null): void {
   audio.currentTime = 0;
 }
 
+async function unlockAudioElement(audio: HTMLAudioElement): Promise<boolean> {
+  try {
+    const originalVolume = audio.volume;
+    const originalMuted = audio.muted;
+    audio.muted = true;
+    audio.volume = 0.0001;
+    await audio.play();
+    audio.pause();
+    audio.currentTime = 0;
+    audio.muted = originalMuted;
+    audio.volume = originalVolume;
+    return true;
+  } catch {
+    try {
+      audio.pause();
+      audio.currentTime = 0;
+    } catch {
+      // ignore
+    }
+    return false;
+  }
+}
+
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
@@ -275,7 +298,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const spinEndsAtMs = spinStartedAtMs ? spinStartedAtMs + WHEEL_SPIN_START_DELAY_MS + spinDurationMs : null;
   const revealKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
   const showResultPending = ceremony?.status === "result_pending" && resultRevealReadyKey === revealKey;
-  const spinShouldStillAnimate = ceremony?.status === "spinning" || (ceremony?.status === "result_pending" && !showResultPending);
+  const spinShouldStillAnimate = ceremony?.status === "spinning";
   const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? finalRotationDeg : 0;
 
   useEffect(() => {
@@ -312,6 +335,24 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       reencryptAudioRef.current.volume = 0.9;
     }
   }, []);
+
+  function playOneShot(audioRefObj: { current: HTMLAudioElement | null }, path: string, volume: number, failureNotice?: string) {
+    const audio = audioRefObj.current ?? new Audio(path);
+    audioRefObj.current = audio;
+    audio.src = path;
+    audio.loop = false;
+    audio.preload = "auto";
+    audio.volume = volume;
+    try {
+      audio.pause();
+      audio.currentTime = 0;
+      void audio.play().catch(() => {
+        if (failureNotice) setAudioNotice(failureNotice);
+      });
+    } catch {
+      if (failureNotice) setAudioNotice(failureNotice);
+    }
+  }
 
   useEffect(() => {
     if (audioFadeFrameRef.current !== null) {
@@ -398,15 +439,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     const cheerKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
     if (lastCheerKeyRef.current === cheerKey) return undefined;
     lastCheerKeyRef.current = cheerKey;
-    const cheer = cheerAudioRef.current;
-    if (!cheer) return undefined;
-    try {
-      cheer.pause();
-      cheer.currentTime = 0;
-      void cheer.play().catch(() => undefined);
-    } catch {
-      // non-blocking winner SFX
-    }
+    playOneShot(cheerAudioRef, WHEEL_WINNER_CHEER_AUDIO_PATH, 0.9, "CHEER SFX UNAVAILABLE");
     return undefined;
   }, [showResultPending, spinShouldStillAnimate, ceremony?.status, ceremony?.resultTrackId]);
 
@@ -415,15 +448,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     if (ceremony?.status !== "reencrypting" || !nonce) return;
     if (lastReencryptKeyRef.current === nonce) return;
     lastReencryptKeyRef.current = nonce;
-    const sfx = reencryptAudioRef.current;
-    if (!sfx) return;
-    try {
-      sfx.pause();
-      sfx.currentTime = 0;
-      void sfx.play().catch(() => undefined);
-    } catch {
-      // non-blocking re-encrypt SFX
-    }
+    playOneShot(reencryptAudioRef, WHEEL_REENCRYPT_AUDIO_PATH, 0.9, "RE-ENCRYPT SFX UNAVAILABLE");
   }, [ceremony?.status, ceremony?.reencryptNonce, ceremony?.reencryptCycleId]);
 
   useEffect(() => {
@@ -439,30 +464,35 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     }, waitMs);
   }, [ceremony?.status, spinEndsAtMs, ceremony?.resultTrackId, revealKey]);
 
-  function enableWheelAudio() {
+  async function enableWheelAudio() {
     const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
-    const unlockAudio = new Audio(unlockPath);
-    unlockAudio.loop = false;
-    unlockAudio.muted = false;
-    unlockAudio.volume = 0.04;
-    unlockAudio.preload = "auto";
-    unlockAudio.load();
-    audioRef.current = unlockAudio;
-    unlockAudio.play().then(() => {
-      window.setTimeout(() => stopWheelAudio(unlockAudio), 280);
-      setAudioArmed(true);
-      setAudioJustArmed(true);
+    const spinAudio = new Audio(unlockPath);
+    const cheerAudio = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
+    const encryptAudio = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
+    audioRef.current = spinAudio;
+    cheerAudioRef.current = cheerAudio;
+    reencryptAudioRef.current = encryptAudio;
+    const [spinUnlocked, cheerUnlocked, encryptUnlocked] = await Promise.all([
+      unlockAudioElement(spinAudio),
+      unlockAudioElement(cheerAudio),
+      unlockAudioElement(encryptAudio),
+    ]);
+    setAudioArmed(spinUnlocked);
+    setAudioJustArmed(spinUnlocked);
+    if (!spinUnlocked) {
+      setAudioNotice("AUDIO COULD NOT BE ENABLED — CLICK AGAIN");
+      return;
+    }
+    if (!cheerUnlocked || !encryptUnlocked) {
+      setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
+    } else {
       setAudioNotice(null);
-    }).catch(() => {
-      stopWheelAudio(unlockAudio);
-      setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
-      setAudioArmed(false);
-    });
+    }
   }
 
   return (
     <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinShouldStillAnimate ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
-      {!audioArmed ? <div className="live-overlay-wheel-audio-modal" role="dialog" aria-modal="true" aria-label="Enable wheel audio"><div className="live-overlay-wheel-audio-modal-card"><p>ENABLE WHEEL AUDIO</p><span>Required before wheel sounds can play.</span><button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button>{audioNotice && <em>{audioNotice.includes("UNAVAILABLE") ? "AUDIO COULD NOT BE ENABLED — CLICK AGAIN" : audioNotice}</em>}</div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+      {!audioArmed ? <div className="live-overlay-wheel-audio-modal" role="dialog" aria-modal="true" aria-label="Enable wheel audio"><div className="live-overlay-wheel-audio-modal-card"><p>ENABLE WHEEL AUDIO</p><span>Required for wheel music and winner sounds.</span><span>Click once before the show.</span><button type="button" className="live-overlay-wheel-audio-arm" onClick={() => { void enableWheelAudio(); }}>ENABLE AUDIO</button>{audioNotice && <em>{audioNotice}</em>}</div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {reencryptVisualActive && <div key={`glitch-${animationKey}`} className="live-overlay-wheel-glitch-stack" aria-hidden="true"><div className="live-overlay-wheel-static" /><div className="live-overlay-wheel-glitch">RE-ENCRYPTING SIGNAL</div><div className="live-overlay-wheel-corrupt-labels">010010 // SIGNAL MUTATING // 101101</div></div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -189,29 +189,6 @@ async function decodeAudioBuffer(context: AudioContext, path: string): Promise<A
   }
 }
 
-async function unlockAudioElement(audio: HTMLAudioElement): Promise<boolean> {
-  try {
-    const originalVolume = audio.volume;
-    const originalMuted = audio.muted;
-    audio.muted = true;
-    audio.volume = 0.0001;
-    await audio.play();
-    audio.pause();
-    audio.currentTime = 0;
-    audio.muted = originalMuted;
-    audio.volume = originalVolume;
-    return true;
-  } catch {
-    try {
-      audio.pause();
-      audio.currentTime = 0;
-    } catch {
-      // ignore
-    }
-    return false;
-  }
-}
-
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
@@ -350,11 +327,15 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   }, [ceremony?.status, ceremony?.reencryptNonce, ceremony?.reencryptCycleId]);
 
   useEffect(() => {
-    if (ceremony?.status !== "spinning") { window.setTimeout(() => setFrozenRotationDeg(null), 0); return; }
+    if (ceremony?.status !== "spinning") return;
+    const clearTimer = window.setTimeout(() => setFrozenRotationDeg(null), 0);
     const freezeTimer = window.setTimeout(() => {
       setFrozenRotationDeg(finalRotationDeg);
     }, Math.max(0, (spinEndsAtMs ?? Date.now()) - Date.now()));
-    return () => window.clearTimeout(freezeTimer);
+    return () => {
+      window.clearTimeout(clearTimer);
+      window.clearTimeout(freezeTimer);
+    };
   }, [ceremony?.status, spinEndsAtMs, finalRotationDeg]);
 
   useEffect(() => {
@@ -587,7 +568,7 @@ export function LiveOverlayReceiver() {
   function playOneShotBuffer(buffer: AudioBuffer | null, volume: number) {
     const ctx = audioContextRef.current;
     if (!ctx || !buffer || !audioArmed) return;
-    try {
+    const play = () => {
       const source = ctx.createBufferSource();
       const gain = ctx.createGain();
       gain.gain.value = volume;
@@ -595,9 +576,12 @@ export function LiveOverlayReceiver() {
       source.connect(gain);
       gain.connect(ctx.destination);
       source.start(0);
-    } catch {
-      setAudioNotice("WHEEL SFX PLAYBACK LOCKED");
+    };
+    if (ctx.state === "suspended") {
+      void ctx.resume().then(play).catch(() => setAudioNotice("WHEEL SFX PLAYBACK LOCKED"));
+      return;
     }
+    try { play(); } catch { setAudioNotice("WHEEL SFX PLAYBACK LOCKED"); }
   }
 
   return (

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -241,9 +241,9 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   const lastReencryptKeyRef = useRef<string | null>(null);
   const resultRevealTimeoutRef = useRef<number | null>(null);
   const [resultRevealReadyKey, setResultRevealReadyKey] = useState<string | null>(null);
-  const [frozenRotationDeg, setFrozenRotationDeg] = useState<number | null>(null);
-  const [frozenWheelTransform, setFrozenWheelTransform] = useState<string | null>(null);
-  const wheelRef = useRef<HTMLDivElement | null>(null);
+  const [wheelRotationDeg, setWheelRotationDeg] = useState(0);
+  const [wheelFrozen, setWheelFrozen] = useState(false);
+  const spinRafRef = useRef<number | null>(null);
   const candidateCount = Math.max(1, candidates.length);
   const wheelSegments = buildWheelSegments(candidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
   const resultSegment = wheelSegments.find((segment) => segment.candidateId === result?.id) ?? wheelSegments[0];
@@ -272,8 +272,8 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   const spinEndsAtMs = spinStartedAtMs ? spinStartedAtMs + WHEEL_SPIN_START_DELAY_MS + spinDurationMs : null;
   const revealKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
   const showResultPending = ceremony?.status === "result_pending" && resultRevealReadyKey === revealKey;
-  const spinShouldStillAnimate = ceremony?.status === "spinning" && frozenWheelTransform === null;
-  const displayRotationDeg = frozenRotationDeg ?? finalRotationDeg;
+  const spinShouldStillAnimate = ceremony?.status === "spinning" && !wheelFrozen;
+  const displayRotationDeg = wheelRotationDeg;
   const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? displayRotationDeg : 0;
 
   useEffect(() => {
@@ -319,13 +319,40 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   }, [ceremony?.status, ceremony?.reencryptNonce, ceremony?.reencryptCycleId]);
 
   useEffect(() => {
+    if (spinRafRef.current !== null) {
+      window.cancelAnimationFrame(spinRafRef.current);
+      spinRafRef.current = null;
+    }
     if (ceremony?.status !== "spinning") return;
-    const clearTimer = window.setTimeout(() => {
-      setFrozenWheelTransform(null);
-      setFrozenRotationDeg(null);
-    }, 0);
-    return () => window.clearTimeout(clearTimer);
-  }, [ceremony?.status, ceremony?.spinStartedAt]);
+    const unfreezeTimer = window.setTimeout(() => setWheelFrozen(false), 0);
+    const startRotation = wheelRotationDeg;
+    const targetRotation = finalRotationDeg;
+    const duration = Math.max(16_000, ceremony?.spinDurationMs ?? 24_000);
+    const startAt = performance.now() + WHEEL_SPIN_START_DELAY_MS;
+    const easeOut = (t: number) => 1 - Math.pow(1 - t, 3);
+    const tick = (now: number) => {
+      if (now < startAt) {
+        spinRafRef.current = window.requestAnimationFrame(tick);
+        return;
+      }
+      const t = Math.max(0, Math.min(1, (now - startAt) / duration));
+      const eased = easeOut(t);
+      setWheelRotationDeg(startRotation + (targetRotation - startRotation) * eased);
+      if (t >= 1) {
+        setWheelRotationDeg(targetRotation);
+        setWheelFrozen(true);
+        spinRafRef.current = null;
+        return;
+      }
+      spinRafRef.current = window.requestAnimationFrame(tick);
+    };
+    spinRafRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      window.clearTimeout(unfreezeTimer);
+      if (spinRafRef.current !== null) window.cancelAnimationFrame(spinRafRef.current);
+      spinRafRef.current = null;
+    };
+  }, [ceremony?.status, ceremony?.spinStartedAt, ceremony?.spinDurationMs, finalRotationDeg]);
 
   useEffect(() => {
     if (resultRevealTimeoutRef.current !== null) {
@@ -333,7 +360,7 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
       resultRevealTimeoutRef.current = null;
     }
     if (ceremony?.status !== "result_pending") return;
-    const waitMs = Math.max(0, (spinEndsAtMs ?? Date.now()) - Date.now()) + WHEEL_RESULT_REVEAL_DELAY_MS;
+    const waitMs = WHEEL_RESULT_REVEAL_DELAY_MS;
     resultRevealTimeoutRef.current = window.setTimeout(() => {
       setResultRevealReadyKey(revealKey);
       resultRevealTimeoutRef.current = null;
@@ -352,13 +379,7 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
 
       <div className="live-overlay-wheel-wrap">
         <div className="live-overlay-wheel-pointer" aria-hidden="true" />
-        <div ref={wheelRef} onAnimationEnd={() => {
-          const el = wheelRef.current;
-          if (!el) return;
-          const computed = window.getComputedStyle(el).transform;
-          if (computed && computed !== "none") setFrozenWheelTransform(computed);
-          else setFrozenRotationDeg(finalRotationDeg);
-        }} className="live-overlay-wheel" style={{ ...wheelStyle, ...(frozenWheelTransform ? { transform: frozenWheelTransform } : frozenRotationDeg !== null ? { transform: `rotate(${displayRotationDeg}deg)` } : {}) }}>
+        <div className="live-overlay-wheel" style={{ ...wheelStyle, transform: `rotate(${displayRotationDeg}deg)` }}>
           <div className="live-overlay-wheel-slices" aria-hidden="true" />
           {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-winning-segment" aria-hidden="true" />}
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -178,6 +178,17 @@ function stopWheelAudio(audio: HTMLAudioElement | null): void {
   audio.currentTime = 0;
 }
 
+async function decodeAudioBuffer(context: AudioContext, path: string): Promise<AudioBuffer | null> {
+  try {
+    const res = await fetch(path, { cache: "no-store" });
+    if (!res.ok) return null;
+    const bytes = await res.arrayBuffer();
+    return await context.decodeAudioData(bytes.slice(0));
+  } catch {
+    return null;
+  }
+}
+
 async function unlockAudioElement(audio: HTMLAudioElement): Promise<boolean> {
   try {
     const originalVolume = audio.volume;
@@ -494,8 +505,9 @@ export function LiveOverlayReceiver() {
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const spinAudioRef = useRef<HTMLAudioElement | null>(null);
-  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
-  const encryptAudioRef = useRef<HTMLAudioElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const cheerBufferRef = useRef<AudioBuffer | null>(null);
+  const encryptBufferRef = useRef<AudioBuffer | null>(null);
   const spinFadeFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -528,9 +540,7 @@ export function LiveOverlayReceiver() {
 
   async function enableOverlayAudio() {
     const spin = new Audio("/audio/wheel/142.mp3");
-    const cheer = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
-    const enc = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
-    spinAudioRef.current = spin; cheerAudioRef.current = cheer; encryptAudioRef.current = enc;
+    spinAudioRef.current = spin;
     const testPlay = async (a: HTMLAudioElement) => {
       try {
         a.volume = 0.08;
@@ -550,32 +560,21 @@ export function LiveOverlayReceiver() {
       }
     };
 
-    const [spinOk, cheerOk, encOk] = await Promise.all([testPlay(spin), testPlay(cheer), testPlay(enc)]);
+    const spinOk = await testPlay(spin);
 
-    // Arm overlay when any audible unlock succeeds. Only fail modal when every attempt fails.
-    if (spinOk || cheerOk || encOk) {
+    if (spinOk) {
+      if (!audioContextRef.current) audioContextRef.current = new AudioContext();
+      try { await audioContextRef.current.resume(); } catch { /* ignore */ }
+      const [cheerBuffer, encryptBuffer] = await Promise.all([
+        decodeAudioBuffer(audioContextRef.current, WHEEL_WINNER_CHEER_AUDIO_PATH),
+        decodeAudioBuffer(audioContextRef.current, WHEEL_REENCRYPT_AUDIO_PATH),
+      ]);
+      cheerBufferRef.current = cheerBuffer;
+      encryptBufferRef.current = encryptBuffer;
       setAudioArmed(true);
       setAudioJustArmed(true);
       window.setTimeout(() => setAudioJustArmed(false), 2200);
-
-      if (spinOk && cheerOk && encOk) {
-        setAudioNotice(null);
-        return;
-      }
-
-      try {
-        const [cheerHead, encHead] = await Promise.all([
-          fetch(WHEEL_WINNER_CHEER_AUDIO_PATH, { method: "HEAD", cache: "no-store" }),
-          fetch(WHEEL_REENCRYPT_AUDIO_PATH, { method: "HEAD", cache: "no-store" }),
-        ]);
-        if (!cheerHead.ok || !encHead.ok) {
-          setAudioNotice("WHEEL SFX FILE NOT FOUND");
-        } else {
-          setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
-        }
-      } catch {
-        setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
-      }
+      setAudioNotice(!cheerBuffer || !encryptBuffer ? "WHEEL SFX UNAVAILABLE" : null);
       return;
     }
 
@@ -585,7 +584,21 @@ export function LiveOverlayReceiver() {
 
   async function playSpinMusic(path?: string) { const a = spinAudioRef.current; if (!a || !audioArmed) return; a.loop = true; a.volume = 0.82; const p = safeWheelAudioPath(path) ?? a.src ?? "/audio/wheel/142.mp3"; if (!a.src || !a.src.endsWith(p)) a.src = p; try { await a.play(); } catch {} }
   function fadeSpinMusic() { const a = spinAudioRef.current; if (!a) return; const sv = a.volume || 0.82; const st = performance.now(); const tick = (n: number) => { const pr = Math.max(0, Math.min(1, (n - st) / WHEEL_AUDIO_FADE_OUT_MS)); a.volume = sv * (1 - pr); if (pr >= 1) { stopWheelAudio(a); a.volume = sv; spinFadeFrameRef.current = null; return; } spinFadeFrameRef.current = window.requestAnimationFrame(tick); }; if (spinFadeFrameRef.current) window.cancelAnimationFrame(spinFadeFrameRef.current); spinFadeFrameRef.current = window.requestAnimationFrame(tick); }
-  function playOneShotFromRef(ref: React.MutableRefObject<HTMLAudioElement | null>, path: string, volume: number) { const a = ref.current; if (!a || !audioArmed) return; if (!a.src || !a.src.endsWith(path)) a.src = path; a.volume = volume; a.pause(); a.currentTime = 0; void a.play().catch(() => setAudioNotice("AUDIO SFX PLAYBACK BLOCKED")); }
+  function playOneShotBuffer(buffer: AudioBuffer | null, volume: number) {
+    const ctx = audioContextRef.current;
+    if (!ctx || !buffer || !audioArmed) return;
+    try {
+      const source = ctx.createBufferSource();
+      const gain = ctx.createGain();
+      gain.gain.value = volume;
+      source.buffer = buffer;
+      source.connect(gain);
+      gain.connect(ctx.destination);
+      source.start(0);
+    } catch {
+      setAudioNotice("WHEEL SFX PLAYBACK LOCKED");
+    }
+  }
 
   return (
     <div className="live-overlay-shell" aria-label="BARCODE Radio live overlay receiver">
@@ -599,7 +612,7 @@ export function LiveOverlayReceiver() {
 
         <main className="live-overlay-content">
           {wheelVisible ? (
-            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playOneShotFromRef(cheerAudioRef, WHEEL_WINNER_CHEER_AUDIO_PATH, 0.9)} playEncryptSfx={() => playOneShotFromRef(encryptAudioRef, WHEEL_REENCRYPT_AUDIO_PATH, 0.9)} />
+            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playOneShotBuffer(cheerBufferRef.current, 0.95)} playEncryptSfx={() => playOneShotBuffer(encryptBufferRef.current, 0.92)} />
           ) : youtubeVisible && scene.youtube && scene.track ? (
             <div className="live-overlay-youtube-scene">
               <YouTubeOverlayPlayer sync={scene.youtube} />

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -178,6 +178,17 @@ function stopWheelAudio(audio: HTMLAudioElement | null): void {
   audio.currentTime = 0;
 }
 
+async function decodeAudioBuffer(context: AudioContext, path: string): Promise<AudioBuffer | null> {
+  try {
+    const response = await fetch(path, { cache: "no-store" });
+    if (!response.ok) return null;
+    const bytes = await response.arrayBuffer();
+    return await context.decodeAudioData(bytes.slice(0));
+  } catch {
+    return null;
+  }
+}
+
 
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -502,8 +513,9 @@ export function LiveOverlayReceiver() {
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const spinAudioRef = useRef<HTMLAudioElement | null>(null);
-  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
-  const encryptAudioRef = useRef<HTMLAudioElement | null>(null);
+  const sfxContextRef = useRef<AudioContext | null>(null);
+  const cheerBufferRef = useRef<AudioBuffer | null>(null);
+  const encryptBufferRef = useRef<AudioBuffer | null>(null);
   const spinFadeFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -536,14 +548,8 @@ export function LiveOverlayReceiver() {
 
   async function enableOverlayAudio() {
     const spin = new Audio("/audio/wheel/142.mp3");
-    const cheer = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
-    const encrypt = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
     spinAudioRef.current = spin;
-    cheerAudioRef.current = cheer;
-    encryptAudioRef.current = encrypt;
     spin.preload = "auto";
-    cheer.preload = "auto";
-    encrypt.preload = "auto";
     const testPlay = async (a: HTMLAudioElement) => {
       try {
         a.volume = 0.08;
@@ -563,13 +569,25 @@ export function LiveOverlayReceiver() {
       }
     };
 
-    const [spinOk, cheerOk, encryptOk] = await Promise.all([testPlay(spin), testPlay(cheer), testPlay(encrypt)]);
+    const spinOk = await testPlay(spin);
 
     if (spinOk) {
+      if (!sfxContextRef.current) sfxContextRef.current = new AudioContext();
+      try {
+        await sfxContextRef.current.resume();
+      } catch {
+        // non-blocking
+      }
+      const [cheerBuffer, encryptBuffer] = await Promise.all([
+        decodeAudioBuffer(sfxContextRef.current, WHEEL_WINNER_CHEER_AUDIO_PATH),
+        decodeAudioBuffer(sfxContextRef.current, WHEEL_REENCRYPT_AUDIO_PATH),
+      ]);
+      cheerBufferRef.current = cheerBuffer;
+      encryptBufferRef.current = encryptBuffer;
       setAudioArmed(true);
       setAudioJustArmed(true);
       window.setTimeout(() => setAudioJustArmed(false), 2200);
-      setAudioNotice(!cheerOk || !encryptOk ? "WHEEL SFX MAY BE BLOCKED" : null);
+      setAudioNotice(!cheerBuffer || !encryptBuffer ? "WHEEL SFX UNAVAILABLE" : null);
       return;
     }
 
@@ -579,13 +597,31 @@ export function LiveOverlayReceiver() {
 
   async function playSpinMusic(path?: string) { const a = spinAudioRef.current; if (!a || !audioArmed) return; a.loop = true; a.volume = 0.82; const p = safeWheelAudioPath(path) ?? a.src ?? "/audio/wheel/142.mp3"; if (!a.src || !a.src.endsWith(p)) a.src = p; try { await a.play(); } catch {} }
   function fadeSpinMusic() { const a = spinAudioRef.current; if (!a) return; const sv = a.volume || 0.82; const st = performance.now(); const tick = (n: number) => { const pr = Math.max(0, Math.min(1, (n - st) / WHEEL_AUDIO_FADE_OUT_MS)); a.volume = sv * (1 - pr); if (pr >= 1) { stopWheelAudio(a); a.volume = sv; spinFadeFrameRef.current = null; return; } spinFadeFrameRef.current = window.requestAnimationFrame(tick); }; if (spinFadeFrameRef.current) window.cancelAnimationFrame(spinFadeFrameRef.current); spinFadeFrameRef.current = window.requestAnimationFrame(tick); }
-  function playSfxFromRef(ref: React.MutableRefObject<HTMLAudioElement | null>, volume: number) {
-    const audio = ref.current;
-    if (!audio || !audioArmed) return;
-    audio.pause();
-    audio.currentTime = 0;
-    audio.volume = volume;
-    void audio.play().catch(() => setAudioNotice("WHEEL SFX PLAYBACK BLOCKED"));
+  function playSfxBuffer(bufferRef: React.MutableRefObject<AudioBuffer | null>, volume: number) {
+    const context = sfxContextRef.current;
+    const buffer = bufferRef.current;
+    if (!context || !buffer || !audioArmed) {
+      setAudioNotice("WHEEL SFX UNAVAILABLE");
+      return;
+    }
+    const run = () => {
+      const source = context.createBufferSource();
+      const gain = context.createGain();
+      gain.gain.value = volume;
+      source.buffer = buffer;
+      source.connect(gain);
+      gain.connect(context.destination);
+      source.start(0);
+    };
+    if (context.state === "suspended") {
+      void context.resume().then(run).catch(() => setAudioNotice("WHEEL SFX UNAVAILABLE"));
+      return;
+    }
+    try {
+      run();
+    } catch {
+      setAudioNotice("WHEEL SFX UNAVAILABLE");
+    }
   }
 
   return (
@@ -600,7 +636,7 @@ export function LiveOverlayReceiver() {
 
         <main className="live-overlay-content">
           {wheelVisible ? (
-            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playSfxFromRef(cheerAudioRef, 0.95)} playEncryptSfx={() => playSfxFromRef(encryptAudioRef, 0.9)} />
+            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playSfxBuffer(cheerBufferRef, 0.95)} playEncryptSfx={() => playSfxBuffer(encryptBufferRef, 0.9)} />
           ) : youtubeVisible && scene.youtube && scene.track ? (
             <div className="live-overlay-youtube-scene">
               <YouTubeOverlayPlayer sync={scene.youtube} />

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -70,6 +70,8 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
 const WHEEL_SPIN_START_DELAY_MS = 850;
 const WHEEL_AUDIO_FADE_OUT_MS = 10_000;
 const WHEEL_WINNER_CHEER_AUDIO_PATH = "/audio/wheel/WheelCheer.mp3";
+const WHEEL_REENCRYPT_AUDIO_PATH = "/audio/wheel/WheelEncrypt.mp3";
+const WHEEL_RESULT_REVEAL_DELAY_MS = 700;
 
 const FALLBACK_WHEEL_AUDIO_FILES = [
   "/audio/wheel/142.mp3",
@@ -236,10 +238,15 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
+  const reencryptAudioRef = useRef<HTMLAudioElement | null>(null);
   const audioFadeFrameRef = useRef<number | null>(null);
+  const lastCheerKeyRef = useRef<string | null>(null);
+  const lastReencryptKeyRef = useRef<string | null>(null);
+  const resultRevealTimeoutRef = useRef<number | null>(null);
   const [audioArmed, setAudioArmed] = useState(false);
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
+  const [resultRevealReadyKey, setResultRevealReadyKey] = useState<string | null>(null);
   const candidateCount = Math.max(1, candidates.length);
   const wheelSegments = buildWheelSegments(candidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
   const resultSegment = wheelSegments.find((segment) => segment.candidateId === result?.id) ?? wheelSegments[0];
@@ -263,6 +270,12 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-winning-end": `${resultSegment.endAngle}deg`,
   } as CSSProperties;
   const status = ceremony?.status ?? "idle";
+  const spinDurationMs = Math.max(16_000, ceremony?.spinDurationMs ?? 24_000);
+  const spinStartedAtMs = ceremony?.spinStartedAt ? new Date(ceremony.spinStartedAt).getTime() : null;
+  const spinEndsAtMs = spinStartedAtMs ? spinStartedAtMs + WHEEL_SPIN_START_DELAY_MS + spinDurationMs : null;
+  const revealKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
+  const showResultPending = ceremony?.status === "result_pending" && resultRevealReadyKey === revealKey;
+  const spinShouldStillAnimate = ceremony?.status === "spinning" || (ceremony?.status === "result_pending" && !showResultPending);
   const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? finalRotationDeg : 0;
 
   useEffect(() => {
@@ -291,6 +304,12 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       cheerAudioRef.current.preload = "auto";
       cheerAudioRef.current.loop = false;
       cheerAudioRef.current.volume = 0.85;
+    }
+    if (!reencryptAudioRef.current) {
+      reencryptAudioRef.current = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
+      reencryptAudioRef.current.preload = "auto";
+      reencryptAudioRef.current.loop = false;
+      reencryptAudioRef.current.volume = 0.9;
     }
   }, []);
 
@@ -345,7 +364,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
   useEffect(() => {
     const audio = audioRef.current;
-    if (!audio || spinning || ceremony?.status !== "result_pending") return undefined;
+    if (!audio || !showResultPending || spinShouldStillAnimate) return undefined;
     if (audio.paused || audio.currentTime <= 0) return undefined;
     const startVolume = audio.volume;
     if (startVolume <= 0.001) {
@@ -372,10 +391,13 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
         audioFadeFrameRef.current = null;
       }
     };
-  }, [ceremony?.status, spinning]);
+  }, [showResultPending, spinShouldStillAnimate]);
 
   useEffect(() => {
-    if (ceremony?.status !== "result_pending") return undefined;
+    if (!showResultPending || spinShouldStillAnimate) return undefined;
+    const cheerKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
+    if (lastCheerKeyRef.current === cheerKey) return undefined;
+    lastCheerKeyRef.current = cheerKey;
     const cheer = cheerAudioRef.current;
     if (!cheer) return undefined;
     try {
@@ -386,7 +408,36 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       // non-blocking winner SFX
     }
     return undefined;
-  }, [ceremony?.status, ceremony?.resultTrackId]);
+  }, [showResultPending, spinShouldStillAnimate, ceremony?.status, ceremony?.resultTrackId]);
+
+  useEffect(() => {
+    const nonce = ceremony?.reencryptNonce ?? ceremony?.reencryptCycleId;
+    if (ceremony?.status !== "reencrypting" || !nonce) return;
+    if (lastReencryptKeyRef.current === nonce) return;
+    lastReencryptKeyRef.current = nonce;
+    const sfx = reencryptAudioRef.current;
+    if (!sfx) return;
+    try {
+      sfx.pause();
+      sfx.currentTime = 0;
+      void sfx.play().catch(() => undefined);
+    } catch {
+      // non-blocking re-encrypt SFX
+    }
+  }, [ceremony?.status, ceremony?.reencryptNonce, ceremony?.reencryptCycleId]);
+
+  useEffect(() => {
+    if (resultRevealTimeoutRef.current !== null) {
+      window.clearTimeout(resultRevealTimeoutRef.current);
+      resultRevealTimeoutRef.current = null;
+    }
+    if (ceremony?.status !== "result_pending") return;
+    const waitMs = Math.max(0, (spinEndsAtMs ?? Date.now()) - Date.now()) + WHEEL_RESULT_REVEAL_DELAY_MS;
+    resultRevealTimeoutRef.current = window.setTimeout(() => {
+      setResultRevealReadyKey(revealKey);
+      resultRevealTimeoutRef.current = null;
+    }, waitMs);
+  }, [ceremony?.status, spinEndsAtMs, ceremony?.resultTrackId, revealKey]);
 
   function enableWheelAudio() {
     const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
@@ -410,8 +461,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }
 
   return (
-    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinning ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
-      {!audioArmed ? <button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE OPTIONAL WHEEL AUDIO</button> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">OPTIONAL AUDIO ARMED</div> : null}
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinShouldStillAnimate ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
+      {!audioArmed ? <div className="live-overlay-wheel-audio-modal" role="dialog" aria-modal="true" aria-label="Enable wheel audio"><div className="live-overlay-wheel-audio-modal-card"><p>ENABLE WHEEL AUDIO</p><span>Required before wheel sounds can play.</span><button type="button" className="live-overlay-wheel-audio-arm" onClick={enableWheelAudio}>ENABLE WHEEL AUDIO</button>{audioNotice && <em>{audioNotice.includes("UNAVAILABLE") ? "AUDIO COULD NOT BE ENABLED — CLICK AGAIN" : audioNotice}</em>}</div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {reencryptVisualActive && <div key={`glitch-${animationKey}`} className="live-overlay-wheel-glitch-stack" aria-hidden="true"><div className="live-overlay-wheel-static" /><div className="live-overlay-wheel-glitch">RE-ENCRYPTING SIGNAL</div><div className="live-overlay-wheel-corrupt-labels">010010 // SIGNAL MUTATING // 101101</div></div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
@@ -451,7 +502,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
         </div>
       </div>
 
-      {result && ceremony?.status === "result_pending" && <div className="live-overlay-wheel-result-reveal" aria-live="assertive">
+      {result && showResultPending && <div className="live-overlay-wheel-result-reveal" aria-live="assertive">
         <div className="live-overlay-binary-confetti" aria-hidden="true">{BINARY_CONFETTI.map((bit, index) => <span key={`${bit.bit}-${index}`} style={{ "--bit-left": bit.left, "--bit-delay": bit.delay, "--bit-drift": bit.drift, "--bit-duration": bit.duration } as CSSProperties}>{bit.bit}</span>)}</div>
         <div className="live-overlay-wheel-result-card"><span>WHEEL WINNER</span><strong>{result.artistName}</strong><em>{result.trackTitle}</em><p>20 SECONDS TO CLAIM YOUR WINNINGS</p></div>
       </div>}

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -531,12 +531,56 @@ export function LiveOverlayReceiver() {
     const cheer = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
     const enc = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
     spinAudioRef.current = spin; cheerAudioRef.current = cheer; encryptAudioRef.current = enc;
-    const testPlay = async (a: HTMLAudioElement) => { a.volume = 0.08; await a.play(); await new Promise((r) => window.setTimeout(r, 160)); a.pause(); a.currentTime = 0; };
-    try {
-      await testPlay(spin); await testPlay(cheer); await testPlay(enc);
-      setAudioArmed(true); setAudioJustArmed(true); setAudioNotice(null);
+    const testPlay = async (a: HTMLAudioElement) => {
+      try {
+        a.volume = 0.08;
+        await a.play();
+        await new Promise((r) => window.setTimeout(r, 160));
+        a.pause();
+        a.currentTime = 0;
+        return true;
+      } catch {
+        try {
+          a.pause();
+          a.currentTime = 0;
+        } catch {
+          // ignore
+        }
+        return false;
+      }
+    };
+
+    const [spinOk, cheerOk, encOk] = await Promise.all([testPlay(spin), testPlay(cheer), testPlay(enc)]);
+
+    // Arm overlay when any audible unlock succeeds. Only fail modal when every attempt fails.
+    if (spinOk || cheerOk || encOk) {
+      setAudioArmed(true);
+      setAudioJustArmed(true);
       window.setTimeout(() => setAudioJustArmed(false), 2200);
-    } catch { setAudioNotice("AUDIO COULD NOT BE ENABLED — CLICK AGAIN"); }
+
+      if (spinOk && cheerOk && encOk) {
+        setAudioNotice(null);
+        return;
+      }
+
+      try {
+        const [cheerHead, encHead] = await Promise.all([
+          fetch(WHEEL_WINNER_CHEER_AUDIO_PATH, { method: "HEAD", cache: "no-store" }),
+          fetch(WHEEL_REENCRYPT_AUDIO_PATH, { method: "HEAD", cache: "no-store" }),
+        ]);
+        if (!cheerHead.ok || !encHead.ok) {
+          setAudioNotice("WHEEL SFX FILE NOT FOUND");
+        } else {
+          setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
+        }
+      } catch {
+        setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
+      }
+      return;
+    }
+
+    setAudioArmed(false);
+    setAudioNotice("AUDIO COULD NOT BE ENABLED — CLICK AGAIN");
   }
 
   async function playSpinMusic(path?: string) { const a = spinAudioRef.current; if (!a || !audioArmed) return; a.loop = true; a.volume = 0.82; const p = safeWheelAudioPath(path) ?? a.src ?? "/audio/wheel/142.mp3"; if (!a.src || !a.src.endsWith(p)) a.src = p; try { await a.play(); } catch {} }

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -178,16 +178,6 @@ function stopWheelAudio(audio: HTMLAudioElement | null): void {
   audio.currentTime = 0;
 }
 
-async function decodeAudioBuffer(context: AudioContext, path: string): Promise<AudioBuffer | null> {
-  try {
-    const res = await fetch(path, { cache: "no-store" });
-    if (!res.ok) return null;
-    const bytes = await res.arrayBuffer();
-    return await context.decodeAudioData(bytes.slice(0));
-  } catch {
-    return null;
-  }
-}
 
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -252,6 +242,8 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   const resultRevealTimeoutRef = useRef<number | null>(null);
   const [resultRevealReadyKey, setResultRevealReadyKey] = useState<string | null>(null);
   const [frozenRotationDeg, setFrozenRotationDeg] = useState<number | null>(null);
+  const [frozenWheelTransform, setFrozenWheelTransform] = useState<string | null>(null);
+  const wheelRef = useRef<HTMLDivElement | null>(null);
   const candidateCount = Math.max(1, candidates.length);
   const wheelSegments = buildWheelSegments(candidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
   const resultSegment = wheelSegments.find((segment) => segment.candidateId === result?.id) ?? wheelSegments[0];
@@ -280,7 +272,7 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
   const spinEndsAtMs = spinStartedAtMs ? spinStartedAtMs + WHEEL_SPIN_START_DELAY_MS + spinDurationMs : null;
   const revealKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
   const showResultPending = ceremony?.status === "result_pending" && resultRevealReadyKey === revealKey;
-  const spinShouldStillAnimate = ceremony?.status === "spinning" && frozenRotationDeg === null;
+  const spinShouldStillAnimate = ceremony?.status === "spinning" && frozenWheelTransform === null;
   const displayRotationDeg = frozenRotationDeg ?? finalRotationDeg;
   const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? displayRotationDeg : 0;
 
@@ -328,15 +320,12 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
 
   useEffect(() => {
     if (ceremony?.status !== "spinning") return;
-    const clearTimer = window.setTimeout(() => setFrozenRotationDeg(null), 0);
-    const freezeTimer = window.setTimeout(() => {
-      setFrozenRotationDeg(finalRotationDeg);
-    }, Math.max(0, (spinEndsAtMs ?? Date.now()) - Date.now()));
-    return () => {
-      window.clearTimeout(clearTimer);
-      window.clearTimeout(freezeTimer);
-    };
-  }, [ceremony?.status, spinEndsAtMs, finalRotationDeg]);
+    const clearTimer = window.setTimeout(() => {
+      setFrozenWheelTransform(null);
+      setFrozenRotationDeg(null);
+    }, 0);
+    return () => window.clearTimeout(clearTimer);
+  }, [ceremony?.status, ceremony?.spinStartedAt]);
 
   useEffect(() => {
     if (resultRevealTimeoutRef.current !== null) {
@@ -363,7 +352,13 @@ function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, 
 
       <div className="live-overlay-wheel-wrap">
         <div className="live-overlay-wheel-pointer" aria-hidden="true" />
-        <div className="live-overlay-wheel" style={{ ...wheelStyle, ...(frozenRotationDeg !== null ? { transform: `rotate(${displayRotationDeg}deg)` } : {}) }}>
+        <div ref={wheelRef} onAnimationEnd={() => {
+          const el = wheelRef.current;
+          if (!el) return;
+          const computed = window.getComputedStyle(el).transform;
+          if (computed && computed !== "none") setFrozenWheelTransform(computed);
+          else setFrozenRotationDeg(finalRotationDeg);
+        }} className="live-overlay-wheel" style={{ ...wheelStyle, ...(frozenWheelTransform ? { transform: frozenWheelTransform } : frozenRotationDeg !== null ? { transform: `rotate(${displayRotationDeg}deg)` } : {}) }}>
           <div className="live-overlay-wheel-slices" aria-hidden="true" />
           {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-winning-segment" aria-hidden="true" />}
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
@@ -486,9 +481,8 @@ export function LiveOverlayReceiver() {
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const spinAudioRef = useRef<HTMLAudioElement | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const cheerBufferRef = useRef<AudioBuffer | null>(null);
-  const encryptBufferRef = useRef<AudioBuffer | null>(null);
+  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
+  const encryptAudioRef = useRef<HTMLAudioElement | null>(null);
   const spinFadeFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -521,7 +515,14 @@ export function LiveOverlayReceiver() {
 
   async function enableOverlayAudio() {
     const spin = new Audio("/audio/wheel/142.mp3");
+    const cheer = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
+    const encrypt = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
     spinAudioRef.current = spin;
+    cheerAudioRef.current = cheer;
+    encryptAudioRef.current = encrypt;
+    spin.preload = "auto";
+    cheer.preload = "auto";
+    encrypt.preload = "auto";
     const testPlay = async (a: HTMLAudioElement) => {
       try {
         a.volume = 0.08;
@@ -541,21 +542,13 @@ export function LiveOverlayReceiver() {
       }
     };
 
-    const spinOk = await testPlay(spin);
+    const [spinOk, cheerOk, encryptOk] = await Promise.all([testPlay(spin), testPlay(cheer), testPlay(encrypt)]);
 
     if (spinOk) {
-      if (!audioContextRef.current) audioContextRef.current = new AudioContext();
-      try { await audioContextRef.current.resume(); } catch { /* ignore */ }
-      const [cheerBuffer, encryptBuffer] = await Promise.all([
-        decodeAudioBuffer(audioContextRef.current, WHEEL_WINNER_CHEER_AUDIO_PATH),
-        decodeAudioBuffer(audioContextRef.current, WHEEL_REENCRYPT_AUDIO_PATH),
-      ]);
-      cheerBufferRef.current = cheerBuffer;
-      encryptBufferRef.current = encryptBuffer;
       setAudioArmed(true);
       setAudioJustArmed(true);
       window.setTimeout(() => setAudioJustArmed(false), 2200);
-      setAudioNotice(!cheerBuffer || !encryptBuffer ? "WHEEL SFX UNAVAILABLE" : null);
+      setAudioNotice(!cheerOk || !encryptOk ? "WHEEL SFX MAY BE BLOCKED" : null);
       return;
     }
 
@@ -565,23 +558,13 @@ export function LiveOverlayReceiver() {
 
   async function playSpinMusic(path?: string) { const a = spinAudioRef.current; if (!a || !audioArmed) return; a.loop = true; a.volume = 0.82; const p = safeWheelAudioPath(path) ?? a.src ?? "/audio/wheel/142.mp3"; if (!a.src || !a.src.endsWith(p)) a.src = p; try { await a.play(); } catch {} }
   function fadeSpinMusic() { const a = spinAudioRef.current; if (!a) return; const sv = a.volume || 0.82; const st = performance.now(); const tick = (n: number) => { const pr = Math.max(0, Math.min(1, (n - st) / WHEEL_AUDIO_FADE_OUT_MS)); a.volume = sv * (1 - pr); if (pr >= 1) { stopWheelAudio(a); a.volume = sv; spinFadeFrameRef.current = null; return; } spinFadeFrameRef.current = window.requestAnimationFrame(tick); }; if (spinFadeFrameRef.current) window.cancelAnimationFrame(spinFadeFrameRef.current); spinFadeFrameRef.current = window.requestAnimationFrame(tick); }
-  function playOneShotBuffer(buffer: AudioBuffer | null, volume: number) {
-    const ctx = audioContextRef.current;
-    if (!ctx || !buffer || !audioArmed) return;
-    const play = () => {
-      const source = ctx.createBufferSource();
-      const gain = ctx.createGain();
-      gain.gain.value = volume;
-      source.buffer = buffer;
-      source.connect(gain);
-      gain.connect(ctx.destination);
-      source.start(0);
-    };
-    if (ctx.state === "suspended") {
-      void ctx.resume().then(play).catch(() => setAudioNotice("WHEEL SFX PLAYBACK LOCKED"));
-      return;
-    }
-    try { play(); } catch { setAudioNotice("WHEEL SFX PLAYBACK LOCKED"); }
+  function playSfxFromRef(ref: React.MutableRefObject<HTMLAudioElement | null>, volume: number) {
+    const audio = ref.current;
+    if (!audio || !audioArmed) return;
+    audio.pause();
+    audio.currentTime = 0;
+    audio.volume = volume;
+    void audio.play().catch(() => setAudioNotice("WHEEL SFX PLAYBACK BLOCKED"));
   }
 
   return (
@@ -596,7 +579,7 @@ export function LiveOverlayReceiver() {
 
         <main className="live-overlay-content">
           {wheelVisible ? (
-            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playOneShotBuffer(cheerBufferRef.current, 0.95)} playEncryptSfx={() => playOneShotBuffer(encryptBufferRef.current, 0.92)} />
+            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playSfxFromRef(cheerAudioRef, 0.95)} playEncryptSfx={() => playSfxFromRef(encryptAudioRef, 0.9)} />
           ) : youtubeVisible && scene.youtube && scene.track ? (
             <div className="live-overlay-youtube-scene">
               <YouTubeOverlayPlayer sync={scene.youtube} />

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -250,7 +250,7 @@ function wheelLabelPosition(angle: number, radius: number, wheelRotationDeg: num
   return { x: `${x.toFixed(3)}vmin`, y: `${y.toFixed(3)}vmin`, rotation: `${rotation.toFixed(3)}deg` };
 }
 
-function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
+function WheelCeremonyOverlay({ scene, audioArmed, audioNotice, audioJustArmed, playSpinMusic, fadeSpinMusic, playCheerSfx, playEncryptSfx }: { scene: ResolvedLiveOverlayScene; audioArmed: boolean; audioNotice: string | null; audioJustArmed: boolean; playSpinMusic: (path?: string) => Promise<void>; fadeSpinMusic: () => void; playCheerSfx: () => void; playEncryptSfx: () => void }) {
   const ceremony = scene.wheelCeremony;
   const candidates = ceremony?.displayCandidates ?? [];
   const result = ceremony?.resultTrack;
@@ -259,17 +259,11 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const lastSeenReencryptNonceRef = useRef<string | undefined>(undefined);
   const reencryptVisualActive = ceremony?.status === "reencrypting" || Boolean(reencryptNonce && visibleReencryptNonce === reencryptNonce);
   const spinning = ceremony?.status === "spinning";
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
-  const reencryptAudioRef = useRef<HTMLAudioElement | null>(null);
-  const audioFadeFrameRef = useRef<number | null>(null);
   const lastCheerKeyRef = useRef<string | null>(null);
   const lastReencryptKeyRef = useRef<string | null>(null);
   const resultRevealTimeoutRef = useRef<number | null>(null);
-  const [audioArmed, setAudioArmed] = useState(false);
-  const [audioNotice, setAudioNotice] = useState<string | null>(null);
-  const [audioJustArmed, setAudioJustArmed] = useState(false);
   const [resultRevealReadyKey, setResultRevealReadyKey] = useState<string | null>(null);
+  const [frozenRotationDeg, setFrozenRotationDeg] = useState<number | null>(null);
   const candidateCount = Math.max(1, candidates.length);
   const wheelSegments = buildWheelSegments(candidates.map((candidate) => ({ id: candidate.id, label: candidate.artistName, weight: candidate.weight })));
   const resultSegment = wheelSegments.find((segment) => segment.candidateId === result?.id) ?? wheelSegments[0];
@@ -298,8 +292,9 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const spinEndsAtMs = spinStartedAtMs ? spinStartedAtMs + WHEEL_SPIN_START_DELAY_MS + spinDurationMs : null;
   const revealKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
   const showResultPending = ceremony?.status === "result_pending" && resultRevealReadyKey === revealKey;
-  const spinShouldStillAnimate = ceremony?.status === "spinning";
-  const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? finalRotationDeg : 0;
+  const spinShouldStillAnimate = ceremony?.status === "spinning" && frozenRotationDeg === null;
+  const displayRotationDeg = frozenRotationDeg ?? finalRotationDeg;
+  const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? displayRotationDeg : 0;
 
   useEffect(() => {
     if (!reencryptNonce || lastSeenReencryptNonceRef.current === reencryptNonce) return undefined;
@@ -312,126 +307,18 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   }, [reencryptNonce]);
 
   useEffect(() => {
-    if (!audioJustArmed) return undefined;
-    const timeout = window.setTimeout(() => setAudioJustArmed(false), 2200);
-    return () => window.clearTimeout(timeout);
-  }, [audioJustArmed]);
-
-  useEffect(() => {
-    if (!audioRef.current) {
-      audioRef.current = new Audio();
-      audioRef.current.preload = "auto";
-    }
-    if (!cheerAudioRef.current) {
-      cheerAudioRef.current = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
-      cheerAudioRef.current.preload = "auto";
-      cheerAudioRef.current.loop = false;
-      cheerAudioRef.current.volume = 0.85;
-    }
-    if (!reencryptAudioRef.current) {
-      reencryptAudioRef.current = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
-      reencryptAudioRef.current.preload = "auto";
-      reencryptAudioRef.current.loop = false;
-      reencryptAudioRef.current.volume = 0.9;
-    }
-  }, []);
-
-  function playOneShot(audioRefObj: { current: HTMLAudioElement | null }, path: string, volume: number, failureNotice?: string) {
-    const audio = audioRefObj.current ?? new Audio(path);
-    audioRefObj.current = audio;
-    audio.src = path;
-    audio.loop = false;
-    audio.preload = "auto";
-    audio.volume = volume;
-    try {
-      audio.pause();
-      audio.currentTime = 0;
-      void audio.play().catch(() => {
-        if (failureNotice) setAudioNotice(failureNotice);
-      });
-    } catch {
-      if (failureNotice) setAudioNotice(failureNotice);
-    }
-  }
-
-  useEffect(() => {
-    if (audioFadeFrameRef.current !== null) {
-      window.cancelAnimationFrame(audioFadeFrameRef.current);
-      audioFadeFrameRef.current = null;
-    }
-    const existingAudio = audioRef.current;
-    if (!audioArmed) {
-      stopWheelAudio(existingAudio);
-      return undefined;
-    }
+    if (!audioArmed) return;
     if (!spinning) {
       return undefined;
     }
-
-    let cancelled = false;
-    loadWheelAudioFiles().then(async (files) => {
-      const storedPath = safeWheelAudioPath(ceremony?.audioPath);
-      const candidatePaths = [storedPath, ...shuffledAudioPaths(files)].filter((path, index, paths): path is string => Boolean(path) && paths.indexOf(path) === index);
-      const audio = audioRef.current ?? new Audio();
-      audioRef.current = audio;
-      audio.loop = true;
-      audio.preload = "auto";
-      audio.volume = 0.82;
-      for (const audioPath of candidatePaths) {
-        if (cancelled) return;
-        try {
-          stopWheelAudio(audio);
-          audio.src = audioPath;
-          audio.load();
-          await audio.play();
-          if (!cancelled) setAudioNotice(null);
-          return;
-        } catch (error) {
-          stopWheelAudio(audio);
-          if (audioPlayWasBlocked(error)) {
-            setAudioArmed(false);
-            setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
-            return;
-          }
-        }
-      }
-      if (!cancelled) setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    void playSpinMusic(ceremony?.audioPath);
+    return undefined;
   }, [audioArmed, spinning, ceremony?.audioPath, ceremony?.spinStartedAt, ceremony?.resultTrackId]);
 
   useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio || !showResultPending || spinShouldStillAnimate) return undefined;
-    if (audio.paused || audio.currentTime <= 0) return undefined;
-    const startVolume = audio.volume;
-    if (startVolume <= 0.001) {
-      stopWheelAudio(audio);
-      return undefined;
-    }
-    const startedAt = performance.now();
-    const fade = (now: number) => {
-      const elapsed = now - startedAt;
-      const progress = Math.max(0, Math.min(1, elapsed / WHEEL_AUDIO_FADE_OUT_MS));
-      audio.volume = startVolume * (1 - progress);
-      if (progress >= 1) {
-        stopWheelAudio(audio);
-        audio.volume = startVolume;
-        audioFadeFrameRef.current = null;
-        return;
-      }
-      audioFadeFrameRef.current = window.requestAnimationFrame(fade);
-    };
-    audioFadeFrameRef.current = window.requestAnimationFrame(fade);
-    return () => {
-      if (audioFadeFrameRef.current !== null) {
-        window.cancelAnimationFrame(audioFadeFrameRef.current);
-        audioFadeFrameRef.current = null;
-      }
-    };
+    if (!showResultPending || spinShouldStillAnimate) return;
+    fadeSpinMusic();
+    return;
   }, [showResultPending, spinShouldStillAnimate]);
 
   useEffect(() => {
@@ -439,7 +326,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     const cheerKey = `${ceremony?.resultTrackId ?? "none"}:${ceremony?.status ?? "none"}`;
     if (lastCheerKeyRef.current === cheerKey) return undefined;
     lastCheerKeyRef.current = cheerKey;
-    playOneShot(cheerAudioRef, WHEEL_WINNER_CHEER_AUDIO_PATH, 0.9, "CHEER SFX UNAVAILABLE");
+    playCheerSfx();
     return undefined;
   }, [showResultPending, spinShouldStillAnimate, ceremony?.status, ceremony?.resultTrackId]);
 
@@ -448,8 +335,16 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     if (ceremony?.status !== "reencrypting" || !nonce) return;
     if (lastReencryptKeyRef.current === nonce) return;
     lastReencryptKeyRef.current = nonce;
-    playOneShot(reencryptAudioRef, WHEEL_REENCRYPT_AUDIO_PATH, 0.9, "RE-ENCRYPT SFX UNAVAILABLE");
+    playEncryptSfx();
   }, [ceremony?.status, ceremony?.reencryptNonce, ceremony?.reencryptCycleId]);
+
+  useEffect(() => {
+    if (ceremony?.status !== "spinning") { window.setTimeout(() => setFrozenRotationDeg(null), 0); return; }
+    const freezeTimer = window.setTimeout(() => {
+      setFrozenRotationDeg(finalRotationDeg);
+    }, Math.max(0, (spinEndsAtMs ?? Date.now()) - Date.now()));
+    return () => window.clearTimeout(freezeTimer);
+  }, [ceremony?.status, spinEndsAtMs, finalRotationDeg]);
 
   useEffect(() => {
     if (resultRevealTimeoutRef.current !== null) {
@@ -464,35 +359,9 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     }, waitMs);
   }, [ceremony?.status, spinEndsAtMs, ceremony?.resultTrackId, revealKey]);
 
-  async function enableWheelAudio() {
-    const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
-    const spinAudio = new Audio(unlockPath);
-    const cheerAudio = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
-    const encryptAudio = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
-    audioRef.current = spinAudio;
-    cheerAudioRef.current = cheerAudio;
-    reencryptAudioRef.current = encryptAudio;
-    const [spinUnlocked, cheerUnlocked, encryptUnlocked] = await Promise.all([
-      unlockAudioElement(spinAudio),
-      unlockAudioElement(cheerAudio),
-      unlockAudioElement(encryptAudio),
-    ]);
-    setAudioArmed(spinUnlocked);
-    setAudioJustArmed(spinUnlocked);
-    if (!spinUnlocked) {
-      setAudioNotice("AUDIO COULD NOT BE ENABLED — CLICK AGAIN");
-      return;
-    }
-    if (!cheerUnlocked || !encryptUnlocked) {
-      setAudioNotice("SOME WHEEL SFX MAY BE BLOCKED");
-    } else {
-      setAudioNotice(null);
-    }
-  }
-
   return (
-    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinShouldStillAnimate ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : ""}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
-      {!audioArmed ? <div className="live-overlay-wheel-audio-modal" role="dialog" aria-modal="true" aria-label="Enable wheel audio"><div className="live-overlay-wheel-audio-modal-card"><p>ENABLE WHEEL AUDIO</p><span>Required for wheel music and winner sounds.</span><span>Click once before the show.</span><button type="button" className="live-overlay-wheel-audio-arm" onClick={() => { void enableWheelAudio(); }}>ENABLE AUDIO</button>{audioNotice && <em>{audioNotice}</em>}</div></div> : audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
+    <div className={`live-overlay-wheel-scene live-overlay-wheel-scene--${ceremony?.status ?? "idle"} ${reencryptVisualActive ? "live-overlay-wheel-scene--reencrypting" : ""} ${spinShouldStillAnimate ? "live-overlay-wheel-scene--spinning live-overlay-wheel-scene--spin-armed" : "live-overlay-wheel-scene--frozen"}`} data-wheel-seed={ceremony?.seed} data-wheel-animation-key={animationKey}>
+      {audioJustArmed ? <div className="live-overlay-wheel-audio-armed" role="status">AUDIO ARMED</div> : null}
       {audioNotice && <div className="live-overlay-wheel-audio-notice" role="status">{audioNotice}</div>}
       {reencryptVisualActive && <div key={`glitch-${animationKey}`} className="live-overlay-wheel-glitch-stack" aria-hidden="true"><div className="live-overlay-wheel-static" /><div className="live-overlay-wheel-glitch">RE-ENCRYPTING SIGNAL</div><div className="live-overlay-wheel-corrupt-labels">010010 // SIGNAL MUTATING // 101101</div></div>}
       <div className="live-overlay-wheel-heading" aria-live="polite">
@@ -502,7 +371,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
       <div className="live-overlay-wheel-wrap">
         <div className="live-overlay-wheel-pointer" aria-hidden="true" />
-        <div className="live-overlay-wheel" style={wheelStyle}>
+        <div className="live-overlay-wheel" style={{ ...wheelStyle, ...(frozenRotationDeg !== null ? { transform: `rotate(${displayRotationDeg}deg)` } : {}) }}>
           <div className="live-overlay-wheel-slices" aria-hidden="true" />
           {result && (ceremony?.status === "result_pending" || ceremony?.status === "confirmed") && <div className="live-overlay-wheel-winning-segment" aria-hidden="true" />}
           {candidates.length === 0 ? <span className="live-overlay-wheel-empty">NO CANDIDATES</span> : candidates.map((candidate, index) => {
@@ -621,6 +490,13 @@ function YouTubeOverlayPlayer({ sync }: { sync: LiveOverlayYouTubeSync }) {
 export function LiveOverlayReceiver() {
   const [scene, setScene] = useState<ResolvedLiveOverlayScene>(fallbackScene());
   const [connected, setConnected] = useState(false);
+  const [audioArmed, setAudioArmed] = useState(false);
+  const [audioNotice, setAudioNotice] = useState<string | null>(null);
+  const [audioJustArmed, setAudioJustArmed] = useState(false);
+  const spinAudioRef = useRef<HTMLAudioElement | null>(null);
+  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
+  const encryptAudioRef = useRef<HTMLAudioElement | null>(null);
+  const spinFadeFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -650,6 +526,23 @@ export function LiveOverlayReceiver() {
   const youtubeVisible = scene.mode === "now_playing" && scene.automatic && scene.youtube && scene.track;
   const wheelVisible = Boolean(scene.wheelCeremony);
 
+  async function enableOverlayAudio() {
+    const spin = new Audio("/audio/wheel/142.mp3");
+    const cheer = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
+    const enc = new Audio(WHEEL_REENCRYPT_AUDIO_PATH);
+    spinAudioRef.current = spin; cheerAudioRef.current = cheer; encryptAudioRef.current = enc;
+    const testPlay = async (a: HTMLAudioElement) => { a.volume = 0.08; await a.play(); await new Promise((r) => window.setTimeout(r, 160)); a.pause(); a.currentTime = 0; };
+    try {
+      await testPlay(spin); await testPlay(cheer); await testPlay(enc);
+      setAudioArmed(true); setAudioJustArmed(true); setAudioNotice(null);
+      window.setTimeout(() => setAudioJustArmed(false), 2200);
+    } catch { setAudioNotice("AUDIO COULD NOT BE ENABLED — CLICK AGAIN"); }
+  }
+
+  async function playSpinMusic(path?: string) { const a = spinAudioRef.current; if (!a || !audioArmed) return; a.loop = true; a.volume = 0.82; const p = safeWheelAudioPath(path) ?? a.src ?? "/audio/wheel/142.mp3"; if (!a.src || !a.src.endsWith(p)) a.src = p; try { await a.play(); } catch {} }
+  function fadeSpinMusic() { const a = spinAudioRef.current; if (!a) return; const sv = a.volume || 0.82; const st = performance.now(); const tick = (n: number) => { const pr = Math.max(0, Math.min(1, (n - st) / WHEEL_AUDIO_FADE_OUT_MS)); a.volume = sv * (1 - pr); if (pr >= 1) { stopWheelAudio(a); a.volume = sv; spinFadeFrameRef.current = null; return; } spinFadeFrameRef.current = window.requestAnimationFrame(tick); }; if (spinFadeFrameRef.current) window.cancelAnimationFrame(spinFadeFrameRef.current); spinFadeFrameRef.current = window.requestAnimationFrame(tick); }
+  function playOneShotFromRef(ref: React.MutableRefObject<HTMLAudioElement | null>, path: string, volume: number) { const a = ref.current; if (!a || !audioArmed) return; if (!a.src || !a.src.endsWith(path)) a.src = path; a.volume = volume; a.pause(); a.currentTime = 0; void a.play().catch(() => setAudioNotice("AUDIO SFX PLAYBACK BLOCKED")); }
+
   return (
     <div className="live-overlay-shell" aria-label="BARCODE Radio live overlay receiver">
       <section className={`live-overlay-stage ${frameTone(scene.mode)} ${youtubeVisible ? "live-overlay-stage--youtube" : ""} ${wheelVisible ? "live-overlay-stage--wheel-ceremony" : ""}`}>
@@ -662,7 +555,7 @@ export function LiveOverlayReceiver() {
 
         <main className="live-overlay-content">
           {wheelVisible ? (
-            <WheelCeremonyOverlay scene={scene} />
+            <WheelCeremonyOverlay scene={scene} audioArmed={audioArmed} audioNotice={audioNotice} audioJustArmed={audioJustArmed} playSpinMusic={playSpinMusic} fadeSpinMusic={fadeSpinMusic} playCheerSfx={() => playOneShotFromRef(cheerAudioRef, WHEEL_WINNER_CHEER_AUDIO_PATH, 0.9)} playEncryptSfx={() => playOneShotFromRef(encryptAudioRef, WHEEL_REENCRYPT_AUDIO_PATH, 0.9)} />
           ) : youtubeVisible && scene.youtube && scene.track ? (
             <div className="live-overlay-youtube-scene">
               <YouTubeOverlayPlayer sync={scene.youtube} />
@@ -703,6 +596,7 @@ export function LiveOverlayReceiver() {
           <span>{scene.automatic ? "AUTO LIVE SOURCE" : "OVERRIDE LIVE SOURCE"} / 1:1</span>
           <span>{new Date(scene.updatedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
         </div>}
+        {!audioArmed && <div className="live-overlay-wheel-audio-modal" role="dialog" aria-modal="true" aria-label="Enable live overlay audio"><div className="live-overlay-wheel-audio-modal-card"><p>ENABLE LIVE OVERLAY AUDIO</p><span>Required for wheel music, winner sounds, and broadcast effects.</span><span>Click once before the show.</span><button type="button" className="live-overlay-wheel-audio-arm" onClick={() => { void enableOverlayAudio(); }}>ENABLE AUDIO</button>{audioNotice && <em>{audioNotice}</em>}</div></div>}
       </section>
     </div>
   );

--- a/src/components/LiveOverlayReceiver.tsx
+++ b/src/components/LiveOverlayReceiver.tsx
@@ -67,9 +67,9 @@ function showTrack(scene: ResolvedLiveOverlayScene): boolean {
   return Boolean((scene.mode === "now_playing" || scene.mode === "artist_card") && scene.track);
 }
 
-const WHEEL_AUDIO_ARMED_STORAGE_KEY = "barcode-wheel-audio-armed";
 const WHEEL_SPIN_START_DELAY_MS = 850;
 const WHEEL_AUDIO_FADE_OUT_MS = 10_000;
+const WHEEL_WINNER_CHEER_AUDIO_PATH = "/audio/wheel/WheelCheer.mp3";
 
 const FALLBACK_WHEEL_AUDIO_FILES = [
   "/audio/wheel/142.mp3",
@@ -176,25 +176,6 @@ function stopWheelAudio(audio: HTMLAudioElement | null): void {
   audio.currentTime = 0;
 }
 
-function readWheelAudioArmed(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(WHEEL_AUDIO_ARMED_STORAGE_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function rememberWheelAudioArmed(armed: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    if (armed) window.localStorage.setItem(WHEEL_AUDIO_ARMED_STORAGE_KEY, "true");
-    else window.localStorage.removeItem(WHEEL_AUDIO_ARMED_STORAGE_KEY);
-  } catch {
-    // localStorage can be unavailable in private or embedded preview contexts.
-  }
-}
-
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
@@ -234,12 +215,12 @@ function wheelLabelFit(value: string, count: number, segmentAngle: number) {
   };
 }
 
-function wheelLabelPosition(angle: number, radius: number) {
+function wheelLabelPosition(angle: number, radius: number, wheelRotationDeg: number) {
   const radians = (angle * Math.PI) / 180;
   const x = Math.sin(radians) * radius;
   const y = Math.cos(radians) * -radius;
-  const normalizedAngle = ((angle % 360) + 360) % 360;
-  const inRightSelectorZone = normalizedAngle >= 60 && normalizedAngle <= 120;
+  const finalVisualAngle = (((angle + wheelRotationDeg) % 360) + 360) % 360;
+  const inRightSelectorZone = finalVisualAngle >= 60 && finalVisualAngle <= 120;
   const rotation = inRightSelectorZone ? 0 : wheelUprightLabelRotationDegrees(angle);
   return { x: `${x.toFixed(3)}vmin`, y: `${y.toFixed(3)}vmin`, rotation: `${rotation.toFixed(3)}deg` };
 }
@@ -254,8 +235,9 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
   const reencryptVisualActive = ceremony?.status === "reencrypting" || Boolean(reencryptNonce && visibleReencryptNonce === reencryptNonce);
   const spinning = ceremony?.status === "spinning";
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const cheerAudioRef = useRef<HTMLAudioElement | null>(null);
   const audioFadeFrameRef = useRef<number | null>(null);
-  const [audioArmed, setAudioArmed] = useState(() => readWheelAudioArmed());
+  const [audioArmed, setAudioArmed] = useState(false);
   const [audioNotice, setAudioNotice] = useState<string | null>(null);
   const [audioJustArmed, setAudioJustArmed] = useState(false);
   const candidateCount = Math.max(1, candidates.length);
@@ -280,6 +262,8 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     "--wheel-winning-start": `${resultSegment.startAngle}deg`,
     "--wheel-winning-end": `${resultSegment.endAngle}deg`,
   } as CSSProperties;
+  const status = ceremony?.status ?? "idle";
+  const visualWheelRotationDeg = status === "result_pending" || status === "confirmed" || status === "spinning" ? finalRotationDeg : 0;
 
   useEffect(() => {
     if (!reencryptNonce || lastSeenReencryptNonceRef.current === reencryptNonce) return undefined;
@@ -302,6 +286,12 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       audioRef.current = new Audio();
       audioRef.current.preload = "auto";
     }
+    if (!cheerAudioRef.current) {
+      cheerAudioRef.current = new Audio(WHEEL_WINNER_CHEER_AUDIO_PATH);
+      cheerAudioRef.current.preload = "auto";
+      cheerAudioRef.current.loop = false;
+      cheerAudioRef.current.volume = 0.85;
+    }
   }, []);
 
   useEffect(() => {
@@ -310,8 +300,11 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       audioFadeFrameRef.current = null;
     }
     const existingAudio = audioRef.current;
-    if (!spinning || !audioArmed) {
+    if (!audioArmed) {
       stopWheelAudio(existingAudio);
+      return undefined;
+    }
+    if (!spinning) {
       return undefined;
     }
 
@@ -337,7 +330,6 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
           stopWheelAudio(audio);
           if (audioPlayWasBlocked(error)) {
             setAudioArmed(false);
-            rememberWheelAudioArmed(false);
             setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
             return;
           }
@@ -353,7 +345,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
 
   useEffect(() => {
     const audio = audioRef.current;
-    if (!audio || spinning || ceremony?.status === "reencrypting") return undefined;
+    if (!audio || spinning || ceremony?.status !== "result_pending") return undefined;
     if (audio.paused || audio.currentTime <= 0) return undefined;
     const startVolume = audio.volume;
     if (startVolume <= 0.001) {
@@ -382,6 +374,20 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
     };
   }, [ceremony?.status, spinning]);
 
+  useEffect(() => {
+    if (ceremony?.status !== "result_pending") return undefined;
+    const cheer = cheerAudioRef.current;
+    if (!cheer) return undefined;
+    try {
+      cheer.pause();
+      cheer.currentTime = 0;
+      void cheer.play().catch(() => undefined);
+    } catch {
+      // non-blocking winner SFX
+    }
+    return undefined;
+  }, [ceremony?.status, ceremony?.resultTrackId]);
+
   function enableWheelAudio() {
     const unlockPath = safeWheelAudioPath(ceremony?.audioPath) ?? FALLBACK_WHEEL_AUDIO_FILES[0];
     const unlockAudio = new Audio(unlockPath);
@@ -396,12 +402,10 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
       setAudioArmed(true);
       setAudioJustArmed(true);
       setAudioNotice(null);
-      rememberWheelAudioArmed(true);
     }).catch(() => {
       stopWheelAudio(unlockAudio);
       setAudioNotice("AUDIO UNAVAILABLE — SPIN CONTINUES");
       setAudioArmed(false);
-      rememberWheelAudioArmed(false);
     });
   }
 
@@ -425,7 +429,7 @@ function WheelCeremonyOverlay({ scene }: { scene: ResolvedLiveOverlayScene }) {
             const angle = segment.centerAngle;
             const label = candidate.artistName.replace(/\s+/g, " ").trim();
             const labelFit = wheelLabelFit(label, candidateCount, segment.angleSize);
-            const position = wheelLabelPosition(angle, labelFit.radius);
+            const position = wheelLabelPosition(angle, labelFit.radius, visualWheelRotationDeg);
             // Wheel labels are visual only. Winner selection is based on slice geometry and the right-side pointer.
             const labelStyle = {
               "--wheel-label-x": position.x,

--- a/src/lib/live-overlay.ts
+++ b/src/lib/live-overlay.ts
@@ -649,3 +649,38 @@ export async function setLiveOverlayState(payload: LiveOverlayPayload): Promise<
   await writeLiveOverlayState(next);
   return getLiveOverlayAdminSnapshot();
 }
+
+export async function resetWheelCeremonyStateForNewSession(): Promise<void> {
+  const current = await getStoredLiveOverlayState();
+  const now = new Date().toISOString();
+  const next: LiveOverlayState = {
+    ...current,
+    mode: "standby",
+    wheelOverlayActive: false,
+    wheelOverlayLaunchedAt: undefined,
+    wheelOverlayStatus: "ready",
+    wheelCeremonyStatus: "idle",
+    wheelCeremonyStartedAt: undefined,
+    wheelCeremonySpinStartedAt: undefined,
+    wheelCeremonyResultTrackId: undefined,
+    wheelCeremonyChosenTrackId: undefined,
+    wheelCeremonyResultSelectedAt: undefined,
+    wheelCeremonySeed: undefined,
+    wheelCeremonyPreviousSeed: undefined,
+    wheelCeremonyCandidateOrder: undefined,
+    wheelCeremonyPreviousCandidateOrder: undefined,
+    wheelCeremonyReencryptNonce: undefined,
+    wheelCeremonyReencryptCycleId: undefined,
+    wheelCeremonyFinalRotationDeg: undefined,
+    wheelCeremonyLandingAngleDeg: undefined,
+    wheelCeremonyWinningSegmentId: undefined,
+    wheelCeremonyWinningSegmentIndex: undefined,
+    wheelCeremonyJingleKey: "silent",
+    wheelCeremonySpinDurationMs: undefined,
+    wheelCeremonyAudioPath: undefined,
+    artistName: undefined,
+    trackTitle: undefined,
+    updatedAt: now,
+  };
+  await writeLiveOverlayState(next);
+}


### PR DESCRIPTION
### Motivation
- Fix readability and UX polish for the wheel ceremony by keeping selector-zone labels upright, improving audio/spin sync, smoothing audio stop, and preventing stale wheel state across sessions.
- Preserve all winner geometry, stored rotation, grouping, and queue/payment/submission behavior while making only presentation/audio/session-reset changes.

### Description
- Force upright label rendering for labels whose slice center falls in the right-side selector zone by adjusting `wheelLabelPosition` to use an upright rotation when the normalized angle is within the selector range; this is a visual-only change and does not affect winner math. (`src/components/LiveOverlayReceiver.tsx`)
- Add `WHEEL_SPIN_START_DELAY_MS` (850ms) and delay the visible wheel spin via a CSS animation delay using `--wheel-spin-delay`, so audio can start immediately and the visual rotation begins after the short buffer. (`src/components/LiveOverlayReceiver.tsx`, `src/app/overlay/live/overlay-live.css`)
- Add `WHEEL_AUDIO_FADE_OUT_MS` (10000ms) and implement a smooth audio fadeout using `requestAnimationFrame` when the ceremony reaches result/pending states, with cancellation handling to avoid overlapping fades. (`src/components/LiveOverlayReceiver.tsx`)
- Add `resetWheelCeremonyStateForNewSession()` to clear all wheel overlay/ceremony display state (result/chosen ids, candidate order, re-encrypt fields, final rotation/landing/winner segment, audio path, artist/track display, etc.) and call it from the admin `startSession` path so a new session starts with a fresh/idle wheel overlay. (`src/lib/live-overlay.ts`, `src/app/api/admin/queue/route.ts`)
- Files changed: `src/components/LiveOverlayReceiver.tsx`, `src/app/overlay/live/overlay-live.css`, `src/lib/live-overlay.ts`, `src/app/api/admin/queue/route.ts`.

### Testing
- Ran TypeScript check: `npx tsc --noEmit --pretty false` — success.
- Ran targeted lint: `npx eslint src/components/LiveOverlayReceiver.tsx src/lib/live-overlay.ts src/app/api/admin/queue/route.ts` — success after adjustments.
- Ran `git diff --check` to confirm no whitespace or diff issues — success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fc650a148321943026d278555b5b)