### PR TITLE
PR #102: Harden public session identity and submission reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:queue": "node --test tests/queue-playback.test.mjs",
+    "check": "npx tsc --noEmit && npm run lint && npm run test:queue"
   },
   "dependencies": {
     "@upstash/ratelimit": "^2.0.8",

--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -12,6 +12,7 @@ const UPLOAD_FALLBACK_MESSAGE = "Upload could not be completed. Please try again
 const DUPLICATE_TRANSMISSION_MESSAGE = "Duplicate transmission detected. This track is already in the queue for this session.";
 const BLOB_HOST_SUFFIX = ".private.blob.vercel-storage.com";
 const UPLOAD_PREFIX = "/barcode-radio-queue/";
+const SESSION_SYNC_MESSAGE = "This session has changed. Re-enter the current BARCODE Radio queue and submit again.";
 
 function validateUploadedBlobUrl(value: unknown): string {
   if (typeof value !== "string" || !value.trim()) throw new Error("Uploaded audio file is missing.");
@@ -134,7 +135,7 @@ export async function POST(req: Request) {
   }
 }
 
-async function submitTrackFromBody(body: Record<string, unknown>): Promise<NextResponse> {
+export async function submitTrackFromBody(body: Record<string, unknown>): Promise<NextResponse> {
   const artist = cleanBodyText(body.artist);
   const title = cleanBodyText(body.title);
   const mode = cleanBodyText(body.mode);
@@ -147,9 +148,8 @@ async function submitTrackFromBody(body: Record<string, unknown>): Promise<NextR
   const sessionId = cleanBodyText(body.sessionId);
   const active = await getPublicQueueSnapshot();
 
-  if (sessionId && active.session.sessionId !== sessionId) {
-    return NextResponse.json({ error: "This broadcast queue is closed." }, { status: 409 });
-  }
+  if (!sessionId) return NextResponse.json({ error: "Session sync required. Refresh the queue and try again.", code: "session_sync_required" }, { status: 409 });
+  if (active.session.sessionId !== sessionId) return NextResponse.json({ error: SESSION_SYNC_MESSAGE, code: "stale_session" }, { status: 409 });
   if (!active.status.isOpen) {
     return NextResponse.json({ error: "This broadcast queue is closed." }, { status: 409 });
   }

--- a/src/app/api/queue/upload/route.ts
+++ b/src/app/api/queue/upload/route.ts
@@ -8,6 +8,7 @@ export const runtime = "nodejs";
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 const AUDIO_MIME_TYPES = ["audio/mpeg", "audio/mp3", "audio/wav", "audio/wave", "audio/x-wav"];
 const UPLOAD_PREFIX = "barcode-radio-queue/";
+const SESSION_SYNC_MESSAGE = "This session has changed. Re-enter the current BARCODE Radio queue and submit again.";
 
 type ClientPayload = {
   sessionId?: string;
@@ -26,6 +27,11 @@ function parseClientPayload(value: string | null | undefined): ClientPayload {
   }
 }
 
+export function assertCurrentUploadSession(payloadSessionId: string | undefined, activeSessionId: string): void {
+  if (!payloadSessionId?.trim()) throw new Error(SESSION_SYNC_MESSAGE);
+  if (payloadSessionId !== activeSessionId) throw new Error(SESSION_SYNC_MESSAGE);
+}
+
 export async function POST(request: Request): Promise<NextResponse> {
   const body = (await request.json()) as HandleUploadBody;
 
@@ -37,7 +43,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         const payload = parseClientPayload(clientPayload);
         const snapshot = await getPublicQueueSnapshot();
 
-        if (payload.sessionId && payload.sessionId !== snapshot.session.sessionId) throw new Error("This broadcast queue is closed.");
+        assertCurrentUploadSession(payload.sessionId, snapshot.session.sessionId);
         if (!snapshot.status.isOpen) throw new Error("This broadcast queue is closed.");
         if (snapshot.status.isFull || snapshot.status.activeCount >= snapshot.status.capacity) throw new Error("This broadcast queue is full for new transmissions.");
         if (!pathname.startsWith(UPLOAD_PREFIX)) throw new Error("Invalid upload path.");

--- a/src/app/api/queue/upload/route.ts
+++ b/src/app/api/queue/upload/route.ts
@@ -32,6 +32,11 @@ export function assertCurrentUploadSession(payloadSessionId: string | undefined,
   if (payloadSessionId !== activeSessionId) throw new Error(SESSION_SYNC_MESSAGE);
 }
 
+export function assertUploadSessionOpen(isOpen: boolean, isFull: boolean | undefined, activeCount: number, capacity: number): void {
+  if (!isOpen) throw new Error("This broadcast queue is closed.");
+  if (isFull || activeCount >= capacity) throw new Error("This broadcast queue is full for new transmissions.");
+}
+
 export async function POST(request: Request): Promise<NextResponse> {
   const body = (await request.json()) as HandleUploadBody;
 
@@ -44,8 +49,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         const snapshot = await getPublicQueueSnapshot();
 
         assertCurrentUploadSession(payload.sessionId, snapshot.session.sessionId);
-        if (!snapshot.status.isOpen) throw new Error("This broadcast queue is closed.");
-        if (snapshot.status.isFull || snapshot.status.activeCount >= snapshot.status.capacity) throw new Error("This broadcast queue is full for new transmissions.");
+        assertUploadSessionOpen(snapshot.status.isOpen, snapshot.status.isFull, snapshot.status.activeCount, snapshot.status.capacity);
         if (!pathname.startsWith(UPLOAD_PREFIX)) throw new Error("Invalid upload path.");
         if (!payload.uploadOriginalName?.trim()) throw new Error("Uploaded audio file name is missing.");
         if (!payload.mimeType || !AUDIO_MIME_TYPES.includes(payload.mimeType)) throw new Error("Only MP3 and WAV uploads are accepted.");

--- a/src/app/queue/[sessionId]/page.tsx
+++ b/src/app/queue/[sessionId]/page.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable react/jsx-no-comment-textnodes */
+import Link from "next/link";
+import { redirect } from "next/navigation";
 import { PublicQueueSession } from "@/components/PublicQueueSession";
+import { getPublicQueueSnapshot } from "@/lib/queue";
 
 export const metadata = {
   title: "BARCODE Radio Broadcast Queue | BARCODE Network",
@@ -7,6 +10,27 @@ export const metadata = {
 
 export default async function QueueSessionPage({ params }: { params: Promise<{ sessionId: string }> }) {
   const { sessionId } = await params;
+  const snapshot = await getPublicQueueSnapshot();
+  const activeSessionId = snapshot.session.sessionId;
+  if (!snapshot.status.isOpen) {
+    return (
+      <main className="pt-14 min-h-screen">
+        <section className="border-b border-border noise-bg">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
+            <p className="text-xs uppercase tracking-[0.5em] text-muted mb-4">// BARCODE RADIO</p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground"><span className="text-accent text-glow">Broadcast</span> Queue</h1>
+          </div>
+        </section>
+        <section className="mx-auto max-w-4xl px-4 sm:px-6 py-12">
+          <div className="border border-border bg-surface p-6 text-center">
+            <p className="text-sm text-muted">No active public session is accepting submissions right now.</p>
+            <Link href="/queue" className="mt-4 inline-block border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Back to Queue</Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+  if (sessionId !== activeSessionId) redirect(`/queue/${activeSessionId}`);
   return (
     <main className="pt-14 min-h-screen">
       <section className="border-b border-border noise-bg">

--- a/src/app/queue/[sessionId]/page.tsx
+++ b/src/app/queue/[sessionId]/page.tsx
@@ -12,7 +12,8 @@ export default async function QueueSessionPage({ params }: { params: Promise<{ s
   const { sessionId } = await params;
   const snapshot = await getPublicQueueSnapshot();
   const activeSessionId = snapshot.session.sessionId;
-  if (!snapshot.status.isOpen) {
+  const hasCurrentActiveSession = snapshot.session.status !== "archived" && snapshot.session.broadcastPhase !== "ended";
+  if (!hasCurrentActiveSession) {
     return (
       <main className="pt-14 min-h-screen">
         <section className="border-b border-border noise-bg">

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -19,6 +19,8 @@ const UPLOAD_FALLBACK_MESSAGE = "Upload could not be completed. Please try again
 const PRIORITY_SIGNAL_LABEL = "Priority Signal";
 const PRIORITY_CHECKOUT_UNAVAILABLE_MESSAGE = "Priority checkout could not be started. Your song stays in the free queue if still active.";
 const PRIORITY_DEPTH_UNAVAILABLE_MESSAGE = "Priority Signal opens when there are enough songs waiting.";
+const SESSION_SYNC_REQUIRED_MESSAGE = "Session sync required. Refresh the queue and try again.";
+const SESSION_CHANGED_MESSAGE = "This session has changed. Re-enter the current BARCODE Radio queue and submit again.";
 const MIN_PRIORITY_ACTIVE_DEPTH = 2;
 function formatPrice(cents: number, currency = "usd"): string { return `${new Intl.NumberFormat("en-US", { style: "currency", currency: currency.toUpperCase() }).format(Math.max(0, cents) / 100)} ${currency.toUpperCase()}`; }
 
@@ -134,6 +136,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
   const [transmissionState, setTransmissionState] = useState<TransmissionState>("idle");
   const [warpData, setWarpData] = useState<WarpData | null>(null);
   const [cooldownRemaining, setCooldownRemaining] = useState(0);
+  const [acceptedReceipt, setAcceptedReceipt] = useState<{ artist: string; title: string; sessionTitle: string; sessionDate: string; trackCode: string } | null>(null);
 
   async function loadStatus() {
     const params = new URLSearchParams();
@@ -349,8 +352,14 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
     }
     finalSubmitIntent.current = false;
     setError(null);
+    setAcceptedReceipt(null);
     setSubmitting(true);
     try {
+      const refreshedBeforeSubmit = await loadStatus();
+      const latestSessionId = refreshedBeforeSubmit?.session?.sessionId ?? session?.sessionId ?? sessionId;
+      if (!latestSessionId) throw new Error(SESSION_SYNC_REQUIRED_MESSAGE);
+      const visibleSessionId = session?.sessionId ?? sessionId;
+      if (visibleSessionId && latestSessionId !== visibleSessionId) throw new Error(SESSION_CHANGED_MESSAGE);
       const body: Record<string, string | number> = {
         mode,
         artist: artist.trim(),
@@ -360,7 +369,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
         contactEmail: contactEmail.trim(),
         submitterToken,
       };
-      if (sessionId) body.sessionId = sessionId;
+      body.sessionId = latestSessionId;
       if (note.trim()) body.note = note.trim();
       if (detectedDuration) body.detectedDurationSeconds = detectedDuration;
       if (mode === "upload") {
@@ -387,6 +396,13 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
       }
       if (payload.track?.id) {
         const submitted = publicTrackFromApi(payload.track);
+        setAcceptedReceipt({
+          artist: artist.trim(),
+          title: title.trim(),
+          sessionTitle: refreshedBeforeSubmit?.session?.title ?? session?.title ?? "BARCODE Radio",
+          sessionDate: refreshedBeforeSubmit?.session?.showDate ?? session?.showDate ?? "ACTIVE SESSION",
+          trackCode: submitted.id.slice(0, 8).toUpperCase(),
+        });
         window.localStorage.setItem("barcode-radio-submit-artist", artist.trim());
         window.localStorage.setItem("barcode-radio-submit-tiktok", tiktokHandle.trim());
         window.localStorage.setItem("barcode-radio-submit-email", contactEmail.trim());
@@ -478,7 +494,6 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
       setStep("track");
     } catch (err) {
       setTransmissionState("idle");
-      clearTrackDraftFields();
       setStep("track");
       setError(err instanceof Error ? err.message : "Submission failed");
     } finally {
@@ -512,6 +527,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel }: { sessionId
 
   return (
     <form onSubmit={submit} className="space-y-3">
+      {acceptedReceipt && <div className="border border-accent bg-accent/10 p-3 text-xs text-foreground"><p className="font-bold text-accent">Submission accepted</p><p>{acceptedReceipt.artist} — {acceptedReceipt.title}</p><p>{acceptedReceipt.sessionTitle} · {acceptedReceipt.sessionDate}</p><p>Confirmation: {acceptedReceipt.trackCode}</p></div>}
       <div className="grid gap-2 border border-border bg-surface p-3 text-xs sm:grid-cols-4">
         <div><p className="text-[10px] uppercase tracking-widest text-muted">Session</p><p className="truncate text-foreground">{session?.title ?? "BARCODE Radio"}</p></div>
         <div><p className="text-[10px] uppercase tracking-widest text-muted">Queue</p><p className={status?.isOpen ? "text-accent" : "text-danger"}>{status?.isOpen ? "Open" : "Closed"}</p></div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,7 +11,9 @@ const TOKEN_TTL = 60 * 60 * 24; // 24 hours in seconds
 // --------------- HMAC helpers (Web Crypto) ---------------
 
 async function getKey(): Promise<CryptoKey> {
-  const secret = process.env.JWT_SECRET || process.env.QUEUE_API_KEY || "dev-fallback-secret";
+  const isProduction = process.env.NODE_ENV === "production";
+  const secret = process.env.JWT_SECRET || process.env.QUEUE_API_KEY || (!isProduction ? "dev-fallback-secret" : "");
+  if (!secret) throw new Error("Admin auth is not configured.");
   const enc = new TextEncoder();
   return crypto.subtle.importKey(
     "raw",
@@ -79,6 +81,10 @@ export async function verifyAdminToken(token: string): Promise<boolean> {
 }
 
 export function getAdminPassword(): string {
+  if (process.env.NODE_ENV === "production") {
+    if (!process.env.ADMIN_PASSWORD) throw new Error("Admin auth is not configured.");
+    return process.env.ADMIN_PASSWORD;
+  }
   return process.env.ADMIN_PASSWORD || "barcode2026";
 }
 

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1336,10 +1336,30 @@ test("public POST accepts current active sessionId", async () => {
   assert.ok(payload.track?.id);
 });
 
+test("public POST remains rejected while submissions are closed", async () => {
+  const sessionId = await freshOpenSession("closed submit");
+  await queue.setQueueOpen(false);
+  const response = await queueApi.submitTrackFromBody({
+    sessionId,
+    mode: "link",
+    artist: "Closed Artist",
+    title: "Closed Track",
+    tiktokHandle: "@closedartist",
+    link: "https://example.com/closed-track",
+  });
+  const payload = await jsonOf(response);
+  assert.equal(response.status, 409);
+  assert.equal(payload.error, "This broadcast queue is closed.");
+});
+
 test("upload session guard rejects missing sessionId", async () => {
   assert.throws(() => uploadApi.assertCurrentUploadSession(undefined, "active_session"), /This session has changed/);
 });
 
 test("upload session guard rejects stale sessionId", async () => {
   assert.throws(() => uploadApi.assertCurrentUploadSession("old_session", "active_session"), /This session has changed/);
+});
+
+test("upload token guard remains rejected while submissions are closed", async () => {
+  assert.throws(() => uploadApi.assertUploadSessionOpen(false, false, 0, 50), /This broadcast queue is closed/);
 });

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -13,7 +13,13 @@ const projectRoot = path.resolve(import.meta.dirname, "..");
 const originalResolveFilename = Module._resolveFilename;
 
 Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
-  if (request.startsWith("@/")) return path.join(projectRoot, "src", request.slice(2));
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, "src", request.slice(2));
+    if (fs.existsSync(resolved)) return resolved;
+    if (fs.existsSync(`${resolved}.ts`)) return `${resolved}.ts`;
+    if (fs.existsSync(`${resolved}.tsx`)) return `${resolved}.tsx`;
+    return resolved;
+  }
   return originalResolveFilename.call(this, request, parent, isMain, options);
 };
 
@@ -1274,4 +1280,66 @@ test("wheel ceremony spin and stale confirm errors do not mutate queue", async (
   state = await queue.getRadioQueueState();
   assert.equal(state.session.wheelSpinsOwed, 1, "stale confirm keeps owed wheel");
   assert.equal(state.queue.some((entry) => entry.lane === "wheel"), false, "stale confirm does not mark Wheel Chosen");
+});
+
+const queueApi = require("../src/app/api/queue/route.ts");
+const uploadApi = require("../src/app/api/queue/upload/route.ts");
+
+function jsonOf(response) {
+  return response.json();
+}
+
+test("public POST rejects missing sessionId", async () => {
+  const sessionId = await freshOpenSession("session required");
+  const response = await queueApi.submitTrackFromBody({
+    mode: "link",
+    artist: "Session Artist",
+    title: "Session Track",
+    tiktokHandle: "@sessionartist",
+    link: "https://example.com/session-required",
+  });
+  const payload = await jsonOf(response);
+  assert.equal(response.status, 409);
+  assert.equal(payload.code, "session_sync_required");
+  assert.equal(payload.error, "Session sync required. Refresh the queue and try again.");
+  assert.ok(sessionId);
+});
+
+test("public POST rejects stale sessionId", async () => {
+  const sessionId = await freshOpenSession("stale session");
+  await freshOpenSession("new active session");
+  const response = await queueApi.submitTrackFromBody({
+    sessionId,
+    mode: "link",
+    artist: "Stale Artist",
+    title: "Stale Track",
+    tiktokHandle: "@staleartist",
+    link: "https://example.com/stale-track",
+  });
+  const payload = await jsonOf(response);
+  assert.equal(response.status, 409);
+  assert.equal(payload.code, "stale_session");
+});
+
+test("public POST accepts current active sessionId", async () => {
+  const sessionId = await freshOpenSession("current session");
+  const response = await queueApi.submitTrackFromBody({
+    sessionId,
+    mode: "link",
+    artist: "Current Artist",
+    title: "Current Track",
+    tiktokHandle: "@currentartist",
+    link: "https://example.com/current-track",
+  });
+  const payload = await jsonOf(response);
+  assert.equal(response.status, 201);
+  assert.ok(payload.track?.id);
+});
+
+test("upload session guard rejects missing sessionId", async () => {
+  assert.throws(() => uploadApi.assertCurrentUploadSession(undefined, "active_session"), /This session has changed/);
+});
+
+test("upload session guard rejects stale sessionId", async () => {
+  assert.throws(() => uploadApi.assertCurrentUploadSession("old_session", "active_session"), /This session has changed/);
 });


### PR DESCRIPTION
### Motivation
- Prevent users from submitting to stale or non-active public queue sessions and avoid losing draft data on submission errors by enforcing explicit session sync and improving receipts.
- Close production admin auth fallback to avoid unsafe default secrets in live environments.

### Description
- Enforced stale-session protection on the public session route by fetching the active snapshot and redirecting stale `/queue/[sessionId]` URLs to the current active session or rendering a clear no-active-session state when submissions are closed (`src/app/queue/[sessionId]/page.tsx`).
- Require explicit `sessionId` on public submissions and return clear 409 responses for missing (`code: session_sync_required`) or stale (`code: stale_session`) session IDs while preserving existing duplicate/cooldown/full/priority behaviors (`src/app/api/queue/route.ts`).
- Harden upload token generation to require and validate `clientPayload.sessionId` against the active session and reject missing/stale session payloads (`src/app/api/queue/upload/route.ts`).
- Update the public submission form to always include an explicit current session ID, refresh `/api/queue` before final submit and block if the session changed, preserve draft fields on failed submit (no longer clearing them on error), and display a clear accepted receipt with artist/title/session/date/short confirmation code on success (`src/components/RadioQueueForm.tsx`).
- Fail-closed admin auth in production by removing dev fallback secrets when `NODE_ENV === "production"` and requiring `ADMIN_PASSWORD`/JWT secret presence (`src/lib/auth.ts`).
- Add focused test and check scripts: `test:queue` and `check` in `package.json` (check runs `tsc --noEmit && lint && test:queue`) (`package.json`).
- Add focused tests to validate session guards for public POST and upload token generation and adjusted test harness resolution for `@/` imports (`tests/queue-playback.test.mjs`).
- Small refactors and helper extraction to support the above (see modified files list below). No queue resolver logic, admin dashboard design, Priority/payment/Stripe behavior (aside from session validation), or BNL bot files were changed.

Files modified:
- `src/app/queue/[sessionId]/page.tsx` — stale-session redirect and no-active-session UI.
- `src/app/api/queue/route.ts` — require `body.sessionId` and explicit stale/session-sync error codes.
- `src/app/api/queue/upload/route.ts` — require `clientPayload.sessionId` and helper guard function.
- `src/components/RadioQueueForm.tsx` — pre-submit session refresh, explicit sessionId in POST, preserve drafts on failure, accepted receipt UI.
- `src/lib/auth.ts` — production fail-closed behavior for admin secrets.
- `package.json` — `test:queue` and `check` scripts.
- `tests/queue-playback.test.mjs` — added session-guard tests and small loader resolution fix.

### Testing
- Ran targeted ESLint on the modified files (`npx eslint src/app/api/queue/route.ts src/app/api/queue/upload/route.ts src/components/RadioQueueForm.tsx src/components/PublicQueueSession.tsx src/lib/auth.ts`) which completed for the scoped files listed (no new lint issues introduced there).
- Ran `npm run check` which executes `tsc --noEmit && npm run lint && npm run test:queue`; this surfaced pre-existing repo-wide lint errors unrelated to these changes and therefore the full `check` run did not pass end-to-end (failures are outside the scope of this PR).
- Ran `npm run test:queue` which executes the in-repo node test harness; the two existing unrelated wheel-ceremony tests failed but the newly added session-hardening tests (missing/stale/current public POST and upload session guard tests) passed.
- Summary: session guard behavior and upload token guards validated by unit tests; form behavior and receipt UI updated locally; `check` flagged unrelated lint/test issues elsewhere in the repo but did not indicate regressions in the modified queue/session paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d39cfe788321b23ba1ccb94b4da3)