### PR TITLE
PR #110: Public submission confirmation hardening

### DIFF
--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { detectQueueSourceType } from "@/lib/queue-types";
-import { getPublicQueueSnapshot, getRadioQueueState, normalizeQueueSourceKey, requestPriorityUpgradePlaceholder, submitRadioTrack, toPublicQueueTrack } from "@/lib/queue";
+import { getPublicQueueSnapshot, getRadioQueueState, isTrackPersistedInSessionQueue, normalizeQueueSourceKey, requestPriorityUpgradePlaceholder, submitRadioTrack, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry } from "@/lib/queue-types";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +13,7 @@ const DUPLICATE_TRANSMISSION_MESSAGE = "Duplicate transmission detected. This tr
 const BLOB_HOST_SUFFIX = ".private.blob.vercel-storage.com";
 const UPLOAD_PREFIX = "/barcode-radio-queue/";
 const SESSION_SYNC_MESSAGE = "This session has changed. Re-enter the current BARCODE Radio queue and submit again.";
+const QUEUE_ACCEPTANCE_UNCONFIRMED_MESSAGE = "Submission could not be confirmed in the queue. Please try again.";
 
 function validateUploadedBlobUrl(value: unknown): string {
   if (typeof value !== "string" || !value.trim()) throw new Error("Uploaded audio file is missing.");
@@ -186,6 +187,9 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
       contactEmail,
       submitterToken,
     });
+    if (!(await isTrackPersistedInSessionQueue(track.id, active.session.sessionId))) {
+      return NextResponse.json({ error: QUEUE_ACCEPTANCE_UNCONFIRMED_MESSAGE, code: "queue_acceptance_unconfirmed" }, { status: 500 });
+    }
     return acceptedResponse(toPublicQueueTrack(track), active.session.submissionCooldownSeconds);
   }
 
@@ -196,5 +200,8 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
 
   const sourceType = detectQueueSourceType(link);
   const track = await submitRadioTrack({ artist, title, link, sourceType, note, submitterArtistName: artist, tiktokHandle, collaboratorNames, contactEmail, submitterToken });
+  if (!(await isTrackPersistedInSessionQueue(track.id, active.session.sessionId))) {
+    return NextResponse.json({ error: QUEUE_ACCEPTANCE_UNCONFIRMED_MESSAGE, code: "queue_acceptance_unconfirmed" }, { status: 500 });
+  }
   return acceptedResponse(toPublicQueueTrack(track), active.session.submissionCooldownSeconds);
 }

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -22,6 +22,7 @@ const PRIORITY_CHECKOUT_UNAVAILABLE_MESSAGE = "Priority checkout could not be st
 const PRIORITY_DEPTH_UNAVAILABLE_MESSAGE = "Priority Signal opens when there are enough songs waiting.";
 const SESSION_SYNC_REQUIRED_MESSAGE = "Session sync required. Refresh the queue and try again.";
 const SESSION_CHANGED_MESSAGE = "This session has changed. Re-enter the current BARCODE Radio queue and submit again.";
+const QUEUE_CONFIRMATION_FAILED_MESSAGE = "Submission could not be confirmed in the queue. Your info was kept. Please try again or contact the host.";
 const MIN_PRIORITY_ACTIVE_DEPTH = 2;
 function formatPrice(cents: number, currency = "usd"): string { return `${new Intl.NumberFormat("en-US", { style: "currency", currency: currency.toUpperCase() }).format(Math.max(0, cents) / 100)} ${currency.toUpperCase()}`; }
 
@@ -325,6 +326,19 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
     setRouteChoice("free");
   }
 
+  async function waitForTrackConfirmation(trackId: string): Promise<QueuePublicSnapshot | null> {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const snapshot = await loadStatus();
+      const foundInQueue = snapshot?.queue.some((entry) => entry.id === trackId);
+      const foundInNowPlaying = snapshot?.nowPlaying?.id === trackId;
+      const foundInUpNext = snapshot?.upNext?.id === trackId;
+      const foundInCompleted = snapshot?.completed.some((entry) => entry.id === trackId);
+      if (foundInQueue || foundInNowPlaying || foundInUpNext || foundInCompleted) return snapshot;
+      if (attempt < 4) await wait(500);
+    }
+    return null;
+  }
+
   async function startPriorityCheckout(trackId: string): Promise<boolean> {
     const checkoutSessionId = sessionId ?? session?.sessionId;
     if (!checkoutSessionId) return false;
@@ -395,6 +409,11 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
       }
       if (payload.track?.id) {
         const submitted = publicTrackFromApi(payload.track);
+        const confirmedSnapshot = await waitForTrackConfirmation(submitted.id);
+        if (!confirmedSnapshot) {
+          await loadStatus();
+          throw new Error(`${QUEUE_CONFIRMATION_FAILED_MESSAGE} Reference: ${submitted.id.slice(0, 8).toUpperCase()}`);
+        }
         const receipt = {
           artist: artist.trim(),
           title: title.trim(),
@@ -458,8 +477,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
         setTransmissionState("signal");
         setPublicQueue((current) => [submitted, ...current.filter((entry) => entry.id !== submitted.id)]);
         await wait(1000);
-        const refreshed = await loadStatus();
-        let resolved = findSubmittedTrack(refreshed, submitted.id);
+        let resolved = findSubmittedTrack(confirmedSnapshot, submitted.id);
         if (resolved.targetId === "up-next-slot" && preSubmit.upNextWasEmpty) {
           resolved = { ...resolved, targetId: preSubmit.nowPlayingWasEmpty && preSubmit.activeCount === 0 ? "broadcast-queue-top" : "up-next-slot", laneLabel: "UP_NEXT" };
         }
@@ -469,8 +487,8 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
           durationLabel: resolvedTrack.durationLabel,
           lane: resolved.laneLabel,
           artworkUrl: resolvedTrack.sourceArtworkUrl ?? baseWarpData.artworkUrl,
-          queueStatus: refreshed ? `${refreshed.status.activeCount}/${refreshed.status.capacity}` : baseWarpData.queueStatus,
-          submissionSlot: resolvedTrack.id === refreshed?.upNext?.id ? "UP_NEXT" : baseWarpData.submissionSlot,
+          queueStatus: confirmedSnapshot ? `${confirmedSnapshot.status.activeCount}/${confirmedSnapshot.status.capacity}` : baseWarpData.queueStatus,
+          submissionSlot: resolvedTrack.id === confirmedSnapshot?.upNext?.id ? "UP_NEXT" : baseWarpData.submissionSlot,
         });
         onSubmitted?.(submitted.id, "resolved", resolved.targetId);
         setTransmissionState("received");
@@ -560,7 +578,10 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
             {mode === "link" ? (
               <label className="space-y-1 block"><span className="text-xs uppercase tracking-widest text-muted">Track link / upload</span><span className="block text-[11px] text-muted">Paste a link or upload your file.</span><input type="url" value={link} onChange={(e) => setLink(e.target.value)} placeholder="https://soundcloud.com/..." className="w-full bg-background border border-border px-3 py-2 text-sm" required /></label>
             ) : (
-              <label className="space-y-1 block"><span className="text-xs uppercase tracking-widest text-muted">Track link / upload</span><span className="block text-[11px] text-muted">Paste a link or upload your file.</span><input key={fileInputKey} type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/wave,.mp3,.wav" onChange={(e) => onFileSelected(e.target.files?.[0] ?? null)} className="w-full bg-background border border-border px-3 py-2 text-sm" required /></label>
+              <>
+                <label className="space-y-1 block"><span className="text-xs uppercase tracking-widest text-muted">Track link / upload</span><span className="block text-[11px] text-muted">Paste a link or upload your file.</span><input key={fileInputKey} type="file" accept="audio/mpeg,audio/mp3,audio/wav,audio/wave,.mp3,.wav" onChange={(e) => onFileSelected(e.target.files?.[0] ?? null)} className="w-full bg-background border border-border px-3 py-2 text-sm" required={!file} /></label>
+                {file && <div className="border border-border bg-background/40 p-2 text-xs text-muted"><p>Selected file: {file.name}</p><p>Size: {(file.size / (1024 * 1024)).toFixed(2)} MB</p><p>Duration: {detectedDuration ? formatRuntime(detectedDuration) : "pending"}</p><button type="button" onClick={() => { setFile(null); setDetectedDuration(null); setUploadProgress(null); setReadState("idle"); setFileInputKey((value) => value + 1); }} className="mt-2 border border-border px-2 py-1 text-[11px] uppercase tracking-widest hover:border-accent hover:text-accent">Remove file</button></div>}
+              </>
             )}
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
               <button type="button" onClick={onCancel} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted">Collapse Intake</button>

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1165,6 +1165,15 @@ export async function submitRadioTrack(input: Parameters<typeof createQueueTrack
   return track;
 }
 
+export async function isTrackPersistedInSessionQueue(trackId: string, sessionId?: string): Promise<boolean> {
+  const state = await getRadioQueueState(sessionId);
+  if (state.queue.some((entry) => entry.id === trackId)) return true;
+  if (state.nextInLine?.id === trackId) return true;
+  if (state.loadedTrack?.id === trackId) return true;
+  if (state.nowPlaying?.id === trackId) return true;
+  return false;
+}
+
 
 function wheelEligibleArtistsForSession(session: QueueSession): QueueWheelArtistOption[] {
   const byArtist = new Map<string, QueueWheelArtistOption>();


### PR DESCRIPTION
### Motivation
- Preserve a user-selected upload file when toggling between Upload MP3/WAV and Track Link so uploads are not accidentally lost during mode switches.
- Prevent the client from treating the success animation/receipt as proof of persistence by requiring durable confirmation that the submitted track exists in the persisted queue state before showing final accepted UX.
- Prevent Priority checkout or clearing draft data unless the queue actually confirms the newly-submitted track is present, so users never pay or lose their submission when writes did not persist.

### Description
- Retain upload selection and show a retained-file summary in the UI by keeping `file` state, making the native file input `required` only when there is no retained file, and adding an explicit Remove action (`src/components/RadioQueueForm.tsx`).
- Gate the final accepted/receipt flow on a queue-state confirmation by adding `waitForTrackConfirmation` with retries on the client and only proceeding with `onAcceptedReceipt`, animations, `onSubmitted`, draft clearing, and Priority checkout after the track is observed in a refreshed snapshot (`src/components/RadioQueueForm.tsx`).
- Harden the public queue API to verify persistence before returning 201 by introducing a post-write check that re-reads persisted session state and returns `500` with `code: queue_acceptance_unconfirmed` if the track cannot be found (`src/app/api/queue/route.ts`).
- Centralized the persistence check in a new helper `isTrackPersistedInSessionQueue` exposed from `src/lib/queue.ts` that inspects `queue`, `nextInLine`, `loadedTrack`, and `nowPlaying`.
- Preserve all draft fields and the selected file on any confirmation failure and do not start Priority checkout unless confirmation succeeds, and surface a clear error including a short reference code for support in that case (`RadioQueueForm` behavior).

### Testing
- Ran `npx tsc --noEmit`, which completed successfully.
- Ran `npx eslint src/components/RadioQueueForm.tsx src/app/api/queue/route.ts src/app/api/queue/upload/route.ts src/lib/queue.ts`, which completed successfully.
- Ran `npm run test:queue`, which executed the queue suite and returned two failing tests that are pre-existing wheel-ceremony failures unrelated to the changed files (70 passing, 2 failing); the failures did not originate from the submission confirmation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1514e4385c83219402572571f02a95)