### PR TITLE
PR #111: Queue test suite health — wheel ceremony test fixes

### DIFF
--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1240,28 +1240,40 @@ test("wheel ceremony eligibility helper excludes unsafe queue states", () => {
 
 test("wheel re-encrypt rerolls visually without consuming owed spin or marking Wheel Chosen", async () => {
   await freshOpenSession("wheel reencrypt", { showStarted: true });
-  const first = await addTrack("Reencrypt One");
-  const second = await addTrack("Reencrypt Two");
+  await addTrack("Reencrypt One");
+  await addTrack("Reencrypt Two");
   await queue.updateRadioTrack("", "addWheelSpinOwed");
 
   await overlay.setLiveOverlayState({ action: "launchWheel" });
-  await overlay.setLiveOverlayState({ action: "spinWheel" });
-  const pending = await overlay.getLiveOverlayAdminSnapshot();
-  const firstResult = pending.overlayState.wheelCeremonyResultTrackId;
-  assert.ok(firstResult === first.id || firstResult === second.id, "spin stores a pending eligible result");
-
-  const afterSpin = await queue.getRadioQueueState();
-  assert.equal(afterSpin.session.wheelSpinsOwed, 1, "visual spin does not consume the owed wheel");
-  assert.equal(afterSpin.queue.some((entry) => entry.lane === "wheel"), false, "visual spin does not mark Wheel Chosen");
+  const launched = await overlay.getLiveOverlayAdminSnapshot();
+  const launchOrder = launched.overlayState.wheelCeremonyCandidateOrder ?? [];
+  assert.ok(launchOrder.length > 0, "launch stores a candidate order before spin");
 
   await overlay.setLiveOverlayState({ action: "reencryptWheel" });
   const reencrypted = await overlay.getLiveOverlayAdminSnapshot();
   assert.equal(reencrypted.overlayState.wheelCeremonyStatus, "reencrypting", "re-encrypt enters ceremony effect state");
-  assert.ok(reencrypted.overlayState.wheelCeremonyResultTrackId === first.id || reencrypted.overlayState.wheelCeremonyResultTrackId === second.id, "re-encrypt stores a pending eligible result");
+  assert.equal(reencrypted.overlayState.wheelCeremonyResultTrackId, undefined, "re-encrypt remains visual-only and does not preselect a result");
+  const candidateOrder = reencrypted.overlayState.wheelCeremonyCandidateOrder ?? [];
+  assert.equal(candidateOrder.length, (reencrypted.wheelCandidates ?? []).length, "re-encrypt keeps candidate ordering aligned with active candidates");
+  assert.equal(new Set(candidateOrder).size, candidateOrder.length, "re-encrypt candidate order contains unique candidate ids");
+  assert.ok(candidateOrder.every((candidateId) => (reencrypted.wheelCandidates ?? []).some((candidate) => candidate.id === candidateId)), "re-encrypt order only references eligible wheel candidates");
+  assert.notDeepEqual(candidateOrder, launchOrder, "re-encrypt rerolls candidate order while keeping eligible candidates");
 
   const afterReencrypt = await queue.getRadioQueueState();
   assert.equal(afterReencrypt.session.wheelSpinsOwed, 1, "re-encrypt does not consume the owed wheel");
   assert.equal(afterReencrypt.queue.some((entry) => entry.lane === "wheel"), false, "re-encrypt does not mark Wheel Chosen");
+
+  const reencryptReadyAt = new Date(new Date(reencrypted.overlayState.wheelCeremonySpinStartedAt).getTime() + 2300);
+  await withFakeNow(reencryptReadyAt, async () => {
+    await overlay.setLiveOverlayState({ action: "spinWheel" });
+  });
+  const pending = await overlay.getLiveOverlayAdminSnapshot();
+  const pendingCandidateIds = (pending.wheelCandidates ?? []).map((candidate) => candidate.id);
+  assert.ok(pendingCandidateIds.includes(pending.overlayState.wheelCeremonyResultTrackId), "spin after re-encrypt stores a pending eligible wheel candidate result");
+
+  const afterSpin = await queue.getRadioQueueState();
+  assert.equal(afterSpin.session.wheelSpinsOwed, 1, "visual spin does not consume the owed wheel");
+  assert.equal(afterSpin.queue.some((entry) => entry.lane === "wheel"), false, "visual spin does not mark Wheel Chosen");
 });
 
 test("wheel ceremony spin and stale confirm errors do not mutate queue", async () => {
@@ -1273,10 +1285,21 @@ test("wheel ceremony spin and stale confirm errors do not mutate queue", async (
   assert.equal(state.session.wheelSpinsOwed, 1, "failed spin keeps owed wheel");
   assert.equal(state.queue.some((entry) => entry.lane === "wheel"), false, "failed spin does not mark Wheel Chosen");
 
-  const stale = await addTrack("Stale Ceremony Result");
+  await addTrack("Stale Ceremony Result A", { artist: "Stale Artist" });
+  await addTrack("Stale Ceremony Result B", { artist: "Stale Artist" });
   await overlay.setLiveOverlayState({ action: "spinWheel" });
-  await queue.updateRadioTrack(stale.id, "remove");
-  await assert.rejects(() => overlay.setLiveOverlayState({ action: "confirmWheel" }), /no longer eligible/);
+  const pendingSnapshot = await overlay.getLiveOverlayAdminSnapshot();
+  const winnerCandidate = (pendingSnapshot.wheelCandidates ?? []).find((candidate) => candidate.id === pendingSnapshot.overlayState.wheelCeremonyResultTrackId);
+  assert.ok(winnerCandidate, "spin stores a result candidate that exists in active wheel candidates");
+  const winnerTrackIds = winnerCandidate?.trackIds?.length ? winnerCandidate.trackIds : (winnerCandidate?.tracks ?? []).map((track) => track.id);
+  assert.ok(winnerTrackIds?.length, "winning candidate exposes at least one represented queued track");
+  for (const trackId of winnerTrackIds) await queue.updateRadioTrack(trackId, "remove");
+  const spinStartedAt = pendingSnapshot.overlayState.wheelCeremonySpinStartedAt;
+  const spinDurationMs = pendingSnapshot.overlayState.wheelCeremonySpinDurationMs ?? 24_000;
+  const confirmNow = new Date(new Date(spinStartedAt).getTime() + spinDurationMs + 50);
+  await withFakeNow(confirmNow, async () => {
+    await assert.rejects(() => overlay.setLiveOverlayState({ action: "confirmWheel", selectedTrackId: winnerTrackIds[0] }), /no longer eligible/);
+  });
   state = await queue.getRadioQueueState();
   assert.equal(state.session.wheelSpinsOwed, 1, "stale confirm keeps owed wheel");
   assert.equal(state.queue.some((entry) => entry.lane === "wheel"), false, "stale confirm does not mark Wheel Chosen");


### PR DESCRIPTION
### Motivation
- Reproduce and resolve two recurring failing wheel ceremony tests in `tests/queue-playback.test.mjs` without changing production queue/live-overlay behavior. 
- Classification of original failures: **mixed** (stale test expectation about result IDs + timing/nondeterministic confirm setup). 
- The live-overlay now uses grouped wheel candidate IDs from `getWheelCandidatesFromQueue()` so tests must assert candidate semantics rather than raw track IDs. 

### Description
- Updated `tests/queue-playback.test.mjs` to assert that `wheelCeremonyResultTrackId` references an active wheel candidate ID and not assume a raw queued track id. 
- Made the re-encrypt test confirm that `reencryptWheel` is visual-only, does not preselect a result, rerolls candidate order, and does not consume owed spins or mark any queue entry as `lane === "wheel"`. 
- Made the stale-confirm test deterministic by deriving the actual winner candidate from the admin snapshot, resolving represented `trackIds` (or `tracks`), removing those tracks, advancing fake time into `result_pending`, and asserting `confirmWheel` rejects with `no longer eligible` while the queue remains unchanged. 
- Scope: single test-only change in `tests/queue-playback.test.mjs`; no production code modified and no changes to public submission, layout, Stripe/payment, admin layout, BNL bot files, or queue resolver behavior. 

### Testing
- Reproduced failures by running `npm run test:queue` and confirmed the two failing tests before changes. 
- Performed static checks with `npx tsc --noEmit` and linting via `npx eslint tests/queue-playback.test.mjs src/lib/live-overlay.ts src/lib/live-overlay-resolver.ts src/lib/queue.ts`, both passing. 
- Ran `npm run test:queue` after the test update and observed a full success (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152423a14483218b70f1945e750cd5)