### PR TITLE
Show Management: move archive to dedicated page, add clearArchive, and default capacity 44

### DIFF
--- a/src/app/admin/show-management/archive/page.tsx
+++ b/src/app/admin/show-management/archive/page.tsx
@@ -1,0 +1,22 @@
+import { AdminQueueArchive } from "@/components/AdminQueueArchive";
+
+export const metadata = {
+  title: "Queue Archive | BARCODE Admin",
+};
+
+export default function ShowManagementArchivePage() {
+  return (
+    <main className="pt-14 min-h-screen">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+          <p className="text-xs uppercase tracking-[0.5em] text-muted mb-4">// ADMIN: BARCODE RADIO</p>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground"><span className="text-accent text-glow">Queue</span> Archive</h1>
+          <p className="text-sm text-muted mt-3">Review archived sessions and manage archive cleanup.</p>
+        </div>
+      </section>
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
+        <AdminQueueArchive />
+      </section>
+    </main>
+  );
+}

--- a/src/app/api/admin/queue/route.ts
+++ b/src/app/api/admin/queue/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
 import { resetWheelCeremonyStateForNewSession } from "@/lib/live-overlay";
-import { archiveCurrentQueueSession, getRadioQueueState, setQueueOpen, startNewQueueSession, activateQueueSession, updatePriorityUpgradeSettings, updateRadioTrack, updateSponsorBreakState, updateSubmissionCooldownSettings } from "@/lib/queue";
+import { archiveCurrentQueueSession, clearArchivedQueueSessions, getRadioQueueState, setQueueOpen, startNewQueueSession, activateQueueSession, updatePriorityUpgradeSettings, updateRadioTrack, updateSponsorBreakState, updateSubmissionCooldownSettings } from "@/lib/queue";
 
 export const dynamic = "force-dynamic";
 
@@ -71,6 +71,12 @@ export async function POST(req: Request) {
   }
   if (body.action === "updateSponsorBreakState" && ["start", "complete", "skip", "reset"].includes(body.sponsorAction)) return NextResponse.json(await updateSponsorBreakState(body.sponsorAction));
   if (body.action === "archiveSession") return NextResponse.json(await archiveCurrentQueueSession());
+  if (body.action === "clearArchive") {
+    if (body.confirmation !== "Delete the archive") {
+      return NextResponse.json({ error: "Confirmation text must exactly match: Delete the archive" }, { status: 400 });
+    }
+    return NextResponse.json(await clearArchivedQueueSessions());
+  }
   if (body.action === "activateSession" && typeof body.sessionId === "string") return NextResponse.json(await activateQueueSession(body.sessionId));
   if (body.action === "viewSession" && typeof body.sessionId === "string") return NextResponse.json(await getRadioQueueState(body.sessionId));
   if (["pullNext", "pullWheelChosen", "pullFreeTransmission", "startShow", "addWheelSpinOwed", "addSimulationFreeTrack", "addSimulationPaidPriority", "addSimulationCheckoutPending", "addSimulationPaymentFailed", "addSimulationHeldPriority", "clearSimulationTracks"].includes(body.action)) return NextResponse.json(await updateRadioTrack("", body.action));

--- a/src/components/AdminQueueArchive.tsx
+++ b/src/components/AdminQueueArchive.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable react-hooks/set-state-in-effect, react/jsx-no-comment-textnodes */
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { formatRuntime } from "@/lib/queue-types";
+import type { QueueSessionSummary, QueueState } from "@/lib/queue-types";
+
+function exportHref(sessionId?: string): string { return `/api/admin/queue/export${sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : ""}`; }
+
+export function AdminQueueArchive() {
+  const [state, setState] = useState<QueueState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function load() {
+    const res = await fetch("/api/admin/queue", { cache: "no-store" });
+    if (!res.ok) {
+      setError(res.status === 401 ? "Admin authentication required. Log in at /admin first." : "Archive unavailable.");
+      return;
+    }
+    setError(null);
+    setState(await res.json());
+  }
+
+  async function clearArchive() {
+    setDeleting(true);
+    setMessage(null);
+    const res = await fetch("/api/admin/queue", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "clearArchive", confirmation }) });
+    const payload = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setMessage(typeof payload?.error === "string" ? payload.error : "Archive was not deleted.");
+      setDeleting(false);
+      return;
+    }
+    setState(payload);
+    setConfirmOpen(false);
+    setConfirmation("");
+    setDeleting(false);
+    setMessage("Queue archive deleted.");
+  }
+
+  useEffect(() => { load(); }, []);
+
+  if (error) return <div className="border border-danger/40 bg-danger/5 p-6 text-danger">{error}</div>;
+
+  const archivedSessions = (state?.sessions ?? []).filter((session) => session.status === "archived");
+
+  return <div className="space-y-6">
+    <section className="border border-border bg-surface p-5 space-y-4"><div className="flex items-center justify-between gap-3"><div><p className="text-xs uppercase tracking-[0.35em] text-muted">// Queue Archive</p><p className="mt-2 text-sm text-muted">Review archived sessions and export finished queue data.</p></div><a href="/admin/show-management" className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Back to Show Management</a></div>{archivedSessions.length===0 ? <p className="border border-border/60 p-4 text-sm text-muted">No archived sessions saved.</p> : <div className="grid gap-3">{archivedSessions.map((session: QueueSessionSummary) => <article key={session.sessionId} className="border border-border bg-background/40 p-4"><div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"><div><p className="font-bold text-foreground">{session.title}</p><p className="text-xs text-muted">{session.showDate} · {session.status} · active {session.activeCount}/{session.queueCapacity} · completed {session.completedCount} · removed {session.removedCount}</p><p className="text-xs text-muted">Active runtime {formatRuntime(session.estimatedActiveRuntimeSeconds)} · completed runtime {formatRuntime(session.completedRuntimeSeconds)}</p></div><div className="flex flex-wrap gap-2"><a href={`/admin/show-management/session/${encodeURIComponent(session.sessionId)}`} className="border border-accent/60 px-3 py-1.5 text-xs text-accent">View Finished Session</a><a href={`/admin/queue?sessionId=${encodeURIComponent(session.sessionId)}`} className="border border-border px-3 py-1.5 text-xs text-muted">Review Queue</a><a href={exportHref(session.sessionId)} className="border border-border px-3 py-1.5 text-xs text-muted">Download CSV</a></div></div></article>)}</div>}</section>
+    <section className="border border-danger/50 bg-danger/5 p-5 space-y-3"><h2 className="text-lg font-bold text-danger">Delete Queue Archive</h2><p className="text-sm text-muted">This permanently deletes archived sessions and their saved queue data.</p><button type="button" onClick={() => { setMessage(null); setConfirmOpen(true); }} className="border border-danger px-4 py-2 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background">Delete Archive</button>{message && <p className="text-sm text-muted">{message}</p>}</section>
+    {confirmOpen && createPortal(<div className="fixed inset-0 z-[10000] grid place-items-center bg-black/75 p-4 backdrop-blur-sm"><div className="w-full max-w-md border border-danger/50 bg-background p-5"><p className="text-xs uppercase tracking-[0.35em] text-danger">Danger Zone</p><h3 className="mt-2 text-xl font-bold text-foreground">Delete the queue archive?</h3><p className="mt-2 text-sm text-muted">This cannot be undone.</p><p className="mt-2 text-sm text-muted">Type &quot;Delete the archive&quot; to confirm.</p><input value={confirmation} onChange={(event) => setConfirmation(event.target.value)} className="mt-3 w-full border border-border bg-background px-3 py-2 text-sm" /><div className="mt-4 flex justify-end gap-2"><button type="button" onClick={() => { setConfirmOpen(false); setConfirmation(""); }} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted">Cancel</button><button type="button" disabled={confirmation !== "Delete the archive" || deleting} onClick={clearArchive} className="border border-danger px-4 py-2 text-xs uppercase tracking-widest text-danger hover:bg-danger hover:text-background disabled:opacity-40">{deleting ? "Deleting…" : "Delete Archive"}</button></div></div></div>, document.body)}
+  </div>;
+}

--- a/src/components/AdminShowManagement.tsx
+++ b/src/components/AdminShowManagement.tsx
@@ -44,7 +44,7 @@ export function AdminShowManagement() {
   const [title, setTitle] = useState(`BARCODE Radio — ${todayDate()}`);
   const [description, setDescription] = useState(defaultDescription(todayDate()));
   const [trackLimitPerArtist, setTrackLimitPerArtist] = useState(3);
-  const [queueCapacity, setQueueCapacity] = useState(50);
+  const [queueCapacity, setQueueCapacity] = useState(44);
   const [submissionCooldownSeconds, setSubmissionCooldownSeconds] = useState(300);
   const [priorityUpgradesEnabled, setPriorityUpgradesEnabled] = useState(true);
   const [priorityUpgradePriceCents, setPriorityUpgradePriceCents] = useState(1000);
@@ -100,7 +100,7 @@ export function AdminShowManagement() {
   const session = state?.session;
   const readOnly = Boolean(state?.readOnly || session?.status === "archived");
   const currentSession = session && state?.isCurrentSession && !readOnly ? session : null;
-  const pastSessions = (state?.sessions ?? []).filter((item) => item.sessionId !== currentSession?.sessionId);
+  const archiveCount = (state?.sessions ?? []).filter((item) => item.status === "archived").length;
   const startLocked = Boolean(currentSession);
   const queueIsOpen = Boolean(currentSession?.queueOpen);
 
@@ -110,7 +110,7 @@ export function AdminShowManagement() {
       <CurrentSession session={currentSession} onPost={post} onEnd={() => setEndConfirmOpen(true)} />
       <SessionData session={currentSession} />
       {endConfirmOpen && createPortal(<EndSessionConfirm ending={endingSession} onCancel={() => setEndConfirmOpen(false)} onConfirm={endSession} />, document.body)}
-      <ArchivedShows sessions={pastSessions} />
+      <ArchivePanel archiveCount={archiveCount} />
     </div>
   );
 }
@@ -179,7 +179,7 @@ function CurrentSession({ session, onPost, onEnd }: { session: QueueSessionSumma
         <p className="text-xs uppercase tracking-[0.35em] text-muted">// Current Session</p>
         <h2 className="mt-2 text-xl font-bold text-foreground">No session in progress.</h2>
         <p className="mt-1 text-sm text-muted">Start a new session or select an archived session below.</p>
-        <a href="#archived-shows" className="mt-4 inline-flex border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Archived Shows</a>
+        <a href="/admin/show-management/archive" className="mt-4 inline-flex border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Open Queue Archive</a>
       </section>
     );
   }
@@ -280,6 +280,7 @@ function SessionData({ session }: { session: QueueSessionSummary | null | undefi
   return <section className="border border-border bg-surface p-6 space-y-4"><div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"><div><p className="text-xs uppercase tracking-[0.35em] text-muted">// Session Data / Submission Export</p><p className="text-sm text-muted mt-2">Admin-only submitter/contact data for this session. Private contact fields are not exposed publicly.</p></div><div className="flex flex-wrap gap-2"><button onClick={viewList} className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">View Submitter List</button><a href={exportHref(session.sessionId)} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Download CSV</a></div></div>{open && <div className="overflow-x-auto border border-border bg-background/40"><table className="min-w-full text-left text-xs"><thead className="text-muted"><tr><th className="p-2">Submitter</th><th className="p-2">Display Artist</th><th className="p-2">Song</th><th className="p-2">TikTok</th><th className="p-2">Email/contact</th><th className="p-2">Status</th><th className="p-2">Lane</th></tr></thead><tbody>{loading ? <tr><td colSpan={7} className="p-3 text-muted">Loading submitter list…</td></tr> : rows.length === 0 ? <tr><td colSpan={7} className="p-3 text-muted">No submissions found for this session.</td></tr> : rows.map((row, index) => <tr key={`${row.sessionId}-${row.sourceLink}-${index}`} className="border-t border-border/60"><td className="p-2">{row.submitterArtistName}</td><td className="p-2">{row.submittedArtistName}</td><td className="p-2">{row.submittedSongTitle}</td><td className="p-2">{row.tiktokHandle || "—"}</td><td className="p-2">{row.contactEmail || "—"}</td><td className="p-2">{row.status}</td><td className="p-2">{row.lane}{row.spotlight ? " · spotlight" : ""}</td></tr>)}</tbody></table></div>}</section>;
 }
 
-function ArchivedShows({ sessions }: { sessions: QueueSessionSummary[] }) {
-  return <section id="archived-shows" className="border border-border bg-surface p-5 space-y-4"><div><p className="text-xs uppercase tracking-[0.35em] text-muted">// Archived Shows</p><p className="text-sm text-muted mt-2">Past sessions stay closed. Review finished-session reports and export session-scoped data here.</p></div><div className="grid gap-3">{sessions.length === 0 ? <p className="border border-border/60 p-4 text-sm text-muted">No archived or past shows saved yet.</p> : sessions.map((session) => <article key={session.sessionId} className="border border-border bg-background/40 p-4"><div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"><div><p className="font-bold text-foreground">{session.title}</p><p className="text-xs text-muted">{session.showDate} · {session.status} · active {session.activeCount}/{session.queueCapacity} · completed {session.completedCount} · removed {session.removedCount}</p><p className="text-xs text-muted">Active runtime {formatRuntime(session.estimatedActiveRuntimeSeconds)} · completed runtime {formatRuntime(session.completedRuntimeSeconds)}</p></div><div className="flex flex-wrap gap-2"><a href={`/admin/show-management/session/${encodeURIComponent(session.sessionId)}`} className="border border-accent/60 px-3 py-1.5 text-xs text-accent">View Finished Session</a><a href={`/admin/queue?sessionId=${encodeURIComponent(session.sessionId)}`} className="border border-border px-3 py-1.5 text-xs text-muted">Review Queue</a><a href={exportHref(session.sessionId)} className="border border-border px-3 py-1.5 text-xs text-muted">Download CSV</a></div></div></article>)}</div></section>;
+
+function ArchivePanel({ archiveCount }: { archiveCount: number }) {
+  return <section className="border border-border bg-surface p-5 space-y-3"><p className="text-xs uppercase tracking-[0.35em] text-muted">// Queue Archive</p><p className="text-sm text-muted">Archived sessions are managed from a dedicated page to keep Show Management focused on live operations.</p><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-sm text-foreground">Archived sessions: <span className="font-bold">{archiveCount}</span></p><a href="/admin/show-management/archive" className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Open Queue Archive</a></div></section>;
 }

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -32,7 +32,7 @@ import type {
 
 const STATE_KEY = "radioQueue:v2:sessions";
 const LEGACY_STATE_KEY = "radioQueue:v1:state";
-const DEFAULT_QUEUE_CAPACITY = 50;
+const DEFAULT_QUEUE_CAPACITY = 44;
 const DEFAULT_SUBMISSION_COOLDOWN_SECONDS = 5 * 60;
 const MAX_SUBMISSION_COOLDOWN_SECONDS = 60 * 60;
 const DEFAULT_PRIORITY_UPGRADE_LABEL = "Priority Signal Upgrade";
@@ -1698,6 +1698,19 @@ export async function archiveCurrentQueueSession(): Promise<QueueState> {
   return queueStateFromSession(session, archivedStore, session.sessionId);
 }
 
+
+export async function clearArchivedQueueSessions(): Promise<QueueState> {
+  const store = await readStore();
+  const sessions = store.sessions.filter((session) => session.status !== "archived");
+  const fallback = sessions[0] ?? defaultSession();
+  const activeExists = sessions.some((session) => session.sessionId === store.activeSessionId);
+  const nextStore: QueueStore = {
+    activeSessionId: activeExists ? store.activeSessionId : fallback.sessionId,
+    sessions: sessions.length > 0 ? sessions : [fallback],
+  };
+  await writeStore(nextStore);
+  return queueStateFromSession(getSession(nextStore), nextStore);
+}
 export async function activateQueueSession(sessionId: string): Promise<QueueState> {
   const store = await readStore();
   const target = store.sessions.find((session) => session.sessionId === sessionId);

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -928,6 +928,28 @@ test("ending broadcast is separate from closing submissions", async () => {
   assert.equal(state.streamStatus, "offline");
 });
 
+
+
+test("new sessions default queue capacity to 44", async () => {
+  await queue.setQueueOpen(false);
+  const state = await queue.startNewQueueSession({ title: `default capacity ${Date.now()} ${trackSequence}` });
+  assert.equal(state.session.queueCapacity, 44);
+});
+
+test("clear archive removes archived sessions and preserves active session", async () => {
+  const activeSessionId = await freshOpenSession("clear archive preserve active");
+  await queue.archiveCurrentQueueSession();
+  await queue.startNewQueueSession({ title: `active after archive ${Date.now()} ${trackSequence}` });
+
+  const before = await queue.getRadioQueueState();
+  assert.ok(before.sessions.some((session) => session.status === "archived"));
+
+  const after = await queue.clearArchivedQueueSessions();
+  assert.equal(after.session.sessionId !== activeSessionId, true);
+  assert.equal(after.sessions.some((session) => session.status === "archived"), false);
+  assert.ok(after.sessions.some((session) => session.sessionId === after.session.sessionId));
+});
+
 test("admin phase display uses showStarted language instead of opening state", () => {
   const source = fs.readFileSync(path.join(projectRoot, "src/components/AdminRadioQueueControl.tsx"), "utf8");
 


### PR DESCRIPTION
### Motivation

- Reduce Show Management clutter and avoid rendering a growing archived sessions list on the primary admin screen by moving archive controls to a dedicated admin flow.
- Make new sessions use the desired queue capacity default of 44 instead of 50 without touching existing stored sessions.
- Provide a safe, admin-only destructive action to clear/delete archived sessions that requires an exact typed confirmation to avoid accidental data loss.

### Description

- Change the default queue capacity constant to 44 and ensure the Show Management start form initializes to 44 so new sessions created without an explicit capacity use 44; this only affects new sessions and preserves existing stored capacities (`src/lib/queue.ts`, `src/components/AdminShowManagement.tsx`).
- Replace the full inline archived sessions rendering with a compact Archive panel on the Show Management screen and add a dedicated admin archive page and component at `/admin/show-management/archive` to list archived sessions and preserve existing session actions like View Finished Session, Review Queue, and Download CSV (`src/components/AdminShowManagement.tsx`, `src/components/AdminQueueArchive.tsx`, `src/app/admin/show-management/archive/page.tsx`).
- Add a conservative backend admin action `clearArchive` to `POST /api/admin/queue` which requires `confirmation === "Delete the archive"` and calls a focused helper `clearArchivedQueueSessions()` that removes only sessions with `status === "archived"` while preserving or providing a safe active session (`src/app/api/admin/queue/route.ts`, `src/lib/queue.ts`).
- Add and update queue tests to cover the new default capacity and archive-clear behavior (`tests/queue-playback.test.mjs`).

### Testing

- Ran type check: `npx tsc --noEmit` and it completed successfully.
- Ran lint: `npx eslint src/lib/queue.ts src/app/api/admin/queue/route.ts src/components/AdminShowManagement.tsx src/components/AdminQueueArchive.tsx` and reported no remaining errors after a minor JSX escaping fix.
- Ran queue unit suite: `npm run test:queue` and all queue tests passed (74 tests total), including the added tests verifying default capacity is 44 and that clearing the archive removes archived sessions while preserving an active session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1539d0f54883219c14f5e8d5e4d927)