### PR TITLE
PR #118: Duration accuracy and metadata reliability audit

### DIFF
--- a/src/lib/queue-timing.ts
+++ b/src/lib/queue-timing.ts
@@ -309,6 +309,10 @@ function knownRuntime(track: QueueTimingTrack | null | undefined): number | null
   return safePositiveSeconds(track?.detectedDurationSeconds) ?? safePositiveSeconds(track?.estimatedDurationSeconds);
 }
 
+function hasKnownDetectedDuration(track: QueueTimingTrack | null | undefined): boolean {
+  return safePositiveSeconds(track?.detectedDurationSeconds) !== null && track?.durationIsEstimate !== true;
+}
+
 export function getEstimatedTrackRuntimeSeconds(track?: QueueTimingTrack | null, options?: QueueTimingOptions): number {
   const normalized = normalizeOptions(options);
   return knownRuntime(track) ?? normalized.unknownTrackSeconds;
@@ -323,13 +327,14 @@ export function estimateRuntimeForTracks(tracks: readonly (QueueTimingTrack | nu
   const normalized = normalizeOptions(options);
   return tracks.reduce<QueueRuntimeEstimate>((estimate, track) => {
     if (!track || isRemovedTrack(track)) return estimate;
-    const knownSeconds = knownRuntime(track);
-    const trackSeconds = knownSeconds ?? normalized.unknownTrackSeconds;
+    const runtimeSeconds = knownRuntime(track);
+    const isKnownDuration = hasKnownDetectedDuration(track);
+    const trackSeconds = runtimeSeconds ?? normalized.unknownTrackSeconds;
     return {
       trackSeconds: estimate.trackSeconds + trackSeconds,
       slotSeconds: estimate.slotSeconds + trackSeconds + normalized.preTrackTalkSeconds + normalized.postTrackTalkSeconds,
-      knownDurationCount: estimate.knownDurationCount + (knownSeconds ? 1 : 0),
-      unknownDurationCount: estimate.unknownDurationCount + (knownSeconds ? 0 : 1),
+      knownDurationCount: estimate.knownDurationCount + (isKnownDuration ? 1 : 0),
+      unknownDurationCount: estimate.unknownDurationCount + (isKnownDuration ? 0 : 1),
       preTrackTalkSeconds: estimate.preTrackTalkSeconds + normalized.preTrackTalkSeconds,
       postTrackTalkSeconds: estimate.postTrackTalkSeconds + normalized.postTrackTalkSeconds,
       hostBufferSeconds: estimate.hostBufferSeconds + normalized.preTrackTalkSeconds + normalized.postTrackTalkSeconds,
@@ -340,8 +345,8 @@ export function estimateRuntimeForTracks(tracks: readonly (QueueTimingTrack | nu
 function segmentsForTrack(track: QueueTimingTrack, options: NormalizedQueueTimingOptions, nowPlaying = false): ProjectedShowSegment[] {
   const trackId = track.id;
   const runtime = getEstimatedTrackRuntimeSeconds(track, options);
-  const source = track.durationSource ?? (knownRuntime(track) ? "stored_duration" : "estimated");
-  const isEstimate = !knownRuntime(track) || track.durationIsEstimate === true;
+  const source = track.durationSource ?? (hasKnownDetectedDuration(track) ? "stored_duration" : "estimated");
+  const isEstimate = !hasKnownDetectedDuration(track);
   if (nowPlaying && !options.includeHostBufferForNowPlaying) {
     return [{ type: "now_playing_remaining", trackId, label: "Now playing remaining runtime", seconds: runtime, durationSource: source, isEstimate, notes: ["Exact elapsed playback time is unavailable, so stored full duration is used conservatively."] }];
   }

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1129,7 +1129,7 @@ export async function createQueueTrack(input: {
     : providerMetadata.detectedDurationSeconds;
   const durationSource = detectedDurationSeconds
     ? input.durationSource ?? providerMetadata.durationSource ?? (sourceType === "upload" ? "upload_metadata" : "provider_metadata")
-    : "estimated";
+    : "internal_estimate";
 
   return normalizeEntry({
     id: generateQueueId(),

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1498,3 +1498,41 @@ test("upload session guard rejects stale sessionId", async () => {
 test("upload token guard remains rejected while submissions are closed", async () => {
   assert.throws(() => uploadApi.assertUploadSessionOpen(false, false, 0, 50), /This broadcast queue is closed/);
 });
+
+test("upload submission with valid detected duration stores known runtime metadata", async () => {
+  const track = await queue.createQueueTrack({
+    artist: "Upload Artist",
+    title: "Upload Known",
+    tiktokHandle: "@uploadknown",
+    sourceType: "upload",
+    fileUrl: "https://files.example.com/upload-known.mp3",
+    fileName: "Upload Artist - Upload Known.mp3",
+    fileSize: 12345,
+    mimeType: "audio/mpeg",
+    detectedDurationSeconds: 222.4,
+    durationSource: "upload_metadata",
+  });
+
+  assert.equal(track.detectedDurationSeconds, 222);
+  assert.equal(track.estimatedDurationSeconds, 222);
+  assert.equal(track.durationIsEstimate, false);
+  assert.equal(track.durationSource, "upload_metadata");
+});
+
+test("upload submission without detected duration stays internal estimate and not detected", async () => {
+  const track = await queue.createQueueTrack({
+    artist: "Upload Artist",
+    title: "Upload Unknown",
+    tiktokHandle: "@uploadunknown",
+    sourceType: "upload",
+    fileUrl: "https://files.example.com/upload-unknown.mp3",
+    fileName: "Upload Artist - Upload Unknown.mp3",
+    fileSize: 99999,
+    mimeType: "audio/mpeg",
+  });
+
+  assert.equal(track.detectedDurationSeconds, null);
+  assert.equal(track.estimatedDurationSeconds, 300);
+  assert.equal(track.durationIsEstimate, true);
+  assert.equal(track.durationSource, "internal_estimate");
+});

--- a/tests/queue-timing.test.mjs
+++ b/tests/queue-timing.test.mjs
@@ -170,6 +170,16 @@ test("multiple tracks include pre and post talk for each track", () => {
   assert.equal(estimate.slotSeconds, 680);
 });
 
+test("known and estimated duration counts remain distinct even when fallback seconds are stored", () => {
+  const estimate = timing.estimateRuntimeForTracks([
+    track("detected", { detectedDurationSeconds: 180, estimatedDurationSeconds: 180, durationIsEstimate: false }),
+    track("fallback", { estimatedDurationSeconds: 300, detectedDurationSeconds: null, durationIsEstimate: true, durationSource: "internal_estimate" }),
+  ]);
+  assert.equal(estimate.knownDurationCount, 1);
+  assert.equal(estimate.unknownDurationCount, 1);
+  assert.equal(estimate.trackSeconds, 480);
+});
+
 test("completed sponsor break is not included again", () => {
   const completed = Array.from({ length: 20 }, (_, index) => track(`played-completed-sponsor-${index}`, { status: "played", completedAt: "2026-01-01T00:00:00.000Z" }));
   const queue = Array.from({ length: 20 }, (_, index) => track(`queued-completed-sponsor-${index}`));


### PR DESCRIPTION
### Motivation
- Audit and tighten the existing duration flow so durations feeding timing are trustworthy and clearly labeled without rebuilding the submission system. 
- From the code: uploads may supply client-side duration metadata; provider lookups attempt YouTube/Spotify/SoundCloud APIs and fall back to `detectTrackDurationFromLink`; unsupported links fall back to an internal estimate. 
- Queue entries must continue to expose `detectedDurationSeconds`, `estimatedDurationSeconds`, `durationIsEstimate`, and `durationSource`, and timing must favor detected values while treating fallback estimates as low confidence.

### Description
- Made fallback source naming consistent in queue creation by storing `durationSource: "internal_estimate"` (instead of `"estimated"`) whenever no detected duration is available to align with queue normalization and avoid confusing sources. (file: `src/lib/queue.ts`)
- Tightened timing confidence logic so known/unknown counters only treat a track as "known" when a true detected duration exists and is not marked as an estimate; runtime projection still uses `detected -> estimated -> default` for numeric values. (file: `src/lib/queue-timing.ts`)
- Added tests to validate upload behavior and timing confidence semantics: an upload with valid detected duration is stored as detected; an upload without detected duration uses internal fallback and remains an estimate; timing tests assert counts distinguish detected durations from fallback estimates. (files: `tests/queue-playback.test.mjs`, `tests/queue-timing.test.mjs`)
- Files changed: `src/lib/queue.ts`, `src/lib/queue-timing.ts`, `tests/queue-playback.test.mjs`, `tests/queue-timing.test.mjs`.

### Testing
- Ran TypeScript check: `npx tsc --noEmit` (succeeded).
- Ran ESLint on the touched files: `npx eslint src/lib/track-duration.ts src/lib/queue.ts src/components/AdminRadioQueueControl.tsx` (succeeded with one pre-existing React hooks warning in `AdminRadioQueueControl.tsx`; no new lint errors introduced).
- Ran duration unit tests: `node --test tests/track-duration.test.mjs` (all tests passed).
- Ran queue suite: `npm run test:queue` (all tests passed, including new upload storage tests).
- Ran timing suite: `node --test tests/queue-timing.test.mjs` (all tests passed, including new known/unknown count check).

Notes: No queue resolver, PlayerDock, public submission flow, payment, wheel, commercial break, overlay, or archive behaviors were changed; changes are narrowly scoped to storage/source labeling and timing confidence handling so fallback estimates remain clearly marked as estimates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172a0dba9c8321b5c8443a24efee2b)