### PR TITLE
Add BNL public read model API v1

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,0 +1,280 @@
+import { NextResponse } from "next/server";
+import { databasePage, radioPage, siteConfig } from "@/content";
+import { getPublicQueueSnapshot } from "@/lib/queue";
+import type { QueueLane, QueuePublicSnapshot, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const CACHE_CONTROL = "public, max-age=15, s-maxage=30";
+const MAX_ARTISTS = 25;
+const MAX_TRACKS_PER_ARTIST = 5;
+
+type BnlReadModelTrackStatus = "queued" | "completed" | "nowPlaying" | "upNext";
+
+type BnlReadModelArtist = {
+  name: string;
+  normalizedName: string;
+  tiktokHandle?: string | null;
+  tracks: Array<{
+    trackId: string;
+    title: string;
+    lane: QueueLane;
+    status: BnlReadModelTrackStatus;
+    sourceType: QueueSourceType;
+    publicSourceUrl?: string | null;
+  }>;
+  source: "queue_public_snapshot";
+};
+
+type BnlQueueTrack = Pick<
+  QueuePublicTrack,
+  | "id"
+  | "submittedArtistName"
+  | "submittedSongTitle"
+  | "detectedArtistName"
+  | "detectedSongTitle"
+  | "providerTitle"
+  | "sourceType"
+  | "lane"
+  | "durationLabel"
+  | "estimatedDurationSeconds"
+  | "detectedDurationSeconds"
+  | "durationIsEstimate"
+  | "sourceArtworkUrl"
+  | "publicSourceUrl"
+  | "tiktokHandle"
+  | "priorityUpgradeRequested"
+  | "priorityUpgradeStatus"
+>;
+
+function publicTrack(track: QueuePublicTrack | null | undefined): BnlQueueTrack | null {
+  if (!track) return null;
+  return {
+    id: track.id,
+    submittedArtistName: track.submittedArtistName,
+    submittedSongTitle: track.submittedSongTitle,
+    detectedArtistName: track.detectedArtistName ?? null,
+    detectedSongTitle: track.detectedSongTitle ?? null,
+    providerTitle: track.providerTitle ?? null,
+    sourceType: track.sourceType,
+    lane: track.lane,
+    durationLabel: track.durationLabel,
+    estimatedDurationSeconds: track.estimatedDurationSeconds,
+    detectedDurationSeconds: track.detectedDurationSeconds ?? null,
+    durationIsEstimate: track.durationIsEstimate,
+    sourceArtworkUrl: track.sourceArtworkUrl ?? null,
+    publicSourceUrl: track.publicSourceUrl ?? null,
+    tiktokHandle: track.tiktokHandle ?? null,
+    priorityUpgradeRequested: track.priorityUpgradeRequested === true,
+    priorityUpgradeStatus: track.priorityUpgradeStatus ?? "none",
+  };
+}
+
+function compactQueue(snapshot: QueuePublicSnapshot) {
+  return {
+    available: true,
+    session: {
+      sessionId: snapshot.session.sessionId,
+      title: snapshot.session.title,
+      showDate: snapshot.session.showDate,
+      status: snapshot.session.status,
+      queueOpen: snapshot.session.queueOpen,
+      broadcastPhase: snapshot.session.broadcastPhase ?? null,
+      activeCount: snapshot.session.activeCount,
+      completedCount: snapshot.session.completedCount,
+      removedCount: snapshot.session.removedCount,
+      wheelSpinsOwed: snapshot.session.wheelSpinsOwed ?? 0,
+      priorityUpgradesEnabled: snapshot.session.priorityUpgradesEnabled,
+      priorityUpgradeLabel: snapshot.session.priorityUpgradeLabel,
+    },
+    status: {
+      isOpen: snapshot.status.isOpen,
+      activeCount: snapshot.status.activeCount,
+      capacity: snapshot.status.capacity,
+      pressure: snapshot.status.pressure,
+    },
+    nowPlaying: publicTrack(snapshot.nowPlaying),
+    upNext: publicTrack(snapshot.upNext),
+    queue: snapshot.queue.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
+    completed: snapshot.completed.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
+  };
+}
+
+function normalizeArtistName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function artistNameForTrack(track: QueuePublicTrack): string {
+  return (track.detectedArtistName || track.submittedArtistName).trim();
+}
+
+function titleForTrack(track: QueuePublicTrack): string {
+  return (track.detectedSongTitle || track.submittedSongTitle || track.providerTitle || "Untitled track").trim();
+}
+
+function addArtistTrack(artists: Map<string, BnlReadModelArtist>, track: QueuePublicTrack | null | undefined, status: BnlReadModelTrackStatus) {
+  if (!track) return;
+  const name = artistNameForTrack(track);
+  if (!name) return;
+  const normalizedName = normalizeArtistName(name);
+  if (!normalizedName) return;
+
+  const existing = artists.get(normalizedName);
+  const artist: BnlReadModelArtist = existing ?? {
+    name,
+    normalizedName,
+    tiktokHandle: track.tiktokHandle ?? null,
+    tracks: [],
+    source: "queue_public_snapshot",
+  };
+
+  if (!artist.tiktokHandle && track.tiktokHandle) artist.tiktokHandle = track.tiktokHandle;
+  if (!artist.tracks.some((artistTrack) => artistTrack.trackId === track.id) && artist.tracks.length < MAX_TRACKS_PER_ARTIST) {
+    artist.tracks.push({
+      trackId: track.id,
+      title: titleForTrack(track),
+      lane: track.lane,
+      status,
+      sourceType: track.sourceType,
+      publicSourceUrl: track.publicSourceUrl ?? null,
+    });
+  }
+
+  artists.set(normalizedName, artist);
+}
+
+function artistsFromQueue(snapshot: QueuePublicSnapshot): BnlReadModelArtist[] {
+  const artists = new Map<string, BnlReadModelArtist>();
+  addArtistTrack(artists, snapshot.nowPlaying, "nowPlaying");
+  addArtistTrack(artists, snapshot.upNext, "upNext");
+  for (const track of snapshot.queue) addArtistTrack(artists, track, "queued");
+  for (const track of snapshot.completed) addArtistTrack(artists, track, "completed");
+  return [...artists.values()].slice(0, MAX_ARTISTS);
+}
+
+function publicDossiers() {
+  const publicEntries = databasePage.entries
+    .filter((entry) => entry.clearance === "PUBLIC")
+    .map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      category: entry.category,
+      status: entry.status,
+      role: entry.role,
+      origin: entry.origin,
+      summary: entry.summary,
+      tags: entry.tags,
+      link: entry.link || null,
+      source: "public_database_dossier",
+    }));
+
+  if (publicEntries.length === 0) {
+    return {
+      implemented: false,
+      public: [],
+      note: "Public dossier runtime is not implemented yet.",
+    };
+  }
+
+  return {
+    implemented: true,
+    public: publicEntries,
+    note: "Only public-clearance database dossier summaries are included.",
+  };
+}
+
+const sourceContext = [
+  {
+    id: "barcode_network",
+    title: "BARCODE Network",
+    summary: `${siteConfig.name} is the public broadcast infrastructure behind BARCODE Radio: a connected site, archive, and signal surface for programs, transmissions, releases, and live-show context.`,
+  },
+  {
+    id: "barcode_radio",
+    title: "BARCODE Radio",
+    summary: `${radioPage.hero.heading1} ${radioPage.hero.heading2} is the weekly live broadcast. Public submissions enter the show through Auxchord and the website queue surface reflects public session state.`,
+  },
+  {
+    id: "bnl_01",
+    title: "BNL-01",
+    summary: "BNL-01 is the BARCODE Network liaison/bot surface for public-safe context and community-facing continuity. This read model does not grant BNL private system control or admin access.",
+  },
+  {
+    id: "broadcast_memory",
+    title: "Broadcast Memory",
+    summary: "Broadcast memory is public-facing continuity about what the Network has already surfaced through broadcasts, site copy, queue state, and public records. It is not raw Discord data, private notes, or hidden R&D process material.",
+  },
+  {
+    id: "priority_signal",
+    title: "Priority Signal",
+    summary: "Priority Signal is the public queue upgrade concept shown on the BARCODE Radio queue surface when enabled. This endpoint only exposes public-safe priority labels/statuses, never Stripe secrets, checkout records, or payment facts.",
+  },
+  {
+    id: "boundaries",
+    title: "Public Read Boundary",
+    summary: "This source context is not user accounts, payment records, private queue notes, Discord identity mapping, hidden dossiers, private upload access, or private admin state.",
+  },
+];
+
+const rules = {
+  allowedUse: [
+    "public-safe BNL context",
+    "R&D reference",
+    "public replies when relevant",
+    "queue/session awareness",
+    "artist/track awareness from public queue snapshot",
+  ],
+  disallowedUse: [
+    "private user identity",
+    "payment facts",
+    "Stripe/session details",
+    "contact emails",
+    "submitter tokens",
+    "private upload URLs",
+    "private queue notes",
+    "account profiles",
+    "Discord identity merging",
+    "automatic canon creation",
+    "claiming public dossiers exist when not implemented",
+  ],
+  sourceAuthority: {
+    queue: "public runtime snapshot",
+    artists: "derived from public queue snapshot",
+    dossiers: "public dossier runtime only if implemented",
+    sourceContext: "static public site context",
+  },
+};
+
+export async function GET() {
+  const queueSnapshot = await getPublicQueueSnapshot();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      scope: "bnl_public_read_model",
+      source: "barcode-network-site",
+      publicOnly: true,
+      sections: {
+        sourceContext,
+        queue: compactQueue(queueSnapshot),
+        artists: artistsFromQueue(queueSnapshot),
+        dossiers: publicDossiers(),
+        rules,
+      },
+    },
+    {
+      headers: {
+        "Cache-Control": CACHE_CONTROL,
+      },
+    },
+  );
+}

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -137,14 +137,27 @@ async function readPublicLiveQueueForBnl() {
   };
 }
 
+function stableArtistKeyFallback(name: string): string {
+  let hash = 0;
+  for (const char of name) {
+    hash = (hash * 31 + char.codePointAt(0)!) >>> 0;
+  }
+  return `artist-${hash.toString(36)}`;
+}
+
 function normalizeArtistName(name: string): string {
-  return name
-    .trim()
-    .toLowerCase()
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+
+  const normalized = trimmed
+    .normalize("NFKC")
+    .toLocaleLowerCase()
     .replace(/['’]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
+
+  return normalized || stableArtistKeyFallback(trimmed);
 }
 
 function artistNameForTrack(track: QueuePublicTrack): string {

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { databasePage, radioPage, siteConfig } from "@/content";
-import { getPublicQueueSnapshot } from "@/lib/queue";
-import type { QueueLane, QueuePublicSnapshot, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
+import { getRadioQueueState, toPublicQueueTrack } from "@/lib/queue";
+import type { QueueEntry, QueueLane, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -71,33 +71,69 @@ function publicTrack(track: QueuePublicTrack | null | undefined): BnlQueueTrack 
   };
 }
 
-function compactQueue(snapshot: QueuePublicSnapshot) {
+function isRealQueueEntry(entry: QueueEntry | null | undefined): entry is QueueEntry {
+  return Boolean(entry && entry.isTestTrack !== true);
+}
+
+function pressureFor(activeCount: number, capacity: number): "low" | "medium" | "high" | "max" {
+  if (capacity <= 0) return "low";
+  const load = activeCount / capacity;
+  if (load >= 1) return "max";
+  if (load >= 0.75) return "high";
+  if (load >= 0.4) return "medium";
+  return "low";
+}
+
+async function readPublicLiveQueueForBnl() {
+  const state = await getRadioQueueState();
+  const realQueueEntries = state.queue.filter(isRealQueueEntry);
+  const realCompletedEntries = state.history.filter(isRealQueueEntry).slice(0, 10);
+  const realRemovedCount = (state.removed ?? []).filter(isRealQueueEntry).length;
+  const realNowPlaying = isRealQueueEntry(state.nowPlaying) ? state.nowPlaying : null;
+  const realUpNext = isRealQueueEntry(state.nextInLine) ? state.nextInLine : null;
+  const activeIds = new Set<string>();
+  for (const entry of realQueueEntries) {
+    if (entry.status === "queued" || entry.status === "playing") activeIds.add(entry.id);
+  }
+  if (realNowPlaying) activeIds.add(realNowPlaying.id);
+  if (realUpNext) activeIds.add(realUpNext.id);
+
+  const capacity = state.publicStatus?.capacity ?? state.session?.queueCapacity ?? 0;
+  const activeCount = activeIds.size;
+  const publicQueueTracks = realQueueEntries.map(toPublicQueueTrack);
+  const publicCompletedTracks = realCompletedEntries.map(toPublicQueueTrack);
+  const nowPlaying = realNowPlaying ? toPublicQueueTrack(realNowPlaying) : null;
+  const upNext = realUpNext ? toPublicQueueTrack(realUpNext) : null;
+
   return {
-    available: true,
-    session: {
-      sessionId: snapshot.session.sessionId,
-      title: snapshot.session.title,
-      showDate: snapshot.session.showDate,
-      status: snapshot.session.status,
-      queueOpen: snapshot.session.queueOpen,
-      broadcastPhase: snapshot.session.broadcastPhase ?? null,
-      activeCount: snapshot.session.activeCount,
-      completedCount: snapshot.session.completedCount,
-      removedCount: snapshot.session.removedCount,
-      wheelSpinsOwed: snapshot.session.wheelSpinsOwed ?? 0,
-      priorityUpgradesEnabled: snapshot.session.priorityUpgradesEnabled,
-      priorityUpgradeLabel: snapshot.session.priorityUpgradeLabel,
+    queue: {
+      available: true,
+      session: {
+        sessionId: state.session?.sessionId ?? "",
+        title: state.session?.title ?? "",
+        showDate: state.session?.showDate ?? "",
+        status: state.session?.status ?? "prepared",
+        queueOpen: state.session?.queueOpen === true,
+        broadcastPhase: state.session?.broadcastPhase ?? null,
+        activeCount,
+        completedCount: publicCompletedTracks.length,
+        removedCount: realRemovedCount,
+        wheelSpinsOwed: state.session?.wheelSpinsOwed ?? 0,
+        priorityUpgradesEnabled: state.session?.priorityUpgradesEnabled === true,
+        priorityUpgradeLabel: state.session?.priorityUpgradeLabel ?? "Priority Signal",
+      },
+      status: {
+        isOpen: state.publicStatus?.isOpen ?? state.session?.queueOpen === true,
+        activeCount,
+        capacity,
+        pressure: pressureFor(activeCount, capacity),
+      },
+      nowPlaying: publicTrack(nowPlaying),
+      upNext: publicTrack(upNext),
+      queue: publicQueueTracks.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
+      completed: publicCompletedTracks.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
     },
-    status: {
-      isOpen: snapshot.status.isOpen,
-      activeCount: snapshot.status.activeCount,
-      capacity: snapshot.status.capacity,
-      pressure: snapshot.status.pressure,
-    },
-    nowPlaying: publicTrack(snapshot.nowPlaying),
-    upNext: publicTrack(snapshot.upNext),
-    queue: snapshot.queue.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
-    completed: snapshot.completed.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
+    artists: artistsFromTracks(nowPlaying, upNext, publicQueueTracks, publicCompletedTracks),
   };
 }
 
@@ -150,12 +186,17 @@ function addArtistTrack(artists: Map<string, BnlReadModelArtist>, track: QueuePu
   artists.set(normalizedName, artist);
 }
 
-function artistsFromQueue(snapshot: QueuePublicSnapshot): BnlReadModelArtist[] {
+function artistsFromTracks(
+  nowPlaying: QueuePublicTrack | null,
+  upNext: QueuePublicTrack | null,
+  queue: QueuePublicTrack[],
+  completed: QueuePublicTrack[],
+): BnlReadModelArtist[] {
   const artists = new Map<string, BnlReadModelArtist>();
-  addArtistTrack(artists, snapshot.nowPlaying, "nowPlaying");
-  addArtistTrack(artists, snapshot.upNext, "upNext");
-  for (const track of snapshot.queue) addArtistTrack(artists, track, "queued");
-  for (const track of snapshot.completed) addArtistTrack(artists, track, "completed");
+  addArtistTrack(artists, nowPlaying, "nowPlaying");
+  addArtistTrack(artists, upNext, "upNext");
+  for (const track of queue) addArtistTrack(artists, track, "queued");
+  for (const track of completed) addArtistTrack(artists, track, "completed");
   return [...artists.values()].slice(0, MAX_ARTISTS);
 }
 
@@ -230,6 +271,7 @@ const rules = {
     "public replies when relevant",
     "queue/session awareness",
     "artist/track awareness from public queue snapshot",
+    "simulation/test tracks are excluded from this read model",
   ],
   disallowedUse: [
     "private user identity",
@@ -243,17 +285,19 @@ const rules = {
     "Discord identity merging",
     "automatic canon creation",
     "claiming public dossiers exist when not implemented",
+    "treating admin simulation data as live/public context",
   ],
   sourceAuthority: {
-    queue: "public runtime snapshot",
-    artists: "derived from public queue snapshot",
+    queue: "public runtime snapshot with read-model-only simulation/test filtering",
+    artists: "derived from read-model-filtered public queue fields",
     dossiers: "public dossier runtime only if implemented",
     sourceContext: "static public site context",
+    simulationData: "BNL must treat this read model as live/public context only, not admin simulation data",
   },
 };
 
 export async function GET() {
-  const queueSnapshot = await getPublicQueueSnapshot();
+  const liveQueue = await readPublicLiveQueueForBnl();
 
   return NextResponse.json(
     {
@@ -265,8 +309,8 @@ export async function GET() {
       publicOnly: true,
       sections: {
         sourceContext,
-        queue: compactQueue(queueSnapshot),
-        artists: artistsFromQueue(queueSnapshot),
+        queue: liveQueue.queue,
+        artists: liveQueue.artists,
         dossiers: publicDossiers(),
         rules,
       },

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1003,6 +1003,38 @@ test("simulation tracks include visible sequence numbers without lane status tit
   assert.match(sim.note ?? "", /\[QUEUE SIMULATION TRACK\]/);
 });
 
+test("BNL read model excludes simulation tracks from queue and artists", async () => {
+  await freshOpenSession("bnl read model sim exclusion", { showStarted: false });
+  const real = await submitTrack("BNL Real", { artist: "BNL Real Artist" });
+  let simState = await queue.updateRadioTrack("", "addSimulationPaidPriority");
+  const simUpNext = simState.nextInLine;
+  assert.ok(simUpNext?.isTestTrack, "simulation priority track should exist in underlying up-next state");
+  simState = await queue.updateRadioTrack("", "addSimulationFreeTrack");
+  const simQueued = simState.queue.find((entry) => entry.isTestTrack);
+  assert.ok(simQueued, "simulation free track should exist in underlying queue state");
+
+  const publicSnapshot = await queue.getPublicQueueSnapshot();
+  assert.ok(publicSnapshot.upNext?.id === simUpNext.id || publicSnapshot.queue.some((track) => track.id === simQueued.id), "existing public queue snapshot behavior is preserved for simulation tracks");
+
+  const readModelRoute = require("../src/app/api/bnl/read-model/route.ts");
+  const response = await readModelRoute.GET();
+  const data = await response.json();
+
+  assert.equal(data.ok, true);
+  const queueTrackIds = data.sections.queue.queue.map((track) => track.id);
+  assert.ok(queueTrackIds.includes(real.id), "real queue track should remain in the BNL read model");
+  assert.equal(queueTrackIds.includes(simQueued.id), false, "simulation queue track must not enter the BNL read model");
+  assert.notEqual(data.sections.queue.upNext?.id ?? null, simUpNext.id, "simulation track must not be exposed as up next");
+  assert.notEqual(data.sections.queue.nowPlaying?.id ?? null, simUpNext.id, "simulation track must not be exposed as now playing");
+  assert.equal(data.sections.queue.completed.some((track) => track.id === simQueued.id || track.id === simUpNext.id), false, "simulation track must not enter completed history");
+
+  const artistNames = data.sections.artists.map((artist) => artist.name);
+  assert.ok(artistNames.includes("BNL Real Artist"), "real artist should remain in derived artist surface");
+  assert.equal(artistNames.some((name) => /^SIM /i.test(name)), false, "simulation artist must not enter derived artist surface");
+  assert.ok(data.sections.rules.allowedUse.includes("simulation/test tracks are excluded from this read model"));
+  assert.equal(data.sections.rules.sourceAuthority.simulationData, "BNL must treat this read model as live/public context only, not admin simulation data");
+});
+
 test("simulation free is blocked while submissions are closed", async () => {
   await queue.setQueueOpen(false);
   await queue.startNewQueueSession({ title: `sim free blocked ${Date.now()} ${trackSequence}` });

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1006,6 +1006,7 @@ test("simulation tracks include visible sequence numbers without lane status tit
 test("BNL read model excludes simulation tracks from queue and artists", async () => {
   await freshOpenSession("bnl read model sim exclusion", { showStarted: false });
   const real = await submitTrack("BNL Real", { artist: "BNL Real Artist" });
+  const nonLatin = await submitTrack("BNL Non Latin", { artist: "東京ビート" });
   let simState = await queue.updateRadioTrack("", "addSimulationPaidPriority");
   const simUpNext = simState.nextInLine;
   assert.ok(simUpNext?.isTestTrack, "simulation priority track should exist in underlying up-next state");
@@ -1023,6 +1024,7 @@ test("BNL read model excludes simulation tracks from queue and artists", async (
   assert.equal(data.ok, true);
   const queueTrackIds = data.sections.queue.queue.map((track) => track.id);
   assert.ok(queueTrackIds.includes(real.id), "real queue track should remain in the BNL read model");
+  assert.ok(queueTrackIds.includes(nonLatin.id), "non-Latin artist track should remain in the BNL read model queue");
   assert.equal(queueTrackIds.includes(simQueued.id), false, "simulation queue track must not enter the BNL read model");
   assert.notEqual(data.sections.queue.upNext?.id ?? null, simUpNext.id, "simulation track must not be exposed as up next");
   assert.notEqual(data.sections.queue.nowPlaying?.id ?? null, simUpNext.id, "simulation track must not be exposed as now playing");
@@ -1030,6 +1032,10 @@ test("BNL read model excludes simulation tracks from queue and artists", async (
 
   const artistNames = data.sections.artists.map((artist) => artist.name);
   assert.ok(artistNames.includes("BNL Real Artist"), "real artist should remain in derived artist surface");
+  const nonLatinArtist = data.sections.artists.find((artist) => artist.name === "東京ビート");
+  assert.ok(nonLatinArtist, "non-Latin artist display name should remain in derived artist surface");
+  assert.equal(typeof nonLatinArtist.normalizedName, "string");
+  assert.notEqual(nonLatinArtist.normalizedName, "", "non-Latin artist normalizedName should not be empty");
   assert.equal(artistNames.some((name) => /^SIM /i.test(name)), false, "simulation artist must not enter derived artist surface");
   assert.ok(data.sections.rules.allowedUse.includes("simulation/test tracks are excluded from this read model"));
   assert.equal(data.sections.rules.sourceAuthority.simulationData, "BNL must treat this read model as live/public context only, not admin simulation data");


### PR DESCRIPTION
### Motivation

- Provide a compact, public-safe read model for BNL consumption that surfaces site source context, the public queue snapshot, a bounded artist surface, and a dossiers contract without exposing private/admin data.
- Reuse existing public queue helpers and the public dossier source (site content) so the endpoint stays lightweight and stable for future BNL bot consumers.

### Description

- Adds a new public GET endpoint `GET /api/bnl/read-model` implemented at `src/app/api/bnl/read-model/route.ts` that returns a stable v1 envelope with `sourceContext`, `queue`, `artists`, `dossiers`, and `rules` sections and `Cache-Control: public, max-age=15, s-maxage=30`.
- `queue` is derived from `getPublicQueueSnapshot()` and compacted to only include session summary, public status, `nowPlaying`, `upNext`, `queue`, and `completed` tracks using a whitelisted set of public-safe track fields (explicitly excludes contact emails, submitter tokens, Stripe/checkouts, private blob/file metadata, notes, suspicious/internal flags, and other private fields).
- `artists` is a bounded surface (max 25 artists, max 5 tracks per artist) derived only from the public queue snapshot, deduplicated by normalized artist name, exposing name, normalizedName, optional TikTok handle, and compact track entries with public-safe fields.
- `dossiers` returns compact summaries for only `clearance === "PUBLIC"` entries from `databasePage.entries` and otherwise provides an `implemented: false` contract note; this does not invent dossiers or expose restricted/internal data.

### Testing

- Ran TypeScript check: `npx tsc --noEmit` — passed.
- Linted the new file only: `npx eslint src/app/api/bnl/read-model/route.ts` — passed; full `npm run lint` failed due to unrelated pre-existing lint issues elsewhere in the repo (archived/UI files), not the new route.
- Ran unit integration queue tests: `npm run test:queue` — all queue tests passed (85 passing).
- Manual/dev smoke: started dev server and exercised endpoints; `GET /api/bnl/read-model` returned 200 with expected envelope (`ok: true`, `version: 1`, `publicOnly: true`) and cache header; `GET /api/queue` and `GET /api/bnl/status` returned expected existing shapes; `GET /api/admin/bnl` still returns 401 without admin auth.
- Data validation: verified the read-model JSON does not contain forbidden private keys (e.g. `contactEmail`, `submitterToken`, `stripeSessionId`, `priorityUpgradePaymentId`, `priorityUpgradeCheckoutUrl`, `fileUrl`, `fileName`, `fileSize`, `mimeType`, `suspiciousFlags`, `adminNote`).

Files changed

- `src/app/api/bnl/read-model/route.ts` — new public read-only BNL read model route (implements the response envelope, queue compaction, artist surface derivation, public dossier summaries, source context, rules, and cache headers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19451916308321b8a959ac8b6561f7)