### PR TITLE
BNL Read Model: Operator Semantics & Lane Hints (schemaRevision 1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:queue": "node --test tests/queue-playback.test.mjs",
+    "test:queue": "node --test tests/queue-playback.test.mjs tests/bnl-read-model.test.mjs",
     "check": "npx tsc --noEmit && npm run lint && npm run test:queue"
   },
   "dependencies": {

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -12,6 +12,21 @@ const MAX_TRACKS_PER_ARTIST = 5;
 
 type BnlReadModelTrackStatus = "queued" | "completed" | "nowPlaying" | "upNext";
 
+type BnlTrackContextRole = "runtime" | "recap_candidate";
+
+type BnlTrackContext = {
+  source: "queue_public_snapshot";
+  visibility: "public";
+  contextRole: BnlTrackContextRole;
+  status: BnlReadModelTrackStatus;
+  memoryDefault: "do_not_store" | "recap_candidate_only";
+  profileDefault: "not_profile";
+  identityDefault: "not_discord_identity";
+  recapDefault: "not_until_completed" | "recap_candidate";
+};
+
+type BnlArtistTrackStatusCounts = Record<BnlReadModelTrackStatus, number>;
+
 type BnlReadModelArtist = {
   name: string;
   normalizedName: string;
@@ -25,6 +40,16 @@ type BnlReadModelArtist = {
     publicSourceUrl?: string | null;
   }>;
   source: "queue_public_snapshot";
+  trackStatusCounts: BnlArtistTrackStatusCounts;
+  bnlContext: {
+    source: "queue_public_snapshot";
+    visibility: "public";
+    surfaceType: "queue_derived_artist_surface";
+    profileStatus: "not_profile";
+    identityStatus: "not_discord_or_account_identity";
+    memoryDefault: "do_not_store";
+    dossierDefault: "not_seed_without_operator_reason";
+  };
 };
 
 type BnlQueueTrack = Pick<
@@ -46,9 +71,25 @@ type BnlQueueTrack = Pick<
   | "tiktokHandle"
   | "priorityUpgradeRequested"
   | "priorityUpgradeStatus"
->;
+> & {
+  bnlContext: BnlTrackContext;
+};
 
-function publicTrack(track: QueuePublicTrack | null | undefined): BnlQueueTrack | null {
+function bnlTrackContext(status: BnlReadModelTrackStatus): BnlTrackContext {
+  const completed = status === "completed";
+  return {
+    source: "queue_public_snapshot",
+    visibility: "public",
+    contextRole: completed ? "recap_candidate" : "runtime",
+    status,
+    memoryDefault: completed ? "recap_candidate_only" : "do_not_store",
+    profileDefault: "not_profile",
+    identityDefault: "not_discord_identity",
+    recapDefault: completed ? "recap_candidate" : "not_until_completed",
+  };
+}
+
+function publicTrack(track: QueuePublicTrack | null | undefined, status: BnlReadModelTrackStatus): BnlQueueTrack | null {
   if (!track) return null;
   return {
     id: track.id,
@@ -68,11 +109,15 @@ function publicTrack(track: QueuePublicTrack | null | undefined): BnlQueueTrack 
     tiktokHandle: track.tiktokHandle ?? null,
     priorityUpgradeRequested: track.priorityUpgradeRequested === true,
     priorityUpgradeStatus: track.priorityUpgradeStatus ?? "none",
+    bnlContext: bnlTrackContext(status),
   };
 }
 
 function isRealQueueEntry(entry: QueueEntry | null | undefined): entry is QueueEntry {
-  return Boolean(entry && entry.isTestTrack !== true);
+  if (!entry || entry.isTestTrack === true) return false;
+  if (entry.note?.includes("[QUEUE SIMULATION TRACK]") === true) return false;
+  if (entry.artist.startsWith("SIM ") || entry.title.startsWith("SIM ")) return false;
+  return true;
 }
 
 function pressureFor(activeCount: number, capacity: number): "low" | "medium" | "high" | "max" {
@@ -128,10 +173,10 @@ async function readPublicLiveQueueForBnl() {
         capacity,
         pressure: pressureFor(activeCount, capacity),
       },
-      nowPlaying: publicTrack(nowPlaying),
-      upNext: publicTrack(upNext),
-      queue: publicQueueTracks.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
-      completed: publicCompletedTracks.map(publicTrack).filter((track): track is BnlQueueTrack => Boolean(track)),
+      nowPlaying: publicTrack(nowPlaying, "nowPlaying"),
+      upNext: publicTrack(upNext, "upNext"),
+      queue: publicQueueTracks.map((track) => publicTrack(track, "queued")).filter((track): track is BnlQueueTrack => Boolean(track)),
+      completed: publicCompletedTracks.map((track) => publicTrack(track, "completed")).filter((track): track is BnlQueueTrack => Boolean(track)),
     },
     artists: artistsFromTracks(nowPlaying, upNext, publicQueueTracks, publicCompletedTracks),
   };
@@ -182,6 +227,21 @@ function addArtistTrack(artists: Map<string, BnlReadModelArtist>, track: QueuePu
     tiktokHandle: track.tiktokHandle ?? null,
     tracks: [],
     source: "queue_public_snapshot",
+    trackStatusCounts: {
+      queued: 0,
+      completed: 0,
+      nowPlaying: 0,
+      upNext: 0,
+    },
+    bnlContext: {
+      source: "queue_public_snapshot",
+      visibility: "public",
+      surfaceType: "queue_derived_artist_surface",
+      profileStatus: "not_profile",
+      identityStatus: "not_discord_or_account_identity",
+      memoryDefault: "do_not_store",
+      dossierDefault: "not_seed_without_operator_reason",
+    },
   };
 
   if (!artist.tiktokHandle && track.tiktokHandle) artist.tiktokHandle = track.tiktokHandle;
@@ -195,6 +255,7 @@ function addArtistTrack(artists: Map<string, BnlReadModelArtist>, track: QueuePu
       publicSourceUrl: track.publicSourceUrl ?? null,
     });
   }
+  artist.trackStatusCounts[status] += 1;
 
   artists.set(normalizedName, artist);
 }
@@ -227,19 +288,43 @@ function publicDossiers() {
       tags: entry.tags,
       link: entry.link || null,
       source: "public_database_dossier",
+      bnlContext: {
+        source: "public_database_dossier",
+        visibility: "public",
+        dossierStatus: "existing_public_dossier",
+        memoryDefault: "site_context_not_broadcast_memory",
+        seedDefault: "not_seed_already_public_dossier",
+        identityDefault: "public_site_entity_not_discord_identity",
+      },
     }));
 
   if (publicEntries.length === 0) {
     return {
       implemented: false,
       public: [],
-      note: "Public dossier runtime is not implemented yet.",
+      items: [],
+      sourceAuthority: "public_database_entries_only",
+      rules: [
+        "Existing public dossiers are website-published public context.",
+        "They are not private profiles.",
+        "They are not Discord identity mappings.",
+        "They are not automatic broadcast memory.",
+      ],
+      note: "No public-clearance database dossier summaries are currently included.",
     };
   }
 
   return {
     implemented: true,
     public: publicEntries,
+    items: publicEntries,
+    sourceAuthority: "public_database_entries_only",
+    rules: [
+      "Existing public dossiers are website-published public context.",
+      "They are not private profiles.",
+      "They are not Discord identity mappings.",
+      "They are not automatic broadcast memory.",
+    ],
     note: "Only public-clearance database dossier summaries are included.",
   };
 }
@@ -277,6 +362,80 @@ const sourceContext = [
   },
 ];
 
+type OperatorLaneItem = {
+  id: string;
+  label: string;
+  source: "queue_public_snapshot" | "public_database_dossier" | "read_model_boundary";
+  kind: string;
+  trackId?: string;
+  status?: BnlReadModelTrackStatus;
+  value?: string | number | boolean | null;
+  reason: string;
+};
+
+function trackLaneItem(track: BnlQueueTrack, status: BnlReadModelTrackStatus, lane: "temporaryRuntimeContext" | "recapCandidates" | "publicSafeCopyCandidates"): OperatorLaneItem {
+  const title = track.detectedSongTitle || track.submittedSongTitle || track.providerTitle || "Untitled track";
+  const artist = track.detectedArtistName || track.submittedArtistName || "Unknown artist";
+  return {
+    id: `${lane}:${track.id}:${status}`,
+    label: `${artist} — ${title}`,
+    source: "queue_public_snapshot",
+    kind: "track",
+    trackId: track.id,
+    status,
+    reason: lane === "recapCandidates" ? "Completed public queue track; possible recap item only." : "Public queue track; temporary runtime/site context only.",
+  };
+}
+
+function buildOperatorLanes(queue: Awaited<ReturnType<typeof readPublicLiveQueueForBnl>>["queue"], dossiers: ReturnType<typeof publicDossiers>) {
+  const temporaryRuntimeContext: OperatorLaneItem[] = [
+    { id: "queue:open", label: "Queue open/closed", source: "queue_public_snapshot", kind: "queue_status", value: queue.session.queueOpen, reason: "Public queue runtime status." },
+    { id: "session:status", label: "Session status", source: "queue_public_snapshot", kind: "session_status", value: queue.session.status, reason: "Public session runtime status." },
+    { id: "session:broadcastPhase", label: "Broadcast phase", source: "queue_public_snapshot", kind: "broadcast_phase", value: queue.session.broadcastPhase, reason: "Public broadcast phase runtime status." },
+    { id: "queue:activeCount", label: "Active queue count", source: "queue_public_snapshot", kind: "queue_count", value: queue.session.activeCount, reason: "Public count of active queue tracks." },
+    { id: "priority:enabled", label: "Priority Signal enabled", source: "queue_public_snapshot", kind: "priority_signal_status", value: queue.session.priorityUpgradesEnabled, reason: "Public feature availability label only, not a payment fact." },
+    { id: "priority:label", label: "Priority Signal label", source: "queue_public_snapshot", kind: "priority_signal_label", value: queue.session.priorityUpgradeLabel, reason: "Public queue label only." },
+    { id: "wheel:spinsOwed", label: "Wheel spins owed", source: "queue_public_snapshot", kind: "wheel_status", value: queue.session.wheelSpinsOwed, reason: "Public queue runtime status." },
+  ];
+
+  if (queue.nowPlaying) temporaryRuntimeContext.push(trackLaneItem(queue.nowPlaying, "nowPlaying", "temporaryRuntimeContext"));
+  if (queue.upNext) temporaryRuntimeContext.push(trackLaneItem(queue.upNext, "upNext", "temporaryRuntimeContext"));
+  temporaryRuntimeContext.push(...queue.queue.map((track) => trackLaneItem(track, "queued", "temporaryRuntimeContext")));
+
+  const recapCandidates = queue.completed.map((track) => trackLaneItem(track, "completed", "recapCandidates"));
+  const publicSafeCopyCandidates: OperatorLaneItem[] = [
+    { id: "copy:queue:open", label: "Queue open/closed", source: "queue_public_snapshot", kind: "queue_status", value: queue.session.queueOpen, reason: "High-level public queue copy is safe to reference." },
+  ];
+  if (queue.nowPlaying) publicSafeCopyCandidates.push(trackLaneItem(queue.nowPlaying, "nowPlaying", "publicSafeCopyCandidates"));
+  if (queue.upNext) publicSafeCopyCandidates.push(trackLaneItem(queue.upNext, "upNext", "publicSafeCopyCandidates"));
+  publicSafeCopyCandidates.push(...queue.completed.map((track) => trackLaneItem(track, "completed", "publicSafeCopyCandidates")));
+  publicSafeCopyCandidates.push(...dossiers.public.map((dossier) => ({
+    id: `copy:dossier:${dossier.id}`,
+    label: dossier.name,
+    source: "public_database_dossier" as const,
+    kind: "public_dossier_summary",
+    reason: "Published public dossier summary is public site context, not private memory.",
+  })));
+
+  return {
+    temporaryRuntimeContext,
+    recapCandidates,
+    broadcastMemoryCandidates: [] as OperatorLaneItem[],
+    dossierSeedCandidates: [] as OperatorLaneItem[],
+    publicSafeCopyCandidates,
+    doNotStore: [
+      "queue artist surface is not a permanent profile",
+      "queue track presence is not broadcast memory",
+      "TikTok handle is not Discord identity",
+      "Priority Signal status is not payment fact",
+      "public dossier summary is not private dossier seed",
+      "website read model is public temporary context",
+      "simulation/test tracks are excluded",
+      "no private payment/contact/upload/admin data",
+    ],
+  };
+}
+
 const rules = {
   allowedUse: [
     "public-safe BNL context",
@@ -285,6 +444,12 @@ const rules = {
     "queue/session awareness",
     "artist/track awareness from public queue snapshot",
     "simulation/test tracks are excluded from this read model",
+    "operatorLanes are hints, not actions",
+    "broadcastMemoryCandidates are drafts only",
+    "recapCandidates are possible recap items only",
+    "dossierSeedCandidates are possible seeds only",
+    "temporaryRuntimeContext should not be stored",
+    "BNL must not treat this endpoint as private access",
   ],
   disallowedUse: [
     "private user identity",
@@ -301,9 +466,10 @@ const rules = {
     "treating admin simulation data as live/public context",
   ],
   sourceAuthority: {
-    queue: "public runtime snapshot with read-model-only simulation/test filtering",
-    artists: "derived from read-model-filtered public queue fields",
-    dossiers: "public dossier runtime only if implemented",
+    queue: "public runtime snapshot with simulation/test filtering",
+    artists: "queue-derived public artist surface, not profiles",
+    dossiers: "public dossier/database entries only if clearance is PUBLIC",
+    operatorLanes: "deterministic public-safe lane hints, not automatic actions",
     sourceContext: "static public site context",
     simulationData: "BNL must treat this read model as live/public context only, not admin simulation data",
   },
@@ -311,11 +477,13 @@ const rules = {
 
 export async function GET() {
   const liveQueue = await readPublicLiveQueueForBnl();
+  const dossiers = publicDossiers();
 
   return NextResponse.json(
     {
       ok: true,
       version: 1,
+      schemaRevision: "1.1",
       generatedAt: new Date().toISOString(),
       scope: "bnl_public_read_model",
       source: "barcode-network-site",
@@ -324,7 +492,8 @@ export async function GET() {
         sourceContext,
         queue: liveQueue.queue,
         artists: liveQueue.artists,
-        dossiers: publicDossiers(),
+        dossiers,
+        operatorLanes: buildOperatorLanes(liveQueue.queue, dossiers),
         rules,
       },
     },

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+// Keep endpoint tests isolated to the in-memory queue store instead of any configured Redis.
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, "src", request.slice(2));
+    if (fs.existsSync(resolved)) return resolved;
+    if (fs.existsSync(`${resolved}.ts`)) return `${resolved}.ts`;
+    if (fs.existsSync(`${resolved}.tsx`)) return `${resolved}.tsx`;
+    return resolved;
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+Module._extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+const require = createRequire(import.meta.url);
+const queue = require("../src/lib/queue.ts");
+const readModel = require("../src/app/api/bnl/read-model/route.ts");
+
+const forbiddenKeys = [
+  "contactEmail",
+  "submitterToken",
+  "stripeSessionId",
+  "priorityUpgradePaymentId",
+  "priorityUpgradeCheckoutUrl",
+  "fileUrl",
+  "fileName",
+  "fileSize",
+  "mimeType",
+  "suspiciousFlags",
+  "adminNote",
+];
+
+let sequence = 0;
+
+async function freshReadModelSession() {
+  sequence += 1;
+  await queue.setQueueOpen(false);
+  const state = await queue.startNewQueueSession({ title: `BNL Read Model ${Date.now()} ${sequence}` });
+  await queue.setQueueOpen(true);
+  await queue.updateRadioTrack("", "startShow");
+  return state.session.sessionId;
+}
+
+async function addTrack(label, options = {}) {
+  sequence += 1;
+  const artist = options.artist ?? `${label} Artist`;
+  return queue.addToQueue({
+    artist,
+    title: `${label} Track`,
+    tiktokHandle: `@${artist.toLowerCase().replace(/[^a-z0-9]/g, "")}${sequence}`,
+    link: `https://example.com/${label.toLowerCase().replace(/[^a-z0-9]/g, "")}-${sequence}`,
+    tier: "free",
+    lane: options.lane ?? "regular",
+    amount: 0,
+    stripeSessionId: options.stripeSessionId ?? null,
+    createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, sequence)).toISOString(),
+    contactEmail: `${label.toLowerCase().replace(/[^a-z0-9]/g, "")}${sequence}@example.com`,
+    submitterToken: `token-${label}-${sequence}`,
+    fileUrl: "https://private.example.test/upload.mp3",
+    fileName: "upload.mp3",
+    fileSize: 123456,
+    mimeType: "audio/mpeg",
+    suspiciousFlags: ["test-only"],
+    priorityUpgradePaymentId: "pi_private_test",
+    priorityUpgradeCheckoutUrl: "https://checkout.example.test/private",
+  });
+}
+
+async function modelJson() {
+  const response = await readModel.GET();
+  return response.json();
+}
+
+function findForbiddenKeys(value, pathName = "$", found = []) {
+  if (!value || typeof value !== "object") return found;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findForbiddenKeys(item, `${pathName}[${index}]`, found));
+    return found;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (forbiddenKeys.includes(key)) found.push(`${pathName}.${key}`);
+    findForbiddenKeys(child, `${pathName}.${key}`, found);
+  }
+  return found;
+}
+
+function allTrackIds(model) {
+  const queueSection = model.sections.queue;
+  return [
+    queueSection.nowPlaying?.id,
+    queueSection.upNext?.id,
+    ...queueSection.queue.map((track) => track.id),
+    ...queueSection.completed.map((track) => track.id),
+  ].filter(Boolean);
+}
+
+test("BNL read model preserves v1 compatibility and adds semantic sections", async () => {
+  await freshReadModelSession();
+  const queued = await addTrack("Queued", { artist: "Queued Artist" });
+  const completed = await addTrack("Completed", { artist: "完成 Artist" });
+  await queue.updateRadioTrack(completed.id, "finish");
+
+  const model = await modelJson();
+
+  assert.equal(model.ok, true);
+  assert.equal(model.version, 1);
+  assert.equal(model.schemaRevision, "1.1");
+  assert.equal(model.publicOnly, true);
+  assert.ok(model.sections.sourceContext);
+  assert.ok(model.sections.queue);
+  assert.ok(model.sections.artists);
+  assert.ok(model.sections.dossiers);
+  assert.ok(model.sections.rules);
+  assert.ok(model.sections.operatorLanes);
+
+  for (const lane of ["temporaryRuntimeContext", "recapCandidates", "broadcastMemoryCandidates", "dossierSeedCandidates", "publicSafeCopyCandidates", "doNotStore"]) {
+    assert.ok(Array.isArray(model.sections.operatorLanes[lane]), `${lane} should be an array`);
+  }
+
+  const queuedModelTrack = [model.sections.queue.nowPlaying, model.sections.queue.upNext, ...model.sections.queue.queue].filter(Boolean).find((track) => track.id === queued.id);
+  assert.ok(queuedModelTrack, "queued/runtime track should be exposed on an active public queue surface");
+  assert.equal(queuedModelTrack.bnlContext.contextRole, "runtime");
+  assert.match(queuedModelTrack.bnlContext.status, /^(queued|upNext|nowPlaying)$/);
+  assert.equal(queuedModelTrack.bnlContext.memoryDefault, "do_not_store");
+  assert.equal(queuedModelTrack.bnlContext.profileDefault, "not_profile");
+  assert.equal(queuedModelTrack.bnlContext.identityDefault, "not_discord_identity");
+  assert.equal(queuedModelTrack.bnlContext.recapDefault, "not_until_completed");
+
+  const completedModelTrack = model.sections.queue.completed.find((track) => track.id === completed.id);
+  assert.equal(completedModelTrack.bnlContext.contextRole, "recap_candidate");
+  assert.equal(completedModelTrack.bnlContext.status, "completed");
+  assert.equal(completedModelTrack.bnlContext.memoryDefault, "recap_candidate_only");
+
+  const artist = model.sections.artists.find((entry) => entry.normalizedName === "queued-artist");
+  assert.equal(artist.bnlContext.profileStatus, "not_profile");
+  assert.equal(artist.bnlContext.identityStatus, "not_discord_or_account_identity");
+  assert.equal(artist.trackStatusCounts.queued + artist.trackStatusCounts.upNext + artist.trackStatusCounts.nowPlaying, 1);
+
+  assert.ok(model.sections.dossiers.public.length > 0, "expected public database dossiers in fixture content");
+  assert.equal(model.sections.dossiers.public[0].bnlContext.dossierStatus, "existing_public_dossier");
+  assert.equal(model.sections.dossiers.items.length, model.sections.dossiers.public.length);
+});
+
+test("BNL read model labels now playing and up next as runtime context", async () => {
+  await freshReadModelSession();
+  const nowPlaying = await addTrack("Now Playing", { artist: "Now Artist" });
+  const upNext = await addTrack("Up Next", { artist: "Next Artist" });
+  await queue.updateRadioTrack(nowPlaying.id, "load");
+  await queue.updateRadioTrack("", "pullNext");
+
+  const model = await modelJson();
+
+  assert.equal(model.sections.queue.nowPlaying.id, nowPlaying.id);
+  assert.equal(model.sections.queue.nowPlaying.bnlContext.status, "nowPlaying");
+  assert.equal(model.sections.queue.nowPlaying.bnlContext.contextRole, "runtime");
+  assert.equal(model.sections.queue.upNext.id, upNext.id);
+  assert.equal(model.sections.queue.upNext.bnlContext.status, "upNext");
+  assert.equal(model.sections.queue.upNext.bnlContext.contextRole, "runtime");
+});
+
+test("BNL read model excludes simulation/test tracks from all public semantic surfaces", async () => {
+  await freshReadModelSession();
+  const real = await addTrack("Real", { artist: "Real Artist" });
+  await queue.updateRadioTrack("", "addSimulationFreeTrack");
+  await queue.updateRadioTrack("", "addSimulationCheckoutPending");
+
+  const model = await modelJson();
+  const json = JSON.stringify(model);
+
+  assert.ok(allTrackIds(model).includes(real.id));
+  assert.equal(json.includes("SIM "), false);
+  assert.equal(json.includes("[QUEUE SIMULATION TRACK]"), false);
+  assert.equal(json.includes("sim-track"), false);
+  assert.equal(json.includes("Glass Circuit"), false);
+});
+
+test("BNL read model excludes private queue/payment/upload keys", async () => {
+  await freshReadModelSession();
+  await addTrack("Private Fields", { artist: "Private Artist", stripeSessionId: "cs_private_test" });
+
+  const model = await modelJson();
+  assert.deepEqual(findForbiddenKeys(model), []);
+});
+
+test("BNL read model keeps normal queue items out of broadcast memory candidates", async () => {
+  await freshReadModelSession();
+  const queued = await addTrack("Memory Queued", { artist: "Memory Queue Artist" });
+  const completed = await addTrack("Memory Completed", { artist: "Memory Completed Artist" });
+  await queue.updateRadioTrack(completed.id, "finish");
+
+  const model = await modelJson();
+  const lanes = model.sections.operatorLanes;
+
+  assert.ok(lanes.temporaryRuntimeContext.some((item) => item.trackId === queued.id));
+  assert.ok(lanes.recapCandidates.some((item) => item.trackId === completed.id));
+  assert.equal(lanes.broadcastMemoryCandidates.some((item) => item.trackId === queued.id), false);
+  assert.equal(lanes.broadcastMemoryCandidates.some((item) => item.trackId === completed.id), false);
+
+  const artist = model.sections.artists.find((entry) => entry.normalizedName === "memory-queue-artist");
+  assert.equal(artist.bnlContext.profileStatus, "not_profile");
+  assert.equal(artist.bnlContext.identityStatus, "not_discord_or_account_identity");
+});


### PR DESCRIPTION
### Motivation
- The BNL public read model was semantically loose and forced downstream code to infer whether items are runtime-only, recap candidates, or safe to promote into broadcast memory. 
- Provide deterministic, conservative, public-safe operator hints so R&D/Bots can reliably treat queue, track, artist, and dossier data without guessing or using private fields. 
- Preserve full compatibility with existing consumers by keeping `version: 1` and only adding additive fields.

### Description
- Files changed: `src/app/api/bnl/read-model/route.ts` (adds `schemaRevision: "1.1"`, `sections.operatorLanes`, per-track `bnlContext`, per-artist `bnlContext` + `trackStatusCounts`, enhanced public dossier metadata and source authority rules), `tests/bnl-read-model.test.mjs` (new endpoint tests), and `package.json` (`test:queue` updated to include new tests). 
- Added top-level `schemaRevision: "1.1"` while leaving `version: 1`, and added `sections.operatorLanes` with deterministic arrays `temporaryRuntimeContext`, `recapCandidates`, `broadcastMemoryCandidates`, `dossierSeedCandidates`, `publicSafeCopyCandidates`, and `doNotStore`. 
- Added per-track `bnlContext` (source, visibility, `contextRole`, `status`, `memoryDefault`, `profileDefault`, `identityDefault`, `recapDefault`) and per-artist `bnlContext` plus `trackStatusCounts`; public dossiers now include additive `bnlContext`, `items`, `sourceAuthority`, and section-level rules, while keeping only `clearance === "PUBLIC"` entries. 
- Strengthened deterministic simulation/test filtering (exclude admin simulation markers), explicitly kept all additions additive and public-safe, and expanded `sections.rules.sourceAuthority` to document storage/action boundaries and lane semantics.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it passed. 
- Lint: ran `npx eslint src/app/api/bnl/read-model/route.ts` and it passed for the modified route. 
- Unit tests: added `tests/bnl-read-model.test.mjs` and ran `node --test tests/bnl-read-model.test.mjs`, which passed; updated `npm run test:queue` and ran `npm run test:queue`, and the full suite passed. 
- Verification: confirmed `GET /api/bnl/read-model` still returns `version: 1` and includes `schemaRevision: "1.1"`, `sections.operatorLanes`, no forbidden private keys, and excludes simulation/test tracks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196515ff388321b5a911977d0599aa)