### PR TITLE
PR #124 — Public Dossier Registry Structure v1

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { databasePage, radioPage, siteConfig } from "@/content";
+import type { PublicDossierAuthority, PublicDossierKind, PublicDossierLifecycle } from "@/content";
 import { getRadioQueueState, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry, QueueLane, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
 
@@ -274,42 +275,155 @@ function artistsFromTracks(
   return [...artists.values()].slice(0, MAX_ARTISTS);
 }
 
+type DatabaseEntry = (typeof databasePage.entries)[number];
+type PublicDossierStatus = "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN";
+type PublicDatabaseEntry = DatabaseEntry & {
+  kind?: PublicDossierKind;
+  lifecycle?: PublicDossierLifecycle;
+  authority?: PublicDossierAuthority;
+  publicFacts?: string[];
+  knownBoundaries?: string[];
+  relatedPublicIds?: string[];
+};
+
+type BnlPublicDossier = {
+  id: string;
+  name: string;
+  kind: PublicDossierKind;
+  category: DatabaseEntry["category"];
+  status: PublicDossierStatus;
+  lifecycle: PublicDossierLifecycle;
+  role: string;
+  origin: DatabaseEntry["origin"];
+  authority: PublicDossierAuthority;
+  summary: string;
+  tags: string[];
+  link: string | null;
+  publicFacts: string[];
+  knownBoundaries: string[];
+  relatedPublicIds: string[];
+  source: "public_database_dossier";
+  bnlContext: {
+    source: "public_database_dossier";
+    visibility: "public";
+    dossierStatus: "existing_public_dossier";
+    memoryDefault: "site_context_not_broadcast_memory";
+    seedDefault: "not_seed_already_public_dossier";
+    identityDefault: "public_site_entity_not_discord_identity";
+  };
+};
+
+type PublicDossierRegistry = {
+  source: "databasePage.entries";
+  publicCount: number;
+  kinds: Partial<Record<PublicDossierKind, number>>;
+  lifecycleCounts: Partial<Record<PublicDossierLifecycle, number>>;
+  authority: PublicDossierAuthority;
+  autoPromotion: false;
+  queueDerivedProfiles: false;
+};
+
+const PUBLIC_DOSSIER_BOUNDARIES = [
+  "not Discord identity",
+  "not payment profile",
+  "not private account",
+  "not automatic broadcast memory",
+];
+
+const DOSSIER_RULES = [
+  "Existing public dossiers are website-published public context.",
+  "Public dossiers are not private profiles.",
+  "Public dossiers are not Discord identity mappings.",
+  "Public dossiers are not payment/customer/account records.",
+  "Public dossiers are not automatic broadcast memory.",
+  "Queue-derived artists are not public dossiers unless manually promoted through a future approved workflow.",
+  "Research classifier dossier seeds are not public dossiers until a future approved site workflow publishes them.",
+];
+
+function lifecycleForStatus(status: PublicDossierStatus): PublicDossierLifecycle {
+  if (status === "ACTIVE") return "active";
+  if (status === "INACTIVE") return "inactive";
+  if (status === "ARCHIVED") return "archived";
+  if (status === "PENDING") return "planned";
+  return "unknown";
+}
+
+function inferPublicDossierKind(entry: DatabaseEntry): PublicDossierKind {
+  const name = entry.name.toLocaleLowerCase();
+  const category = entry.category.toLocaleLowerCase();
+
+  if (name === "barcode radio") return "program";
+  if (name === "discord community") return "interface";
+  if (name === "auxchord" || name === "tiktok live") return "platform";
+  if (name.includes("bnl-01")) return "system";
+  if (category === "production") return "program";
+  if (category === "interface") return "interface";
+  if (category === "sponsor") return "sponsor_character";
+  if ((entry.status as PublicDossierStatus) === "ARCHIVED") return "archive_record";
+  return "entity";
+}
+
+function normalizePublicDossier(entry: PublicDatabaseEntry): BnlPublicDossier {
+  return {
+    id: entry.id,
+    name: entry.name,
+    kind: entry.kind ?? inferPublicDossierKind(entry),
+    category: entry.category,
+    status: entry.status as PublicDossierStatus,
+    lifecycle: entry.lifecycle ?? lifecycleForStatus(entry.status as PublicDossierStatus),
+    role: entry.role,
+    origin: entry.origin,
+    authority: entry.authority ?? "website_public_database",
+    summary: entry.summary,
+    tags: [...entry.tags],
+    link: entry.link || null,
+    publicFacts: entry.publicFacts ?? [],
+    knownBoundaries: entry.knownBoundaries ?? [...PUBLIC_DOSSIER_BOUNDARIES],
+    relatedPublicIds: entry.relatedPublicIds ?? [],
+    source: "public_database_dossier",
+    bnlContext: {
+      source: "public_database_dossier",
+      visibility: "public",
+      dossierStatus: "existing_public_dossier",
+      memoryDefault: "site_context_not_broadcast_memory",
+      seedDefault: "not_seed_already_public_dossier",
+      identityDefault: "public_site_entity_not_discord_identity",
+    },
+  };
+}
+
+function buildDossierRegistry(publicEntries: BnlPublicDossier[]): PublicDossierRegistry {
+  return {
+    source: "databasePage.entries",
+    publicCount: publicEntries.length,
+    kinds: publicEntries.reduce<Partial<Record<PublicDossierKind, number>>>((counts, entry) => {
+      counts[entry.kind] = (counts[entry.kind] ?? 0) + 1;
+      return counts;
+    }, {}),
+    lifecycleCounts: publicEntries.reduce<Partial<Record<PublicDossierLifecycle, number>>>((counts, entry) => {
+      counts[entry.lifecycle] = (counts[entry.lifecycle] ?? 0) + 1;
+      return counts;
+    }, {}),
+    authority: "website_public_database",
+    autoPromotion: false,
+    queueDerivedProfiles: false,
+  };
+}
+
 function publicDossiers() {
   const publicEntries = databasePage.entries
     .filter((entry) => entry.clearance === "PUBLIC")
-    .map((entry) => ({
-      id: entry.id,
-      name: entry.name,
-      category: entry.category,
-      status: entry.status,
-      role: entry.role,
-      origin: entry.origin,
-      summary: entry.summary,
-      tags: entry.tags,
-      link: entry.link || null,
-      source: "public_database_dossier",
-      bnlContext: {
-        source: "public_database_dossier",
-        visibility: "public",
-        dossierStatus: "existing_public_dossier",
-        memoryDefault: "site_context_not_broadcast_memory",
-        seedDefault: "not_seed_already_public_dossier",
-        identityDefault: "public_site_entity_not_discord_identity",
-      },
-    }));
+    .map((entry) => normalizePublicDossier(entry));
+  const registry = buildDossierRegistry(publicEntries);
 
   if (publicEntries.length === 0) {
     return {
       implemented: false,
       public: [],
       items: [],
+      registry,
       sourceAuthority: "public_database_entries_only",
-      rules: [
-        "Existing public dossiers are website-published public context.",
-        "They are not private profiles.",
-        "They are not Discord identity mappings.",
-        "They are not automatic broadcast memory.",
-      ],
+      rules: DOSSIER_RULES,
       note: "No public-clearance database dossier summaries are currently included.",
     };
   }
@@ -318,13 +432,9 @@ function publicDossiers() {
     implemented: true,
     public: publicEntries,
     items: publicEntries,
+    registry,
     sourceAuthority: "public_database_entries_only",
-    rules: [
-      "Existing public dossiers are website-published public context.",
-      "They are not private profiles.",
-      "They are not Discord identity mappings.",
-      "They are not automatic broadcast memory.",
-    ],
+    rules: DOSSIER_RULES,
     note: "Only public-clearance database dossier summaries are included.",
   };
 }
@@ -348,7 +458,7 @@ const sourceContext = [
   {
     id: "broadcast_memory",
     title: "Broadcast Memory",
-    summary: "Broadcast memory is public-facing continuity about what the Network has already surfaced through broadcasts, site copy, queue state, and public records. It is not raw Discord data, private notes, or hidden R&D process material.",
+    summary: "Broadcast memory is public-facing continuity about what the Network has already surfaced through broadcasts, site copy, queue state, and public records. It is not raw Discord data, private notes, or hidden research process material.",
   },
   {
     id: "priority_signal",
@@ -368,6 +478,7 @@ type OperatorLaneItem = {
   source: "queue_public_snapshot" | "public_database_dossier" | "read_model_boundary";
   kind: string;
   trackId?: string;
+  dossierId?: string;
   status?: BnlReadModelTrackStatus;
   value?: string | number | boolean | null;
   reason: string;
@@ -414,6 +525,8 @@ function buildOperatorLanes(queue: Awaited<ReturnType<typeof readPublicLiveQueue
     label: dossier.name,
     source: "public_database_dossier" as const,
     kind: "public_dossier_summary",
+    dossierId: dossier.id,
+    value: dossier.kind,
     reason: "Published public dossier summary is public site context, not private memory.",
   })));
 
@@ -439,7 +552,7 @@ function buildOperatorLanes(queue: Awaited<ReturnType<typeof readPublicLiveQueue
 const rules = {
   allowedUse: [
     "public-safe BNL context",
-    "R&D reference",
+    "research/reference use",
     "public replies when relevant",
     "queue/session awareness",
     "artist/track awareness from public queue snapshot",

--- a/src/content.ts
+++ b/src/content.ts
@@ -265,6 +265,40 @@ export const terminalPage = {
 
 // ----- DATABASE PAGE -----
 
+export type PublicDossierKind =
+  | "program"
+  | "interface"
+  | "platform"
+  | "system"
+  | "entity"
+  | "artist"
+  | "sponsor_character"
+  | "story_arc"
+  | "technical_component"
+  | "archive_record";
+
+export type PublicDossierLifecycle =
+  | "active"
+  | "inactive"
+  | "archived"
+  | "planned"
+  | "unknown";
+
+export type PublicDossierAuthority =
+  | "website_public_database"
+  | "broadcast_memory_confirmed"
+  | "manual_public_entry"
+  | "legacy_static_content";
+
+export type PublicDossierRegistryFields = {
+  kind?: PublicDossierKind;
+  lifecycle?: PublicDossierLifecycle;
+  authority?: PublicDossierAuthority;
+  publicFacts?: string[];
+  knownBoundaries?: string[];
+  relatedPublicIds?: string[];
+};
+
 // Designation prefixes:
 //   EN-### = Entity | PE-### = Personnel | SP-### = Sponsor | IF-### = Interface | PD-### = Production
 // Categories: Entity | Personnel | Sponsor | Interface | Production

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -39,6 +39,7 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 
 const require = createRequire(import.meta.url);
 const queue = require("../src/lib/queue.ts");
+const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 
 const forbiddenKeys = [
@@ -53,6 +54,10 @@ const forbiddenKeys = [
   "mimeType",
   "suspiciousFlags",
   "adminNote",
+  "discordUserId",
+  "discordId",
+  "privateSeed",
+  "internalNote",
 ];
 
 let sequence = 0;
@@ -105,6 +110,28 @@ function findForbiddenKeys(value, pathName = "$", found = []) {
   for (const [key, child] of Object.entries(value)) {
     if (forbiddenKeys.includes(key)) found.push(`${pathName}.${key}`);
     findForbiddenKeys(child, `${pathName}.${key}`, found);
+  }
+  return found;
+}
+
+function publicDatabaseEntries() {
+  return databasePage.entries.filter((entry) => entry.clearance === "PUBLIC");
+}
+
+function findForbiddenStringValues(value, pathName = "$", found = []) {
+  if (typeof value === "string") {
+    if (/contactEmail|submitterToken|stripeSessionId|priorityUpgradePaymentId|priorityUpgradeCheckoutUrl|fileUrl|fileName|fileSize|mimeType|suspiciousFlags|adminNote|discordUserId|discordId|privateSeed|r&d|internalNote/i.test(value)) {
+      found.push(`${pathName}: ${value}`);
+    }
+    return found;
+  }
+  if (!value || typeof value !== "object") return found;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findForbiddenStringValues(item, `${pathName}[${index}]`, found));
+    return found;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    findForbiddenStringValues(child, `${pathName}.${key}`, found);
   }
   return found;
 }
@@ -166,6 +193,42 @@ test("BNL read model preserves v1 compatibility and adds semantic sections", asy
   assert.equal(model.sections.dossiers.items.length, model.sections.dossiers.public.length);
 });
 
+test("BNL read model exposes public dossier registry metadata", async () => {
+  await freshReadModelSession();
+
+  const model = await modelJson();
+  const registry = model.sections.dossiers.registry;
+  const publicEntries = publicDatabaseEntries();
+
+  assert.ok(registry);
+  assert.equal(registry.source, "databasePage.entries");
+  assert.equal(registry.publicCount, publicEntries.length);
+  assert.equal(registry.publicCount, model.sections.dossiers.public.length);
+  assert.ok(registry.kinds);
+  assert.ok(registry.lifecycleCounts);
+  assert.equal(registry.autoPromotion, false);
+  assert.equal(registry.queueDerivedProfiles, false);
+  assert.equal(model.sections.dossiers.public.some((entry) => entry.kind === "program"), true);
+  assert.equal(model.sections.dossiers.public.some((entry) => entry.kind === "interface" || entry.kind === "platform"), true);
+});
+
+test("BNL read model normalizes public dossiers with safe structured fields", async () => {
+  await freshReadModelSession();
+
+  const model = await modelJson();
+
+  for (const dossier of model.sections.dossiers.public) {
+    for (const field of ["id", "name", "kind", "lifecycle", "authority", "bnlContext", "category", "status", "role", "summary", "tags", "link", "source"]) {
+      assert.ok(Object.hasOwn(dossier, field), `public dossier should expose ${field}`);
+    }
+    assert.ok(Array.isArray(dossier.knownBoundaries));
+    assert.ok(Array.isArray(dossier.publicFacts));
+    assert.ok(Array.isArray(dossier.relatedPublicIds));
+    assert.equal(dossier.bnlContext.visibility, "public");
+    assert.equal(dossier.bnlContext.seedDefault, "not_seed_already_public_dossier");
+  }
+});
+
 test("BNL read model labels now playing and up next as runtime context", async () => {
   await freshReadModelSession();
   const nowPlaying = await addTrack("Now Playing", { artist: "Now Artist" });
@@ -205,6 +268,7 @@ test("BNL read model excludes private queue/payment/upload keys", async () => {
 
   const model = await modelJson();
   assert.deepEqual(findForbiddenKeys(model), []);
+  assert.deepEqual(findForbiddenStringValues(model), []);
 });
 
 test("BNL read model keeps normal queue items out of broadcast memory candidates", async () => {
@@ -220,6 +284,11 @@ test("BNL read model keeps normal queue items out of broadcast memory candidates
   assert.ok(lanes.recapCandidates.some((item) => item.trackId === completed.id));
   assert.equal(lanes.broadcastMemoryCandidates.some((item) => item.trackId === queued.id), false);
   assert.equal(lanes.broadcastMemoryCandidates.some((item) => item.trackId === completed.id), false);
+  assert.equal(lanes.broadcastMemoryCandidates.length, 0);
+  assert.equal(lanes.dossierSeedCandidates.length, 0);
+  assert.equal(lanes.publicSafeCopyCandidates.some((item) => item.source === "public_database_dossier" && item.dossierId), true);
+  assert.equal(model.sections.dossiers.public.some((dossier) => JSON.stringify(dossier).includes("Memory Queue Artist")), false);
+  assert.equal(model.sections.artists.some((entry) => entry.normalizedName === "memory-queue-artist"), true);
 
   const artist = model.sections.artists.find((entry) => entry.normalizedName === "memory-queue-artist");
   assert.equal(artist.bnlContext.profileStatus, "not_profile");


### PR DESCRIPTION
### Motivation
- The public read-model currently exposed shallow dossier summaries that make it hard for BNL and future features to distinguish public dossiers, seeds, queue-derived surfaces, and other entity types. 
- Introduce an additive, public-safe registry structure so clients can rely on consistent dossier typing and lifecycle metadata without pulling private/admin data. 
- Preserve existing `/api/bnl/read-model` compatibility (`version: 1`, `schemaRevision: "1.1"`) and avoid any admin/accounts/queue-to-dossier promotion behavior. 

### Description
- Added explicit public-dossier type aliases to `src/content.ts` (`PublicDossierKind`, `PublicDossierLifecycle`, `PublicDossierAuthority`, and `PublicDossierRegistryFields`) to provide a stable schema for future content entries. 
- Implemented normalization and registry helpers in `src/app/api/bnl/read-model/route.ts`: added `normalizePublicDossier`, `buildDossierRegistry`, `BnlPublicDossier` shape, conservative `inferPublicDossierKind`/`lifecycleForStatus` defaults, `PUBLIC_DOSSIER_BOUNDARIES`, and `DOSSIER_RULES`; these produce a consistent, public-safe dossier item shape and an additive `sections.dossiers.registry` object. 
- Kept existing compatibility fields and behavior while adding fields only (preserving `sections.dossiers.public`, `sections.dossiers.items`, `version: 1`, and `schemaRevision: "1.1"`), and updated `operatorLanes` so public dossiers appear as `publicSafeCopyCandidates` (with `dossierId` and `value`) while `broadcastMemoryCandidates` and `dossierSeedCandidates` remain empty by default. 
- Tests and small test harness changes were added in `tests/bnl-read-model.test.mjs` to assert the registry exists, that public dossiers are normalized, that forbidden private keys/strings are not present, and to verify queue/dossier separation; files changed: `src/content.ts`, `src/app/api/bnl/read-model/route.ts`, and `tests/bnl-read-model.test.mjs`. 

### Testing
- Type-check: ran `npx tsc --noEmit` and it passed. 
- Lint: ran `npx eslint src/app/api/bnl/read-model/route.ts` and it passed. 
- Integration/unit: ran `npm run test:queue` (which executes `tests/queue-playback.test.mjs` and `tests/bnl-read-model.test.mjs`) and all tests passed (93 tests green). 
- Manual endpoint checks (recommended after deployment): run `curl -sS https://www.barcode-network.com/api/bnl/read-model | python3 -m json.tool | grep -E '"registry"|"publicCount"|"kinds"|"lifecycleCounts"|"knownBoundaries"|"publicFacts"|"relatedPublicIds"' -n` and the forbidden-field grep shown in the branch notes to confirm no private/payment/Discord/admin fields are exposed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198048593483218d32d13f22739df5)