### PR TITLE
Fix BNL read-model: centralize database aggregate stats and expose full aggregates

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { databasePage, radioPage, siteConfig } from "@/content";
 import type { PublicDossierAuthority, PublicDossierKind, PublicDossierLifecycle } from "@/content";
+import { getDatabaseAggregateStats } from "@/lib/database-stats";
 import { getRadioQueueState, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry, QueueLane, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
 
@@ -313,15 +314,6 @@ type BnlPublicDossier = {
   };
 };
 
-type PublicDossierRegistry = {
-  source: "databasePage.entries";
-  publicCount: number;
-  kinds: Partial<Record<PublicDossierKind, number>>;
-  lifecycleCounts: Partial<Record<PublicDossierLifecycle, number>>;
-  authority: PublicDossierAuthority;
-  autoPromotion: false;
-  queueDerivedProfiles: false;
-};
 
 const PUBLIC_DOSSIER_BOUNDARIES = [
   "not Discord identity",
@@ -332,12 +324,18 @@ const PUBLIC_DOSSIER_BOUNDARIES = [
 
 const DOSSIER_RULES = [
   "Existing public dossiers are website-published public context.",
+  "Full database aggregate counts are public-safe count summaries, not dossier details.",
+  "Restricted records may be counted in aggregate but not exposed by name, ID, summary, tags, link, origin, or role.",
+  "publicCount is the number of public-clearance database dossiers exposed to BNL.",
+  "totalCount is the number of records in the full website database source of truth.",
   "Public dossiers are not private profiles.",
   "Public dossiers are not Discord identity mappings.",
   "Public dossiers are not payment/customer/account records.",
   "Public dossiers are not automatic broadcast memory.",
-  "Queue-derived artists are not public dossiers unless manually promoted through a future approved workflow.",
+  "Queue-derived artists are not dossier records unless manually promoted through a future approved workflow.",
   "Research classifier dossier seeds are not public dossiers until a future approved site workflow publishes them.",
+  "BNL may cite aggregate counts, but may not claim access to restricted records.",
+  "BNL may say restricted records exist by count, but not identify them.",
 ];
 
 function lifecycleForStatus(status: PublicDossierStatus): PublicDossierLifecycle {
@@ -392,10 +390,38 @@ function normalizePublicDossier(entry: PublicDatabaseEntry): BnlPublicDossier {
   };
 }
 
-function buildDossierRegistry(publicEntries: BnlPublicDossier[]): PublicDossierRegistry {
+function buildDossierRegistry(allEntries: DatabaseEntry[], publicEntries: BnlPublicDossier[]) {
+  const stats = getDatabaseAggregateStats(allEntries);
+
   return {
     source: "databasePage.entries",
+    sourceOfTruth: "src/content.ts:databasePage.entries",
+    statsHelper: "src/lib/database-stats.ts:getDatabaseAggregateStats",
+    countScope: "full_database_aggregates",
+    publicItemScope: "public_clearance_only",
+    totalCount: stats.totalCount,
     publicCount: publicEntries.length,
+    restrictedCount: stats.restrictedCount,
+    activeCount: stats.activeCount,
+    pendingCount: stats.pendingCount,
+    categoryCount: stats.categoryCount,
+    statusCounts: stats.statusCounts,
+    clearanceCounts: stats.clearanceCounts,
+    categoryCounts: stats.categoryCounts,
+    restrictedDetailsExposed: false,
+    scope: {
+      aggregateCounts: "full_database",
+      publicItems: "public_clearance_only",
+      restrictedDetails: "not_exposed",
+    },
+    rules: {
+      aggregateCounts: "Full database aggregate counts are public-safe count summaries.",
+      restrictedRecords: "Restricted records are counted but not exposed by name, ID, summary, tags, link, origin, or role.",
+      publicCount: "Number of public-clearance database dossiers exposed to BNL.",
+      totalCount: "Number of records in the full website database source of truth.",
+      queueDerivedProfiles: "Queue-derived artists are not dossier records unless manually promoted through a future approved workflow.",
+      citationBoundary: "BNL may cite aggregate counts and say restricted records exist by count, but may not identify restricted records.",
+    },
     kinds: publicEntries.reduce<Partial<Record<PublicDossierKind, number>>>((counts, entry) => {
       counts[entry.kind] = (counts[entry.kind] ?? 0) + 1;
       return counts;
@@ -404,17 +430,18 @@ function buildDossierRegistry(publicEntries: BnlPublicDossier[]): PublicDossierR
       counts[entry.lifecycle] = (counts[entry.lifecycle] ?? 0) + 1;
       return counts;
     }, {}),
-    authority: "website_public_database",
+    authority: "website_public_database" as PublicDossierAuthority,
     autoPromotion: false,
     queueDerivedProfiles: false,
   };
 }
 
 function publicDossiers() {
-  const publicEntries = databasePage.entries
+  const databaseEntries = databasePage.entries;
+  const publicEntries = databaseEntries
     .filter((entry) => entry.clearance === "PUBLIC")
     .map((entry) => normalizePublicDossier(entry));
-  const registry = buildDossierRegistry(publicEntries);
+  const registry = buildDossierRegistry(databaseEntries, publicEntries);
 
   if (publicEntries.length === 0) {
     return {

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -1,6 +1,7 @@
 import { databasePage } from "@/content";
 import { PageHero } from "@/components/LiveEffects";
 import { DatabaseTable } from "@/components/DatabaseTable";
+import { getDatabaseAggregateStats } from "@/lib/database-stats";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -16,15 +17,12 @@ export const metadata: Metadata = {
 
 const databaseEntries = databasePage.entries;
 
-const activeCount = databaseEntries.filter((e) => e.status === "ACTIVE").length;
-const pendingCount = databaseEntries.filter((e) => e.status === "PENDING").length;
-const restrictedCount = databaseEntries.filter((e) => e.clearance === "RESTRICTED").length;
-const categoryCount = new Set(databaseEntries.map((e) => e.category)).size;
+const databaseStats = getDatabaseAggregateStats(databaseEntries);
 const databaseTerminalQuery = [
-  `INDEXED ${databaseEntries.length} TOTAL DOSSIERS`,
-  `STATUS FILTER: ${activeCount} ACTIVE / ${pendingCount} PENDING`,
-  `CLEARANCE WATCH: ${restrictedCount} RESTRICTED RECORDS`,
-  `CATEGORY GROUPS ONLINE: ${categoryCount}`,
+  `INDEXED ${databaseStats.totalCount} TOTAL DOSSIERS`,
+  `STATUS FILTER: ${databaseStats.activeCount} ACTIVE / ${databaseStats.pendingCount} PENDING`,
+  `CLEARANCE WATCH: ${databaseStats.restrictedCount} RESTRICTED RECORDS`,
+  `CATEGORY GROUPS ONLINE: ${databaseStats.categoryCount}`,
 ];
 
 export default function DatabasePage() {
@@ -45,22 +43,22 @@ export default function DatabasePage() {
       <section className="border-b border-border bg-surface">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4">
           <div className="flex flex-wrap gap-6">
-            <StatItem label="Total Dossiers" value={databaseEntries.length.toString()} />
+            <StatItem label="Total Dossiers" value={databaseStats.totalCount.toString()} />
             <StatItem
               label="Active"
-              value={databaseEntries.filter((e) => e.status === "ACTIVE").length.toString()}
+              value={databaseStats.activeCount.toString()}
             />
             <StatItem
               label="Pending"
-              value={databaseEntries.filter((e) => e.status === "PENDING").length.toString()}
+              value={databaseStats.pendingCount.toString()}
             />
             <StatItem
               label="Categories"
-              value={[...new Set(databaseEntries.map((e) => e.category))].length.toString()}
+              value={databaseStats.categoryCount.toString()}
             />
             <StatItem
               label="Restricted"
-              value={databaseEntries.filter((e) => e.clearance === "RESTRICTED").length.toString()}
+              value={databaseStats.restrictedCount.toString()}
             />
           </div>
         </div>
@@ -85,7 +83,7 @@ export default function DatabasePage() {
                 <p key={i}>&gt; {line}</p>
               ))}
               <p className="text-accent mt-3">
-                &gt; {databaseEntries.filter((e) => e.status === "ACTIVE").length} RECORDS FOUND
+                &gt; {databaseStats.activeCount} RECORDS FOUND
                 <span className="cursor-blink">_</span>
               </p>
             </div>

--- a/src/lib/database-stats.ts
+++ b/src/lib/database-stats.ts
@@ -1,0 +1,28 @@
+import type { databasePage } from "@/content";
+
+export type DatabaseEntry = (typeof databasePage.entries)[number];
+
+function countBy<TEntry, TValue extends string>(
+  entries: TEntry[],
+  getValue: (entry: TEntry) => TValue,
+): Partial<Record<TValue, number>> {
+  return entries.reduce<Partial<Record<TValue, number>>>((counts, entry) => {
+    const value = getValue(entry);
+    counts[value] = (counts[value] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function getDatabaseAggregateStats(entries: DatabaseEntry[]) {
+  return {
+    totalCount: entries.length,
+    activeCount: entries.filter((entry) => entry.status === "ACTIVE").length,
+    pendingCount: entries.filter((entry) => entry.status === "PENDING").length,
+    restrictedCount: entries.filter((entry) => entry.clearance === "RESTRICTED").length,
+    publicCount: entries.filter((entry) => entry.clearance === "PUBLIC").length,
+    categoryCount: new Set(entries.map((entry) => entry.category)).size,
+    statusCounts: countBy(entries, (entry) => entry.status),
+    clearanceCounts: countBy(entries, (entry) => entry.clearance),
+    categoryCounts: countBy(entries, (entry) => entry.category),
+  };
+}

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -40,6 +40,7 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 const require = createRequire(import.meta.url);
 const queue = require("../src/lib/queue.ts");
 const { databasePage } = require("../src/content.ts");
+const { getDatabaseAggregateStats } = require("../src/lib/database-stats.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 
 const forbiddenKeys = [
@@ -118,6 +119,13 @@ function publicDatabaseEntries() {
   return databasePage.entries.filter((entry) => entry.clearance === "PUBLIC");
 }
 
+function countBy(entries, key) {
+  return entries.reduce((counts, entry) => {
+    counts[entry[key]] = (counts[entry[key]] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
 function findForbiddenStringValues(value, pathName = "$", found = []) {
   if (typeof value === "string") {
     if (/contactEmail|submitterToken|stripeSessionId|priorityUpgradePaymentId|priorityUpgradeCheckoutUrl|fileUrl|fileName|fileSize|mimeType|suspiciousFlags|adminNote|discordUserId|discordId|privateSeed|r&d|internalNote/i.test(value)) {
@@ -193,23 +201,73 @@ test("BNL read model preserves v1 compatibility and adds semantic sections", asy
   assert.equal(model.sections.dossiers.items.length, model.sections.dossiers.public.length);
 });
 
-test("BNL read model exposes public dossier registry metadata", async () => {
+test("BNL read model exposes dynamic full database aggregate registry metadata", async () => {
   await freshReadModelSession();
 
   const model = await modelJson();
   const registry = model.sections.dossiers.registry;
   const publicEntries = publicDatabaseEntries();
+  const entries = databasePage.entries;
 
   assert.ok(registry);
   assert.equal(registry.source, "databasePage.entries");
+  assert.equal(registry.sourceOfTruth, "src/content.ts:databasePage.entries");
+  assert.equal(registry.statsHelper, "src/lib/database-stats.ts:getDatabaseAggregateStats");
+  assert.equal(registry.countScope, "full_database_aggregates");
+  assert.equal(registry.publicItemScope, "public_clearance_only");
+  assert.equal(registry.totalCount, entries.length);
+  assert.equal(registry.activeCount, entries.filter((entry) => entry.status === "ACTIVE").length);
+  assert.equal(registry.pendingCount, entries.filter((entry) => entry.status === "PENDING").length);
+  assert.equal(registry.restrictedCount, entries.filter((entry) => entry.clearance === "RESTRICTED").length);
   assert.equal(registry.publicCount, publicEntries.length);
+  assert.equal(registry.categoryCount, new Set(entries.map((entry) => entry.category)).size);
+  assert.deepEqual(registry.statusCounts, countBy(entries, "status"));
+  assert.deepEqual(registry.clearanceCounts, countBy(entries, "clearance"));
+  assert.deepEqual(registry.categoryCounts, countBy(entries, "category"));
   assert.equal(registry.publicCount, model.sections.dossiers.public.length);
+  assert.equal(registry.publicCount, model.sections.dossiers.items.length);
+  assert.equal(registry.restrictedDetailsExposed, false);
+  assert.deepEqual(registry.scope, {
+    aggregateCounts: "full_database",
+    publicItems: "public_clearance_only",
+    restrictedDetails: "not_exposed",
+  });
+  assert.ok(registry.rules.aggregateCounts.includes("count summaries"));
   assert.ok(registry.kinds);
   assert.ok(registry.lifecycleCounts);
   assert.equal(registry.autoPromotion, false);
   assert.equal(registry.queueDerivedProfiles, false);
   assert.equal(model.sections.dossiers.public.some((entry) => entry.kind === "program"), true);
   assert.equal(model.sections.dossiers.public.some((entry) => entry.kind === "interface" || entry.kind === "platform"), true);
+});
+
+test("database aggregate stats helper matches the source of truth", () => {
+  const entries = databasePage.entries;
+  const stats = getDatabaseAggregateStats(entries);
+
+  assert.equal(stats.totalCount, entries.length);
+  assert.equal(stats.activeCount, entries.filter((entry) => entry.status === "ACTIVE").length);
+  assert.equal(stats.pendingCount, entries.filter((entry) => entry.status === "PENDING").length);
+  assert.equal(stats.restrictedCount, entries.filter((entry) => entry.clearance === "RESTRICTED").length);
+  assert.equal(stats.publicCount, entries.filter((entry) => entry.clearance === "PUBLIC").length);
+  assert.equal(stats.categoryCount, new Set(entries.map((entry) => entry.category)).size);
+  assert.deepEqual(stats.statusCounts, countBy(entries, "status"));
+  assert.deepEqual(stats.clearanceCounts, countBy(entries, "clearance"));
+  assert.deepEqual(stats.categoryCounts, countBy(entries, "category"));
+});
+
+test("database page and read model route use the shared aggregate stats helper without hardcoded stat totals", () => {
+  const databasePageSource = fs.readFileSync(path.join(projectRoot, "src/app/database/page.tsx"), "utf8");
+  const routeSource = fs.readFileSync(path.join(projectRoot, "src/app/api/bnl/read-model/route.ts"), "utf8");
+
+  assert.match(databasePageSource, /getDatabaseAggregateStats\(databaseEntries\)/);
+  assert.match(routeSource, /getDatabaseAggregateStats\(allEntries\)/);
+  assert.doesNotMatch(routeSource, /totalCount:\s*\d+/);
+  assert.doesNotMatch(routeSource, /publicCount:\s*\d+/);
+  assert.doesNotMatch(routeSource, /restrictedCount:\s*\d+/);
+  assert.doesNotMatch(routeSource, /activeCount:\s*\d+/);
+  assert.doesNotMatch(routeSource, /pendingCount:\s*\d+/);
+  assert.doesNotMatch(routeSource, /categoryCount:\s*\d+/);
 });
 
 test("BNL read model normalizes public dossiers with safe structured fields", async () => {
@@ -226,6 +284,34 @@ test("BNL read model normalizes public dossiers with safe structured fields", as
     assert.ok(Array.isArray(dossier.relatedPublicIds));
     assert.equal(dossier.bnlContext.visibility, "public");
     assert.equal(dossier.bnlContext.seedDefault, "not_seed_already_public_dossier");
+  }
+});
+
+test("BNL read model keeps restricted dossier details out of public dossier arrays", async () => {
+  await freshReadModelSession();
+
+  const model = await modelJson();
+  const publicIds = new Set(publicDatabaseEntries().map((entry) => entry.id));
+  const publicDossierJson = JSON.stringify({
+    public: model.sections.dossiers.public,
+    items: model.sections.dossiers.items,
+  });
+
+  assert.equal(model.sections.dossiers.registry.restrictedDetailsExposed, false);
+  for (const dossier of [...model.sections.dossiers.public, ...model.sections.dossiers.items]) {
+    assert.equal(publicIds.has(dossier.id), true, `${dossier.id} should be public-clearance only`);
+  }
+
+  const publicEntryJson = JSON.stringify(publicDatabaseEntries());
+  for (const entry of databasePage.entries.filter((item) => item.clearance !== "PUBLIC")) {
+    assert.equal(publicDossierJson.includes(entry.id), false, `${entry.id} should not be exposed`);
+    if (!publicEntryJson.includes(entry.name)) {
+      assert.equal(publicDossierJson.includes(entry.name), false, `${entry.name} should not be exposed`);
+    }
+    assert.equal(publicDossierJson.includes(entry.summary), false, `${entry.id} summary should not be exposed`);
+    if (entry.link && !publicEntryJson.includes(entry.link)) {
+      assert.equal(publicDossierJson.includes(entry.link), false, `${entry.id} link should not be exposed`);
+    }
   }
 });
 


### PR DESCRIPTION
### Motivation
- BNL reported seeing only public dossier counts (6) while the site UI counted the full database (22), indicating a scope mismatch between the database page and the BNL read model.
- The goal is to prove source-of-truth and ensure both UI and read-model metrics are derived from a single, dynamic helper rather than hardcoded or duplicated logic.
- The read model must continue to avoid exposing restricted/private dossier details while allowing BNL to cite full aggregate counts safely.

### Description
- Added a deterministic helper `getDatabaseAggregateStats(entries)` at `src/lib/database-stats.ts` that derives `totalCount`, `activeCount`, `pendingCount`, `restrictedCount`, `publicCount`, `categoryCount`, `statusCounts`, `clearanceCounts`, and `categoryCounts` from any entries array.
- Refactored `/database` to use the shared helper (`src/app/database/page.tsx`) so the stat bar and terminal readout are computed from `getDatabaseAggregateStats(databasePage.entries)` instead of inline duplicated logic.
- Extended `/api/bnl/read-model` (`src/app/api/bnl/read-model/route.ts`) to include a public-safe registry that reports full database aggregates (with `sourceOfTruth`, `statsHelper`, `totalCount`, `publicCount`, `restrictedCount`, `activeCount`, `pendingCount`, `categoryCount`, `statusCounts`, `clearanceCounts`, `categoryCounts`, `restrictedDetailsExposed: false`, and `scope`/`rules`) while still exposing only `PUBLIC`-clearance dossier items in `sections.dossiers.public` and `sections.dossiers.items`.
- Updated tests (`tests/bnl-read-model.test.mjs`) to assert the helper matches `databasePage.entries`, validate dynamic count maps, ensure public-only exposure of dossier items, and guard against hardcoded stat literals.

### Testing
- Ran type-checking: `npx tsc --noEmit` — succeeded without errors.
- Ran lint on changed files: `npx eslint src/app/api/bnl/read-model/route.ts src/app/database/page.tsx` — succeeded after addressing an unused-type warning.
- Ran full queue/read-model test suite: `npm run test:queue` — all tests passed (96 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d2caeff883219a042d9d965cfb04)