### PR TITLE
Align BNL dossier visibility semantics

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,7 +1,23 @@
 import { NextResponse } from "next/server";
 import { databasePage, radioPage, siteConfig } from "@/content";
-import type { PublicDossierAuthority, PublicDossierKind, PublicDossierLifecycle } from "@/content";
+import type {
+  BnlReadModelExposure,
+  ClearanceMeaning,
+  PublicDossierAuthority,
+  PublicDossierKind,
+  PublicDossierLifecycle,
+  PublicPageVisibility,
+} from "@/content";
 import { getDatabaseAggregateStats } from "@/lib/database-stats";
+import {
+  getBnlReadModelExposure,
+  getClearanceMeaning,
+  getPublicPageVisibility,
+  isBnlAggregateOnly,
+  isBnlReadModelDossierVisible,
+  isHiddenFromBnl,
+  isPublicDatabasePageVisible,
+} from "@/lib/database-visibility";
 import { getRadioQueueState, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry, QueueLane, QueuePublicTrack, QueueSourceType } from "@/lib/queue-types";
 
@@ -285,6 +301,9 @@ type PublicDatabaseEntry = DatabaseEntry & {
   publicFacts?: string[];
   knownBoundaries?: string[];
   relatedPublicIds?: string[];
+  publicPageVisibility?: PublicPageVisibility;
+  bnlReadModelExposure?: BnlReadModelExposure;
+  clearanceMeaning?: ClearanceMeaning;
 };
 
 type BnlPublicDossier = {
@@ -296,6 +315,11 @@ type BnlPublicDossier = {
   lifecycle: PublicDossierLifecycle;
   role: string;
   origin: DatabaseEntry["origin"];
+  clearance: DatabaseEntry["clearance"];
+  publicPageVisibility: PublicPageVisibility;
+  bnlReadModelExposure: BnlReadModelExposure;
+  clearanceMeaning: ClearanceMeaning;
+  visibilityBoundary: "same_summary_fields_as_public_database_page";
   authority: PublicDossierAuthority;
   summary: string;
   tags: string[];
@@ -306,8 +330,10 @@ type BnlPublicDossier = {
   source: "public_database_dossier";
   bnlContext: {
     source: "public_database_dossier";
-    visibility: "public";
-    dossierStatus: "existing_public_dossier";
+    visibility: "public_page_visible";
+    dossierStatus: "existing_public_page_dossier";
+    clearanceMeaning: ClearanceMeaning;
+    hiddenDetailsDefault: "do_not_infer";
     memoryDefault: "site_context_not_broadcast_memory";
     seedDefault: "not_seed_already_public_dossier";
     identityDefault: "public_site_entity_not_discord_identity";
@@ -320,22 +346,25 @@ const PUBLIC_DOSSIER_BOUNDARIES = [
   "not payment profile",
   "not private account",
   "not automatic broadcast memory",
+  "same summary fields as public database page",
+  "do not infer hidden restricted/internal details",
 ];
 
 const DOSSIER_RULES = [
-  "Existing public dossiers are website-published public context.",
-  "Full database aggregate counts are public-safe count summaries, not dossier details.",
-  "Restricted records may be counted in aggregate but not exposed by name, ID, summary, tags, link, origin, or role.",
-  "publicCount is the number of public-clearance database dossiers exposed to BNL.",
-  "totalCount is the number of records in the full website database source of truth.",
-  "Public dossiers are not private profiles.",
-  "Public dossiers are not Discord identity mappings.",
-  "Public dossiers are not payment/customer/account records.",
-  "Public dossiers are not automatic broadcast memory.",
-  "Queue-derived artists are not dossier records unless manually promoted through a future approved workflow.",
+  "Existing public-page-visible dossiers are website-published public context.",
+  "Clearance is a public-facing classification label unless a record explicitly says otherwise.",
+  "Public database page visibility means BNL may summarize the same public-safe fields shown by the website.",
+  "RESTRICTED means restricted-classified in universe, not private user data by default.",
+  "BNL must not infer hidden details from RESTRICTED or INTERNAL clearance labels.",
+  "BNL must not claim private access to dossiers, systems, admin tools, Discord identity, or payment data.",
+  "BNL must not expose admin notes, Discord IDs, payment/customer data, contact fields, upload fields, or private fields.",
+  "Full database aggregate counts are public-safe count summaries.",
+  "publicCount is a compatibility alias for BNL-visible public-page-safe dossier summaries, not PUBLIC-clearance-only records.",
+  "publicClearanceOnly contains records whose clearance label is PUBLIC.",
+  "Public-page-visible dossiers are not automatic broadcast memory.",
+  "Public-page-visible dossiers are not automatic dossier seeds.",
+  "Queue-derived artists are still not dossier records unless manually promoted through a future approved workflow.",
   "Research classifier dossier seeds are not public dossiers until a future approved site workflow publishes them.",
-  "BNL may cite aggregate counts, but may not claim access to restricted records.",
-  "BNL may say restricted records exist by count, but not identify them.",
 ];
 
 function lifecycleForStatus(status: PublicDossierStatus): PublicDossierLifecycle {
@@ -371,6 +400,11 @@ function normalizePublicDossier(entry: PublicDatabaseEntry): BnlPublicDossier {
     lifecycle: entry.lifecycle ?? lifecycleForStatus(entry.status as PublicDossierStatus),
     role: entry.role,
     origin: entry.origin,
+    clearance: entry.clearance,
+    publicPageVisibility: getPublicPageVisibility(entry),
+    bnlReadModelExposure: getBnlReadModelExposure(entry),
+    clearanceMeaning: getClearanceMeaning(entry),
+    visibilityBoundary: "same_summary_fields_as_public_database_page",
     authority: entry.authority ?? "website_public_database",
     summary: entry.summary,
     tags: [...entry.tags],
@@ -381,8 +415,10 @@ function normalizePublicDossier(entry: PublicDatabaseEntry): BnlPublicDossier {
     source: "public_database_dossier",
     bnlContext: {
       source: "public_database_dossier",
-      visibility: "public",
-      dossierStatus: "existing_public_dossier",
+      visibility: "public_page_visible",
+      dossierStatus: "existing_public_page_dossier",
+      clearanceMeaning: getClearanceMeaning(entry),
+      hiddenDetailsDefault: "do_not_infer",
       memoryDefault: "site_context_not_broadcast_memory",
       seedDefault: "not_seed_already_public_dossier",
       identityDefault: "public_site_entity_not_discord_identity",
@@ -390,17 +426,46 @@ function normalizePublicDossier(entry: PublicDatabaseEntry): BnlPublicDossier {
   };
 }
 
-function buildDossierRegistry(allEntries: DatabaseEntry[], publicEntries: BnlPublicDossier[]) {
+function countVisibleByLifecycle(entries: BnlPublicDossier[]) {
+  return entries.reduce<Partial<Record<PublicDossierLifecycle, number>>>((counts, entry) => {
+    counts[entry.lifecycle] = (counts[entry.lifecycle] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function countVisibleByKind(entries: BnlPublicDossier[]) {
+  return entries.reduce<Partial<Record<PublicDossierKind, number>>>((counts, entry) => {
+    counts[entry.kind] = (counts[entry.kind] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function buildDossierRegistry(allEntries: DatabaseEntry[], bnlVisibleEntries: BnlPublicDossier[]) {
   const stats = getDatabaseAggregateStats(allEntries);
+  const siteVisibleEntries = allEntries.filter(isPublicDatabasePageVisible);
+  const aggregateOnlyCount = allEntries.filter(isBnlAggregateOnly).length;
+  const hiddenFromBnlCount = allEntries.filter(isHiddenFromBnl).length;
+  const publicClearanceCount = allEntries.filter((entry) => entry.clearance === "PUBLIC").length;
+  const internalClearanceCount = allEntries.filter((entry) => entry.clearance === "INTERNAL").length;
+  const restrictedClearanceCount = allEntries.filter((entry) => entry.clearance === "RESTRICTED").length;
+  const restrictedSummariesExposed = bnlVisibleEntries.some((entry) => entry.clearance === "RESTRICTED");
 
   return {
     source: "databasePage.entries",
     sourceOfTruth: "src/content.ts:databasePage.entries",
     statsHelper: "src/lib/database-stats.ts:getDatabaseAggregateStats",
+    visibilityHelper: "src/lib/database-visibility.ts",
     countScope: "full_database_aggregates",
-    publicItemScope: "public_clearance_only",
+    publicItemScope: "public_database_page_visible",
     totalCount: stats.totalCount,
-    publicCount: publicEntries.length,
+    siteVisibleCount: siteVisibleEntries.length,
+    bnlExposedDetailCount: bnlVisibleEntries.length,
+    publicCount: bnlVisibleEntries.length,
+    publicClearanceCount,
+    internalClearanceCount,
+    restrictedClearanceCount,
+    aggregateOnlyCount,
+    hiddenFromBnlCount,
     restrictedCount: stats.restrictedCount,
     activeCount: stats.activeCount,
     pendingCount: stats.pendingCount,
@@ -409,27 +474,28 @@ function buildDossierRegistry(allEntries: DatabaseEntry[], publicEntries: BnlPub
     clearanceCounts: stats.clearanceCounts,
     categoryCounts: stats.categoryCounts,
     restrictedDetailsExposed: false,
+    restrictedSummariesExposed,
+    clearanceMeaning: "public_lore_label" as ClearanceMeaning,
     scope: {
       aggregateCounts: "full_database",
-      publicItems: "public_clearance_only",
-      restrictedDetails: "not_exposed",
+      publicItems: "public_database_page_visible",
+      public: "compatibility_alias_for_public_database_page_visible",
+      publicClearanceOnly: "clearance_label_public_only",
+      restrictedDetails: "summary_only_no_hidden_details",
     },
     rules: {
       aggregateCounts: "Full database aggregate counts are public-safe count summaries.",
-      restrictedRecords: "Restricted records are counted but not exposed by name, ID, summary, tags, link, origin, or role.",
-      publicCount: "Number of public-clearance database dossiers exposed to BNL.",
+      clearance: "Clearance is a public-facing classification label unless a record explicitly says otherwise.",
+      publicPageVisibility: "If a dossier is listed on the public database page, BNL may summarize the same public-safe fields.",
+      restrictedRecords: "Restricted-classified public-page dossiers may expose only the same summary fields as the public database page; hidden details remain unexposed.",
+      publicCount: "Compatibility count for BNL-visible public-page-safe dossier summaries.",
+      publicClearanceCount: "Number of records whose clearance label is PUBLIC.",
       totalCount: "Number of records in the full website database source of truth.",
       queueDerivedProfiles: "Queue-derived artists are not dossier records unless manually promoted through a future approved workflow.",
-      citationBoundary: "BNL may cite aggregate counts and say restricted records exist by count, but may not identify restricted records.",
+      citationBoundary: "BNL may cite public-page-safe summaries and aggregate counts, but must not claim private access or infer hidden details.",
     },
-    kinds: publicEntries.reduce<Partial<Record<PublicDossierKind, number>>>((counts, entry) => {
-      counts[entry.kind] = (counts[entry.kind] ?? 0) + 1;
-      return counts;
-    }, {}),
-    lifecycleCounts: publicEntries.reduce<Partial<Record<PublicDossierLifecycle, number>>>((counts, entry) => {
-      counts[entry.lifecycle] = (counts[entry.lifecycle] ?? 0) + 1;
-      return counts;
-    }, {}),
+    kinds: countVisibleByKind(bnlVisibleEntries),
+    lifecycleCounts: countVisibleByLifecycle(bnlVisibleEntries),
     authority: "website_public_database" as PublicDossierAuthority,
     autoPromotion: false,
     queueDerivedProfiles: false,
@@ -438,31 +504,37 @@ function buildDossierRegistry(allEntries: DatabaseEntry[], publicEntries: BnlPub
 
 function publicDossiers() {
   const databaseEntries = databasePage.entries;
-  const publicEntries = databaseEntries
-    .filter((entry) => entry.clearance === "PUBLIC")
+  const publicPageVisibleEntries = databaseEntries.filter(isPublicDatabasePageVisible);
+  const bnlVisibleEntries = publicPageVisibleEntries
+    .filter(isBnlReadModelDossierVisible)
     .map((entry) => normalizePublicDossier(entry));
-  const registry = buildDossierRegistry(databaseEntries, publicEntries);
+  const publicClearanceOnly = bnlVisibleEntries.filter((entry) => entry.clearance === "PUBLIC");
+  const registry = buildDossierRegistry(databaseEntries, bnlVisibleEntries);
 
-  if (publicEntries.length === 0) {
+  if (bnlVisibleEntries.length === 0) {
     return {
       implemented: false,
       public: [],
       items: [],
+      publicPageVisible: [],
+      publicClearanceOnly: [],
       registry,
-      sourceAuthority: "public_database_entries_only",
+      sourceAuthority: "public_database_page_visible_entries_only",
       rules: DOSSIER_RULES,
-      note: "No public-clearance database dossier summaries are currently included.",
+      note: "No public-page-visible database dossier summaries are currently included.",
     };
   }
 
   return {
     implemented: true,
-    public: publicEntries,
-    items: publicEntries,
+    public: bnlVisibleEntries,
+    items: bnlVisibleEntries,
+    publicPageVisible: bnlVisibleEntries,
+    publicClearanceOnly,
     registry,
-    sourceAuthority: "public_database_entries_only",
+    sourceAuthority: "public_database_page_visible_entries_only",
     rules: DOSSIER_RULES,
-    note: "Only public-clearance database dossier summaries are included.",
+    note: "Public/read-model dossier summaries include the same public-safe fields visible on the public database page; clearance labels are preserved as lore classification labels unless explicitly overridden.",
   };
 }
 
@@ -554,7 +626,7 @@ function buildOperatorLanes(queue: Awaited<ReturnType<typeof readPublicLiveQueue
     kind: "public_dossier_summary",
     dossierId: dossier.id,
     value: dossier.kind,
-    reason: "Published public dossier summary is public site context, not private memory.",
+    reason: "Public-page-visible dossier summary is safe site context with clearance label preserved; not private memory or a seed.",
   })));
 
   return {
@@ -590,6 +662,11 @@ const rules = {
     "dossierSeedCandidates are possible seeds only",
     "temporaryRuntimeContext should not be stored",
     "BNL must not treat this endpoint as private access",
+    "clearance labels are public-facing classification labels unless a dossier explicitly says otherwise",
+    "public database page visibility permits only the same public-safe summary fields",
+    "RESTRICTED means restricted-classified in universe, not private user data by default",
+    "public-page-visible dossiers are not automatically broadcast memory or dossier seeds",
+    "queue-derived artists are still not dossier records",
   ],
   disallowedUse: [
     "private user identity",
@@ -602,13 +679,16 @@ const rules = {
     "account profiles",
     "Discord identity merging",
     "automatic canon creation",
+    "claiming private access to restricted/internal dossier details",
+    "inferring hidden details from restricted/internal clearance labels",
+    "exposing admin notes, Discord IDs, payment/customer data, contact fields, upload fields, or private fields",
     "claiming public dossiers exist when not implemented",
     "treating admin simulation data as live/public context",
   ],
   sourceAuthority: {
     queue: "public runtime snapshot with simulation/test filtering",
     artists: "queue-derived public artist surface, not profiles",
-    dossiers: "public dossier/database entries only if clearance is PUBLIC",
+    dossiers: "public-page-visible database dossier summaries with clearance labels preserved; hidden/private details are not exposed",
     operatorLanes: "deterministic public-safe lane hints, not automatic actions",
     sourceContext: "static public site context",
     simulationData: "BNL must treat this read model as live/public context only, not admin simulation data",

--- a/src/content.ts
+++ b/src/content.ts
@@ -299,6 +299,20 @@ export type PublicDossierRegistryFields = {
   relatedPublicIds?: string[];
 };
 
+export type PublicPageVisibility =
+  | "listed_publicly"
+  | "hidden_from_public_page";
+
+export type BnlReadModelExposure =
+  | "public_summary"
+  | "aggregate_only"
+  | "hidden";
+
+export type ClearanceMeaning =
+  | "public_lore_label"
+  | "access_control"
+  | "mixed";
+
 // Designation prefixes:
 //   EN-### = Entity | PE-### = Personnel | SP-### = Sponsor | IF-### = Interface | PD-### = Production
 // Categories: Entity | Personnel | Sponsor | Interface | Production

--- a/src/lib/database-visibility.ts
+++ b/src/lib/database-visibility.ts
@@ -1,0 +1,40 @@
+import type { BnlReadModelExposure, ClearanceMeaning, PublicPageVisibility, databasePage } from "@/content";
+
+export type DatabaseVisibilityEntry = (typeof databasePage.entries)[number] & {
+  publicPageVisibility?: PublicPageVisibility;
+  bnlReadModelExposure?: BnlReadModelExposure;
+  clearanceMeaning?: ClearanceMeaning;
+};
+
+export const DEFAULT_PUBLIC_PAGE_VISIBILITY: PublicPageVisibility = "listed_publicly";
+export const DEFAULT_BNL_READ_MODEL_EXPOSURE: BnlReadModelExposure = "public_summary";
+export const DEFAULT_CLEARANCE_MEANING: ClearanceMeaning = "public_lore_label";
+
+export function getPublicPageVisibility(entry: DatabaseVisibilityEntry): PublicPageVisibility {
+  return entry.publicPageVisibility ?? DEFAULT_PUBLIC_PAGE_VISIBILITY;
+}
+
+export function getBnlReadModelExposure(entry: DatabaseVisibilityEntry): BnlReadModelExposure {
+  if (entry.bnlReadModelExposure) return entry.bnlReadModelExposure;
+  return isPublicDatabasePageVisible(entry) ? DEFAULT_BNL_READ_MODEL_EXPOSURE : "hidden";
+}
+
+export function getClearanceMeaning(entry: DatabaseVisibilityEntry): ClearanceMeaning {
+  return entry.clearanceMeaning ?? DEFAULT_CLEARANCE_MEANING;
+}
+
+export function isPublicDatabasePageVisible(entry: DatabaseVisibilityEntry): boolean {
+  return getPublicPageVisibility(entry) === "listed_publicly";
+}
+
+export function isBnlReadModelDossierVisible(entry: DatabaseVisibilityEntry): boolean {
+  return isPublicDatabasePageVisible(entry) && getBnlReadModelExposure(entry) === "public_summary";
+}
+
+export function isBnlAggregateOnly(entry: DatabaseVisibilityEntry): boolean {
+  return getBnlReadModelExposure(entry) === "aggregate_only";
+}
+
+export function isHiddenFromBnl(entry: DatabaseVisibilityEntry): boolean {
+  return getBnlReadModelExposure(entry) === "hidden";
+}

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -41,6 +41,7 @@ const require = createRequire(import.meta.url);
 const queue = require("../src/lib/queue.ts");
 const { databasePage } = require("../src/content.ts");
 const { getDatabaseAggregateStats } = require("../src/lib/database-stats.ts");
+const { isBnlReadModelDossierVisible, isPublicDatabasePageVisible } = require("../src/lib/database-visibility.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 
 const forbiddenKeys = [
@@ -59,6 +60,8 @@ const forbiddenKeys = [
   "discordId",
   "privateSeed",
   "internalNote",
+  "privateNotes",
+  "adminOnly",
 ];
 
 let sequence = 0;
@@ -115,8 +118,16 @@ function findForbiddenKeys(value, pathName = "$", found = []) {
   return found;
 }
 
-function publicDatabaseEntries() {
+function publicClearanceEntries() {
   return databasePage.entries.filter((entry) => entry.clearance === "PUBLIC");
+}
+
+function publicPageVisibleEntries() {
+  return databasePage.entries.filter(isPublicDatabasePageVisible);
+}
+
+function bnlVisibleDossierEntries() {
+  return databasePage.entries.filter(isBnlReadModelDossierVisible);
 }
 
 function countBy(entries, key) {
@@ -128,7 +139,7 @@ function countBy(entries, key) {
 
 function findForbiddenStringValues(value, pathName = "$", found = []) {
   if (typeof value === "string") {
-    if (/contactEmail|submitterToken|stripeSessionId|priorityUpgradePaymentId|priorityUpgradeCheckoutUrl|fileUrl|fileName|fileSize|mimeType|suspiciousFlags|adminNote|discordUserId|discordId|privateSeed|r&d|internalNote/i.test(value)) {
+    if (/contactEmail|submitterToken|stripeSessionId|priorityUpgradePaymentId|priorityUpgradeCheckoutUrl|fileUrl|fileName|fileSize|mimeType|suspiciousFlags|adminNote|discordUserId|discordId|privateSeed|r&d|internalNote|privateNotes|adminOnly/i.test(value)) {
       found.push(`${pathName}: ${value}`);
     }
     return found;
@@ -197,42 +208,58 @@ test("BNL read model preserves v1 compatibility and adds semantic sections", asy
   assert.equal(artist.trackStatusCounts.queued + artist.trackStatusCounts.upNext + artist.trackStatusCounts.nowPlaying, 1);
 
   assert.ok(model.sections.dossiers.public.length > 0, "expected public database dossiers in fixture content");
-  assert.equal(model.sections.dossiers.public[0].bnlContext.dossierStatus, "existing_public_dossier");
+  assert.equal(model.sections.dossiers.public[0].bnlContext.dossierStatus, "existing_public_page_dossier");
   assert.equal(model.sections.dossiers.items.length, model.sections.dossiers.public.length);
 });
 
-test("BNL read model exposes dynamic full database aggregate registry metadata", async () => {
+test("BNL read model exposes dynamic full database aggregate registry metadata and visibility counts", async () => {
   await freshReadModelSession();
 
   const model = await modelJson();
   const registry = model.sections.dossiers.registry;
-  const publicEntries = publicDatabaseEntries();
   const entries = databasePage.entries;
+  const siteVisibleEntries = publicPageVisibleEntries();
+  const bnlEntries = bnlVisibleDossierEntries();
+  const publicClearance = publicClearanceEntries();
 
   assert.ok(registry);
   assert.equal(registry.source, "databasePage.entries");
   assert.equal(registry.sourceOfTruth, "src/content.ts:databasePage.entries");
   assert.equal(registry.statsHelper, "src/lib/database-stats.ts:getDatabaseAggregateStats");
+  assert.equal(registry.visibilityHelper, "src/lib/database-visibility.ts");
   assert.equal(registry.countScope, "full_database_aggregates");
-  assert.equal(registry.publicItemScope, "public_clearance_only");
+  assert.equal(registry.publicItemScope, "public_database_page_visible");
   assert.equal(registry.totalCount, entries.length);
+  assert.equal(registry.siteVisibleCount, siteVisibleEntries.length);
+  assert.equal(registry.bnlExposedDetailCount, bnlEntries.length);
+  assert.equal(registry.publicCount, bnlEntries.length);
+  assert.equal(registry.publicClearanceCount, publicClearance.length);
+  assert.equal(registry.internalClearanceCount, entries.filter((entry) => entry.clearance === "INTERNAL").length);
+  assert.equal(registry.restrictedClearanceCount, entries.filter((entry) => entry.clearance === "RESTRICTED").length);
+  assert.equal(registry.aggregateOnlyCount, 0);
+  assert.equal(registry.hiddenFromBnlCount, 0);
   assert.equal(registry.activeCount, entries.filter((entry) => entry.status === "ACTIVE").length);
   assert.equal(registry.pendingCount, entries.filter((entry) => entry.status === "PENDING").length);
   assert.equal(registry.restrictedCount, entries.filter((entry) => entry.clearance === "RESTRICTED").length);
-  assert.equal(registry.publicCount, publicEntries.length);
   assert.equal(registry.categoryCount, new Set(entries.map((entry) => entry.category)).size);
   assert.deepEqual(registry.statusCounts, countBy(entries, "status"));
   assert.deepEqual(registry.clearanceCounts, countBy(entries, "clearance"));
   assert.deepEqual(registry.categoryCounts, countBy(entries, "category"));
-  assert.equal(registry.publicCount, model.sections.dossiers.public.length);
-  assert.equal(registry.publicCount, model.sections.dossiers.items.length);
+  assert.equal(registry.bnlExposedDetailCount, model.sections.dossiers.public.length);
+  assert.equal(registry.bnlExposedDetailCount, model.sections.dossiers.items.length);
+  assert.equal(model.sections.dossiers.publicClearanceOnly.length, registry.publicClearanceCount);
   assert.equal(registry.restrictedDetailsExposed, false);
+  assert.equal(registry.restrictedSummariesExposed, entries.some((entry) => entry.clearance === "RESTRICTED" && isBnlReadModelDossierVisible(entry)));
+  assert.equal(registry.clearanceMeaning, "public_lore_label");
   assert.deepEqual(registry.scope, {
     aggregateCounts: "full_database",
-    publicItems: "public_clearance_only",
-    restrictedDetails: "not_exposed",
+    publicItems: "public_database_page_visible",
+    public: "compatibility_alias_for_public_database_page_visible",
+    publicClearanceOnly: "clearance_label_public_only",
+    restrictedDetails: "summary_only_no_hidden_details",
   });
   assert.ok(registry.rules.aggregateCounts.includes("count summaries"));
+  assert.ok(registry.rules.clearance.includes("classification label"));
   assert.ok(registry.kinds);
   assert.ok(registry.lifecycleCounts);
   assert.equal(registry.autoPromotion, false);
@@ -270,48 +297,61 @@ test("database page and read model route use the shared aggregate stats helper w
   assert.doesNotMatch(routeSource, /categoryCount:\s*\d+/);
 });
 
-test("BNL read model normalizes public dossiers with safe structured fields", async () => {
+test("BNL read model normalizes public-page-visible dossiers with safe structured fields", async () => {
   await freshReadModelSession();
 
   const model = await modelJson();
+  const bnlVisibleIds = new Set(bnlVisibleDossierEntries().map((entry) => entry.id));
+
+  assert.equal(model.sections.dossiers.items.length, model.sections.dossiers.registry.bnlExposedDetailCount);
+  assert.equal(model.sections.dossiers.public.length, model.sections.dossiers.registry.bnlExposedDetailCount);
 
   for (const dossier of model.sections.dossiers.public) {
-    for (const field of ["id", "name", "kind", "lifecycle", "authority", "bnlContext", "category", "status", "role", "summary", "tags", "link", "source"]) {
+    for (const field of ["id", "name", "kind", "lifecycle", "authority", "bnlContext", "category", "status", "role", "summary", "tags", "link", "source", "clearance", "publicPageVisibility", "bnlReadModelExposure", "clearanceMeaning", "visibilityBoundary"]) {
       assert.ok(Object.hasOwn(dossier, field), `public dossier should expose ${field}`);
     }
+    assert.equal(bnlVisibleIds.has(dossier.id), true, `${dossier.id} should be BNL-visible via public page semantics`);
     assert.ok(Array.isArray(dossier.knownBoundaries));
     assert.ok(Array.isArray(dossier.publicFacts));
     assert.ok(Array.isArray(dossier.relatedPublicIds));
-    assert.equal(dossier.bnlContext.visibility, "public");
+    assert.equal(dossier.publicPageVisibility, "listed_publicly");
+    assert.equal(dossier.bnlReadModelExposure, "public_summary");
+    assert.equal(dossier.clearanceMeaning, "public_lore_label");
+    assert.equal(dossier.visibilityBoundary, "same_summary_fields_as_public_database_page");
+    assert.equal(dossier.bnlContext.visibility, "public_page_visible");
+    assert.equal(dossier.bnlContext.clearanceMeaning, "public_lore_label");
+    assert.equal(dossier.bnlContext.hiddenDetailsDefault, "do_not_infer");
     assert.equal(dossier.bnlContext.seedDefault, "not_seed_already_public_dossier");
   }
 });
 
-test("BNL read model keeps restricted dossier details out of public dossier arrays", async () => {
+test("BNL read model exposes restricted/internal only as public-page-safe summaries", async () => {
   await freshReadModelSession();
 
   const model = await modelJson();
-  const publicIds = new Set(publicDatabaseEntries().map((entry) => entry.id));
-  const publicDossierJson = JSON.stringify({
+  const dossierJson = JSON.stringify({
     public: model.sections.dossiers.public,
     items: model.sections.dossiers.items,
   });
+  const restrictedDossiers = model.sections.dossiers.items.filter((dossier) => dossier.clearance === "RESTRICTED");
+  const internalDossiers = model.sections.dossiers.items.filter((dossier) => dossier.clearance === "INTERNAL");
 
   assert.equal(model.sections.dossiers.registry.restrictedDetailsExposed, false);
-  for (const dossier of [...model.sections.dossiers.public, ...model.sections.dossiers.items]) {
-    assert.equal(publicIds.has(dossier.id), true, `${dossier.id} should be public-clearance only`);
+  assert.equal(model.sections.dossiers.registry.restrictedSummariesExposed, restrictedDossiers.length > 0);
+  assert.ok(restrictedDossiers.length > 0, "fixture should include restricted public-page-visible summaries");
+  assert.ok(internalDossiers.length > 0, "fixture should include internal public-page-visible summaries");
+
+  for (const dossier of [...restrictedDossiers, ...internalDossiers]) {
+    assert.equal(dossier.publicPageVisibility, "listed_publicly");
+    assert.equal(dossier.bnlReadModelExposure, "public_summary");
+    assert.equal(dossier.clearanceMeaning, "public_lore_label");
+    assert.equal(dossier.visibilityBoundary, "same_summary_fields_as_public_database_page");
+    assert.ok(dossier.knownBoundaries.includes("do not infer hidden restricted/internal details"));
+    assert.equal(dossier.bnlContext.hiddenDetailsDefault, "do_not_infer");
   }
 
-  const publicEntryJson = JSON.stringify(publicDatabaseEntries());
-  for (const entry of databasePage.entries.filter((item) => item.clearance !== "PUBLIC")) {
-    assert.equal(publicDossierJson.includes(entry.id), false, `${entry.id} should not be exposed`);
-    if (!publicEntryJson.includes(entry.name)) {
-      assert.equal(publicDossierJson.includes(entry.name), false, `${entry.name} should not be exposed`);
-    }
-    assert.equal(publicDossierJson.includes(entry.summary), false, `${entry.id} summary should not be exposed`);
-    if (entry.link && !publicEntryJson.includes(entry.link)) {
-      assert.equal(publicDossierJson.includes(entry.link), false, `${entry.id} link should not be exposed`);
-    }
+  for (const field of forbiddenKeys) {
+    assert.equal(dossierJson.includes(field), false, `${field} should not appear in public dossier summaries`);
   }
 });
 
@@ -372,7 +412,10 @@ test("BNL read model keeps normal queue items out of broadcast memory candidates
   assert.equal(lanes.broadcastMemoryCandidates.some((item) => item.trackId === completed.id), false);
   assert.equal(lanes.broadcastMemoryCandidates.length, 0);
   assert.equal(lanes.dossierSeedCandidates.length, 0);
-  assert.equal(lanes.publicSafeCopyCandidates.some((item) => item.source === "public_database_dossier" && item.dossierId), true);
+  const dossierCopyCandidates = lanes.publicSafeCopyCandidates.filter((item) => item.source === "public_database_dossier" && item.dossierId);
+  assert.equal(dossierCopyCandidates.length, model.sections.dossiers.registry.bnlExposedDetailCount);
+  assert.equal(dossierCopyCandidates.some((item) => model.sections.dossiers.items.find((dossier) => dossier.id === item.dossierId)?.clearance === "RESTRICTED"), true);
+  assert.equal(dossierCopyCandidates.every((item) => item.reason.includes("not private memory or a seed")), true);
   assert.equal(model.sections.dossiers.public.some((dossier) => JSON.stringify(dossier).includes("Memory Queue Artist")), false);
   assert.equal(model.sections.artists.some((entry) => entry.normalizedName === "memory-queue-artist"), true);
 


### PR DESCRIPTION
### Motivation

- The public `/database` page currently lists 22 records including `PUBLIC`, `INTERNAL`, and `RESTRICTED`, while the BNL read model only exposed detailed dossiers for `clearance === "PUBLIC"`, creating a confusing mismatch. 
- The change aligns the BNL read model to the website’s public-page-visible summary universe so BNL can summarize what the site already shows without inventing or exposing hidden/admin/payment/Discord/private data. 
- All protected behavior (page rendering, stat bar, route shapes, top-level `version`, `schemaRevision`, and queue/admin API semantics) must remain intact.

### Description

- Files changed: `src/content.ts` (added additive visibility types `PublicPageVisibility`, `BnlReadModelExposure`, `ClearanceMeaning`), new `src/lib/database-visibility.ts` (helpers and defaults to compute `isPublicDatabasePageVisible`, `isBnlReadModelDossierVisible`, `isBnlAggregateOnly`, `isHiddenFromBnl`, and getters), `src/app/api/bnl/read-model/route.ts` (use visibility helpers; normalize dossiers to include `clearance`, `publicPageVisibility`, `bnlReadModelExposure`, `clearanceMeaning`, `visibilityBoundary`; extend registry with `siteVisibleCount`, `bnlExposedDetailCount`, clearance breakdowns, aggregate/hidden counts, and updated rules; update operator lanes), and `tests/bnl-read-model.test.mjs` (updated tests to assert new visibility semantics, registry fields, and forbidden-field exclusions). 
- Audit summary (answers to requested audit questions): `databasePage.entries` contains 22 records; `/database` renders 22 records; `INTERNAL` and `RESTRICTED` records are publicly visible on `/database`; detail pages are generated for all entries; prior to this PR `clearance` acted as a public lore/classification label on the site but the read model used `clearance === "PUBLIC"` as the exposure boundary; the read model and the public page therefore did not share the same visibility universe; after this PR `clearance` remains a displayed label while `publicPageVisibility` and `bnlReadModelExposure` separate public-page visibility from exposure rules and default BNL exposure to public-page-visible summaries. 
- Key semantics implemented: new defaults set `publicPageVisibility = "listed_publicly"` and `bnlReadModelExposure = "public_summary"` for existing public entries; `isPublicDatabasePageVisible(entry)` and `isBnlReadModelDossierVisible(entry)` helpers distinguish site-visible vs read-model-visible universes; normalized dossiers preserve `clearance` and add explicit `bnlContext` fields (`dossierStatus: "existing_public_page_dossier"`, `visibility: "public_page_visible"`, `clearanceMeaning`, `hiddenDetailsDefault: "do_not_infer"`) and `visibilityBoundary: "same_summary_fields_as_public_database_page"`; `sections.dossiers.public` and `sections.dossiers.items` are preserved as compatibility aliases and `publicClearanceOnly` plus `publicPageVisible` were added for clarity. 

### Testing

- Automated tests run: `npx tsc --noEmit` passed, `npx eslint src/app/api/bnl/read-model/route.ts src/app/database/page.tsx` passed, and `npm run test:queue` passed with 96 tests (all green). 
- Local verification of read model registry values: `totalCount: 22`, `siteVisibleCount: 22`, `bnlExposedDetailCount: 22`, `publicClearanceCount: 6`, `internalClearanceCount: 11`, `restrictedClearanceCount: 5`, `aggregateOnlyCount: 0`, `hiddenFromBnlCount: 0`, `restrictedDetailsExposed: false`, and `restrictedSummariesExposed: true`. 
- Manual post-deploy checks (recommended): fetch `/api/bnl/read-model`, verify the `sections.dossiers.registry` fields and counts, and run the forbidden-field grep against the payload to ensure no private/admin/payment/Discord/upload fields are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d781f8608321b897cc8b18449212)