### PR TITLE
Dossier Tag Registry + Tag Creation Rules (read-model schema v1.3)

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { databasePage, radioPage, siteConfig } from "@/content";
 import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
+import { buildDossierTagRegistry } from "@/lib/dossier-tags";
 import type {
   BnlReadModelExposure,
   DatabaseEntry,
@@ -504,9 +505,18 @@ function countWords(value: string) {
   return words?.length ?? 0;
 }
 
-function buildDossierStyleProfile(entries: DatabaseEntry[]) {
+function buildDossierStyleProfile(entries: DatabaseEntry[], tagRegistry: ReturnType<typeof buildDossierTagRegistry>) {
   const summaryCounts = entries.map((entry) => countWords(entry.summary));
   const totalSummaryWords = summaryCounts.reduce((sum, count) => sum + count, 0);
+  const mostUsedTags = [...tagRegistry.items]
+    .sort((a, b) => b.usageCount - a.usageCount || a.tag.localeCompare(b.tag))
+    .slice(0, 10)
+    .map((item) => ({ tag: item.tag, usageCount: item.usageCount }));
+  const singleUseTags = tagRegistry.items
+    .filter((item) => item.usageCount === 1)
+    .map((item) => item.tag)
+    .sort((a, b) => a.localeCompare(b))
+    .slice(0, 10);
 
   return {
     entryCount: entries.length,
@@ -516,6 +526,12 @@ function buildDossierStyleProfile(entries: DatabaseEntry[]) {
       average: summaryCounts.length > 0 ? Math.round(totalSummaryWords / summaryCounts.length) : 0,
     },
     notesPresenceCount: entries.filter((entry) => entry.notes.trim().length > 0).length,
+    tagProfile: {
+      totalUniqueTags: tagRegistry.totalUniqueTags,
+      averageTagsPerDossier: entries.length > 0 ? Math.round((tagRegistry.totalTagAssignments / entries.length) * 100) / 100 : 0,
+      mostUsedTags,
+      singleUseTags,
+    },
     commonSections: [
       "Hero / dossier ID",
       "Portrait/card",
@@ -551,6 +567,8 @@ function publicDossiers() {
     .map((entry) => normalizePublicDossier(entry));
   const publicClearanceOnly = bnlVisibleEntries.filter((entry) => entry.clearance === "PUBLIC");
   const registry = buildDossierRegistry(databaseEntries, bnlVisibleEntries);
+  const tagRegistry = buildDossierTagRegistry(databaseEntries);
+  const styleProfile = buildDossierStyleProfile(databaseEntries, tagRegistry);
 
   if (bnlVisibleEntries.length === 0) {
     return {
@@ -561,7 +579,8 @@ function publicDossiers() {
       publicClearanceOnly: [],
       registry,
       authoringGuide: dossierAuthoringGuide,
-      styleProfile: buildDossierStyleProfile(databaseEntries),
+      styleProfile,
+      tagRegistry,
       sourceAuthority: "public_database_page_visible_entries_only",
       rules: DOSSIER_RULES,
       note: "No public-page-visible database dossier summaries are currently included.",
@@ -576,7 +595,8 @@ function publicDossiers() {
     publicClearanceOnly,
     registry,
     authoringGuide: dossierAuthoringGuide,
-    styleProfile: buildDossierStyleProfile(databaseEntries),
+    styleProfile,
+    tagRegistry,
     sourceAuthority: "public_database_page_visible_entries_only",
     rules: DOSSIER_RULES,
     note: "Public/read-model dossier summaries include the same public-safe fields visible on the public database page; clearance labels are preserved as lore classification labels unless explicitly overridden.",
@@ -748,7 +768,7 @@ export async function GET() {
     {
       ok: true,
       version: 1,
-      schemaRevision: "1.2",
+      schemaRevision: "1.3",
       generatedAt: new Date().toISOString(),
       scope: "bnl_public_read_model",
       source: "barcode-network-site",

--- a/src/lib/dossier-authoring-guide.ts
+++ b/src/lib/dossier-authoring-guide.ts
@@ -19,7 +19,7 @@ export const dossierAuthoringGuide = {
     origin: "Known-source confidence label: KNOWN, UNKNOWN, UNVERIFIED, or WITHHELD.",
     summary: "Primary Intelligence Brief paragraph using public-page-safe facts and controlled BARCODE Network language.",
     notes: "Optional contextual note, usually operational or status-oriented, not a second full summary.",
-    tags: "Short searchable labels used by the database table and dossier record.",
+    tags: "Short searchable labels used by the database table and dossier record. Use sections.dossiers.tagRegistry, reuse existing tags first, and treat any new tag as a proposal until an operator/site content update creates it.",
     link: "Legacy single public URL; keep compatible while preferring primaryLink/links for new chosen links.",
     primaryLink: "Optional chosen/featured public-safe link with label, URL, type, and selectedBy metadata.",
     links: "Optional public-safe link list for official, artist, music, social, website, community, submission, portfolio, or other destinations.",
@@ -46,7 +46,7 @@ export const dossierAuthoringGuide = {
     role: "short phrase, usually 2-8 words",
     summary: "usually 1 compact paragraph, roughly 25-80 words depending importance",
     notes: "optional, usually 1-2 sentences, operational/contextual, not a second full summary",
-    tags: "3-6 short labels",
+    tags: "usually 3-6 short labels; prefer existing registry tags over synonyms",
   },
   draftingRules: [
     "Use existing page structure.",
@@ -56,5 +56,7 @@ export const dossierAuthoringGuide = {
     "Do not invent hidden restricted details.",
     "Do not treat Discord identity or payment identity as dossier identity.",
     "Do not auto-promote queue artists into dossiers.",
+    "Use the dossier tag registry before drafting tags, reuse existing canonical tags first, and propose new tags only when clearly justified.",
+    "Do not present a proposed tag as an existing/created tag until it is added to site content or the registry.",
   ],
 } as const;

--- a/src/lib/dossier-tags.ts
+++ b/src/lib/dossier-tags.ts
@@ -1,0 +1,285 @@
+import type { DatabaseEntry } from "@/content";
+
+export type DossierTagCategory =
+  | "role"
+  | "system"
+  | "media"
+  | "function"
+  | "relationship"
+  | "community"
+  | "status"
+  | "identity"
+  | "technology"
+  | "broadcast"
+  | "creative"
+  | "other";
+
+export type DossierTagRegistryItem = {
+  tag: string;
+  canonical: string;
+  category: DossierTagCategory;
+  usageCount: number;
+  usedByIds: string[];
+  aliases: string[];
+  description: string;
+  source: "database_entries" | "manual_registry" | "inferred";
+  status: "active" | "deprecated" | "candidate";
+};
+
+type DossierTagMetadata = {
+  category: DossierTagCategory;
+  aliases?: string[];
+  description: string;
+};
+
+type DossierTagCreationPolicy = {
+  defaultAction: "reuse_existing_tag_first";
+  newTagsAllowed: "proposal_only";
+  creationRequires: "operator_or_site_content_update";
+  doNotCreateFor: string[];
+  newTagProposalRequirements: string[];
+};
+
+type DossierTagRegistry = {
+  source: "databasePage.entries";
+  totalUniqueTags: number;
+  totalTagAssignments: number;
+  items: DossierTagRegistryItem[];
+  usageCounts: Record<string, number>;
+  categories: Record<DossierTagCategory, string[]>;
+  aliases: Record<string, string>;
+  rules: string[];
+  creationPolicy: DossierTagCreationPolicy;
+};
+
+const DOSSIER_TAG_METADATA = {
+  ai: {
+    category: "technology",
+    aliases: ["artificial intelligence", "machine intelligence"],
+    description: "Connected to artificial intelligence, autonomous systems, or AI-assisted BARCODE operations.",
+  },
+  architecture: {
+    category: "system",
+    aliases: ["system design", "infrastructure design"],
+    description: "Connected to structure, system design, or technical architecture.",
+  },
+  artist: {
+    category: "identity",
+    aliases: ["performer", "music artist"],
+    description: "Identifies an artist, performer, or creative subject surfaced as a dossier role.",
+  },
+  automation: {
+    category: "function",
+    aliases: ["automated", "workflow"],
+    description: "Connected to automated workflows, routing, or operational processing.",
+  },
+  broadcast: {
+    category: "broadcast",
+    aliases: ["live", "livestream", "on-air"],
+    description: "Connected to BARCODE Radio, live programming, or broadcast behavior.",
+  },
+  engineer: {
+    category: "role",
+    aliases: ["technical engineer", "systems engineer"],
+    description: "Identifies engineering, technical maintenance, or build responsibility.",
+  },
+  executive: {
+    category: "role",
+    aliases: ["leadership", "director"],
+    description: "Identifies executive, leadership, or organizational authority.",
+  },
+  handler: {
+    category: "role",
+    aliases: ["operator", "control"],
+    description: "Identifies handler, control, or operational stewardship roles.",
+  },
+  host: {
+    category: "role",
+    aliases: ["presenter", "emcee"],
+    description: "Identifies an on-air host or primary presentation role.",
+  },
+  manager: {
+    category: "role",
+    aliases: ["management", "supervisor"],
+    description: "Identifies management, oversight, or coordination responsibility.",
+  },
+  mod: {
+    category: "community",
+    aliases: ["moderation", "moderator"],
+    description: "Connected to community moderation, safety, or participant stewardship.",
+  },
+  producer: {
+    category: "creative",
+    aliases: ["production", "program producer"],
+    description: "Connected to production, programming, or creative assembly work.",
+  },
+  radio: {
+    category: "broadcast",
+    aliases: ["radio program", "radio show"],
+    description: "Connected specifically to radio programming or the BARCODE Radio format.",
+  },
+  sponsor: {
+    category: "relationship",
+    aliases: ["partner", "supporter"],
+    description: "Identifies sponsor, partner, or support relationship context.",
+  },
+  stagehand: {
+    category: "role",
+    aliases: ["crew", "production hand"],
+    description: "Identifies support crew, stage, or behind-the-scenes production work.",
+  },
+  systems: {
+    category: "system",
+    aliases: ["infrastructure", "backend", "network"],
+    description: "Connected to technical systems, infrastructure, or operational mechanisms.",
+  },
+  tech: {
+    category: "technology",
+    aliases: ["technology", "technical"],
+    description: "Connected to technical platforms, tools, or technology-facing operations.",
+  },
+  virus: {
+    category: "system",
+    aliases: ["malware", "infection"],
+    description: "Connected to virus-class, infection, or anomalous system behavior.",
+  },
+  writer: {
+    category: "creative",
+    aliases: ["copywriter", "author"],
+    description: "Identifies writing, text, or authored creative work.",
+  },
+} satisfies Record<string, DossierTagMetadata>;
+
+export const DOSSIER_TAG_RULES = [
+  "Reuse an existing canonical tag before proposing a new one.",
+  "Compare tags case-insensitively, but preserve the spelling already stored on database entries.",
+  "Aliases are lookup hints for reuse; they do not rewrite existing dossier tags.",
+  "Proposed tags are not created tags until an operator or site content update adds them to the registry/source content.",
+  "Do not create tags for one-off wording differences, synonyms of existing tags, temporary queue appearances, private identities, or payment/customer data.",
+  "Queue-derived artists do not automatically create dossier tags or dossier records.",
+  "Tags should support search and organization, not decorative lore.",
+] as const;
+
+export const DOSSIER_TAG_CREATION_POLICY: DossierTagCreationPolicy = {
+  defaultAction: "reuse_existing_tag_first",
+  newTagsAllowed: "proposal_only",
+  creationRequires: "operator_or_site_content_update",
+  doNotCreateFor: [
+    "one-off wording differences",
+    "synonyms of existing tags",
+    "temporary queue appearances",
+    "private identities",
+    "payment/customer data",
+  ],
+  newTagProposalRequirements: [
+    "short lowercase label",
+    "clear reason",
+    "suggested category",
+    "why existing tags do not fit",
+    "which dossier would use it",
+  ],
+};
+
+function normalizeTag(tag: string) {
+  return tag.trim().toLocaleLowerCase();
+}
+
+function emptyCategories(): Record<DossierTagCategory, string[]> {
+  return {
+    role: [],
+    system: [],
+    media: [],
+    function: [],
+    relationship: [],
+    community: [],
+    status: [],
+    identity: [],
+    technology: [],
+    broadcast: [],
+    creative: [],
+    other: [],
+  };
+}
+
+function fallbackDescription(tag: string) {
+  return `Existing dossier tag from databasePage.entries used for search and organization: ${tag}.`;
+}
+
+export function resolveDossierTagCanonical(tagOrAlias: string) {
+  const normalized = normalizeTag(tagOrAlias);
+  if (!normalized) return null;
+  if (DOSSIER_TAG_METADATA[normalized as keyof typeof DOSSIER_TAG_METADATA]) return normalized;
+
+  for (const [canonical, metadata] of Object.entries(DOSSIER_TAG_METADATA)) {
+    if (metadata.aliases?.some((alias) => normalizeTag(alias) === normalized)) return canonical;
+  }
+
+  return null;
+}
+
+export function buildDossierTagRegistry(entries: DatabaseEntry[]): DossierTagRegistry {
+  const tagRecords = new Map<string, { tag: string; usageCount: number; usedByIds: Set<string> }>();
+  let totalTagAssignments = 0;
+
+  for (const entry of entries) {
+    for (const rawTag of entry.tags) {
+      const normalized = normalizeTag(rawTag);
+      if (!normalized) continue;
+      totalTagAssignments += 1;
+
+      const existing = tagRecords.get(normalized);
+      if (existing) {
+        existing.usageCount += 1;
+        existing.usedByIds.add(entry.id);
+      } else {
+        tagRecords.set(normalized, {
+          tag: rawTag,
+          usageCount: 1,
+          usedByIds: new Set([entry.id]),
+        });
+      }
+    }
+  }
+
+  const categories = emptyCategories();
+  const aliases: Record<string, string> = {};
+  const usageCounts: Record<string, number> = {};
+  const items = Array.from(tagRecords.entries())
+    .map(([normalized, record]) => {
+      const metadata = DOSSIER_TAG_METADATA[normalized as keyof typeof DOSSIER_TAG_METADATA];
+      const category = metadata?.category ?? "other";
+      const tagAliases = metadata?.aliases ?? [];
+      const item: DossierTagRegistryItem = {
+        tag: record.tag,
+        canonical: record.tag,
+        category,
+        usageCount: record.usageCount,
+        usedByIds: Array.from(record.usedByIds).sort(),
+        aliases: tagAliases,
+        description: metadata?.description ?? fallbackDescription(record.tag),
+        source: metadata ? "database_entries" : "inferred",
+        status: "active",
+      };
+
+      usageCounts[record.tag] = record.usageCount;
+      categories[category].push(record.tag);
+      for (const alias of tagAliases) aliases[alias] = record.tag;
+
+      return item;
+    })
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+
+  for (const tags of Object.values(categories)) tags.sort((a, b) => a.localeCompare(b));
+
+  return {
+    source: "databasePage.entries",
+    totalUniqueTags: items.length,
+    totalTagAssignments,
+    items,
+    usageCounts,
+    categories,
+    aliases: Object.fromEntries(Object.entries(aliases).sort(([a], [b]) => a.localeCompare(b))),
+    rules: [...DOSSIER_TAG_RULES],
+    creationPolicy: DOSSIER_TAG_CREATION_POLICY,
+  };
+}

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -42,6 +42,7 @@ const queue = require("../src/lib/queue.ts");
 const { databasePage } = require("../src/content.ts");
 const { getDatabaseAggregateStats } = require("../src/lib/database-stats.ts");
 const { getDossierPrimaryLink, getDossierPublicLinks, legacyDossierLink } = require("../src/lib/dossier-links.ts");
+const { buildDossierTagRegistry, resolveDossierTagCanonical } = require("../src/lib/dossier-tags.ts");
 const { isBnlReadModelDossierVisible, isPublicDatabasePageVisible } = require("../src/lib/database-visibility.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 
@@ -176,7 +177,7 @@ test("BNL read model preserves v1 compatibility and adds semantic sections", asy
 
   assert.equal(model.ok, true);
   assert.equal(model.version, 1);
-  assert.equal(model.schemaRevision, "1.2");
+  assert.equal(model.schemaRevision, "1.3");
   assert.equal(model.publicOnly, true);
   assert.ok(model.sections.sourceContext);
   assert.ok(model.sections.queue);
@@ -387,6 +388,85 @@ test("dossier authoring guide matches sections rendered by the dossier page", ()
   }
 });
 
+
+
+test("BNL read model exposes a dynamic dossier tag registry", async () => {
+  await freshReadModelSession();
+  const model = await modelJson();
+  const registry = model.sections.dossiers.tagRegistry;
+  const sourceTags = databasePage.entries.flatMap((entry) => entry.tags);
+  const normalizedUniqueTags = [...new Set(sourceTags.map((tag) => tag.toLowerCase()))];
+  const expectedRegistry = buildDossierTagRegistry(databasePage.entries);
+
+  assert.ok(registry, "tag registry should exist under sections.dossiers");
+  for (const key of ["items", "usageCounts", "categories", "aliases", "rules", "creationPolicy"]) {
+    assert.ok(Object.hasOwn(registry, key), `tag registry should expose ${key}`);
+  }
+  assert.equal(registry.source, "databasePage.entries");
+  assert.equal(registry.totalUniqueTags, normalizedUniqueTags.length);
+  assert.equal(registry.totalTagAssignments, sourceTags.length);
+  assert.deepEqual(registry, expectedRegistry);
+
+  for (const tag of normalizedUniqueTags) {
+    const sourceEntries = databasePage.entries.filter((entry) => entry.tags.some((entryTag) => entryTag.toLowerCase() === tag));
+    const item = registry.items.find((entry) => entry.tag.toLowerCase() === tag);
+    assert.ok(item, `${tag} should appear in registry items`);
+    assert.equal(item.usageCount, sourceEntries.reduce((count, entry) => count + entry.tags.filter((entryTag) => entryTag.toLowerCase() === tag).length, 0));
+    assert.deepEqual(item.usedByIds, sourceEntries.map((entry) => entry.id).sort());
+    assert.equal(registry.usageCounts[item.tag], item.usageCount);
+  }
+});
+
+test("dossier tag registry preserves raw entry tags and leaves database UI tag behavior freeform", async () => {
+  await freshReadModelSession();
+  const beforeTags = databasePage.entries.map((entry) => ({ id: entry.id, tags: [...entry.tags] }));
+  const model = await modelJson();
+  const afterTags = databasePage.entries.map((entry) => ({ id: entry.id, tags: [...entry.tags] }));
+  const databaseTableSource = fs.readFileSync(path.join(projectRoot, "src/components/DatabaseTable.tsx"), "utf8");
+  const dossierPageSource = fs.readFileSync(path.join(projectRoot, "src/app/database/[slug]/page.tsx"), "utf8");
+
+  assert.deepEqual(afterTags, beforeTags);
+  for (const entry of databasePage.entries) {
+    assert.ok(Array.isArray(entry.tags));
+    assert.ok(entry.tags.every((tag) => typeof tag === "string"));
+  }
+  assert.ok(model.sections.dossiers.items.every((entry) => Array.isArray(entry.tags) && entry.tags.every((tag) => typeof tag === "string")));
+  assert.match(databaseTableSource, /entry\.tags\.some\(\(t\) => t\.toLowerCase\(\)\.includes\(q\)\)/);
+  assert.match(databaseTableSource, /entry\.tags\.slice\(0, 3\)\.map/);
+  assert.match(dossierPageSource, /entry\.tags\.map/);
+});
+
+test("dossier tag creation policy keeps new tags proposal-only", async () => {
+  await freshReadModelSession();
+  const model = await modelJson();
+  const { creationPolicy, rules } = model.sections.dossiers.tagRegistry;
+  const policyText = JSON.stringify(creationPolicy).toLowerCase();
+  const rulesText = rules.join(" ").toLowerCase();
+
+  assert.equal(creationPolicy.defaultAction, "reuse_existing_tag_first");
+  assert.equal(creationPolicy.newTagsAllowed, "proposal_only");
+  assert.equal(creationPolicy.creationRequires, "operator_or_site_content_update");
+  for (const phrase of ["synonyms of existing tags", "temporary queue appearances", "payment/customer data", "private identities"]) {
+    assert.ok(policyText.includes(phrase), `${phrase} should be rejected by policy`);
+  }
+  for (const phrase of ["synonyms", "temporary queue", "payment/customer data", "private identities"]) {
+    assert.ok(rulesText.includes(phrase), `${phrase} should be included in rules`);
+  }
+});
+
+test("dossier tag aliases resolve to canonical tags without creating duplicate registry items", async () => {
+  await freshReadModelSession();
+  const model = await modelJson();
+  const registry = model.sections.dossiers.tagRegistry;
+  const aliasCount = Object.keys(registry.aliases).length;
+
+  assert.ok(aliasCount > 0, "registry should expose aliases");
+  assert.equal(registry.aliases.live, "broadcast");
+  assert.equal(resolveDossierTagCanonical("live"), "broadcast");
+  assert.equal(registry.items.filter((item) => item.tag === "broadcast").length, 1);
+  assert.equal(registry.items.some((item) => item.tag === "live"), false);
+});
+
 test("featured dossier link helpers preserve legacy links and prefer public primary links", () => {
   const legacyEntry = { link: "https://discord.gg/4tHazmD528" };
   const legacy = legacyDossierLink(legacyEntry.link);
@@ -456,6 +536,13 @@ test("BNL dossier style profile is dynamically derived from current entries", as
   assert.equal(styleProfile.summaryWordCount.max, Math.max(...wordCounts));
   assert.equal(styleProfile.summaryWordCount.average, average);
   assert.equal(styleProfile.notesPresenceCount, entries.filter((entry) => entry.notes.trim().length > 0).length);
+  const sourceTags = entries.flatMap((entry) => entry.tags);
+  const expectedAverageTags = Math.round((sourceTags.length / entries.length) * 100) / 100;
+  assert.equal(styleProfile.tagProfile.totalUniqueTags, model.sections.dossiers.tagRegistry.totalUniqueTags);
+  assert.equal(styleProfile.tagProfile.averageTagsPerDossier, expectedAverageTags);
+  assert.ok(styleProfile.tagProfile.mostUsedTags.length <= 10);
+  assert.ok(styleProfile.tagProfile.singleUseTags.length <= 10);
+  assert.deepEqual(styleProfile.tagProfile.singleUseTags, model.sections.dossiers.tagRegistry.items.filter((item) => item.usageCount === 1).map((item) => item.tag).sort((a, b) => a.localeCompare(b)).slice(0, 10));
   for (const section of ["Dossier Record", "Intelligence Brief", "Attached Files", "Terminal Readout"]) {
     assert.ok(styleProfile.commonSections.includes(section));
   }


### PR DESCRIPTION
### Motivation
- Provide a public-safe, additive dossier tag registry so BNL and operators can see which tags exist, how often they are used, canonical/alias hints, and clear rules for proposing (not creating) new tags. 
- Preserve existing freeform `databasePage.entries[*].tags` behavior while giving an authoritative read-model reference and guidance to encourage reuse of existing tags.

### Description
- Add `src/lib/dossier-tags.ts` which defines `DossierTagCategory`/`DossierTagRegistryItem` types, a small `DOSSIER_TAG_METADATA` manual map with lightweight aliases, `DOSSIER_TAG_RULES` and `DOSSIER_TAG_CREATION_POLICY`, and `buildDossierTagRegistry(entries)` plus `resolveDossierTagCanonical(tag)` helper. 
- Wire the registry into the BNL read model by importing `buildDossierTagRegistry` in `src/app/api/bnl/read-model/route.ts`, exposing `sections.dossiers.tagRegistry`, including a dynamic `styleProfile.tagProfile` (top used tags, single-use tags, totals), and bumping the additive `schemaRevision` to `"1.3"` while preserving top-level `version: 1`. 
- Update `src/lib/dossier-authoring-guide.ts` to instruct BNL/operators to use `sections.dossiers.tagRegistry`, prefer reuse of canonical tags, and treat any new tag as a proposal until an operator/site content update creates it. 
- Add/readjust tests in `tests/bnl-read-model.test.mjs` to assert the presence and correctness of `sections.dossiers.tagRegistry`, dynamic counts, alias resolution, preservation of raw entry tags and UI tag behavior, the proposal-only creation policy, and style-profile tag stats; files changed in this PR are `src/lib/dossier-tags.ts`, `src/app/api/bnl/read-model/route.ts`, `src/lib/dossier-authoring-guide.ts`, and `tests/bnl-read-model.test.mjs`. 

### Testing
- Type-check and lint: ran `npx tsc --noEmit` and `npx eslint src/app/api/bnl/read-model/route.ts src/lib/dossier-tags.ts src/lib/dossier-authoring-guide.ts`, both passed. 
- Full test suite: ran `npm run test:queue` and all tests passed (106 passing tests). 
- Read-model endpoint check: executed the read-model locally and verified `schemaRevision: "1.3"`, presence of `sections.dossiers.tagRegistry` keys, `totalUniqueTags: 19`, and `totalTagAssignments: 74`. 
- Audit summary from `src/content.ts:databasePage.entries`: 22 dossier entries audited, 19 unique tags, 74 total tag assignments, top used tags include `broadcast (12)`, `systems (10)`, `tech (9)`, `ai (8)`, and single-use tags include `architecture`, `executive`, `host`, `manager`, `sponsor`, `writer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e1125cb883218499468599f7df68)