### PR TITLE
Admin Dossier Control Center Foundation v1

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -35,6 +35,19 @@ const operatorOptions = {
   tagMode: ["Reuse existing tags", "Allow proposed tags"],
 };
 
+function MinimalDossierAdminState({ title, message }: { title: string; message: string }) {
+  return (
+    <main className="pt-14 min-h-screen flex items-center justify-center px-4">
+      <section className="w-full max-w-md border border-border bg-surface p-8">
+        <p className="text-xs uppercase tracking-[0.5em] text-muted mb-5">// ADMIN ACCESS CHECK</p>
+        <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+        <p className="text-sm text-muted mt-3">{message}</p>
+        <Link href="/admin" className="mt-6 inline-flex border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background transition-all">Back to Admin</Link>
+      </section>
+    </main>
+  );
+}
+
 export default function AdminDossiersPage() {
   const [payload, setPayload] = useState<WorkflowPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -67,15 +80,17 @@ export default function AdminDossiersPage() {
     };
   }, []);
 
-  const candidates = payload?.candidates ?? [];
-  const drafts = payload?.drafts ?? [];
-  const boundaries = payload?.workflow.boundaries ?? [
-    "BNL recommends and drafts only.",
-    "Admin approves and publishes through future controlled site updates.",
-    "No automatic dossier creation or automatic tag creation.",
-    "No Discord identity merging, payment/customer identity, or queue-to-dossier promotion.",
-    "Queue frequency is evidence, not identity.",
-  ];
+  if (loading) {
+    return <MinimalDossierAdminState title="Checking admin access..." message="Verifying operator credentials before loading the dossier workflow." />;
+  }
+
+  if (error || !payload) {
+    return <MinimalDossierAdminState title="Admin authentication required" message={error ?? "Sign in from the admin panel before opening this operator workflow."} />;
+  }
+
+  const candidates = payload.candidates;
+  const drafts = payload.drafts;
+  const boundaries = payload.workflow.boundaries;
 
   return (
     <main className="pt-14 min-h-screen">
@@ -97,15 +112,15 @@ export default function AdminDossiersPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 text-xs text-muted">
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Workflow API</p>
-            <p>{loading ? "Loading /api/admin/dossiers..." : error ? error : "Foundation contract loaded."}</p>
+            <p>Foundation contract loaded.</p>
           </div>
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Authoring Guide</p>
-            <p>Version: {payload?.authoringGuide?.version ?? "pending auth"}</p>
+            <p>Version: {payload.authoringGuide?.version ?? "unknown"}</p>
           </div>
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Tag Registry</p>
-            <p>{payload?.tagRegistry ? `${payload.tagRegistry.totalUniqueTags} tags / ${payload.tagRegistry.totalTagAssignments} assignments` : "Loaded after admin API access."}</p>
+            <p>{payload.tagRegistry ? `${payload.tagRegistry.totalUniqueTags} tags / ${payload.tagRegistry.totalTagAssignments} assignments` : "No tag registry summary returned."}</p>
           </div>
         </div>
 

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -1,0 +1,238 @@
+/* eslint-disable react/jsx-no-comment-textnodes */
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  DOSSIER_SOURCE_BOUNDARIES,
+  DOSSIER_WORKFLOW_ACTIONS,
+  type DossierCandidate,
+  type DossierDraft,
+} from "@/lib/dossier-workflow";
+
+type WorkflowPayload = {
+  candidates: DossierCandidate[];
+  drafts: DossierDraft[];
+  workflow: {
+    status: string;
+    storage: string;
+    boundaries: string[];
+  };
+  authoringGuide?: {
+    version: string;
+  };
+  tagRegistry?: {
+    totalUniqueTags: number;
+    totalTagAssignments: number;
+  };
+};
+
+const operatorOptions = {
+  category: ["Entity", "Personnel", "Sponsor", "Interface", "Production"],
+  clearance: ["PUBLIC", "INTERNAL", "RESTRICTED"],
+  status: ["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"],
+  origin: ["KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"],
+  tagMode: ["Reuse existing tags", "Allow proposed tags"],
+};
+
+export default function AdminDossiersPage() {
+  const [payload, setPayload] = useState<WorkflowPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadWorkflow() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(response.status === 401 ? "Admin authentication required." : `Workflow API returned ${response.status}.`);
+        }
+        const data = (await response.json()) as WorkflowPayload;
+        if (!cancelled) setPayload(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load dossier workflow.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadWorkflow();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const candidates = payload?.candidates ?? [];
+  const drafts = payload?.drafts ?? [];
+  const boundaries = payload?.workflow.boundaries ?? [
+    "BNL recommends and drafts only.",
+    "Admin approves and publishes through future controlled site updates.",
+    "No automatic dossier creation or automatic tag creation.",
+    "No Discord identity merging, payment/customer identity, or queue-to-dossier promotion.",
+    "Queue frequency is evidence, not identity.",
+  ];
+
+  return (
+    <main className="pt-14 min-h-screen">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+          <p className="text-xs uppercase tracking-[0.5em] text-muted mb-4">// ADMIN: DOSSIER WORKFLOW</p>
+          <h1 aria-label="Dossier Control Center" className="text-4xl font-bold tracking-tight text-foreground"><span className="text-accent text-glow">Dossier</span> Control Center</h1>
+          <p className="text-sm text-muted mt-3 max-w-3xl">
+            Review dossier candidates, choose minimal drafting options, request BNL draft support, and keep approval/publishing under operator control.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+            <Link href="/admin" className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent transition-all">Back to Admin</Link>
+            <Link href="/database" className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent transition-all">Public Database</Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-8">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 text-xs text-muted">
+          <div className="border border-border bg-surface p-4">
+            <p className="uppercase tracking-[0.35em] text-accent mb-2">Workflow API</p>
+            <p>{loading ? "Loading /api/admin/dossiers..." : error ? error : "Foundation contract loaded."}</p>
+          </div>
+          <div className="border border-border bg-surface p-4">
+            <p className="uppercase tracking-[0.35em] text-accent mb-2">Authoring Guide</p>
+            <p>Version: {payload?.authoringGuide?.version ?? "pending auth"}</p>
+          </div>
+          <div className="border border-border bg-surface p-4">
+            <p className="uppercase tracking-[0.35em] text-accent mb-2">Tag Registry</p>
+            <p>{payload?.tagRegistry ? `${payload.tagRegistry.totalUniqueTags} tags / ${payload.tagRegistry.totalTagAssignments} assignments` : "Loaded after admin API access."}</p>
+          </div>
+        </div>
+
+        <section className="border border-border bg-surface p-6 space-y-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Queue</p>
+              <h2 className="text-2xl font-bold text-foreground">Candidate Queue</h2>
+              <p className="text-sm text-muted mt-2">Candidate intake wiring comes in a later PR. No candidates create dossiers automatically.</p>
+            </div>
+            <p className="text-xs uppercase tracking-widest text-muted">{candidates.length} candidates</p>
+          </div>
+          <div className="overflow-x-auto border border-border/70">
+            <table className="w-full min-w-[760px] text-left text-xs">
+              <thead className="bg-background/60 text-muted uppercase tracking-widest">
+                <tr>
+                  <th className="px-3 py-3">Candidate name</th>
+                  <th className="px-3 py-3">Source</th>
+                  <th className="px-3 py-3">Reason</th>
+                  <th className="px-3 py-3">Confidence / Priority</th>
+                  <th className="px-3 py-3">Status</th>
+                  <th className="px-3 py-3">Last seen / Evidence count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {candidates.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-3 py-8 text-center text-muted">No candidates yet. Candidate intake wiring comes in a later PR.</td>
+                  </tr>
+                ) : candidates.map((candidate) => (
+                  <tr key={candidate.id} className="border-t border-border/70">
+                    <td className="px-3 py-3 text-foreground">{candidate.name}</td>
+                    <td className="px-3 py-3">{candidate.source}</td>
+                    <td className="px-3 py-3">{candidate.reason}</td>
+                    <td className="px-3 py-3">{candidate.confidence ?? "unranked"}</td>
+                    <td className="px-3 py-3">{candidate.status}</td>
+                    <td className="px-3 py-3">{candidate.updatedAt} / {candidate.evidenceCount ?? 0}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-5 gap-8">
+          <div className="lg:col-span-3 border border-border bg-surface p-6 space-y-5">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Draft Workspace</p>
+              <h2 className="text-2xl font-bold text-foreground">Draft Workspace</h2>
+              <p className="text-sm text-muted mt-2">No draft selected. Select an operator-reviewed candidate before BNL drafting is requested.</p>
+            </div>
+            <div className="border border-border bg-background/30 p-4 text-sm text-muted">
+              <p className="text-xs uppercase tracking-widest text-accent mb-2">Selected Candidate</p>
+              <p>No draft selected. Candidate intake wiring comes in a later PR.</p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {Object.entries(operatorOptions).map(([key, values]) => (
+                <label key={key} className="text-xs uppercase tracking-widest text-muted space-y-2">
+                  <span>{key === "tagMode" ? "Tag mode" : key}</span>
+                  <select disabled className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted">
+                    {values.map((value) => <option key={value}>{value}</option>)}
+                  </select>
+                </label>
+              ))}
+              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
+                <span>Selected / featured link</span>
+                <input disabled placeholder="Public-safe link selection will be wired later" className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
+              </label>
+              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
+                <span>Notes to BNL</span>
+                <textarea disabled placeholder="Operator notes for future draft request" className="min-h-28 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
+              </label>
+            </div>
+            <p className="text-xs text-muted">Draft records are workflow records only. Approved drafts do not become website entries until a future operator-controlled site update.</p>
+          </div>
+
+          <div className="lg:col-span-2 border border-border bg-surface p-6 space-y-5">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Review Actions</p>
+              <h2 className="text-2xl font-bold text-foreground">Review Actions</h2>
+              <p className="text-sm text-muted mt-2">Backend mutations return not_implemented_yet in this foundation PR.</p>
+            </div>
+            <div className="grid grid-cols-1 gap-3">
+              {["Generate Draft", "Try Again", "Approve Draft", "Edit Draft", "Deny Candidate", "Mark Needs More Evidence"].map((label) => (
+                <button key={label} disabled className="w-full border border-border px-4 py-3 text-xs uppercase tracking-widest text-muted opacity-60">
+                  {label} — pending backend
+                </button>
+              ))}
+            </div>
+            <div className="border border-border bg-background/30 p-4 text-xs text-muted space-y-2">
+              <p className="uppercase tracking-widest text-accent">Future API actions</p>
+              <p>{DOSSIER_WORKFLOW_ACTIONS.join(", ")}</p>
+              <p>Current drafts loaded: {drafts.length}. Mutations do not publish or mutate real dossier content.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="border border-accent/40 bg-surface p-6 space-y-5">
+          <div>
+            <p className="text-xs uppercase tracking-[0.5em] text-accent mb-3">System Boundaries</p>
+            <h2 className="text-2xl font-bold text-foreground">System Boundaries</h2>
+            <p className="text-sm text-muted mt-2">The dossier workflow keeps evidence, draft generation, approval, and publishing separate.</p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
+            {boundaries.map((boundary) => <p key={boundary} className="border border-border bg-background/30 p-3">{boundary}</p>)}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 text-xs text-muted">
+            {DOSSIER_SOURCE_BOUNDARIES.map((source) => (
+              <div key={source.source} className="border border-border bg-background/30 p-4 space-y-2">
+                <p className="uppercase tracking-widest text-accent">{source.source}</p>
+                <p className="text-foreground">{source.label}</p>
+                <p>{source.boundary}</p>
+                <p>{source.allowedUse}</p>
+              </div>
+            ))}
+          </div>
+          <ul className="list-disc pl-5 text-sm text-muted space-y-1">
+            <li>BNL recommends and drafts only.</li>
+            <li>Admin approves/publishes.</li>
+            <li>No automatic dossier creation.</li>
+            <li>No automatic tag creation.</li>
+            <li>No Discord identity merging.</li>
+            <li>No payment/customer identity.</li>
+            <li>Queue frequency is evidence, not identity.</li>
+          </ul>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -4,6 +4,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
+  DOSSIER_CANDIDATE_SCORING_POLICY,
   DOSSIER_SOURCE_BOUNDARIES,
   DOSSIER_WORKFLOW_ACTIONS,
   type DossierCandidate,
@@ -17,6 +18,7 @@ type WorkflowPayload = {
     status: string;
     storage: string;
     boundaries: string[];
+    scoringPolicy?: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
   };
   authoringGuide?: {
     version: string;
@@ -29,11 +31,35 @@ type WorkflowPayload = {
 
 const operatorOptions = {
   category: ["Entity", "Personnel", "Sponsor", "Interface", "Production"],
-  clearance: ["PUBLIC", "INTERNAL", "RESTRICTED"],
   status: ["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"],
+  clearance: ["PUBLIC", "INTERNAL", "RESTRICTED"],
   origin: ["KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"],
   tagMode: ["Reuse existing tags", "Allow proposed tags"],
+  toneIntensity: ["grounded", "in-universe", "classified"],
 };
+
+const reviewActions = [
+  "Generate Draft",
+  "Try Again: Too Long",
+  "Try Again: Too Vague",
+  "Try Again: Too Much Lore",
+  "Try Again: Too Dry",
+  "Try Again: Wrong Tags",
+  "Rewrite Summary Only",
+  "Rewrite Notes Only",
+  "Approve Draft",
+  "Edit Draft",
+  "Deny Candidate",
+  "Mark Needs More Evidence",
+];
+
+const focusedAssistantPrompts = [
+  "Why was this recommended?",
+  "What evidence is missing?",
+  "Suggest safer public version",
+  "Suggest stronger in-universe version",
+  "Explain tag choices",
+];
 
 function MinimalDossierAdminState({ title, message }: { title: string; message: string }) {
   return (
@@ -46,6 +72,11 @@ function MinimalDossierAdminState({ title, message }: { title: string; message: 
       </section>
     </main>
   );
+}
+
+function listOrEmpty(items: string[] | undefined, empty: string) {
+  if (!items || items.length === 0) return <p className="text-muted">{empty}</p>;
+  return <ul className="list-disc pl-5 space-y-1">{items.map((item) => <li key={item}>{item}</li>)}</ul>;
 }
 
 export default function AdminDossiersPage() {
@@ -91,6 +122,9 @@ export default function AdminDossiersPage() {
   const candidates = payload.candidates;
   const drafts = payload.drafts;
   const boundaries = payload.workflow.boundaries;
+  const scoringPolicy = payload.workflow.scoringPolicy ?? DOSSIER_CANDIDATE_SCORING_POLICY;
+  const selectedCandidate = candidates[0] ?? null;
+  const selectedEvidence = selectedCandidate?.evidenceItems ?? [];
 
   return (
     <main className="pt-14 min-h-screen">
@@ -99,7 +133,7 @@ export default function AdminDossiersPage() {
           <p className="text-xs uppercase tracking-[0.5em] text-muted mb-4">// ADMIN: DOSSIER WORKFLOW</p>
           <h1 aria-label="Dossier Control Center" className="text-4xl font-bold tracking-tight text-foreground"><span className="text-accent text-glow">Dossier</span> Control Center</h1>
           <p className="text-sm text-muted mt-3 max-w-3xl">
-            Review dossier candidates, choose minimal drafting options, request BNL draft support, and keep approval/publishing under operator control.
+            Review why a candidate was recommended, inspect evidence and duplicate risk, then request BNL drafting only after operator selection.
           </p>
           <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
             <Link href="/admin" className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent transition-all">Back to Admin</Link>
@@ -112,7 +146,7 @@ export default function AdminDossiersPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 text-xs text-muted">
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Workflow API</p>
-            <p>Foundation contract loaded.</p>
+            <p>Foundation contract loaded. Storage: {payload.workflow.storage}.</p>
           </div>
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Authoring Guide</p>
@@ -129,39 +163,102 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Queue</p>
               <h2 className="text-2xl font-bold text-foreground">Candidate Queue</h2>
-              <p className="text-sm text-muted mt-2">Candidate intake wiring comes in a later PR. No candidates create dossiers automatically.</p>
+              <p className="text-sm text-muted mt-2">Candidates are recommendations, not dossiers. Candidate intake wiring comes in a later PR.</p>
             </div>
             <p className="text-xs uppercase tracking-widest text-muted">{candidates.length} candidates</p>
           </div>
           <div className="overflow-x-auto border border-border/70">
-            <table className="w-full min-w-[760px] text-left text-xs">
+            <table className="w-full min-w-[980px] text-left text-xs">
               <thead className="bg-background/60 text-muted uppercase tracking-widest">
                 <tr>
                   <th className="px-3 py-3">Candidate name</th>
+                  <th className="px-3 py-3">Type</th>
                   <th className="px-3 py-3">Source</th>
-                  <th className="px-3 py-3">Reason</th>
-                  <th className="px-3 py-3">Confidence / Priority</th>
+                  <th className="px-3 py-3">Tier</th>
+                  <th className="px-3 py-3">Score</th>
+                  <th className="px-3 py-3">Why Now</th>
+                  <th className="px-3 py-3">Evidence count</th>
+                  <th className="px-3 py-3">Duplicate Risk</th>
                   <th className="px-3 py-3">Status</th>
-                  <th className="px-3 py-3">Last seen / Evidence count</th>
                 </tr>
               </thead>
               <tbody>
                 {candidates.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-3 py-8 text-center text-muted">No candidates yet. Candidate intake wiring comes in a later PR.</td>
+                    <td colSpan={9} className="px-3 py-8 text-center text-muted">No candidates yet. Candidate intake wiring comes in a later PR.</td>
                   </tr>
                 ) : candidates.map((candidate) => (
                   <tr key={candidate.id} className="border-t border-border/70">
                     <td className="px-3 py-3 text-foreground">{candidate.name}</td>
+                    <td className="px-3 py-3">{candidate.candidateType}</td>
                     <td className="px-3 py-3">{candidate.source}</td>
-                    <td className="px-3 py-3">{candidate.reason}</td>
-                    <td className="px-3 py-3">{candidate.confidence ?? "unranked"}</td>
+                    <td className="px-3 py-3">{candidate.tier}</td>
+                    <td className="px-3 py-3">{candidate.score}</td>
+                    <td className="px-3 py-3">{candidate.whyNow}</td>
+                    <td className="px-3 py-3">{candidate.evidenceItems?.length ?? candidate.evidenceCount ?? 0}</td>
+                    <td className="px-3 py-3">{candidate.duplicateRisk ?? "unknown"}</td>
                     <td className="px-3 py-3">{candidate.status}</td>
-                    <td className="px-3 py-3">{candidate.updatedAt} / {candidate.evidenceCount ?? 0}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="border border-border bg-surface p-6 space-y-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Evidence</p>
+              <h2 className="text-2xl font-bold text-foreground">Candidate Evidence</h2>
+              <p className="text-sm text-muted mt-2">Evidence is not public copy by default. Each item must be checked for publicSafe status before it can inform a draft.</p>
+            </div>
+            <div className="border border-border bg-background/30 p-4 text-sm text-muted space-y-2">
+              <p><span className="text-foreground">Evidence summary:</span> {selectedCandidate?.evidenceSummary ?? "No candidate selected."}</p>
+              <p><span className="text-foreground">First seen:</span> {selectedCandidate?.firstSeenAt ?? "not available"}</p>
+              <p><span className="text-foreground">Last seen:</span> {selectedCandidate?.lastSeenAt ?? "not available"}</p>
+              <p><span className="text-foreground">publicSafe flag:</span> future evidence items must be individually marked true before public drafting use.</p>
+            </div>
+            <div className="space-y-2 text-xs text-muted">
+              {selectedEvidence.length === 0 ? (
+                <p className="border border-border bg-background/20 p-3">No evidence items yet. Future entries will show type, label, summary, count, first seen, last seen, and publicSafe status.</p>
+              ) : selectedEvidence.map((item) => (
+                <div key={item.id} className="border border-border bg-background/20 p-3">
+                  <p className="text-foreground">{item.label} ({item.type})</p>
+                  <p>{item.summary}</p>
+                  <p>Count: {item.count ?? 1} / publicSafe: {item.publicSafe ? "yes" : "no"}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border border-border bg-surface p-6 space-y-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Gate / Scoring</p>
+              <h2 className="text-2xl font-bold text-foreground">Candidate Gate / Scoring</h2>
+              <p className="text-sm text-muted mt-2">{scoringPolicy.gate}</p>
+            </div>
+            <div className="space-y-2 text-xs text-muted">
+              <p><span className="text-foreground">weak candidate:</span> {scoringPolicy.tiers.weak_candidate} Minimum score {scoringPolicy.thresholds.weakCandidateMin}.</p>
+              <p><span className="text-foreground">review candidate:</span> {scoringPolicy.tiers.review_candidate} Minimum score {scoringPolicy.thresholds.reviewCandidateMin}.</p>
+              <p><span className="text-foreground">draft-ready:</span> {scoringPolicy.tiers.draft_ready} Minimum score {scoringPolicy.thresholds.draftReadyMin}.</p>
+              <p>{scoringPolicy.signals.queueRecurrence}</p>
+              <p>Queue frequency is evidence, not identity.</p>
+              <p>Duplicate risk must be resolved before drafting.</p>
+            </div>
+          </div>
+
+          <div className="border border-border bg-surface p-6 space-y-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Draft Readiness / Missing Info</p>
+              <h2 className="text-2xl font-bold text-foreground">Draft Readiness / Missing Info</h2>
+              <p className="text-sm text-muted mt-2">Missing Info, Do Not Say, public safety notes, and duplicate warnings block draft requests until reviewed.</p>
+            </div>
+            <div className="grid grid-cols-1 gap-3 text-xs text-muted">
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Missing Info</p>{listOrEmpty(selectedCandidate?.missingInfo, "No selected candidate; missing facts will appear here.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Do Not Say</p>{listOrEmpty(selectedCandidate?.doNotSay, "No restricted phrasing recorded yet.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Public Safety Notes</p>{listOrEmpty(selectedCandidate?.publicSafetyNotes, "No public-safety notes recorded yet.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Existing Dossier Match / Duplicate Warning</p><p>{selectedCandidate?.existingDossierMatch ? `${selectedCandidate.existingDossierMatch.name} (${selectedCandidate.existingDossierMatch.confidence})` : "No selected candidate or duplicate match yet."}</p></div>
+            </div>
           </div>
         </section>
 
@@ -170,7 +267,7 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Draft Workspace</p>
               <h2 className="text-2xl font-bold text-foreground">Draft Workspace</h2>
-              <p className="text-sm text-muted mt-2">No draft selected. Select an operator-reviewed candidate before BNL drafting is requested.</p>
+              <p className="text-sm text-muted mt-2">No draft selected. Select a reviewed candidate before BNL drafting is requested.</p>
             </div>
             <div className="border border-border bg-background/30 p-4 text-sm text-muted">
               <p className="text-xs uppercase tracking-widest text-accent mb-2">Selected Candidate</p>
@@ -179,7 +276,7 @@ export default function AdminDossiersPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {Object.entries(operatorOptions).map(([key, values]) => (
                 <label key={key} className="text-xs uppercase tracking-widest text-muted space-y-2">
-                  <span>{key === "tagMode" ? "Tag mode" : key}</span>
+                  <span>{key === "tagMode" ? "Tag mode" : key === "toneIntensity" ? "Tone intensity" : key}</span>
                   <select disabled className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted">
                     {values.map((value) => <option key={value}>{value}</option>)}
                   </select>
@@ -190,8 +287,16 @@ export default function AdminDossiersPage() {
                 <input disabled placeholder="Public-safe link selection will be wired later" className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
               </label>
               <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
+                <span>Known facts</span>
+                <textarea disabled placeholder="Operator-approved facts for BNL drafting" className="min-h-24 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
+              </label>
+              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
+                <span>Do not say</span>
+                <textarea disabled placeholder="Claims, private details, or lore directions BNL must avoid" className="min-h-24 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
+              </label>
+              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
                 <span>Notes to BNL</span>
-                <textarea disabled placeholder="Operator notes for future draft request" className="min-h-28 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
+                <textarea disabled placeholder="Candidate-specific drafting instructions for future BNL request" className="min-h-28 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
               </label>
             </div>
             <p className="text-xs text-muted">Draft records are workflow records only. Approved drafts do not become website entries until a future operator-controlled site update.</p>
@@ -204,7 +309,7 @@ export default function AdminDossiersPage() {
               <p className="text-sm text-muted mt-2">Backend mutations return not_implemented_yet in this foundation PR.</p>
             </div>
             <div className="grid grid-cols-1 gap-3">
-              {["Generate Draft", "Try Again", "Approve Draft", "Edit Draft", "Deny Candidate", "Mark Needs More Evidence"].map((label) => (
+              {reviewActions.map((label) => (
                 <button key={label} disabled className="w-full border border-border px-4 py-3 text-xs uppercase tracking-widest text-muted opacity-60">
                   {label} — pending backend
                 </button>
@@ -215,6 +320,19 @@ export default function AdminDossiersPage() {
               <p>{DOSSIER_WORKFLOW_ACTIONS.join(", ")}</p>
               <p>Current drafts loaded: {drafts.length}. Mutations do not publish or mutate real dossier content.</p>
             </div>
+          </div>
+        </section>
+
+        <section className="border border-border bg-surface p-6 space-y-5">
+          <div>
+            <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Focused BNL Assistant</p>
+            <h2 className="text-2xl font-bold text-foreground">Focused BNL Assistant</h2>
+            <p className="text-sm text-muted mt-2">Not a full chat yet. Future wiring is candidate-specific only and cannot publish, write memory, or create dossiers.</p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3">
+            {focusedAssistantPrompts.map((prompt) => (
+              <button key={prompt} disabled className="border border-border bg-background/30 px-3 py-3 text-xs uppercase tracking-widest text-muted opacity-60">{prompt}</button>
+            ))}
           </div>
         </section>
 
@@ -245,6 +363,7 @@ export default function AdminDossiersPage() {
             <li>No Discord identity merging.</li>
             <li>No payment/customer identity.</li>
             <li>Queue frequency is evidence, not identity.</li>
+            <li>Loose intake / strict publishing keeps early candidates separate from approved public dossiers.</li>
           </ul>
         </section>
       </section>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useLiveStatus } from "@/components/LiveStatusProvider";
+import Link from "next/link";
 import { useState, useEffect } from "react";
 
 type BNLStatusValue = "ONLINE" | "OFFLINE";
@@ -201,7 +202,10 @@ function AdminContent({ isLive, toggleLive, setStreamUrl, isScheduled, manualOve
   const modSignalBriefing = bnl.adminNote?.trim();
 
   return <section><div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 space-y-8">{/* existing cards omitted for brevity in source */}
-  <div className="border border-accent/40 bg-surface p-6 space-y-4"><div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between"><div><p className="text-xs uppercase tracking-[0.5em] text-accent mb-3">Show Management</p><h2 className="text-2xl font-bold text-foreground">Show Management</h2><p className="text-sm text-muted mt-2">Start sessions, open submissions, run the queue, and review archived shows.</p></div><a href="/admin/show-management" className="inline-flex items-center justify-center border border-accent px-5 py-3 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background transition-all">Open Show Management</a></div></div>
+  <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="border border-accent/40 bg-surface p-6 space-y-4"><div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between"><div><p className="text-xs uppercase tracking-[0.5em] text-accent mb-3">Show Management</p><h2 className="text-2xl font-bold text-foreground">Show Management</h2><p className="text-sm text-muted mt-2">Start sessions, open submissions, run the queue, and review archived shows.</p></div><a href="/admin/show-management" className="inline-flex items-center justify-center border border-accent px-5 py-3 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background transition-all">Open Show Management</a></div></div>
+    <div className="border border-accent/40 bg-surface p-6 space-y-4"><div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between"><div><p className="text-xs uppercase tracking-[0.5em] text-accent mb-3">Dossier Workflow</p><h2 className="text-2xl font-bold text-foreground">Dossier Control Center</h2><p className="text-sm text-muted mt-2">Review dossier candidates, manage drafts, and prepare approved website dossier entries.</p></div><Link href="/admin/dossiers" className="inline-flex items-center justify-center border border-accent px-5 py-3 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background transition-all">Open Dossier Control Center</Link></div></div>
+  </div>
 
 
   <div className="grid grid-cols-1 md:grid-cols-2 gap-8"><div className="border border-border bg-surface p-6"><h2 className="text-[10px] uppercase tracking-[0.5em] text-muted mb-6">BARCODE Radio — Live Status</h2><button onClick={toggleLive} className="w-full px-4 py-3 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all font-bold">{isLive ? 'GO OFFLINE':'GO LIVE'}</button><div className="text-xs text-muted/50 mt-3"><p>// Scheduled: {isScheduled ? 'YES' : 'NO'}</p><p>// Override: {manualOverride ? 'ACTIVE' : 'NONE'}</p><p>// Persistence: {persisted === null ? 'UNKNOWN' : persisted ? 'REDIS' : 'IN-MEMORY'}</p>{lastError && <p className='text-danger'>{lastError}</p>}</div></div><div className="border border-border bg-surface p-6"><h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-6">Stream URL</h2><input type="url" value={urlInput} onChange={(e) => setUrlInput(e.target.value)} className="w-full bg-background border border-border px-3 py-2.5 text-sm" /><button onClick={() => setStreamUrl(urlInput)} className="mt-4 w-full px-4 py-2.5 text-sm uppercase tracking-widest border border-border text-muted hover:border-accent hover:text-accent transition-all">Update Stream URL</button></div></div>

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
+import { databasePage } from "@/content";
+import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
+import { buildDossierTagRegistry } from "@/lib/dossier-tags";
+import {
+  DOSSIER_SOURCE_BOUNDARIES,
+  DOSSIER_WORKFLOW_ACTIONS,
+  DOSSIER_WORKFLOW_RULES,
+  type DossierCandidate,
+  type DossierDraft,
+  type DossierWorkflowAction,
+} from "@/lib/dossier-workflow";
+
+export const dynamic = "force-dynamic";
+
+type DossierWorkflowResponse = {
+  candidates: DossierCandidate[];
+  drafts: DossierDraft[];
+  workflow: {
+    version: 1;
+    storage: "not_configured_foundation_only";
+    status: "foundation_only";
+    allowedActions: DossierWorkflowAction[];
+    rules: typeof DOSSIER_WORKFLOW_RULES;
+    candidateSourceBoundaries: typeof DOSSIER_SOURCE_BOUNDARIES;
+    boundaries: string[];
+  };
+  authoringGuide: {
+    version: typeof dossierAuthoringGuide.version;
+  };
+  tagRegistry: {
+    totalUniqueTags: number;
+    totalTagAssignments: number;
+    creationPolicy: ReturnType<typeof buildDossierTagRegistry>["creationPolicy"];
+  };
+};
+
+async function isAuthenticated(req: Request): Promise<boolean> {
+  const cookieHeader = req.headers.get("cookie") || "";
+  const cookies = Object.fromEntries(cookieHeader.split(";").map((cookie) => {
+    const [key, ...value] = cookie.trim().split("=");
+    return [key, value.join("=")];
+  }));
+  const token = cookies[COOKIE_NAME];
+  return Boolean(token && (await verifyAdminToken(token)));
+}
+
+function workflowPayload(): DossierWorkflowResponse {
+  const tagRegistry = buildDossierTagRegistry(databasePage.entries);
+
+  return {
+    candidates: [],
+    drafts: [],
+    workflow: {
+      version: 1,
+      storage: "not_configured_foundation_only",
+      status: "foundation_only",
+      allowedActions: DOSSIER_WORKFLOW_ACTIONS,
+      rules: DOSSIER_WORKFLOW_RULES,
+      candidateSourceBoundaries: DOSSIER_SOURCE_BOUNDARIES,
+      boundaries: [
+        "BNL may recommend and draft only after operator selection.",
+        "Admin operators approve and prepare website dossier entries.",
+        "This endpoint does not publish, create public records, or mutate src/content.ts.",
+        "This endpoint does not invoke BNL, write memory, merge Discord identity, or use payment/customer identity.",
+        "Queue frequency is evidence only, not identity.",
+      ],
+    },
+    authoringGuide: {
+      version: dossierAuthoringGuide.version,
+    },
+    tagRegistry: {
+      totalUniqueTags: tagRegistry.totalUniqueTags,
+      totalTagAssignments: tagRegistry.totalTagAssignments,
+      creationPolicy: tagRegistry.creationPolicy,
+    },
+  };
+}
+
+export async function GET(req: Request) {
+  if (!(await isAuthenticated(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json(workflowPayload());
+}
+
+export async function POST(req: Request) {
+  if (!(await isAuthenticated(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const action = typeof body?.action === "string" ? body.action : "";
+
+  if (!DOSSIER_WORKFLOW_ACTIONS.includes(action as DossierWorkflowAction)) {
+    return NextResponse.json({ error: "Unknown dossier workflow action" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    ok: false,
+    code: "not_implemented_yet",
+    action,
+    message: "Dossier workflow mutations are intentionally disabled in this foundation PR.",
+    boundaries: workflowPayload().workflow.boundaries,
+  }, { status: 501 });
+}

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -4,6 +4,7 @@ import { databasePage } from "@/content";
 import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
 import { buildDossierTagRegistry } from "@/lib/dossier-tags";
 import {
+  DOSSIER_CANDIDATE_SCORING_POLICY,
   DOSSIER_SOURCE_BOUNDARIES,
   DOSSIER_WORKFLOW_ACTIONS,
   DOSSIER_WORKFLOW_RULES,
@@ -23,6 +24,7 @@ type DossierWorkflowResponse = {
     status: "foundation_only";
     allowedActions: DossierWorkflowAction[];
     rules: typeof DOSSIER_WORKFLOW_RULES;
+    scoringPolicy: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
     candidateSourceBoundaries: typeof DOSSIER_SOURCE_BOUNDARIES;
     boundaries: string[];
   };
@@ -58,6 +60,7 @@ function workflowPayload(): DossierWorkflowResponse {
       status: "foundation_only",
       allowedActions: DOSSIER_WORKFLOW_ACTIONS,
       rules: DOSSIER_WORKFLOW_RULES,
+      scoringPolicy: DOSSIER_CANDIDATE_SCORING_POLICY,
       candidateSourceBoundaries: DOSSIER_SOURCE_BOUNDARIES,
       boundaries: [
         "BNL may recommend and draft only after operator selection.",

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -1,0 +1,149 @@
+export type DossierCandidateSource =
+  | "manual"
+  | "rd_conversation"
+  | "queue_frequency"
+  | "discord_context"
+  | "website_read_model"
+  | "combined";
+
+export type DossierCandidateStatus =
+  | "suggested"
+  | "needs_review"
+  | "selected"
+  | "draft_requested"
+  | "draft_ready"
+  | "needs_revision"
+  | "approved"
+  | "denied"
+  | "needs_more_evidence";
+
+export type DossierDraftStatus =
+  | "draft"
+  | "revision_requested"
+  | "approved"
+  | "denied"
+  | "published";
+
+export type DossierCandidate = {
+  id: string;
+  name: string;
+  source: DossierCandidateSource;
+  reason: string;
+  evidenceSummary: string;
+  evidenceCount?: number;
+  confidence?: "low" | "medium" | "high";
+  status: DossierCandidateStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DossierDraft = {
+  id: string;
+  candidateId: string;
+  status: DossierDraftStatus;
+  fields: {
+    id?: string;
+    name: string;
+    category?: "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production";
+    status?: "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN";
+    clearance?: "PUBLIC" | "INTERNAL" | "RESTRICTED";
+    role?: string;
+    origin?: "KNOWN" | "UNKNOWN" | "UNVERIFIED" | "WITHHELD";
+    summary?: string;
+    notes?: string;
+    tags?: string[];
+    proposedTags?: string[];
+    primaryLink?: DossierWorkflowLink;
+    links?: DossierWorkflowLink[];
+    files?: [];
+  };
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DossierWorkflowLink = {
+  label: string;
+  url: string;
+  type: string;
+  selectedBy?: "subject" | "operator" | "legacy";
+  publicSafe?: boolean;
+};
+
+export type DossierWorkflowAction =
+  | "createManualCandidate"
+  | "selectCandidate"
+  | "requestDraft"
+  | "saveDraftEdit"
+  | "requestRevision"
+  | "approveDraft"
+  | "denyCandidate"
+  | "markNeedsMoreEvidence";
+
+export type DossierSourceBoundary = {
+  source: DossierCandidateSource;
+  label: string;
+  boundary: string;
+  allowedUse: string;
+};
+
+export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
+  "createManualCandidate",
+  "selectCandidate",
+  "requestDraft",
+  "saveDraftEdit",
+  "requestRevision",
+  "approveDraft",
+  "denyCandidate",
+  "markNeedsMoreEvidence",
+];
+
+export const DOSSIER_SOURCE_BOUNDARIES: DossierSourceBoundary[] = [
+  {
+    source: "manual",
+    label: "Manual operator intake",
+    boundary: "Operator-entered candidate notes are workflow records only, not published dossiers.",
+    allowedUse: "May create a candidate for review before BNL drafting is requested.",
+  },
+  {
+    source: "rd_conversation",
+    label: "R&D conversation",
+    boundary: "Internal operator discussion evidence is not public automatically.",
+    allowedUse: "May produce a candidate only; public copy still requires operator review.",
+  },
+  {
+    source: "queue_frequency",
+    label: "Queue frequency",
+    boundary: "Repeated artist or song appearance across sessions is evidence only, not account identity.",
+    allowedUse: "May support candidate priority but never auto-promotes a queue participant into a dossier.",
+  },
+  {
+    source: "discord_context",
+    label: "Discord context",
+    boundary: "Internal or community context must not expose private user data and is not payment identity.",
+    allowedUse: "May inform bounded evidence summaries for operator-selected candidates.",
+  },
+  {
+    source: "website_read_model",
+    label: "Website read model",
+    boundary: "Public site state may include existing public-page dossiers and tags only.",
+    allowedUse: "May help compare candidates against existing public database records.",
+  },
+  {
+    source: "combined",
+    label: "Combined signals",
+    boundary: "Multiple source signals still do not create dossiers automatically.",
+    allowedUse: "May raise review priority when each evidence summary remains bounded and safe.",
+  },
+];
+
+export const DOSSIER_WORKFLOW_RULES = [
+  "Workflow records are not published dossier records.",
+  "Drafts are not live website dossiers.",
+  "Candidates are not identities or accounts.",
+  "Queue frequency is evidence only.",
+  "Discord and R&D context must be handled as internal evidence and not automatically public.",
+  "BNL recommends and drafts only; admin operators approve and publish through future controlled site updates.",
+  "No candidate source creates a dossier automatically.",
+  "Drafting requires operator selection.",
+  "Proposed tags are proposal-only until an operator or site content update creates them.",
+] as const;

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -6,6 +6,42 @@ export type DossierCandidateSource =
   | "website_read_model"
   | "combined";
 
+export type DossierCandidateType =
+  | "artist"
+  | "community_member"
+  | "entity"
+  | "production"
+  | "interface"
+  | "sponsor"
+  | "story_arc"
+  | "unknown";
+
+export type DossierCandidateTier = "weak_candidate" | "review_candidate" | "draft_ready";
+
+export type DossierDuplicateRisk = "none" | "low" | "medium" | "high";
+
+export type DossierCandidateEvidenceType =
+  | "manual_nomination"
+  | "rd_conversation"
+  | "queue_recurrence"
+  | "completed_play"
+  | "priority_moment"
+  | "discord_context"
+  | "website_context"
+  | "public_show_moment"
+  | "operator_note";
+
+export type DossierCandidateEvidence = {
+  id: string;
+  type: DossierCandidateEvidenceType;
+  label: string;
+  summary: string;
+  count?: number;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+  publicSafe: boolean;
+};
+
 export type DossierCandidateStatus =
   | "suggested"
   | "needs_review"
@@ -24,14 +60,35 @@ export type DossierDraftStatus =
   | "denied"
   | "published";
 
+export type DossierCategory = "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production";
+export type DossierPublicStatus = "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN";
+export type DossierClearance = "PUBLIC" | "INTERNAL" | "RESTRICTED";
+export type DossierOrigin = "KNOWN" | "UNKNOWN" | "UNVERIFIED" | "WITHHELD";
+
 export type DossierCandidate = {
   id: string;
   name: string;
+  candidateType: DossierCandidateType;
   source: DossierCandidateSource;
+  tier: DossierCandidateTier;
+  score: number;
+  whyNow: string;
   reason: string;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
   evidenceSummary: string;
+  evidenceItems?: DossierCandidateEvidence[];
   evidenceCount?: number;
   confidence?: "low" | "medium" | "high";
+  duplicateRisk?: DossierDuplicateRisk;
+  existingDossierMatch?: { id: string; name: string; confidence: "low" | "medium" | "high" } | null;
+  recommendedCategory?: DossierCategory;
+  recommendedClearance?: DossierClearance;
+  recommendedTags?: string[];
+  proposedTags?: string[];
+  missingInfo?: string[];
+  doNotSay?: string[];
+  publicSafetyNotes?: string[];
   status: DossierCandidateStatus;
   createdAt: string;
   updatedAt: string;
@@ -44,11 +101,11 @@ export type DossierDraft = {
   fields: {
     id?: string;
     name: string;
-    category?: "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production";
-    status?: "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN";
-    clearance?: "PUBLIC" | "INTERNAL" | "RESTRICTED";
+    category?: DossierCategory;
+    status?: DossierPublicStatus;
+    clearance?: DossierClearance;
     role?: string;
-    origin?: "KNOWN" | "UNKNOWN" | "UNVERIFIED" | "WITHHELD";
+    origin?: DossierOrigin;
     summary?: string;
     notes?: string;
     tags?: string[];
@@ -96,6 +153,28 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "denyCandidate",
   "markNeedsMoreEvidence",
 ];
+
+export const DOSSIER_CANDIDATE_SCORING_POLICY = {
+  tiers: {
+    weak_candidate: "Possible future dossier; not draft-ready.",
+    review_candidate: "Enough evidence for operator review.",
+    draft_ready: "Enough public/operator-approved context to request a draft.",
+  },
+  thresholds: {
+    weakCandidateMin: 30,
+    reviewCandidateMin: 50,
+    draftReadyMin: 70,
+  },
+  signals: {
+    queueRecurrence: "Repeated appearances across separate sessions can support candidacy.",
+    rdConversation: "R&D discussion can support candidacy but is not public copy by itself.",
+    discordContext: "Discord context is internal evidence and must be public-safe before use.",
+    manualNomination: "Operator nomination can create a review candidate but still needs facts.",
+    duplicatePenalty: "Likely duplicate dossiers should be merged or rejected before drafting.",
+    privacyPenalty: "Private, payment, or identity-sensitive evidence blocks drafting.",
+  },
+  gate: "Loose intake, strict drafting/publishing.",
+} as const;
 
 export const DOSSIER_SOURCE_BOUNDARIES: DossierSourceBoundary[] = [
   {
@@ -146,4 +225,5 @@ export const DOSSIER_WORKFLOW_RULES = [
   "No candidate source creates a dossier automatically.",
   "Drafting requires operator selection.",
   "Proposed tags are proposal-only until an operator or site content update creates them.",
+  "Loose intake, strict drafting/publishing: candidates can enter review early, but drafting and publishing require evidence, duplicate checks, and public-safety review.",
 ] as const;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, "src", request.slice(2));
+    if (fs.existsSync(resolved)) return resolved;
+    if (fs.existsSync(`${resolved}.ts`)) return `${resolved}.ts`;
+    if (fs.existsSync(`${resolved}.tsx`)) return `${resolved}.tsx`;
+    return resolved;
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+Module._extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+const require = createRequire(import.meta.url);
+const auth = require("../src/lib/auth.ts");
+const route = require("../src/app/api/admin/dossiers/route.ts");
+
+function source(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
+}
+
+async function adminCookie() {
+  const token = await auth.createAdminToken();
+  return `${auth.COOKIE_NAME}=${token}`;
+}
+
+test("admin panel includes Dossier Control Center link", () => {
+  const adminPage = source("src/app/admin/page.tsx");
+  assert.match(adminPage, /Dossier Control Center/);
+  assert.match(adminPage, /Review dossier candidates, manage drafts, and prepare approved website dossier entries\./);
+  assert.match(adminPage, /href="\/admin\/dossiers"/);
+});
+
+test("admin dossier page includes workflow shell sections", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  for (const label of ["Dossier Control Center", "Candidate Queue", "Draft Workspace", "Review Actions", "System Boundaries"]) {
+    assert.match(page, new RegExp(label));
+  }
+  assert.match(page, /\/api\/admin\/dossiers/);
+  assert.match(page, /No candidates yet/);
+  assert.match(page, /No draft selected/);
+  assert.match(page, /Candidate intake wiring comes in a later PR/);
+});
+
+test("admin dossier API uses admin auth and returns empty workflow arrays", async () => {
+  const unauthorized = await route.GET(new Request("https://example.test/api/admin/dossiers"));
+  assert.equal(unauthorized.status, 401);
+
+  const response = await route.GET(new Request("https://example.test/api/admin/dossiers", {
+    headers: { cookie: await adminCookie() },
+  }));
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.deepEqual(payload.candidates, []);
+  assert.deepEqual(payload.drafts, []);
+  assert.equal(payload.workflow.version, 1);
+  assert.equal(payload.workflow.status, "foundation_only");
+  assert.ok(payload.workflow.allowedActions.includes("requestDraft"));
+  assert.ok(payload.workflow.candidateSourceBoundaries.some((entry) => entry.source === "queue_frequency"));
+});
+
+test("admin dossier mutations are placeholder-only and do not publish", async () => {
+  const contentBefore = source("src/content.ts");
+  const response = await route.POST(new Request("https://example.test/api/admin/dossiers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: await adminCookie(),
+    },
+    body: JSON.stringify({ action: "approveDraft", candidateId: "candidate-test" }),
+  }));
+
+  assert.equal(response.status, 501);
+  const payload = await response.json();
+  assert.equal(payload.code, "not_implemented_yet");
+  assert.match(payload.message, /intentionally disabled/);
+  assert.equal(source("src/content.ts"), contentBefore);
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -53,7 +53,7 @@ test("admin panel includes Dossier Control Center link", () => {
   assert.match(adminPage, /href="\/admin\/dossiers"/);
 });
 
-test("admin dossier page includes workflow shell sections", () => {
+test("admin dossier page gates workflow shell behind successful API payload", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   for (const label of ["Dossier Control Center", "Candidate Queue", "Draft Workspace", "Review Actions", "System Boundaries"]) {
     assert.match(page, new RegExp(label));
@@ -62,6 +62,30 @@ test("admin dossier page includes workflow shell sections", () => {
   assert.match(page, /No candidates yet/);
   assert.match(page, /No draft selected/);
   assert.match(page, /Candidate intake wiring comes in a later PR/);
+
+  assert.doesNotMatch(page, /payload\?\.candidates \?\? \[\]/);
+  assert.doesNotMatch(page, /payload\?\.workflow\.boundaries \?\? \[/);
+  assert.match(page, /if \(loading\)/);
+  assert.match(page, /if \(error \|\| !payload\)/);
+  assert.match(page, /const candidates = payload\.candidates/);
+  assert.match(page, /const boundaries = payload\.workflow\.boundaries/);
+
+  const loadingGate = page.indexOf("if (loading)");
+  const authGate = page.indexOf("if (error || !payload)");
+  const payloadRead = page.indexOf("const candidates = payload.candidates");
+  const fullShell = page.indexOf('aria-label="Dossier Control Center"');
+
+  assert.ok(loadingGate > -1 && loadingGate < fullShell, "loading state must return before the full shell");
+  assert.ok(authGate > loadingGate && authGate < fullShell, "auth/error state must return before the full shell");
+  assert.ok(payloadRead > authGate && payloadRead < fullShell, "full shell must use an authenticated payload");
+});
+
+test("admin dossier page has minimal loading and auth-required states", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  assert.match(page, /Checking admin access\.\.\./);
+  assert.match(page, /Admin authentication required/);
+  assert.match(page, /Back to Admin/);
+  assert.match(page, /MinimalDossierAdminState/);
 });
 
 test("admin dossier API uses admin auth and returns empty workflow arrays", async () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -36,6 +36,7 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
 const require = createRequire(import.meta.url);
 const auth = require("../src/lib/auth.ts");
 const route = require("../src/app/api/admin/dossiers/route.ts");
+const workflow = require("../src/lib/dossier-workflow.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -55,13 +56,21 @@ test("admin panel includes Dossier Control Center link", () => {
 
 test("admin dossier page gates workflow shell behind successful API payload", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
-  for (const label of ["Dossier Control Center", "Candidate Queue", "Draft Workspace", "Review Actions", "System Boundaries"]) {
+  for (const label of ["Dossier Control Center", "Candidate Queue", "Candidate Evidence", "Candidate Gate / Scoring", "Draft Readiness / Missing Info", "Draft Workspace", "Review Actions", "Focused BNL Assistant", "System Boundaries"]) {
     assert.match(page, new RegExp(label));
   }
   assert.match(page, /\/api\/admin\/dossiers/);
   assert.match(page, /No candidates yet/);
   assert.match(page, /No draft selected/);
   assert.match(page, /Candidate intake wiring comes in a later PR/);
+  assert.match(page, /Why Now/);
+  assert.match(page, /Duplicate Risk/);
+  assert.match(page, /Missing Info/);
+  assert.match(page, /Do Not Say/);
+  assert.match(page, /loose intake \/ strict publishing/i);
+  assert.match(page, /Try Again: Too Long/);
+  assert.match(page, /Try Again: Too Vague/);
+  assert.match(page, /Rewrite Summary Only/);
 
   assert.doesNotMatch(page, /payload\?\.candidates \?\? \[\]/);
   assert.doesNotMatch(page, /payload\?\.workflow\.boundaries \?\? \[/);
@@ -88,6 +97,21 @@ test("admin dossier page has minimal loading and auth-required states", () => {
   assert.match(page, /MinimalDossierAdminState/);
 });
 
+test("dossier workflow types include candidate evidence and scoring policy contracts", () => {
+  const workflowSource = source("src/lib/dossier-workflow.ts");
+  assert.match(workflowSource, /export type DossierCandidateEvidenceType/);
+  assert.match(workflowSource, /export type DossierCandidateEvidence/);
+  assert.match(workflowSource, /candidateType: DossierCandidateType/);
+  assert.match(workflowSource, /tier: DossierCandidateTier/);
+  assert.match(workflowSource, /score: number/);
+  assert.match(workflowSource, /whyNow: string/);
+  assert.match(workflowSource, /duplicateRisk\?: DossierDuplicateRisk/);
+  assert.match(workflowSource, /missingInfo\?: string\[\]/);
+  assert.match(workflowSource, /doNotSay\?: string\[\]/);
+  assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.gate, "Loose intake, strict drafting/publishing.");
+  assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.reviewCandidateMin, 50);
+});
+
 test("admin dossier API uses admin auth and returns empty workflow arrays", async () => {
   const unauthorized = await route.GET(new Request("https://example.test/api/admin/dossiers"));
   assert.equal(unauthorized.status, 401);
@@ -102,6 +126,8 @@ test("admin dossier API uses admin auth and returns empty workflow arrays", asyn
   assert.equal(payload.workflow.version, 1);
   assert.equal(payload.workflow.status, "foundation_only");
   assert.ok(payload.workflow.allowedActions.includes("requestDraft"));
+  assert.equal(payload.workflow.scoringPolicy.gate, "Loose intake, strict drafting/publishing.");
+  assert.equal(payload.workflow.scoringPolicy.thresholds.draftReadyMin, 70);
   assert.ok(payload.workflow.candidateSourceBoundaries.some((entry) => entry.source === "queue_frequency"));
 });
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated, admin-only control center for managing dossier candidates, drafts, and review actions so dossier drafting becomes an operator-controlled workflow rather than ad-hoc R&D chat.
- Establish safe workflow contracts, UI navigation, and an authenticated admin API foundation while explicitly preventing any automatic publishing, tag creation, or BNL/bot publishing integration in this PR.
- Preserve all existing admin/queue/BNL behavior, read-model exposures, and public content rules while introducing the control-center surface as a non-destructive foundation.

### Description
- Added a navigational entry on the existing admin panel and a new operator-facing page at `/admin/dossiers` that contains the Dossier Control Center shell with the required sections: Header, Candidate Queue, Draft Workspace, Review Actions, and System Boundaries (`src/app/admin/page.tsx`, `src/app/admin/dossiers/page.tsx`).
- Introduced workflow data contracts and constants in `src/lib/dossier-workflow.ts` describing candidate sources, candidate/draft statuses, draft field shapes, allowed future actions, and candidate source boundaries so future UI and APIs share a typed contract.
- Implemented an authenticated placeholder admin API at `src/app/api/admin/dossiers/route.ts` that follows the existing admin cookie verification pattern (`barcode_admin` / `verifyAdminToken`), where `GET` returns `{ candidates: [], drafts: [], workflow: {...}, authoringGuide, tagRegistry }` and `POST` accepts recognized action names but returns `501 not_implemented_yet` to prevent mutations, publishing, or edits to `src/content.ts`.
- Added tests/assertions in `tests/admin-dossiers.test.mjs` that assert the admin page link, dossier page sections, API auth/GET shape, and that mutation attempts are placeholder-only; this PR intentionally does not add persistence, BNL invocation, discord identity mapping, automatic tag/dossier creation, or any site content writes.

### Testing
- Type-check: `npx tsc --noEmit` — passed.
- Lint: `npx eslint src/app/admin/page.tsx src/app/admin/dossiers/page.tsx src/app/api/admin/dossiers/route.ts` — passed with one pre-existing `react-hooks/exhaustive-deps` warning in `src/app/admin/page.tsx` (no new lint errors introduced).
- Queue & read-model tests: `npm run test:queue` — all existing queue/read-model tests passed (106 tests).
- New admin assertions: `node --test tests/admin-dossiers.test.mjs` — passed (4 tests), verifying UI source contracts and API placeholder behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e4d55d248321a0790ccdc7b5e246)