### PR TITLE
Add dossier candidate storage and manual intake

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   DOSSIER_CANDIDATE_SCORING_POLICY,
   DOSSIER_SOURCE_BOUNDARIES,
@@ -17,6 +17,7 @@ type WorkflowPayload = {
   workflow: {
     status: string;
     storage: string;
+    updatedAt?: string;
     boundaries: string[];
     scoringPolicy?: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
   };
@@ -29,14 +30,55 @@ type WorkflowPayload = {
   };
 };
 
-const operatorOptions = {
-  category: ["Entity", "Personnel", "Sponsor", "Interface", "Production"],
-  status: ["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"],
-  clearance: ["PUBLIC", "INTERNAL", "RESTRICTED"],
-  origin: ["KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"],
-  tagMode: ["Reuse existing tags", "Allow proposed tags"],
-  toneIntensity: ["grounded", "in-universe", "classified"],
+type ManualCandidateForm = {
+  name: string;
+  candidateType: DossierCandidate["candidateType"];
+  reason: string;
+  whyNow: string;
+  evidenceSummary: string;
+  knownFacts: string;
+  missingInfo: string;
+  doNotSay: string;
+  publicSafetyNotes: string;
+  recommendedCategory: string;
+  recommendedStatus: string;
+  recommendedClearance: string;
+  recommendedOrigin: string;
+  recommendedTags: string;
+  proposedTags: string;
+  primaryLinkLabel: string;
+  primaryLinkUrl: string;
+  primaryLinkType: string;
+  selectedBy: "operator" | "subject";
 };
+
+const emptyManualCandidateForm: ManualCandidateForm = {
+  name: "",
+  candidateType: "unknown",
+  reason: "",
+  whyNow: "",
+  evidenceSummary: "",
+  knownFacts: "",
+  missingInfo: "",
+  doNotSay: "",
+  publicSafetyNotes: "",
+  recommendedCategory: "",
+  recommendedStatus: "",
+  recommendedClearance: "",
+  recommendedOrigin: "",
+  recommendedTags: "",
+  proposedTags: "",
+  primaryLinkLabel: "",
+  primaryLinkUrl: "",
+  primaryLinkType: "website",
+  selectedBy: "operator",
+};
+
+const candidateTypes: DossierCandidate["candidateType"][] = ["artist", "community_member", "entity", "production", "interface", "sponsor", "story_arc", "unknown"];
+const categoryOptions = ["", "Entity", "Personnel", "Sponsor", "Interface", "Production"];
+const statusOptions = ["", "ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"];
+const clearanceOptions = ["", "PUBLIC", "INTERNAL", "RESTRICTED"];
+const originOptions = ["", "KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"];
 
 const reviewActions = [
   "Generate Draft",
@@ -49,8 +91,6 @@ const reviewActions = [
   "Rewrite Notes Only",
   "Approve Draft",
   "Edit Draft",
-  "Deny Candidate",
-  "Mark Needs More Evidence",
 ];
 
 const focusedAssistantPrompts = [
@@ -79,37 +119,118 @@ function listOrEmpty(items: string[] | undefined, empty: string) {
   return <ul className="list-disc pl-5 space-y-1">{items.map((item) => <li key={item}>{item}</li>)}</ul>;
 }
 
+function lines(value: string): string[] {
+  return value.split("\n").map((item) => item.trim()).filter(Boolean);
+}
+
+function textInputClass() {
+  return "w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground";
+}
+
 export default function AdminDossiersPage() {
   const [payload, setPayload] = useState<WorkflowPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<ManualCandidateForm>(emptyManualCandidateForm);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function loadWorkflow() {
+    try {
+      const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(response.status === 401 ? "Admin authentication required." : `Workflow API returned ${response.status}.`);
+      }
+      const data = (await response.json()) as WorkflowPayload;
+      setPayload(data);
+      setSelectedCandidateId((current) => current && data.candidates.some((candidate) => candidate.id === current) ? current : data.candidates[0]?.id ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load dossier workflow.");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function loadWorkflow() {
-      setLoading(true);
-      setError(null);
-      try {
-        const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(response.status === 401 ? "Admin authentication required." : `Workflow API returned ${response.status}.`);
-        }
-        const data = (await response.json()) as WorkflowPayload;
-        if (!cancelled) setPayload(data);
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load dossier workflow.");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    void loadWorkflow();
-
-    return () => {
-      cancelled = true;
-    };
+    const timer = window.setTimeout(() => {
+      void loadWorkflow();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, []);
+
+  const candidates = useMemo(() => payload?.candidates ?? [], [payload?.candidates]);
+  const drafts = payload?.drafts ?? [];
+  const boundaries = payload?.workflow.boundaries ?? [];
+  const scoringPolicy = payload?.workflow.scoringPolicy ?? DOSSIER_CANDIDATE_SCORING_POLICY;
+  const selectedCandidate = useMemo(() => candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0] ?? null, [candidates, selectedCandidateId]);
+  const selectedEvidence = selectedCandidate?.evidenceItems ?? [];
+
+  async function postWorkflow(body: Record<string, unknown>) {
+    setSaving(true);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/admin/dossiers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await response.json().catch(() => ({})) as Partial<WorkflowPayload> & { candidate?: DossierCandidate; error?: string; message?: string };
+      if (!response.ok) throw new Error(data.error ?? data.message ?? `Workflow API returned ${response.status}.`);
+      if (data.candidates && data.drafts && data.workflow) setPayload(data as WorkflowPayload);
+      if (data.candidate) setSelectedCandidateId(data.candidate.id);
+      return data;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function submitManualCandidate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      const primaryLink = form.primaryLinkUrl.trim() ? {
+        label: form.primaryLinkLabel.trim() || "Featured link",
+        url: form.primaryLinkUrl.trim(),
+        type: form.primaryLinkType.trim() || "website",
+        selectedBy: form.selectedBy,
+        publicSafe: true,
+      } : undefined;
+      const data = await postWorkflow({
+        action: "createManualCandidate",
+        input: {
+          name: form.name,
+          candidateType: form.candidateType,
+          reason: form.reason,
+          whyNow: form.whyNow,
+          evidenceSummary: form.evidenceSummary,
+          knownFacts: lines(form.knownFacts),
+          missingInfo: lines(form.missingInfo),
+          doNotSay: lines(form.doNotSay),
+          publicSafetyNotes: lines(form.publicSafetyNotes),
+          recommendedCategory: form.recommendedCategory || undefined,
+          recommendedStatus: form.recommendedStatus || undefined,
+          recommendedClearance: form.recommendedClearance || undefined,
+          recommendedOrigin: form.recommendedOrigin || undefined,
+          recommendedTags: lines(form.recommendedTags),
+          proposedTags: lines(form.proposedTags),
+          primaryLink,
+        },
+      });
+      setForm(emptyManualCandidateForm);
+      setNotice(`Manual candidate created: ${data.candidate?.name ?? "candidate"}. No public dossier or tag was created.`);
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to create manual candidate.");
+    }
+  }
+
+  async function updateCandidateStatus(candidateId: string, action: "denyCandidate" | "markNeedsMoreEvidence") {
+    try {
+      const data = await postWorkflow({ action, candidateId });
+      setNotice(`${data.candidate?.name ?? "Candidate"} updated to ${data.candidate?.status ?? "requested status"}.`);
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to update candidate status.");
+    }
+  }
 
   if (loading) {
     return <MinimalDossierAdminState title="Checking admin access..." message="Verifying operator credentials before loading the dossier workflow." />;
@@ -118,13 +239,6 @@ export default function AdminDossiersPage() {
   if (error || !payload) {
     return <MinimalDossierAdminState title="Admin authentication required" message={error ?? "Sign in from the admin panel before opening this operator workflow."} />;
   }
-
-  const candidates = payload.candidates;
-  const drafts = payload.drafts;
-  const boundaries = payload.workflow.boundaries;
-  const scoringPolicy = payload.workflow.scoringPolicy ?? DOSSIER_CANDIDATE_SCORING_POLICY;
-  const selectedCandidate = candidates[0] ?? null;
-  const selectedEvidence = selectedCandidate?.evidenceItems ?? [];
 
   return (
     <main className="pt-14 min-h-screen">
@@ -146,7 +260,7 @@ export default function AdminDossiersPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 text-xs text-muted">
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Workflow API</p>
-            <p>Foundation contract loaded. Storage: {payload.workflow.storage}.</p>
+            <p>Candidate store enabled. Storage: {payload.workflow.storage}. Updated: {payload.workflow.updatedAt ?? "not available"}.</p>
           </div>
           <div className="border border-border bg-surface p-4">
             <p className="uppercase tracking-[0.35em] text-accent mb-2">Authoring Guide</p>
@@ -159,45 +273,80 @@ export default function AdminDossiersPage() {
         </div>
 
         <section className="border border-border bg-surface p-6 space-y-5">
+          <div>
+            <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Manual Candidate Intake</p>
+            <h2 className="text-2xl font-bold text-foreground">Manual Candidate Intake</h2>
+            <p className="text-sm text-muted mt-2">Create workflow-only candidates. This form does not call BNL, publish dossiers, create tags, or write src/content.ts.</p>
+          </div>
+          <form onSubmit={submitManualCandidate} className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 text-xs uppercase tracking-widest text-muted">
+            <label className="space-y-2"><span>Name</span><input required value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} className={textInputClass()} /></label>
+            <label className="space-y-2"><span>Candidate type</span><select value={form.candidateType} onChange={(event) => setForm({ ...form, candidateType: event.target.value as DossierCandidate["candidateType"] })} className={textInputClass()}>{candidateTypes.map((type) => <option key={type}>{type}</option>)}</select></label>
+            <label className="xl:col-span-2 space-y-2"><span>Reason</span><input required value={form.reason} onChange={(event) => setForm({ ...form, reason: event.target.value })} className={textInputClass()} /></label>
+            <label className="md:col-span-2 space-y-2"><span>Why now</span><textarea value={form.whyNow} onChange={(event) => setForm({ ...form, whyNow: event.target.value })} className={`${textInputClass()} min-h-24`} /></label>
+            <label className="md:col-span-2 space-y-2"><span>Evidence summary</span><textarea value={form.evidenceSummary} onChange={(event) => setForm({ ...form, evidenceSummary: event.target.value })} className={`${textInputClass()} min-h-24`} /></label>
+            <label className="space-y-2"><span>Known facts</span><textarea placeholder="One per line" value={form.knownFacts} onChange={(event) => setForm({ ...form, knownFacts: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+            <label className="space-y-2"><span>Missing info</span><textarea placeholder="One per line" value={form.missingInfo} onChange={(event) => setForm({ ...form, missingInfo: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+            <label className="space-y-2"><span>Do Not Say</span><textarea placeholder="One per line" value={form.doNotSay} onChange={(event) => setForm({ ...form, doNotSay: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+            <label className="space-y-2"><span>Public safety notes</span><textarea placeholder="One per line" value={form.publicSafetyNotes} onChange={(event) => setForm({ ...form, publicSafetyNotes: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+            <label className="space-y-2"><span>Recommended category</span><select value={form.recommendedCategory} onChange={(event) => setForm({ ...form, recommendedCategory: event.target.value })} className={textInputClass()}>{categoryOptions.map((value) => <option key={value} value={value}>{value || "No recommendation"}</option>)}</select></label>
+            <label className="space-y-2"><span>Recommended status</span><select value={form.recommendedStatus} onChange={(event) => setForm({ ...form, recommendedStatus: event.target.value })} className={textInputClass()}>{statusOptions.map((value) => <option key={value} value={value}>{value || "No recommendation"}</option>)}</select></label>
+            <label className="space-y-2"><span>Recommended clearance</span><select value={form.recommendedClearance} onChange={(event) => setForm({ ...form, recommendedClearance: event.target.value })} className={textInputClass()}>{clearanceOptions.map((value) => <option key={value} value={value}>{value || "No recommendation"}</option>)}</select></label>
+            <label className="space-y-2"><span>Recommended origin</span><select value={form.recommendedOrigin} onChange={(event) => setForm({ ...form, recommendedOrigin: event.target.value })} className={textInputClass()}>{originOptions.map((value) => <option key={value} value={value}>{value || "No recommendation"}</option>)}</select></label>
+            <label className="md:col-span-2 space-y-2"><span>Recommended tags</span><textarea placeholder="One existing tag per line" value={form.recommendedTags} onChange={(event) => setForm({ ...form, recommendedTags: event.target.value })} className={`${textInputClass()} min-h-24`} /></label>
+            <label className="md:col-span-2 space-y-2"><span>Proposed tags</span><textarea placeholder="One proposed tag per line" value={form.proposedTags} onChange={(event) => setForm({ ...form, proposedTags: event.target.value })} className={`${textInputClass()} min-h-24`} /></label>
+            <label className="space-y-2"><span>Featured/primary link label</span><input value={form.primaryLinkLabel} onChange={(event) => setForm({ ...form, primaryLinkLabel: event.target.value })} className={textInputClass()} /></label>
+            <label className="space-y-2"><span>Featured/primary link URL</span><input value={form.primaryLinkUrl} onChange={(event) => setForm({ ...form, primaryLinkUrl: event.target.value })} className={textInputClass()} /></label>
+            <label className="space-y-2"><span>Featured/primary link type</span><input value={form.primaryLinkType} onChange={(event) => setForm({ ...form, primaryLinkType: event.target.value })} className={textInputClass()} /></label>
+            <label className="space-y-2"><span>selectedBy</span><select value={form.selectedBy} onChange={(event) => setForm({ ...form, selectedBy: event.target.value as "operator" | "subject" })} className={textInputClass()}><option value="operator">operator</option><option value="subject">subject</option></select></label>
+            <div className="md:col-span-2 xl:col-span-4 flex flex-col gap-3 md:flex-row md:items-center">
+              <button disabled={saving} className="border border-accent px-5 py-3 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50">{saving ? "Saving candidate..." : "Create Manual Candidate"}</button>
+              {notice ? <p className="text-sm normal-case tracking-normal text-muted">{notice}</p> : null}
+            </div>
+          </form>
+        </section>
+
+        <section className="border border-border bg-surface p-6 space-y-5">
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Queue</p>
               <h2 className="text-2xl font-bold text-foreground">Candidate Queue</h2>
-              <p className="text-sm text-muted mt-2">Candidates are recommendations, not dossiers. Candidate intake wiring comes in a later PR.</p>
+              <p className="text-sm text-muted mt-2">Candidates are recommendations and stored workflow records, not public dossiers.</p>
             </div>
             <p className="text-xs uppercase tracking-widest text-muted">{candidates.length} candidates</p>
           </div>
           <div className="overflow-x-auto border border-border/70">
-            <table className="w-full min-w-[980px] text-left text-xs">
+            <table className="w-full min-w-[1180px] text-left text-xs">
               <thead className="bg-background/60 text-muted uppercase tracking-widest">
                 <tr>
                   <th className="px-3 py-3">Candidate name</th>
                   <th className="px-3 py-3">Type</th>
-                  <th className="px-3 py-3">Source</th>
                   <th className="px-3 py-3">Tier</th>
                   <th className="px-3 py-3">Score</th>
                   <th className="px-3 py-3">Why Now</th>
                   <th className="px-3 py-3">Evidence count</th>
                   <th className="px-3 py-3">Duplicate Risk</th>
                   <th className="px-3 py-3">Status</th>
+                  <th className="px-3 py-3">Updated</th>
+                  <th className="px-3 py-3">Controls</th>
                 </tr>
               </thead>
               <tbody>
                 {candidates.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="px-3 py-8 text-center text-muted">No candidates yet. Candidate intake wiring comes in a later PR.</td>
+                    <td colSpan={10} className="px-3 py-8 text-center text-muted">No candidates yet. Use Manual Candidate Intake to create a workflow-only review record.</td>
                   </tr>
                 ) : candidates.map((candidate) => (
-                  <tr key={candidate.id} className="border-t border-border/70">
-                    <td className="px-3 py-3 text-foreground">{candidate.name}</td>
+                  <tr key={candidate.id} className={`border-t border-border/70 ${selectedCandidate?.id === candidate.id ? "bg-accent/10" : ""}`}>
+                    <td className="px-3 py-3 text-foreground"><button className="text-left underline-offset-4 hover:underline" onClick={() => setSelectedCandidateId(candidate.id)}>{candidate.name}</button></td>
                     <td className="px-3 py-3">{candidate.candidateType}</td>
-                    <td className="px-3 py-3">{candidate.source}</td>
                     <td className="px-3 py-3">{candidate.tier}</td>
                     <td className="px-3 py-3">{candidate.score}</td>
-                    <td className="px-3 py-3">{candidate.whyNow}</td>
+                    <td className="px-3 py-3">{candidate.whyNow || "—"}</td>
                     <td className="px-3 py-3">{candidate.evidenceItems?.length ?? candidate.evidenceCount ?? 0}</td>
                     <td className="px-3 py-3">{candidate.duplicateRisk ?? "unknown"}</td>
                     <td className="px-3 py-3">{candidate.status}</td>
+                    <td className="px-3 py-3">{candidate.updatedAt}</td>
+                    <td className="px-3 py-3"><div className="flex flex-wrap gap-2"><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "denyCandidate")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Deny</button><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "markNeedsMoreEvidence")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Needs More Evidence</button><button disabled className="border border-border px-2 py-1 text-muted opacity-50">Draft placeholder</button></div></td>
                   </tr>
                 ))}
               </tbody>
@@ -210,17 +359,16 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Candidate Evidence</p>
               <h2 className="text-2xl font-bold text-foreground">Candidate Evidence</h2>
-              <p className="text-sm text-muted mt-2">Evidence is not public copy by default. Each item must be checked for publicSafe status before it can inform a draft.</p>
+              <p className="text-sm text-muted mt-2">Evidence is not public copy by default. Select a candidate to review stored operator notes.</p>
             </div>
             <div className="border border-border bg-background/30 p-4 text-sm text-muted space-y-2">
-              <p><span className="text-foreground">Evidence summary:</span> {selectedCandidate?.evidenceSummary ?? "No candidate selected."}</p>
-              <p><span className="text-foreground">First seen:</span> {selectedCandidate?.firstSeenAt ?? "not available"}</p>
-              <p><span className="text-foreground">Last seen:</span> {selectedCandidate?.lastSeenAt ?? "not available"}</p>
-              <p><span className="text-foreground">publicSafe flag:</span> future evidence items must be individually marked true before public drafting use.</p>
+              <p><span className="text-foreground">Evidence summary:</span> {selectedCandidate?.evidenceSummary ?? "No selected candidate."}</p>
+              <p><span className="text-foreground">Source/tier/score:</span> {selectedCandidate ? `${selectedCandidate.source} / ${selectedCandidate.tier} / ${selectedCandidate.score}` : "No selected candidate."}</p>
+              <p><span className="text-foreground">Primary link:</span> {selectedCandidate?.primaryLink ? `${selectedCandidate.primaryLink.label} — ${selectedCandidate.primaryLink.url}` : "No selected candidate primary link."}</p>
             </div>
             <div className="space-y-2 text-xs text-muted">
               {selectedEvidence.length === 0 ? (
-                <p className="border border-border bg-background/20 p-3">No evidence items yet. Future entries will show type, label, summary, count, first seen, last seen, and publicSafe status.</p>
+                <p className="border border-border bg-background/20 p-3">No evidence items yet.</p>
               ) : selectedEvidence.map((item) => (
                 <div key={item.id} className="border border-border bg-background/20 p-3">
                   <p className="text-foreground">{item.label} ({item.type})</p>
@@ -241,8 +389,7 @@ export default function AdminDossiersPage() {
               <p><span className="text-foreground">weak candidate:</span> {scoringPolicy.tiers.weak_candidate} Minimum score {scoringPolicy.thresholds.weakCandidateMin}.</p>
               <p><span className="text-foreground">review candidate:</span> {scoringPolicy.tiers.review_candidate} Minimum score {scoringPolicy.thresholds.reviewCandidateMin}.</p>
               <p><span className="text-foreground">draft-ready:</span> {scoringPolicy.tiers.draft_ready} Minimum score {scoringPolicy.thresholds.draftReadyMin}.</p>
-              <p>{scoringPolicy.signals.queueRecurrence}</p>
-              <p>Queue frequency is evidence, not identity.</p>
+              <p>{scoringPolicy.signals.manualNomination}</p>
               <p>Duplicate risk must be resolved before drafting.</p>
             </div>
           </div>
@@ -254,10 +401,13 @@ export default function AdminDossiersPage() {
               <p className="text-sm text-muted mt-2">Missing Info, Do Not Say, public safety notes, and duplicate warnings block draft requests until reviewed.</p>
             </div>
             <div className="grid grid-cols-1 gap-3 text-xs text-muted">
-              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Missing Info</p>{listOrEmpty(selectedCandidate?.missingInfo, "No selected candidate; missing facts will appear here.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Known facts</p>{listOrEmpty(selectedCandidate?.knownFacts, "No selected candidate; known facts will appear here.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Missing info</p>{listOrEmpty(selectedCandidate?.missingInfo, "No selected candidate; missing facts will appear here.")}</div>
               <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Do Not Say</p>{listOrEmpty(selectedCandidate?.doNotSay, "No restricted phrasing recorded yet.")}</div>
-              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Public Safety Notes</p>{listOrEmpty(selectedCandidate?.publicSafetyNotes, "No public-safety notes recorded yet.")}</div>
-              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Existing Dossier Match / Duplicate Warning</p><p>{selectedCandidate?.existingDossierMatch ? `${selectedCandidate.existingDossierMatch.name} (${selectedCandidate.existingDossierMatch.confidence})` : "No selected candidate or duplicate match yet."}</p></div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Public safety notes</p>{listOrEmpty(selectedCandidate?.publicSafetyNotes, "No public-safety notes recorded yet.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Recommended tags</p>{listOrEmpty(selectedCandidate?.recommendedTags, "No recommended tags recorded yet.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Proposed tags</p>{listOrEmpty(selectedCandidate?.proposedTags, "No proposed tags recorded yet.")}</div>
+              <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Existing Dossier Match / Duplicate Warning</p><p>{selectedCandidate?.existingDossierMatch ? `${selectedCandidate.existingDossierMatch.id} — ${selectedCandidate.existingDossierMatch.name} (${selectedCandidate.existingDossierMatch.confidence})` : "No selected candidate or duplicate match yet."}</p></div>
             </div>
           </div>
         </section>
@@ -267,37 +417,11 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Draft Workspace</p>
               <h2 className="text-2xl font-bold text-foreground">Draft Workspace</h2>
-              <p className="text-sm text-muted mt-2">No draft selected. Select a reviewed candidate before BNL drafting is requested.</p>
+              <p className="text-sm text-muted mt-2">No draft selected. BNL drafting stays placeholder-only in this PR.</p>
             </div>
             <div className="border border-border bg-background/30 p-4 text-sm text-muted">
               <p className="text-xs uppercase tracking-widest text-accent mb-2">Selected Candidate</p>
-              <p>No draft selected. Candidate intake wiring comes in a later PR.</p>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {Object.entries(operatorOptions).map(([key, values]) => (
-                <label key={key} className="text-xs uppercase tracking-widest text-muted space-y-2">
-                  <span>{key === "tagMode" ? "Tag mode" : key === "toneIntensity" ? "Tone intensity" : key}</span>
-                  <select disabled className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted">
-                    {values.map((value) => <option key={value}>{value}</option>)}
-                  </select>
-                </label>
-              ))}
-              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
-                <span>Selected / featured link</span>
-                <input disabled placeholder="Public-safe link selection will be wired later" className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
-              </label>
-              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
-                <span>Known facts</span>
-                <textarea disabled placeholder="Operator-approved facts for BNL drafting" className="min-h-24 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
-              </label>
-              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
-                <span>Do not say</span>
-                <textarea disabled placeholder="Claims, private details, or lore directions BNL must avoid" className="min-h-24 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
-              </label>
-              <label className="md:col-span-2 text-xs uppercase tracking-widest text-muted space-y-2">
-                <span>Notes to BNL</span>
-                <textarea disabled placeholder="Candidate-specific drafting instructions for future BNL request" className="min-h-28 w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-muted" />
-              </label>
+              <p>{selectedCandidate ? `${selectedCandidate.name} is selected for review only. Draft actions are disabled.` : "No selected candidate."}</p>
             </div>
             <p className="text-xs text-muted">Draft records are workflow records only. Approved drafts do not become website entries until a future operator-controlled site update.</p>
           </div>
@@ -306,12 +430,12 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Review Actions</p>
               <h2 className="text-2xl font-bold text-foreground">Review Actions</h2>
-              <p className="text-sm text-muted mt-2">Backend mutations return not_implemented_yet in this foundation PR.</p>
+              <p className="text-sm text-muted mt-2">Deny and Needs More Evidence are enabled from the Candidate Queue. Draft actions remain not_implemented_yet.</p>
             </div>
             <div className="grid grid-cols-1 gap-3">
               {reviewActions.map((label) => (
                 <button key={label} disabled className="w-full border border-border px-4 py-3 text-xs uppercase tracking-widest text-muted opacity-60">
-                  {label} — pending backend
+                  {label} — placeholder only
                 </button>
               ))}
             </div>
@@ -327,7 +451,7 @@ export default function AdminDossiersPage() {
           <div>
             <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Focused BNL Assistant</p>
             <h2 className="text-2xl font-bold text-foreground">Focused BNL Assistant</h2>
-            <p className="text-sm text-muted mt-2">Not a full chat yet. Future wiring is candidate-specific only and cannot publish, write memory, or create dossiers.</p>
+            <p className="text-sm text-muted mt-2">Disabled placeholder only. It does not call BNL, write memory, publish, create tags, or create dossiers in this PR.</p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3">
             {focusedAssistantPrompts.map((prompt) => (
@@ -357,7 +481,7 @@ export default function AdminDossiersPage() {
           </div>
           <ul className="list-disc pl-5 text-sm text-muted space-y-1">
             <li>BNL recommends and drafts only.</li>
-            <li>Admin approves/publishes.</li>
+            <li>Admin approves/publishes in a future controlled publishing workflow.</li>
             <li>No automatic dossier creation.</li>
             <li>No automatic tag creation.</li>
             <li>No Discord identity merging.</li>

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -33,6 +33,7 @@ type DossierWorkflowResponse = {
     storageKey: "barcode:dossier-workflow:v1";
     status: "candidate_store_enabled";
     updatedAt: string;
+    revision: number;
     candidateCount: number;
     draftCount: number;
     allowedActions: DossierWorkflowAction[];
@@ -94,6 +95,7 @@ async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWor
       storageKey: "barcode:dossier-workflow:v1",
       status: "candidate_store_enabled",
       updatedAt: workflowState.updatedAt,
+      revision: workflowState.revision,
       candidateCount: workflowState.candidates.length,
       draftCount: workflowState.drafts.length,
       allowedActions: DOSSIER_WORKFLOW_ACTIONS,

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -8,10 +8,19 @@ import {
   DOSSIER_SOURCE_BOUNDARIES,
   DOSSIER_WORKFLOW_ACTIONS,
   DOSSIER_WORKFLOW_RULES,
+  type CreateManualDossierCandidateInput,
   type DossierCandidate,
+  type DossierCandidateStatus,
   type DossierDraft,
   type DossierWorkflowAction,
 } from "@/lib/dossier-workflow";
+import {
+  createManualDossierCandidate,
+  getDossierWorkflowState,
+  getDossierWorkflowStorageMode,
+  updateDossierCandidateStatus,
+  type DossierWorkflowState,
+} from "@/lib/dossier-workflow-store";
 
 export const dynamic = "force-dynamic";
 
@@ -20,8 +29,12 @@ type DossierWorkflowResponse = {
   drafts: DossierDraft[];
   workflow: {
     version: 1;
-    storage: "not_configured_foundation_only";
-    status: "foundation_only";
+    storage: "redis" | "memory_fallback";
+    storageKey: "barcode:dossier-workflow:v1";
+    status: "candidate_store_enabled";
+    updatedAt: string;
+    candidateCount: number;
+    draftCount: number;
     allowedActions: DossierWorkflowAction[];
     rules: typeof DOSSIER_WORKFLOW_RULES;
     scoringPolicy: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
@@ -30,6 +43,8 @@ type DossierWorkflowResponse = {
   };
   authoringGuide: {
     version: typeof dossierAuthoringGuide.version;
+    fieldCount: number;
+    draftingRuleCount: number;
   };
   tagRegistry: {
     totalUniqueTags: number;
@@ -37,6 +52,12 @@ type DossierWorkflowResponse = {
     creationPolicy: ReturnType<typeof buildDossierTagRegistry>["creationPolicy"];
   };
 };
+
+const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
+  "createManualCandidate",
+  "denyCandidate",
+  "markNeedsMoreEvidence",
+]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
   const cookieHeader = req.headers.get("cookie") || "";
@@ -48,23 +69,41 @@ async function isAuthenticated(req: Request): Promise<boolean> {
   return Boolean(token && (await verifyAdminToken(token)));
 }
 
-function workflowPayload(): DossierWorkflowResponse {
+function validateManualCandidateInput(value: unknown): CreateManualDossierCandidateInput | null {
+  if (!value || typeof value !== "object") return null;
+  const input = value as CreateManualDossierCandidateInput;
+  if (typeof input.name !== "string" || !input.name.trim()) return null;
+  if (typeof input.reason !== "string" || !input.reason.trim()) return null;
+  return input;
+}
+
+function candidateIdFromBody(body: Record<string, unknown>): string {
+  return typeof body.candidateId === "string" ? body.candidateId.trim() : "";
+}
+
+async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWorkflowResponse> {
   const tagRegistry = buildDossierTagRegistry(databasePage.entries);
+  const workflowState = state ?? await getDossierWorkflowState();
 
   return {
-    candidates: [],
-    drafts: [],
+    candidates: workflowState.candidates,
+    drafts: workflowState.drafts,
     workflow: {
       version: 1,
-      storage: "not_configured_foundation_only",
-      status: "foundation_only",
+      storage: getDossierWorkflowStorageMode(),
+      storageKey: "barcode:dossier-workflow:v1",
+      status: "candidate_store_enabled",
+      updatedAt: workflowState.updatedAt,
+      candidateCount: workflowState.candidates.length,
+      draftCount: workflowState.drafts.length,
       allowedActions: DOSSIER_WORKFLOW_ACTIONS,
       rules: DOSSIER_WORKFLOW_RULES,
       scoringPolicy: DOSSIER_CANDIDATE_SCORING_POLICY,
       candidateSourceBoundaries: DOSSIER_SOURCE_BOUNDARIES,
       boundaries: [
-        "BNL may recommend and draft only after operator selection.",
-        "Admin operators approve and prepare website dossier entries.",
+        "Manual candidates are admin/operator workflow records only, not published dossiers.",
+        "BNL may recommend and draft only after operator selection in a future PR.",
+        "Admin operators approve and prepare website dossier entries through future controlled site updates.",
         "This endpoint does not publish, create public records, or mutate src/content.ts.",
         "This endpoint does not invoke BNL, write memory, merge Discord identity, or use payment/customer identity.",
         "Queue frequency is evidence only, not identity.",
@@ -72,6 +111,8 @@ function workflowPayload(): DossierWorkflowResponse {
     },
     authoringGuide: {
       version: dossierAuthoringGuide.version,
+      fieldCount: Object.keys(dossierAuthoringGuide.fieldGuide).length,
+      draftingRuleCount: dossierAuthoringGuide.draftingRules.length,
     },
     tagRegistry: {
       totalUniqueTags: tagRegistry.totalUniqueTags,
@@ -86,7 +127,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  return NextResponse.json(workflowPayload());
+  return NextResponse.json(await workflowPayload());
 }
 
 export async function POST(req: Request) {
@@ -94,18 +135,45 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await req.json().catch(() => ({}));
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>;
   const action = typeof body?.action === "string" ? body.action : "";
 
   if (!DOSSIER_WORKFLOW_ACTIONS.includes(action as DossierWorkflowAction)) {
     return NextResponse.json({ error: "Unknown dossier workflow action" }, { status: 400 });
   }
 
-  return NextResponse.json({
-    ok: false,
-    code: "not_implemented_yet",
-    action,
-    message: "Dossier workflow mutations are intentionally disabled in this foundation PR.",
-    boundaries: workflowPayload().workflow.boundaries,
-  }, { status: 501 });
+  if (!IMPLEMENTED_ACTIONS.has(action as DossierWorkflowAction)) {
+    return NextResponse.json({
+      ok: false,
+      code: "not_implemented_yet",
+      action,
+      message: "Dossier drafting, approval, and publishing mutations remain intentionally disabled in this PR.",
+      boundaries: (await workflowPayload()).workflow.boundaries,
+    }, { status: 501 });
+  }
+
+  if (action === "createManualCandidate") {
+    const input = validateManualCandidateInput(body.input ?? body.candidate ?? body);
+    if (!input) {
+      return NextResponse.json({ error: "Manual candidate name and reason are required" }, { status: 400 });
+    }
+
+    const candidate = await createManualDossierCandidate(input);
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, candidate, ...payload });
+  }
+
+  const candidateId = candidateIdFromBody(body);
+  if (!candidateId) {
+    return NextResponse.json({ error: "candidateId is required" }, { status: 400 });
+  }
+
+  const nextStatus: DossierCandidateStatus = action === "denyCandidate" ? "denied" : "needs_more_evidence";
+  const candidate = await updateDossierCandidateStatus(candidateId, nextStatus);
+  if (!candidate) {
+    return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+  }
+
+  const payload = await workflowPayload();
+  return NextResponse.json({ ok: true, action, candidate, ...payload });
 }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -11,14 +11,21 @@ import {
 
 export type DossierWorkflowState = {
   version: 1;
+  revision: number;
   candidates: DossierCandidate[];
   drafts: DossierDraft[];
   updatedAt: string;
 };
 
 export const DOSSIER_WORKFLOW_STORAGE_KEY = "barcode:dossier-workflow:v1";
+export const DOSSIER_WORKFLOW_LOCK_KEY = "barcode:dossier-workflow:v1:lock";
+
+const MAX_UPDATE_ATTEMPTS = 5;
+const LOCK_TTL_SECONDS = 5;
+const LOCK_RETRY_DELAY_MS = 25;
 
 let memoryState: DossierWorkflowState = emptyWorkflowState();
+let memoryWriteQueue: Promise<void> = Promise.resolve();
 
 function getRedis(): Redis | null {
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -30,6 +37,7 @@ function getRedis(): Redis | null {
 function emptyWorkflowState(): DossierWorkflowState {
   return {
     version: 1,
+    revision: 0,
     candidates: [],
     drafts: [],
     updatedAt: new Date(0).toISOString(),
@@ -98,6 +106,7 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
   const candidateState = value as Partial<DossierWorkflowState>;
   return {
     version: 1,
+    revision: typeof candidateState.revision === "number" && Number.isFinite(candidateState.revision) ? Math.max(0, Math.floor(candidateState.revision)) : 0,
     candidates: Array.isArray(candidateState.candidates) ? candidateState.candidates : [],
     drafts: Array.isArray(candidateState.drafts) ? candidateState.drafts : [],
     updatedAt: typeof candidateState.updatedAt === "string" ? candidateState.updatedAt : new Date().toISOString(),
@@ -129,6 +138,101 @@ export async function saveDossierWorkflowState(state: DossierWorkflowState): Pro
   if (redis) {
     await redis.set(DOSSIER_WORKFLOW_STORAGE_KEY, nextState);
   }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createLockToken(): string {
+  return `dossier_lock_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function acquireRedisLock(redis: Redis): Promise<string> {
+  const token = createLockToken();
+
+  for (let attempt = 0; attempt < MAX_UPDATE_ATTEMPTS; attempt += 1) {
+    const acquired = await redis.set(DOSSIER_WORKFLOW_LOCK_KEY, token, { nx: true, ex: LOCK_TTL_SECONDS });
+    if (acquired === "OK") return token;
+    await delay(LOCK_RETRY_DELAY_MS * (attempt + 1));
+  }
+
+  throw new Error("Unable to acquire dossier workflow write lock");
+}
+
+async function releaseRedisLock(redis: Redis, token: string): Promise<void> {
+  const currentToken = await redis.get<string>(DOSSIER_WORKFLOW_LOCK_KEY);
+  if (currentToken === token) {
+    await redis.del(DOSSIER_WORKFLOW_LOCK_KEY);
+  }
+}
+
+async function withMemoryWriteLock<T>(operation: () => Promise<T>): Promise<T> {
+  const priorOperation = memoryWriteQueue;
+  let releaseLock: () => void = () => undefined;
+  memoryWriteQueue = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+
+  await priorOperation;
+  try {
+    return await operation();
+  } finally {
+    releaseLock();
+  }
+}
+
+export async function updateDossierWorkflowState(
+  updater: (state: DossierWorkflowState) => DossierWorkflowState,
+): Promise<DossierWorkflowState> {
+  const redis = getRedis();
+
+  if (!redis) {
+    return withMemoryWriteLock(async () => {
+      const currentState = sanitizeWorkflowState(memoryState);
+      const updaterResult = updater(currentState);
+      if (updaterResult === currentState) return currentState;
+      const updatedState = sanitizeWorkflowState(updaterResult);
+      const nextState = sanitizeWorkflowState({
+        ...updatedState,
+        version: 1,
+        revision: currentState.revision + 1,
+        updatedAt: updatedState.updatedAt || new Date().toISOString(),
+      });
+      memoryState = nextState;
+      return nextState;
+    });
+  }
+
+  for (let attempt = 0; attempt < MAX_UPDATE_ATTEMPTS; attempt += 1) {
+    const lockToken = await acquireRedisLock(redis);
+    try {
+      const currentState = sanitizeWorkflowState(await redis.get<unknown>(DOSSIER_WORKFLOW_STORAGE_KEY));
+      const updaterResult = updater(currentState);
+      if (updaterResult === currentState) return currentState;
+      const updatedState = sanitizeWorkflowState(updaterResult);
+      const latestState = sanitizeWorkflowState(await redis.get<unknown>(DOSSIER_WORKFLOW_STORAGE_KEY));
+
+      if (latestState.revision !== currentState.revision) {
+        await delay(LOCK_RETRY_DELAY_MS * (attempt + 1));
+        continue;
+      }
+
+      const nextState = sanitizeWorkflowState({
+        ...updatedState,
+        version: 1,
+        revision: currentState.revision + 1,
+        updatedAt: updatedState.updatedAt || new Date().toISOString(),
+      });
+      await redis.set(DOSSIER_WORKFLOW_STORAGE_KEY, nextState);
+      memoryState = nextState;
+      return nextState;
+    } finally {
+      await releaseRedisLock(redis, lockToken);
+    }
+  }
+
+  throw new Error("Unable to update dossier workflow state after revision conflicts");
 }
 
 export async function createManualDossierCandidate(input: CreateManualDossierCandidateInput): Promise<DossierCandidate> {
@@ -204,32 +308,33 @@ export async function createManualDossierCandidate(input: CreateManualDossierCan
     updatedAt: now,
   };
 
-  const currentState = await getDossierWorkflowState();
-  await saveDossierWorkflowState({
+  await updateDossierWorkflowState((currentState) => ({
     ...currentState,
     candidates: [candidate, ...currentState.candidates],
     updatedAt: now,
-  });
+  }));
 
   return candidate;
 }
 
 export async function updateDossierCandidateStatus(candidateId: string, status: DossierCandidateStatus): Promise<DossierCandidate | null> {
-  const currentState = await getDossierWorkflowState();
   const now = new Date().toISOString();
   let updatedCandidate: DossierCandidate | null = null;
-  const candidates = currentState.candidates.map((candidate) => {
-    if (candidate.id !== candidateId) return candidate;
-    updatedCandidate = { ...candidate, status, updatedAt: now };
-    return updatedCandidate;
-  });
 
-  if (!updatedCandidate) return null;
+  await updateDossierWorkflowState((currentState) => {
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== candidateId) return candidate;
+      updatedCandidate = { ...candidate, status, updatedAt: now };
+      return updatedCandidate;
+    });
 
-  await saveDossierWorkflowState({
-    ...currentState,
-    candidates,
-    updatedAt: now,
+    if (!updatedCandidate) return currentState;
+
+    return {
+      ...currentState,
+      candidates,
+      updatedAt: now,
+    };
   });
 
   return updatedCandidate;

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1,0 +1,245 @@
+import { Redis } from "@upstash/redis";
+import { databasePage, type DatabaseEntry } from "@/content";
+import {
+  scoreManualDossierCandidate,
+  type CreateManualDossierCandidateInput,
+  type DossierCandidate,
+  type DossierCandidateStatus,
+  type DossierDraft,
+  type DossierDuplicateRisk,
+} from "@/lib/dossier-workflow";
+
+export type DossierWorkflowState = {
+  version: 1;
+  candidates: DossierCandidate[];
+  drafts: DossierDraft[];
+  updatedAt: string;
+};
+
+export const DOSSIER_WORKFLOW_STORAGE_KEY = "barcode:dossier-workflow:v1";
+
+let memoryState: DossierWorkflowState = emptyWorkflowState();
+
+function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function emptyWorkflowState(): DossierWorkflowState {
+  return {
+    version: 1,
+    candidates: [],
+    drafts: [],
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean);
+}
+
+function normalizeName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\b(the|a|an)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compactName(value: string): string {
+  return normalizeName(value).replace(/\s+/g, "");
+}
+
+function hasNearNameMatch(candidateName: string, entryName: string): boolean {
+  const normalizedCandidate = normalizeName(candidateName);
+  const normalizedEntry = normalizeName(entryName);
+  const compactCandidate = compactName(candidateName);
+  const compactEntry = compactName(entryName);
+
+  if (!normalizedCandidate || !normalizedEntry) return false;
+  if (normalizedCandidate === normalizedEntry || compactCandidate === compactEntry) return true;
+  if (normalizedCandidate.length < 4 || normalizedEntry.length < 4) return false;
+  return normalizedCandidate.includes(normalizedEntry) || normalizedEntry.includes(normalizedCandidate);
+}
+
+function findExistingDossierMatch(name: string): {
+  risk: DossierDuplicateRisk;
+  match: DossierCandidate["existingDossierMatch"];
+} {
+  const exact = databasePage.entries.find((entry: DatabaseEntry) => normalizeName(entry.name) === normalizeName(name));
+  if (exact) {
+    return {
+      risk: "high",
+      match: { id: exact.id, name: exact.name, confidence: "high" },
+    };
+  }
+
+  const near = databasePage.entries.find((entry: DatabaseEntry) => hasNearNameMatch(name, entry.name));
+  if (near) {
+    return {
+      risk: "medium",
+      match: { id: near.id, name: near.name, confidence: "medium" },
+    };
+  }
+
+  return { risk: "none", match: null };
+}
+
+function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
+  if (!value || typeof value !== "object") return emptyWorkflowState();
+  const candidateState = value as Partial<DossierWorkflowState>;
+  return {
+    version: 1,
+    candidates: Array.isArray(candidateState.candidates) ? candidateState.candidates : [],
+    drafts: Array.isArray(candidateState.drafts) ? candidateState.drafts : [],
+    updatedAt: typeof candidateState.updatedAt === "string" ? candidateState.updatedAt : new Date().toISOString(),
+  };
+}
+
+function createCandidateId(): string {
+  return `dossier_candidate_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createEvidenceId(): string {
+  return `evidence_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function getDossierWorkflowState(): Promise<DossierWorkflowState> {
+  const redis = getRedis();
+  if (!redis) return memoryState;
+
+  const state = sanitizeWorkflowState(await redis.get<unknown>(DOSSIER_WORKFLOW_STORAGE_KEY));
+  memoryState = state;
+  return state;
+}
+
+export async function saveDossierWorkflowState(state: DossierWorkflowState): Promise<void> {
+  const nextState = sanitizeWorkflowState({ ...state, version: 1, updatedAt: state.updatedAt || new Date().toISOString() });
+  memoryState = nextState;
+
+  const redis = getRedis();
+  if (redis) {
+    await redis.set(DOSSIER_WORKFLOW_STORAGE_KEY, nextState);
+  }
+}
+
+export async function createManualDossierCandidate(input: CreateManualDossierCandidateInput): Promise<DossierCandidate> {
+  const now = new Date().toISOString();
+  const name = input.name.trim();
+  const reason = input.reason.trim();
+  const knownFacts = normalizeStringArray(input.knownFacts);
+  const missingInfoInput = normalizeStringArray(input.missingInfo);
+  const doNotSay = normalizeStringArray(input.doNotSay);
+  const publicSafetyNotesInput = normalizeStringArray(input.publicSafetyNotes);
+  const recommendedTags = normalizeStringArray(input.recommendedTags);
+  const proposedTags = normalizeStringArray(input.proposedTags);
+  const scored = scoreManualDossierCandidate({
+    ...input,
+    name,
+    reason,
+    knownFacts,
+    missingInfo: missingInfoInput,
+    doNotSay,
+    publicSafetyNotes: publicSafetyNotesInput,
+    recommendedTags,
+    proposedTags,
+  });
+  const duplicate = findExistingDossierMatch(name);
+  const missingInfo = [...scored.missingInfo];
+  const publicSafetyNotes = [...scored.publicSafetyNotes];
+
+  if (duplicate.match) {
+    const duplicateMessage = `Duplicate review required before drafting: possible match ${duplicate.match.id} / ${duplicate.match.name}.`;
+    missingInfo.push(duplicateMessage);
+    publicSafetyNotes.push(duplicateMessage);
+  }
+
+  const candidate: DossierCandidate = {
+    id: createCandidateId(),
+    name,
+    candidateType: input.candidateType ?? "unknown",
+    source: "manual",
+    tier: duplicate.risk === "high" && scored.tier === "draft_ready" ? "review_candidate" : scored.tier,
+    score: scored.score,
+    whyNow: input.whyNow?.trim() ?? "",
+    reason,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    evidenceSummary: input.evidenceSummary?.trim() ?? "",
+    evidenceItems: input.evidenceSummary?.trim() ? [{
+      id: createEvidenceId(),
+      type: "manual_nomination",
+      label: "Manual operator intake",
+      summary: input.evidenceSummary.trim(),
+      count: 1,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      publicSafe: input.primaryLink?.publicSafe !== false,
+    }] : [],
+    evidenceCount: input.evidenceSummary?.trim() ? 1 : 0,
+    knownFacts,
+    confidence: scored.confidence,
+    duplicateRisk: duplicate.risk,
+    existingDossierMatch: duplicate.match,
+    recommendedCategory: input.recommendedCategory,
+    recommendedStatus: input.recommendedStatus,
+    recommendedClearance: input.recommendedClearance,
+    recommendedOrigin: input.recommendedOrigin,
+    recommendedTags,
+    proposedTags,
+    primaryLink: input.primaryLink?.url ? input.primaryLink : undefined,
+    missingInfo,
+    doNotSay,
+    publicSafetyNotes,
+    status: scored.tier === "weak_candidate" ? "suggested" : "needs_review",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const currentState = await getDossierWorkflowState();
+  await saveDossierWorkflowState({
+    ...currentState,
+    candidates: [candidate, ...currentState.candidates],
+    updatedAt: now,
+  });
+
+  return candidate;
+}
+
+export async function updateDossierCandidateStatus(candidateId: string, status: DossierCandidateStatus): Promise<DossierCandidate | null> {
+  const currentState = await getDossierWorkflowState();
+  const now = new Date().toISOString();
+  let updatedCandidate: DossierCandidate | null = null;
+  const candidates = currentState.candidates.map((candidate) => {
+    if (candidate.id !== candidateId) return candidate;
+    updatedCandidate = { ...candidate, status, updatedAt: now };
+    return updatedCandidate;
+  });
+
+  if (!updatedCandidate) return null;
+
+  await saveDossierWorkflowState({
+    ...currentState,
+    candidates,
+    updatedAt: now,
+  });
+
+  return updatedCandidate;
+}
+
+export async function getDossierCandidate(candidateId: string): Promise<DossierCandidate | null> {
+  const currentState = await getDossierWorkflowState();
+  return currentState.candidates.find((candidate) => candidate.id === candidateId) ?? null;
+}
+
+export function getDossierWorkflowStorageMode(): "redis" | "memory_fallback" {
+  return getRedis() ? "redis" : "memory_fallback";
+}

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -79,13 +79,17 @@ export type DossierCandidate = {
   evidenceSummary: string;
   evidenceItems?: DossierCandidateEvidence[];
   evidenceCount?: number;
+  knownFacts?: string[];
   confidence?: "low" | "medium" | "high";
   duplicateRisk?: DossierDuplicateRisk;
   existingDossierMatch?: { id: string; name: string; confidence: "low" | "medium" | "high" } | null;
   recommendedCategory?: DossierCategory;
+  recommendedStatus?: DossierPublicStatus;
   recommendedClearance?: DossierClearance;
+  recommendedOrigin?: DossierOrigin;
   recommendedTags?: string[];
   proposedTags?: string[];
+  primaryLink?: DossierWorkflowLink;
   missingInfo?: string[];
   doNotSay?: string[];
   publicSafetyNotes?: string[];
@@ -124,6 +128,25 @@ export type DossierWorkflowLink = {
   type: string;
   selectedBy?: "subject" | "operator" | "legacy";
   publicSafe?: boolean;
+};
+
+export type CreateManualDossierCandidateInput = {
+  name: string;
+  candidateType?: DossierCandidate["candidateType"];
+  reason: string;
+  whyNow?: string;
+  evidenceSummary?: string;
+  knownFacts?: string[];
+  missingInfo?: string[];
+  doNotSay?: string[];
+  publicSafetyNotes?: string[];
+  recommendedCategory?: DossierDraft["fields"]["category"];
+  recommendedStatus?: DossierDraft["fields"]["status"];
+  recommendedClearance?: DossierDraft["fields"]["clearance"];
+  recommendedOrigin?: DossierDraft["fields"]["origin"];
+  recommendedTags?: string[];
+  proposedTags?: string[];
+  primaryLink?: DossierDraft["fields"]["primaryLink"];
 };
 
 export type DossierWorkflowAction =
@@ -175,6 +198,79 @@ export const DOSSIER_CANDIDATE_SCORING_POLICY = {
   },
   gate: "Loose intake, strict drafting/publishing.",
 } as const;
+
+const IDENTITY_SENSITIVE_PATTERN = /\b(discord|email|payment|stripe|customer|account|phone|address|legal name|real name|ip address|private|dm|direct message)\b/i;
+
+function hasText(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function hasItems(value: string[] | undefined): boolean {
+  return Boolean(value?.some((item) => item.trim()));
+}
+
+function tierForScore(score: number): DossierCandidateTier {
+  if (score >= DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.draftReadyMin) return "draft_ready";
+  if (score >= DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.reviewCandidateMin) return "review_candidate";
+  return "weak_candidate";
+}
+
+export function scoreManualDossierCandidate(input: CreateManualDossierCandidateInput): {
+  score: number;
+  tier: DossierCandidateTier;
+  confidence: "low" | "medium" | "high";
+  publicSafetyNotes: string[];
+  missingInfo: string[];
+} {
+  let score: number = DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.weakCandidateMin;
+  const publicSafetyNotes = [...(input.publicSafetyNotes ?? []).map((item) => item.trim()).filter(Boolean)];
+  const missingInfo = [...(input.missingInfo ?? []).map((item) => item.trim()).filter(Boolean)];
+  const combinedText = [input.name, input.reason, input.whyNow, input.evidenceSummary, ...(input.knownFacts ?? []), ...(input.doNotSay ?? [])].join(" ");
+
+  if (hasText(input.reason)) score += 8;
+  else score -= 12;
+
+  if (hasText(input.whyNow)) score += 8;
+  if (hasText(input.evidenceSummary)) score += 10;
+  else {
+    score -= 8;
+    missingInfo.push("Add a public-safe evidence summary before drafting.");
+  }
+
+  if (hasItems(input.knownFacts)) score += 10;
+  else {
+    score -= 6;
+    missingInfo.push("Add operator-approved known facts before drafting.");
+  }
+
+  const recommendedFieldCount = [input.recommendedCategory, input.recommendedStatus, input.recommendedClearance, input.recommendedOrigin].filter(Boolean).length;
+  score += recommendedFieldCount * 3;
+
+  if (input.primaryLink?.url && input.primaryLink.publicSafe !== false) score += 5;
+  if (hasItems(input.recommendedTags)) score += 5;
+
+  if (!hasItems(publicSafetyNotes)) {
+    score -= 5;
+    publicSafetyNotes.push("Public-safety review required before any draft or publication step.");
+  }
+
+  if (IDENTITY_SENSITIVE_PATTERN.test(combinedText)) {
+    score -= 15;
+    publicSafetyNotes.push("Possible private, payment, account, or identity-sensitive wording detected; review and remove before drafting.");
+  }
+
+  score = Math.max(0, Math.min(100, score));
+  const tier = hasText(input.reason) && hasText(input.whyNow) && hasText(input.evidenceSummary)
+    ? tierForScore(score)
+    : "weak_candidate";
+  const confidence = score >= DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.draftReadyMin
+    ? "high"
+    : score >= DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.reviewCandidateMin
+      ? "medium"
+      : "low";
+
+  return { score, tier, confidence, publicSafetyNotes, missingInfo };
+}
 
 export const DOSSIER_SOURCE_BOUNDARIES: DossierSourceBoundary[] = [
   {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -5,6 +5,9 @@ import path from "node:path";
 import test from "node:test";
 import ts from "typescript";
 
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
 const projectRoot = path.resolve(import.meta.dirname, "..");
 const originalResolveFilename = Module._resolveFilename;
 
@@ -20,8 +23,8 @@ Module._resolveFilename = function resolveFilename(request, parent, isMain, opti
 };
 
 Module._extensions[".ts"] = function loadTypeScript(module, filename) {
-  const source = fs.readFileSync(filename, "utf8");
-  const { outputText } = ts.transpileModule(source, {
+  const sourceText = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(sourceText, {
     compilerOptions: {
       esModuleInterop: true,
       jsx: ts.JsxEmit.ReactJSX,
@@ -33,10 +36,15 @@ Module._extensions[".ts"] = function loadTypeScript(module, filename) {
   module._compile(outputText, filename);
 };
 
+Module._extensions[".tsx"] = Module._extensions[".ts"];
+
 const require = createRequire(import.meta.url);
 const auth = require("../src/lib/auth.ts");
 const route = require("../src/app/api/admin/dossiers/route.ts");
 const workflow = require("../src/lib/dossier-workflow.ts");
+const store = require("../src/lib/dossier-workflow-store.ts");
+const { databasePage } = require("../src/content.ts");
+const readModel = require("../src/app/api/bnl/read-model/route.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -47,6 +55,57 @@ async function adminCookie() {
   return `${auth.COOKIE_NAME}=${token}`;
 }
 
+async function resetWorkflowStore() {
+  await store.saveDossierWorkflowState({
+    version: 1,
+    candidates: [],
+    drafts: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+}
+
+async function authedGet() {
+  return route.GET(new Request("https://example.test/api/admin/dossiers", {
+    headers: { cookie: await adminCookie() },
+  }));
+}
+
+async function authedPost(body) {
+  return route.POST(new Request("https://example.test/api/admin/dossiers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: await adminCookie(),
+    },
+    body: JSON.stringify(body),
+  }));
+}
+
+const manualCandidateInput = {
+  name: "Manual Candidate Alpha",
+  candidateType: "artist",
+  reason: "Operator wants a controlled dossier review record.",
+  whyNow: "The artist has enough public context to inspect manually.",
+  evidenceSummary: "Operator-entered public-safe evidence summary.",
+  knownFacts: ["Appeared in public show context", "Has an operator-approved link"],
+  missingInfo: ["Confirm preferred public role"],
+  doNotSay: ["Do not imply private Discord identity"],
+  publicSafetyNotes: ["Use public facts only"],
+  recommendedCategory: "Personnel",
+  recommendedStatus: "PENDING",
+  recommendedClearance: "PUBLIC",
+  recommendedOrigin: "UNVERIFIED",
+  recommendedTags: ["artist", "radio"],
+  proposedTags: ["manual-review"],
+  primaryLink: {
+    label: "Official link",
+    url: "https://example.test/manual-alpha",
+    type: "website",
+    selectedBy: "operator",
+    publicSafe: true,
+  },
+};
+
 test("admin panel includes Dossier Control Center link", () => {
   const adminPage = source("src/app/admin/page.tsx");
   assert.match(adminPage, /Dossier Control Center/);
@@ -54,39 +113,34 @@ test("admin panel includes Dossier Control Center link", () => {
   assert.match(adminPage, /href="\/admin\/dossiers"/);
 });
 
-test("admin dossier page gates workflow shell behind successful API payload", () => {
+test("admin dossier page gates workflow behind successful API payload and includes manual intake UI", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
-  for (const label of ["Dossier Control Center", "Candidate Queue", "Candidate Evidence", "Candidate Gate / Scoring", "Draft Readiness / Missing Info", "Draft Workspace", "Review Actions", "Focused BNL Assistant", "System Boundaries"]) {
+  for (const label of ["Dossier Control Center", "Manual Candidate Intake", "Candidate Queue", "Candidate Evidence", "Candidate Gate / Scoring", "Draft Readiness / Missing Info", "Draft Workspace", "Review Actions", "Focused BNL Assistant", "System Boundaries"]) {
+    assert.match(page, new RegExp(label));
+  }
+  for (const label of ["Known facts", "Missing info", "Do Not Say", "Public safety notes", "Deny", "Needs More Evidence", "Focused BNL Assistant", "Disabled placeholder only"]) {
     assert.match(page, new RegExp(label));
   }
   assert.match(page, /\/api\/admin\/dossiers/);
-  assert.match(page, /No candidates yet/);
-  assert.match(page, /No draft selected/);
-  assert.match(page, /Candidate intake wiring comes in a later PR/);
+  assert.match(page, /Create Manual Candidate/);
+  assert.match(page, /Featured\/primary link label/);
+  assert.match(page, /selectedBy/);
+  assert.match(page, /No selected candidate/);
   assert.match(page, /Why Now/);
   assert.match(page, /Duplicate Risk/);
-  assert.match(page, /Missing Info/);
-  assert.match(page, /Do Not Say/);
   assert.match(page, /loose intake \/ strict publishing/i);
   assert.match(page, /Try Again: Too Long/);
-  assert.match(page, /Try Again: Too Vague/);
   assert.match(page, /Rewrite Summary Only/);
 
-  assert.doesNotMatch(page, /payload\?\.candidates \?\? \[\]/);
-  assert.doesNotMatch(page, /payload\?\.workflow\.boundaries \?\? \[/);
+  assert.doesNotMatch(page, /fetch\(\"\/api\/bnl/);
   assert.match(page, /if \(loading\)/);
   assert.match(page, /if \(error \|\| !payload\)/);
-  assert.match(page, /const candidates = payload\.candidates/);
-  assert.match(page, /const boundaries = payload\.workflow\.boundaries/);
 
   const loadingGate = page.indexOf("if (loading)");
   const authGate = page.indexOf("if (error || !payload)");
-  const payloadRead = page.indexOf("const candidates = payload.candidates");
   const fullShell = page.indexOf('aria-label="Dossier Control Center"');
-
   assert.ok(loadingGate > -1 && loadingGate < fullShell, "loading state must return before the full shell");
   assert.ok(authGate > loadingGate && authGate < fullShell, "auth/error state must return before the full shell");
-  assert.ok(payloadRead > authGate && payloadRead < fullShell, "full shell must use an authenticated payload");
 });
 
 test("admin dossier page has minimal loading and auth-required states", () => {
@@ -97,54 +151,150 @@ test("admin dossier page has minimal loading and auth-required states", () => {
   assert.match(page, /MinimalDossierAdminState/);
 });
 
-test("dossier workflow types include candidate evidence and scoring policy contracts", () => {
+test("dossier workflow types include manual input and scoring policy contracts", () => {
   const workflowSource = source("src/lib/dossier-workflow.ts");
   assert.match(workflowSource, /export type DossierCandidateEvidenceType/);
-  assert.match(workflowSource, /export type DossierCandidateEvidence/);
-  assert.match(workflowSource, /candidateType: DossierCandidateType/);
-  assert.match(workflowSource, /tier: DossierCandidateTier/);
-  assert.match(workflowSource, /score: number/);
-  assert.match(workflowSource, /whyNow: string/);
-  assert.match(workflowSource, /duplicateRisk\?: DossierDuplicateRisk/);
-  assert.match(workflowSource, /missingInfo\?: string\[\]/);
-  assert.match(workflowSource, /doNotSay\?: string\[\]/);
+  assert.match(workflowSource, /export type CreateManualDossierCandidateInput/);
+  assert.match(workflowSource, /export function scoreManualDossierCandidate/);
+  assert.match(workflowSource, /knownFacts\?: string\[\]/);
+  assert.match(workflowSource, /recommendedOrigin\?: DossierOrigin/);
+  assert.match(workflowSource, /primaryLink\?: DossierWorkflowLink/);
   assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.gate, "Loose intake, strict drafting/publishing.");
   assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.reviewCandidateMin, 50);
 });
 
-test("admin dossier API uses admin auth and returns empty workflow arrays", async () => {
-  const unauthorized = await route.GET(new Request("https://example.test/api/admin/dossiers"));
-  assert.equal(unauthorized.status, 401);
+test("admin dossier API requires auth for GET and POST", async () => {
+  const unauthorizedGet = await route.GET(new Request("https://example.test/api/admin/dossiers"));
+  assert.equal(unauthorizedGet.status, 401);
 
-  const response = await route.GET(new Request("https://example.test/api/admin/dossiers", {
-    headers: { cookie: await adminCookie() },
+  const unauthorizedPost = await route.POST(new Request("https://example.test/api/admin/dossiers", {
+    method: "POST",
+    body: JSON.stringify({ action: "createManualCandidate", input: manualCandidateInput }),
   }));
+  assert.equal(unauthorizedPost.status, 401);
+});
+
+test("authenticated GET returns workflow store, metadata, authoring guide, tag registry, and scoring policy summaries", async () => {
+  await resetWorkflowStore();
+  const response = await authedGet();
   assert.equal(response.status, 200);
   const payload = await response.json();
   assert.deepEqual(payload.candidates, []);
   assert.deepEqual(payload.drafts, []);
   assert.equal(payload.workflow.version, 1);
-  assert.equal(payload.workflow.status, "foundation_only");
+  assert.equal(payload.workflow.status, "candidate_store_enabled");
+  assert.equal(payload.workflow.storage, "memory_fallback");
+  assert.equal(payload.workflow.storageKey, "barcode:dossier-workflow:v1");
   assert.ok(payload.workflow.allowedActions.includes("requestDraft"));
   assert.equal(payload.workflow.scoringPolicy.gate, "Loose intake, strict drafting/publishing.");
   assert.equal(payload.workflow.scoringPolicy.thresholds.draftReadyMin, 70);
   assert.ok(payload.workflow.candidateSourceBoundaries.some((entry) => entry.source === "queue_frequency"));
+  assert.equal(payload.authoringGuide.version, "1.0");
+  assert.ok(payload.authoringGuide.fieldCount > 0);
+  assert.ok(payload.tagRegistry.totalUniqueTags > 0);
+  assert.equal(payload.tagRegistry.creationPolicy.newTagsAllowed, "proposal_only");
 });
 
-test("admin dossier mutations are placeholder-only and do not publish", async () => {
-  const contentBefore = source("src/content.ts");
-  const response = await route.POST(new Request("https://example.test/api/admin/dossiers", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      cookie: await adminCookie(),
-    },
-    body: JSON.stringify({ action: "approveDraft", candidateId: "candidate-test" }),
-  }));
+test("authenticated POST creates and persists a manual candidate without publishing", async () => {
+  await resetWorkflowStore();
+  const databaseEntriesBefore = JSON.stringify(databasePage.entries);
+  const tagCountBefore = databasePage.entries.flatMap((entry) => entry.tags).length;
 
-  assert.equal(response.status, 501);
+  const createResponse = await authedPost({ action: "createManualCandidate", input: manualCandidateInput });
+  assert.equal(createResponse.status, 200);
+  const createPayload = await createResponse.json();
+  const candidate = createPayload.candidate;
+
+  assert.ok(candidate.id);
+  assert.equal(candidate.name, manualCandidateInput.name);
+  assert.equal(candidate.source, "manual");
+  assert.match(candidate.status, /^(needs_review|suggested)$/);
+  assert.ok(["review_candidate", "draft_ready"].includes(candidate.tier));
+  assert.equal(typeof candidate.score, "number");
+  assert.equal(candidate.whyNow, manualCandidateInput.whyNow);
+  assert.equal(candidate.evidenceSummary, manualCandidateInput.evidenceSummary);
+  assert.equal(candidate.knownFacts.length, 2);
+  assert.equal(candidate.missingInfo.includes("Confirm preferred public role"), true);
+  assert.equal(candidate.doNotSay[0], "Do not imply private Discord identity");
+  assert.equal(candidate.publicSafetyNotes[0], "Use public facts only");
+  assert.ok(candidate.createdAt);
+  assert.ok(candidate.updatedAt);
+  assert.equal(candidate.primaryLink.url, manualCandidateInput.primaryLink.url);
+
+  const getResponse = await authedGet();
+  const getPayload = await getResponse.json();
+  assert.equal(getPayload.candidates.length, 1);
+  assert.equal(getPayload.candidates[0].id, candidate.id);
+  assert.equal(getPayload.drafts.length, 0);
+
+  assert.equal(JSON.stringify(databasePage.entries), databaseEntriesBefore);
+  assert.equal(databasePage.entries.flatMap((entry) => entry.tags).length, tagCountBefore);
+});
+
+test("denyCandidate updates status and keeps the candidate record", async () => {
+  await resetWorkflowStore();
+  const createPayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  const denyResponse = await authedPost({ action: "denyCandidate", candidateId: createPayload.candidate.id });
+  assert.equal(denyResponse.status, 200);
+  const denyPayload = await denyResponse.json();
+  assert.equal(denyPayload.candidate.status, "denied");
+  assert.equal(denyPayload.candidates.length, 1);
+  assert.equal(denyPayload.candidates[0].id, createPayload.candidate.id);
+});
+
+test("markNeedsMoreEvidence updates status", async () => {
+  await resetWorkflowStore();
+  const createPayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  const updateResponse = await authedPost({ action: "markNeedsMoreEvidence", candidateId: createPayload.candidate.id });
+  assert.equal(updateResponse.status, 200);
+  const updatePayload = await updateResponse.json();
+  assert.equal(updatePayload.candidate.status, "needs_more_evidence");
+});
+
+test("future actions stay placeholder-only and missing candidates return 404", async () => {
+  await resetWorkflowStore();
+  const draftResponse = await authedPost({ action: "requestDraft", candidateId: "candidate-test" });
+  assert.equal(draftResponse.status, 501);
+  const draftPayload = await draftResponse.json();
+  assert.equal(draftPayload.code, "not_implemented_yet");
+
+  const missingResponse = await authedPost({ action: "denyCandidate", candidateId: "missing" });
+  assert.equal(missingResponse.status, 404);
+});
+
+test("manual candidate workflow does not publish to database, read model dossiers, or tag registry", async () => {
+  await resetWorkflowStore();
+  const publicDossierIdsBefore = databasePage.entries.map((entry) => entry.id).join("|");
+  const tagNamesBefore = new Set(databasePage.entries.flatMap((entry) => entry.tags));
+  const readModelBefore = await (await readModel.GET()).json();
+  const publicReadModelNamesBefore = readModelBefore.sections.dossiers.items.map((entry) => entry.name).join("|");
+
+  const createPayload = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Workflow Only Candidate Zed" } })).json();
+  await authedPost({ action: "denyCandidate", candidateId: createPayload.candidate.id });
+
+  assert.equal(databasePage.entries.map((entry) => entry.id).join("|"), publicDossierIdsBefore);
+  assert.deepEqual(new Set(databasePage.entries.flatMap((entry) => entry.tags)), tagNamesBefore);
+
+  const readModelAfter = await (await readModel.GET()).json();
+  assert.equal(readModelAfter.sections.dossiers.items.map((entry) => entry.name).join("|"), publicReadModelNamesBefore);
+  assert.equal(readModelAfter.sections.dossiers.items.some((entry) => entry.name === "Workflow Only Candidate Zed"), false);
+});
+
+test("duplicate awareness marks candidates matching existing database entries", async () => {
+  await resetWorkflowStore();
+  const response = await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: databasePage.entries[0].name,
+      reason: "Operator wants to verify duplicate handling.",
+    },
+  });
+  assert.equal(response.status, 200);
   const payload = await response.json();
-  assert.equal(payload.code, "not_implemented_yet");
-  assert.match(payload.message, /intentionally disabled/);
-  assert.equal(source("src/content.ts"), contentBefore);
+  assert.equal(payload.candidate.duplicateRisk, "high");
+  assert.equal(payload.candidate.existingDossierMatch.id, databasePage.entries[0].id);
+  assert.equal(payload.candidate.existingDossierMatch.name, databasePage.entries[0].name);
+  assert.ok(payload.candidate.missingInfo.some((item) => /Duplicate review required/.test(item)));
+  assert.ok(payload.candidate.publicSafetyNotes.some((item) => /Duplicate review required/.test(item)));
 });

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -58,6 +58,7 @@ async function adminCookie() {
 async function resetWorkflowStore() {
   await store.saveDossierWorkflowState({
     version: 1,
+    revision: 0,
     candidates: [],
     drafts: [],
     updatedAt: new Date(0).toISOString(),
@@ -159,6 +160,14 @@ test("dossier workflow types include manual input and scoring policy contracts",
   assert.match(workflowSource, /knownFacts\?: string\[\]/);
   assert.match(workflowSource, /recommendedOrigin\?: DossierOrigin/);
   assert.match(workflowSource, /primaryLink\?: DossierWorkflowLink/);
+
+  const storeSource = source("src/lib/dossier-workflow-store.ts");
+  assert.match(storeSource, /revision: number/);
+  assert.match(storeSource, /DOSSIER_WORKFLOW_LOCK_KEY/);
+  assert.match(storeSource, /MAX_UPDATE_ATTEMPTS/);
+  assert.match(storeSource, /memoryWriteQueue/);
+  assert.match(storeSource, /updateDossierWorkflowState/);
+
   assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.gate, "Loose intake, strict drafting/publishing.");
   assert.equal(workflow.DOSSIER_CANDIDATE_SCORING_POLICY.thresholds.reviewCandidateMin, 50);
 });
@@ -185,6 +194,7 @@ test("authenticated GET returns workflow store, metadata, authoring guide, tag r
   assert.equal(payload.workflow.status, "candidate_store_enabled");
   assert.equal(payload.workflow.storage, "memory_fallback");
   assert.equal(payload.workflow.storageKey, "barcode:dossier-workflow:v1");
+  assert.equal(payload.workflow.revision, 0);
   assert.ok(payload.workflow.allowedActions.includes("requestDraft"));
   assert.equal(payload.workflow.scoringPolicy.gate, "Loose intake, strict drafting/publishing.");
   assert.equal(payload.workflow.scoringPolicy.thresholds.draftReadyMin, 70);
@@ -229,6 +239,61 @@ test("authenticated POST creates and persists a manual candidate without publish
 
   assert.equal(JSON.stringify(databasePage.entries), databaseEntriesBefore);
   assert.equal(databasePage.entries.flatMap((entry) => entry.tags).length, tagCountBefore);
+});
+
+test("concurrent manual candidate creation preserves both candidates and increments revision", async () => {
+  await resetWorkflowStore();
+
+  const [firstResponse, secondResponse] = await Promise.all([
+    authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Concurrent Candidate One" } }),
+    authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Concurrent Candidate Two" } }),
+  ]);
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+
+  const payload = await (await authedGet()).json();
+  const names = payload.candidates.map((candidate) => candidate.name).sort();
+  assert.deepEqual(names, ["Concurrent Candidate One", "Concurrent Candidate Two"]);
+  assert.equal(payload.workflow.revision, 2);
+});
+
+test("concurrent status updates preserve unrelated candidates", async () => {
+  await resetWorkflowStore();
+
+  const firstCreate = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Concurrent Status One" } })).json();
+  const secondCreate = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Concurrent Status Two" } })).json();
+
+  const [denyResponse, needsEvidenceResponse] = await Promise.all([
+    authedPost({ action: "denyCandidate", candidateId: firstCreate.candidate.id }),
+    authedPost({ action: "markNeedsMoreEvidence", candidateId: secondCreate.candidate.id }),
+  ]);
+
+  assert.equal(denyResponse.status, 200);
+  assert.equal(needsEvidenceResponse.status, 200);
+
+  const payload = await (await authedGet()).json();
+  const firstCandidate = payload.candidates.find((candidate) => candidate.id === firstCreate.candidate.id);
+  const secondCandidate = payload.candidates.find((candidate) => candidate.id === secondCreate.candidate.id);
+  assert.equal(payload.candidates.length, 2);
+  assert.equal(firstCandidate.status, "denied");
+  assert.equal(secondCandidate.status, "needs_more_evidence");
+  assert.equal(payload.workflow.revision, 4);
+});
+
+test("workflow revision increments on candidate writes but not missing-candidate no-ops", async () => {
+  await resetWorkflowStore();
+  assert.equal((await store.getDossierWorkflowState()).revision, 0);
+
+  const createPayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  assert.equal((await store.getDossierWorkflowState()).revision, 1);
+
+  await authedPost({ action: "denyCandidate", candidateId: createPayload.candidate.id });
+  assert.equal((await store.getDossierWorkflowState()).revision, 2);
+
+  const missingResponse = await authedPost({ action: "denyCandidate", candidateId: "missing" });
+  assert.equal(missingResponse.status, 404);
+  assert.equal((await store.getDossierWorkflowState()).revision, 2);
 });
 
 test("denyCandidate updates status and keeps the candidate record", async () => {


### PR DESCRIPTION
### Motivation

- The Dossier Control Center was a UI/contract-only foundation and lacked persistent candidate storage and a manual intake workflow for operators.
- Before drafting or BNL recommendations can be used, admins need a controlled, admin-only candidate store with manual creation, review, and simple status transitions that do not publish site content.

### Description

- Persisted workflow state: added `src/lib/dossier-workflow-store.ts` (new) which implements a versioned state `{ version: 1, candidates, drafts, updatedAt }`, prefers Upstash Redis under key `barcode:dossier-workflow:v1`, and provides an explicit in-memory fallback when Redis is not configured.
- Manual intake contracts and scoring: extended `src/lib/dossier-workflow.ts` with `CreateManualDossierCandidateInput`, `scoreManualDossierCandidate` (conservative guidance using existing thresholds), and added candidate fields (knownFacts, recommendedStatus/origin, primaryLink, etc.) to preserve evidence/missing-info/do-not-say/public-safety notes without publishing.
- API mutations and payloads: updated `src/app/api/admin/dossiers/route.ts` to return stored candidates/drafts and workflow metadata on authenticated GET, and to implement authenticated POST actions `createManualCandidate`, `denyCandidate`, and `markNeedsMoreEvidence`, while leaving draft/approve/publish actions `not_implemented_yet`.
- Admin UI: updated `src/app/admin/dossiers/page.tsx` to include a compact Manual Candidate Intake form, candidate queue list, candidate selection/evidence panel, Deny and Needs More Evidence controls, and a disabled Focused BNL Assistant placeholder; the UI calls the admin API and does not call BNL or mutate public content.
- Duplicate awareness and privacy boundaries: `createManualDossierCandidate` compares normalized names against `databasePage.entries`, sets `duplicateRisk` and `existingDossierMatch` for exact/near matches, and adds missing-info/public-safety notes; the implementation explicitly avoids writing `src/content.ts`, publishing to `/database`, creating tags, or invoking BNL.
- Tests and scaffolding: added/updated `tests/admin-dossiers.test.mjs` to cover auth, GET shape, create/persist, status updates, placeholder actions, no-public-publish guarantees, and duplicate awareness.

Files changed

- Added: `src/lib/dossier-workflow-store.ts` (new workflow store and helpers).
- Modified: `src/lib/dossier-workflow.ts` (new input type, scoring helper, extra candidate fields).
- Modified: `src/app/api/admin/dossiers/route.ts` (GET returns stored state; POST implements create/deny/needs_more_evidence).
- Modified: `src/app/admin/dossiers/page.tsx` (manual intake UI, candidate list, controls, placeholders).
- Modified: `tests/admin-dossiers.test.mjs` (new/expanded tests and in-memory store reset logic).

Manual notes (intentionally placeholder-only)

- BNL invocation, AI drafting, automatic tag/dossier creation, publishing, GitHub automation, public submission forms, broadcast-memory writes, Discord identity merging, payment/customer features, and bot repo changes remain intentionally not implemented.

### Testing

- Type-check: ran `npx tsc --noEmit` and it passed.
- Lint: ran `npx eslint` on `src/app/admin/dossiers/page.tsx`, `src/app/api/admin/dossiers/route.ts`, `src/lib/dossier-workflow.ts`, and `src/lib/dossier-workflow-store.ts` and it passed.
- Unit/integration tests: ran `node --test tests/admin-dossiers.test.mjs` and all tests passed.
- Queue/read-model tests: ran `npm run test:queue` (runs `tests/queue-playback.test.mjs` and `tests/bnl-read-model.test.mjs`) and all tests passed.

All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f10fdc248321ae62189cde83823d)