### PR TITLE
Dossier Draft Workspace + Owner Review Queue (v1)

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -20,6 +20,12 @@ type WorkflowPayload = {
     updatedAt?: string;
     boundaries: string[];
     scoringPolicy?: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
+    ownerGate?: { message: string; requiresOwnerSecretFuture: boolean; approvalPublishes: boolean };
+  };
+  ownerReviewQueue?: {
+    waitingCount: number;
+    draftCount: number;
+    candidateCount: number;
   };
   authoringGuide?: {
     version: string;
@@ -28,6 +34,23 @@ type WorkflowPayload = {
     totalUniqueTags: number;
     totalTagAssignments: number;
   };
+};
+
+type DraftForm = {
+  name: string;
+  category: string;
+  status: string;
+  clearance: string;
+  role: string;
+  origin: string;
+  summary: string;
+  notes: string;
+  tags: string;
+  proposedTags: string;
+  primaryLinkLabel: string;
+  primaryLinkUrl: string;
+  primaryLinkType: string;
+  selectedBy: "operator" | "subject" | "legacy";
 };
 
 type ManualCandidateForm = {
@@ -50,6 +73,23 @@ type ManualCandidateForm = {
   primaryLinkUrl: string;
   primaryLinkType: string;
   selectedBy: "operator" | "subject";
+};
+
+const emptyDraftForm: DraftForm = {
+  name: "",
+  category: "",
+  status: "",
+  clearance: "",
+  role: "",
+  origin: "",
+  summary: "",
+  notes: "",
+  tags: "",
+  proposedTags: "",
+  primaryLinkLabel: "",
+  primaryLinkUrl: "",
+  primaryLinkType: "website",
+  selectedBy: "operator",
 };
 
 const emptyManualCandidateForm: ManualCandidateForm = {
@@ -89,8 +129,9 @@ const reviewActions = [
   "Try Again: Wrong Tags",
   "Rewrite Summary Only",
   "Rewrite Notes Only",
-  "Approve Draft",
-  "Edit Draft",
+  "Owner Approve Draft",
+  "Owner Request Changes",
+  "Owner Deny Draft",
 ];
 
 const focusedAssistantPrompts = [
@@ -127,12 +168,34 @@ function textInputClass() {
   return "w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground";
 }
 
+function draftFormFromDraft(draft: DossierDraft | null): DraftForm {
+  if (!draft) return emptyDraftForm;
+  return {
+    name: draft.fields.name ?? "",
+    category: draft.fields.category ?? "",
+    status: draft.fields.status ?? "",
+    clearance: draft.fields.clearance ?? "",
+    role: draft.fields.role ?? "",
+    origin: draft.fields.origin ?? "",
+    summary: draft.fields.summary ?? "",
+    notes: draft.fields.notes ?? "",
+    tags: (draft.fields.tags ?? []).join("\n"),
+    proposedTags: (draft.fields.proposedTags ?? []).join("\n"),
+    primaryLinkLabel: draft.fields.primaryLink?.label ?? "",
+    primaryLinkUrl: draft.fields.primaryLink?.url ?? "",
+    primaryLinkType: draft.fields.primaryLink?.type ?? "website",
+    selectedBy: draft.fields.primaryLink?.selectedBy ?? "operator",
+  };
+}
+
 export default function AdminDossiersPage() {
   const [payload, setPayload] = useState<WorkflowPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState<ManualCandidateForm>(emptyManualCandidateForm);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+  const [selectedDraftId, setSelectedDraftId] = useState<string | null>(null);
+  const [draftForm, setDraftForm] = useState<DraftForm>(emptyDraftForm);
   const [saving, setSaving] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -145,6 +208,11 @@ export default function AdminDossiersPage() {
       const data = (await response.json()) as WorkflowPayload;
       setPayload(data);
       setSelectedCandidateId((current) => current && data.candidates.some((candidate) => candidate.id === current) ? current : data.candidates[0]?.id ?? null);
+      setSelectedDraftId((current) => {
+        const nextDraft = current && data.drafts.some((draft) => draft.id === current) ? data.drafts.find((draft) => draft.id === current) ?? null : data.drafts[0] ?? null;
+        setDraftForm(draftFormFromDraft(nextDraft));
+        return nextDraft?.id ?? null;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load dossier workflow.");
     } finally {
@@ -160,10 +228,13 @@ export default function AdminDossiersPage() {
   }, []);
 
   const candidates = useMemo(() => payload?.candidates ?? [], [payload?.candidates]);
-  const drafts = payload?.drafts ?? [];
+  const drafts = useMemo(() => payload?.drafts ?? [], [payload?.drafts]);
   const boundaries = payload?.workflow.boundaries ?? [];
   const scoringPolicy = payload?.workflow.scoringPolicy ?? DOSSIER_CANDIDATE_SCORING_POLICY;
   const selectedCandidate = useMemo(() => candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0] ?? null, [candidates, selectedCandidateId]);
+  const selectedDraft = useMemo(() => drafts.find((draft) => draft.id === selectedDraftId) ?? drafts.find((draft) => draft.candidateId === selectedCandidate?.id) ?? drafts[0] ?? null, [drafts, selectedCandidate?.id, selectedDraftId]);
+  const selectedDraftCandidate = selectedDraft ? candidates.find((candidate) => candidate.id === selectedDraft.candidateId) ?? null : null;
+  const ownerReviewDrafts = drafts.filter((draft) => draft.status === "ready_for_owner_review");
   const selectedEvidence = selectedCandidate?.evidenceItems ?? [];
 
   async function postWorkflow(body: Record<string, unknown>) {
@@ -175,15 +246,26 @@ export default function AdminDossiersPage() {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       });
-      const data = await response.json().catch(() => ({})) as Partial<WorkflowPayload> & { candidate?: DossierCandidate; error?: string; message?: string };
-      if (!response.ok) throw new Error(data.error ?? data.message ?? `Workflow API returned ${response.status}.`);
+      const data = await response.json().catch(() => ({})) as Partial<WorkflowPayload> & { candidate?: DossierCandidate; draft?: DossierDraft; error?: string; message?: string; missingFields?: string[] };
+      if (!response.ok) {
+        const missing = data.missingFields?.length ? ` Missing fields: ${data.missingFields.join(", ")}.` : "";
+        throw new Error(`${data.error ?? data.message ?? `Workflow API returned ${response.status}.`}${missing}`);
+      }
       if (data.candidates && data.drafts && data.workflow) setPayload(data as WorkflowPayload);
       if (data.candidate) setSelectedCandidateId(data.candidate.id);
+      if (data.draft) {
+        setSelectedDraftId(data.draft.id);
+        setSelectedCandidateId(data.draft.candidateId);
+        setDraftForm(draftFormFromDraft(data.draft));
+      }
       return data;
     } finally {
       setSaving(false);
     }
   }
+
+
+
 
   async function submitManualCandidate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -220,6 +302,69 @@ export default function AdminDossiersPage() {
       setNotice(`Manual candidate created: ${data.candidate?.name ?? "candidate"}. No public dossier or tag was created.`);
     } catch (err) {
       setNotice(err instanceof Error ? err.message : "Failed to create manual candidate.");
+    }
+  }
+
+
+
+  async function createOrOpenDraft(candidateId: string) {
+    const existingDraft = drafts.find((draft) => draft.candidateId === candidateId && draft.status !== "denied" && draft.status !== "published");
+    if (existingDraft) {
+      setSelectedCandidateId(candidateId);
+      setSelectedDraftId(existingDraft.id);
+      setDraftForm(draftFormFromDraft(existingDraft));
+      setNotice(`Opened existing draft for ${existingDraft.fields.name || "candidate"}.`);
+      return;
+    }
+
+    try {
+      const data = await postWorkflow({ action: "createDraftFromCandidate", candidateId });
+      setNotice(`Draft created: ${data.draft?.fields.name ?? "draft"}. Saving this draft does not publish anything.`);
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to create draft.");
+    }
+  }
+
+  function draftFieldsFromForm(): DossierDraft["fields"] {
+    return {
+      name: draftForm.name,
+      category: draftForm.category ? draftForm.category as DossierDraft["fields"]["category"] : undefined,
+      status: draftForm.status ? draftForm.status as DossierDraft["fields"]["status"] : undefined,
+      clearance: draftForm.clearance ? draftForm.clearance as DossierDraft["fields"]["clearance"] : undefined,
+      role: draftForm.role,
+      origin: draftForm.origin ? draftForm.origin as DossierDraft["fields"]["origin"] : undefined,
+      summary: draftForm.summary,
+      notes: draftForm.notes,
+      tags: lines(draftForm.tags),
+      proposedTags: lines(draftForm.proposedTags),
+      primaryLink: draftForm.primaryLinkUrl.trim() ? {
+        label: draftForm.primaryLinkLabel.trim() || "Featured link",
+        url: draftForm.primaryLinkUrl.trim(),
+        type: draftForm.primaryLinkType.trim() || "website",
+        selectedBy: draftForm.selectedBy,
+        publicSafe: true,
+      } : undefined,
+      files: [],
+    };
+  }
+
+  async function saveSelectedDraft() {
+    if (!selectedDraft) return;
+    try {
+      const data = await postWorkflow({ action: "saveDraft", draftId: selectedDraft.id, fields: draftFieldsFromForm() });
+      setNotice(`Draft saved: ${data.draft?.fields.name ?? "draft"}. Saving this draft does not publish anything.`);
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to save draft.");
+    }
+  }
+
+  async function submitSelectedDraftForOwnerReview() {
+    if (!selectedDraft) return;
+    try {
+      const data = await postWorkflow({ action: "submitDraftForOwnerReview", draftId: selectedDraft.id });
+      setNotice(`Draft submitted for owner review: ${data.draft?.fields.name ?? "draft"}. Submitting for owner review does not publish anything.`);
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to submit draft for owner review.");
     }
   }
 
@@ -346,7 +491,7 @@ export default function AdminDossiersPage() {
                     <td className="px-3 py-3">{candidate.duplicateRisk ?? "unknown"}</td>
                     <td className="px-3 py-3">{candidate.status}</td>
                     <td className="px-3 py-3">{candidate.updatedAt}</td>
-                    <td className="px-3 py-3"><div className="flex flex-wrap gap-2"><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "denyCandidate")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Deny</button><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "markNeedsMoreEvidence")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Needs More Evidence</button><button disabled className="border border-border px-2 py-1 text-muted opacity-50">Draft placeholder</button></div></td>
+                    <td className="px-3 py-3"><div className="flex flex-wrap gap-2"><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "denyCandidate")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Deny</button><button disabled={saving} onClick={() => updateCandidateStatus(candidate.id, "markNeedsMoreEvidence")} className="border border-border px-2 py-1 text-muted hover:border-accent hover:text-accent disabled:opacity-50">Needs More Evidence</button><button disabled={saving} onClick={() => createOrOpenDraft(candidate.id)} className="border border-accent px-2 py-1 text-accent hover:bg-accent hover:text-background disabled:opacity-50">{drafts.some((draft) => draft.candidateId === candidate.id && draft.status !== "denied" && draft.status !== "published") ? "Open Draft" : "Create Draft"}</button></div></td>
                   </tr>
                 ))}
               </tbody>
@@ -417,20 +562,56 @@ export default function AdminDossiersPage() {
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Draft Workspace</p>
               <h2 className="text-2xl font-bold text-foreground">Draft Workspace</h2>
-              <p className="text-sm text-muted mt-2">No draft selected. BNL drafting stays placeholder-only in this PR.</p>
+              <p className="text-sm text-muted mt-2">Manual draft only — BNL generation comes later. Saving this draft does not publish anything. Submitting for owner review does not publish anything.</p>
             </div>
-            <div className="border border-border bg-background/30 p-4 text-sm text-muted">
-              <p className="text-xs uppercase tracking-widest text-accent mb-2">Selected Candidate</p>
-              <p>{selectedCandidate ? `${selectedCandidate.name} is selected for review only. Draft actions are disabled.` : "No selected candidate."}</p>
-            </div>
-            <p className="text-xs text-muted">Draft records are workflow records only. Approved drafts do not become website entries until a future operator-controlled site update.</p>
+            {!selectedDraft ? (
+              <div className="border border-border bg-background/30 p-4 text-sm text-muted">
+                <p className="text-xs uppercase tracking-widest text-accent mb-2">No Draft Selected</p>
+                <p>{selectedCandidate ? `${selectedCandidate.name} is selected. Use Create Draft in the Candidate Queue to start a manual workflow draft.` : "No selected candidate."}</p>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="border border-border bg-background/30 p-4 text-xs text-muted space-y-2">
+                  <p className="uppercase tracking-widest text-accent">Selected Draft</p>
+                  <p><span className="text-foreground">Draft:</span> {selectedDraft.fields.name || selectedDraft.id}</p>
+                  <p><span className="text-foreground">Status:</span> {selectedDraft.status}</p>
+                  <p><span className="text-foreground">Linked candidate:</span> {selectedDraftCandidate ? `${selectedDraftCandidate.name} (${selectedDraftCandidate.id})` : selectedDraft.candidateId}</p>
+                  <p>Owner approval will require owner secret in a future PR. Owner approval is separate from editor save/submit and still will not publish until publishing workflow exists.</p>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs uppercase tracking-widest text-muted">
+                  <label className="space-y-2"><span>Name</span><input value={draftForm.name} onChange={(event) => setDraftForm({ ...draftForm, name: event.target.value })} className={textInputClass()} /></label>
+                  <label className="space-y-2"><span>Role</span><input value={draftForm.role} onChange={(event) => setDraftForm({ ...draftForm, role: event.target.value })} className={textInputClass()} /></label>
+                  <label className="space-y-2"><span>Category</span><select value={draftForm.category} onChange={(event) => setDraftForm({ ...draftForm, category: event.target.value })} className={textInputClass()}>{categoryOptions.map((option) => <option key={option} value={option}>{option || "Select category"}</option>)}</select></label>
+                  <label className="space-y-2"><span>Status</span><select value={draftForm.status} onChange={(event) => setDraftForm({ ...draftForm, status: event.target.value })} className={textInputClass()}>{statusOptions.map((option) => <option key={option} value={option}>{option || "Select status"}</option>)}</select></label>
+                  <label className="space-y-2"><span>Clearance</span><select value={draftForm.clearance} onChange={(event) => setDraftForm({ ...draftForm, clearance: event.target.value })} className={textInputClass()}>{clearanceOptions.map((option) => <option key={option} value={option}>{option || "Select clearance"}</option>)}</select></label>
+                  <label className="space-y-2"><span>Origin</span><select value={draftForm.origin} onChange={(event) => setDraftForm({ ...draftForm, origin: event.target.value })} className={textInputClass()}>{originOptions.map((option) => <option key={option} value={option}>{option || "Select origin"}</option>)}</select></label>
+                  <label className="md:col-span-2 space-y-2"><span>Summary</span><textarea value={draftForm.summary} onChange={(event) => setDraftForm({ ...draftForm, summary: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+                  <label className="md:col-span-2 space-y-2"><span>Notes</span><textarea value={draftForm.notes} onChange={(event) => setDraftForm({ ...draftForm, notes: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+                  <label className="space-y-2"><span>Tags, one per line</span><textarea value={draftForm.tags} onChange={(event) => setDraftForm({ ...draftForm, tags: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+                  <label className="space-y-2"><span>Proposed tags, one per line</span><textarea value={draftForm.proposedTags} onChange={(event) => setDraftForm({ ...draftForm, proposedTags: event.target.value })} className={`${textInputClass()} min-h-28`} /></label>
+                  <label className="space-y-2"><span>Primary link label</span><input value={draftForm.primaryLinkLabel} onChange={(event) => setDraftForm({ ...draftForm, primaryLinkLabel: event.target.value })} className={textInputClass()} /></label>
+                  <label className="space-y-2"><span>Primary link URL</span><input value={draftForm.primaryLinkUrl} onChange={(event) => setDraftForm({ ...draftForm, primaryLinkUrl: event.target.value })} className={textInputClass()} /></label>
+                  <label className="space-y-2"><span>Primary link type</span><input value={draftForm.primaryLinkType} onChange={(event) => setDraftForm({ ...draftForm, primaryLinkType: event.target.value })} className={textInputClass()} /></label>
+                  <label className="space-y-2"><span>selectedBy</span><select value={draftForm.selectedBy} onChange={(event) => setDraftForm({ ...draftForm, selectedBy: event.target.value as DraftForm["selectedBy"] })} className={textInputClass()}><option value="operator">operator</option><option value="subject">subject</option><option value="legacy">legacy</option></select></label>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-muted">
+                  <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Known facts display from candidate</p>{listOrEmpty(selectedDraftCandidate?.knownFacts, "No known facts recorded on linked candidate.")}</div>
+                  <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Do-not-say display from candidate</p>{listOrEmpty(selectedDraftCandidate?.doNotSay, "No do-not-say notes recorded on linked candidate.")}</div>
+                  <div className="border border-border bg-background/30 p-3"><p className="uppercase tracking-widest text-accent mb-2">Public safety notes display from candidate</p>{listOrEmpty(selectedDraftCandidate?.publicSafetyNotes, "No public-safety notes recorded on linked candidate.")}</div>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <button type="button" disabled={saving} onClick={saveSelectedDraft} className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50">Save Draft</button>
+                  <button type="button" disabled={saving} onClick={submitSelectedDraftForOwnerReview} className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50">Submit for Owner Review</button>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="lg:col-span-2 border border-border bg-surface p-6 space-y-5">
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Review Actions</p>
               <h2 className="text-2xl font-bold text-foreground">Review Actions</h2>
-              <p className="text-sm text-muted mt-2">Deny and Needs More Evidence are enabled from the Candidate Queue. Draft actions remain not_implemented_yet.</p>
+              <p className="text-sm text-muted mt-2">Owner approval actions are disabled placeholders. Owner approval will require owner secret in a future PR and will not publish until publishing exists.</p>
             </div>
             <div className="grid grid-cols-1 gap-3">
               {reviewActions.map((label) => (
@@ -444,6 +625,38 @@ export default function AdminDossiersPage() {
               <p>{DOSSIER_WORKFLOW_ACTIONS.join(", ")}</p>
               <p>Current drafts loaded: {drafts.length}. Mutations do not publish or mutate real dossier content.</p>
             </div>
+          </div>
+        </section>
+
+        <section className="border border-border bg-surface p-6 space-y-5">
+          <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">Owner Review Queue</p>
+              <h2 className="text-2xl font-bold text-foreground">Owner Review Queue</h2>
+              <p className="text-sm text-muted mt-2">Drafts waiting for owner review appear here. Owner approval is separate from editor save/submit and remains placeholder-only.</p>
+            </div>
+            <p className="text-xs uppercase tracking-widest text-muted">{payload.ownerReviewQueue?.waitingCount ?? ownerReviewDrafts.length} waiting / {payload.ownerReviewQueue?.draftCount ?? drafts.length} drafts / {payload.ownerReviewQueue?.candidateCount ?? candidates.length} candidates</p>
+          </div>
+          <div className="grid grid-cols-1 gap-3 text-xs text-muted">
+            {ownerReviewDrafts.length === 0 ? (
+              <p className="border border-border bg-background/30 p-4">No drafts are ready_for_owner_review yet.</p>
+            ) : ownerReviewDrafts.map((draft) => {
+              const candidate = candidates.find((item) => item.id === draft.candidateId);
+              return (
+                <div key={draft.id} className="border border-border bg-background/30 p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                  <div>
+                    <p className="text-foreground">{draft.fields.name || draft.id}</p>
+                    <p>Linked candidate: {candidate ? `${candidate.name} (${candidate.id})` : draft.candidateId}</p>
+                    <p>Updated: {draft.updatedAt}</p>
+                    <p>Status: {draft.status}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button type="button" onClick={() => { setSelectedDraftId(draft.id); setSelectedCandidateId(draft.candidateId); setDraftForm(draftFormFromDraft(draft)); }} className="border border-accent px-3 py-2 uppercase tracking-widest text-accent hover:bg-accent hover:text-background">Open</button>
+                    <button type="button" disabled className="border border-border px-3 py-2 uppercase tracking-widest text-muted opacity-60">Owner Approve — placeholder</button>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </section>
 

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -15,10 +15,14 @@ import {
   type DossierWorkflowAction,
 } from "@/lib/dossier-workflow";
 import {
+  createDraftFromCandidate,
   createManualDossierCandidate,
   getDossierWorkflowState,
   getDossierWorkflowStorageMode,
+  saveDossierDraft,
+  submitDraftForOwnerReview,
   updateDossierCandidateStatus,
+  validateDossierDraftFieldsForOwnerReview,
   type DossierWorkflowState,
 } from "@/lib/dossier-workflow-store";
 
@@ -41,6 +45,17 @@ type DossierWorkflowResponse = {
     scoringPolicy: typeof DOSSIER_CANDIDATE_SCORING_POLICY;
     candidateSourceBoundaries: typeof DOSSIER_SOURCE_BOUNDARIES;
     boundaries: string[];
+    ownerGate: {
+      status: "placeholder_only";
+      requiresOwnerSecretFuture: true;
+      approvalPublishes: false;
+      message: string;
+    };
+  };
+  ownerReviewQueue: {
+    waitingCount: number;
+    draftCount: number;
+    candidateCount: number;
   };
   authoringGuide: {
     version: typeof dossierAuthoringGuide.version;
@@ -56,6 +71,9 @@ type DossierWorkflowResponse = {
 
 const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "createManualCandidate",
+  "createDraftFromCandidate",
+  "saveDraft",
+  "submitDraftForOwnerReview",
   "denyCandidate",
   "markNeedsMoreEvidence",
 ]);
@@ -82,13 +100,32 @@ function candidateIdFromBody(body: Record<string, unknown>): string {
   return typeof body.candidateId === "string" ? body.candidateId.trim() : "";
 }
 
+function draftIdFromBody(body: Record<string, unknown>): string {
+  return typeof body.draftId === "string" ? body.draftId.trim() : "";
+}
+
+function draftFieldsFromBody(body: Record<string, unknown>): DossierDraft["fields"] | null {
+  const fields = body.fields ?? body.draftFields;
+  if (!fields || typeof fields !== "object") return null;
+  const draftFields = fields as DossierDraft["fields"];
+  if (typeof draftFields.name !== "string") return null;
+  return draftFields;
+}
+
 async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWorkflowResponse> {
   const tagRegistry = buildDossierTagRegistry(databasePage.entries);
   const workflowState = state ?? await getDossierWorkflowState();
 
+  const waitingForOwnerReview = workflowState.drafts.filter((draft) => draft.status === "ready_for_owner_review");
+
   return {
     candidates: workflowState.candidates,
     drafts: workflowState.drafts,
+    ownerReviewQueue: {
+      waitingCount: waitingForOwnerReview.length,
+      draftCount: workflowState.drafts.length,
+      candidateCount: workflowState.candidates.length,
+    },
     workflow: {
       version: 1,
       storage: getDossierWorkflowStorageMode(),
@@ -109,7 +146,14 @@ async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWor
         "This endpoint does not publish, create public records, or mutate src/content.ts.",
         "This endpoint does not invoke BNL, write memory, merge Discord identity, or use payment/customer identity.",
         "Queue frequency is evidence only, not identity.",
+        "Owner approval will require an owner secret in a future PR and still will not publish until a publishing workflow exists.",
       ],
+      ownerGate: {
+        status: "placeholder_only",
+        requiresOwnerSecretFuture: true,
+        approvalPublishes: false,
+        message: "Owner approval is separate from editor save/submit and remains disabled until a future owner-secret gate PR.",
+      },
     },
     authoringGuide: {
       version: dossierAuthoringGuide.version,
@@ -163,6 +207,71 @@ export async function POST(req: Request) {
     const candidate = await createManualDossierCandidate(input);
     const payload = await workflowPayload();
     return NextResponse.json({ ok: true, action, candidate, ...payload });
+  }
+
+  if (action === "createDraftFromCandidate") {
+    const candidateId = candidateIdFromBody(body);
+    if (!candidateId) {
+      return NextResponse.json({ error: "candidateId is required" }, { status: 400 });
+    }
+
+    const draft = await createDraftFromCandidate(candidateId);
+    if (!draft) {
+      return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+    }
+
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, draft, ...payload });
+  }
+
+  if (action === "saveDraft") {
+    const draftId = draftIdFromBody(body);
+    if (!draftId) {
+      return NextResponse.json({ error: "draftId is required" }, { status: 400 });
+    }
+
+    const fields = draftFieldsFromBody(body);
+    if (!fields) {
+      return NextResponse.json({ error: "Valid draft fields are required" }, { status: 400 });
+    }
+
+    const draft = await saveDossierDraft(draftId, fields);
+    if (!draft) {
+      return NextResponse.json({ error: "Draft not found or not editable" }, { status: 404 });
+    }
+
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, draft, ...payload });
+  }
+
+  if (action === "submitDraftForOwnerReview") {
+    const draftId = draftIdFromBody(body);
+    if (!draftId) {
+      return NextResponse.json({ error: "draftId is required" }, { status: 400 });
+    }
+
+    const currentState = await getDossierWorkflowState();
+    const currentDraft = currentState.drafts.find((draft) => draft.id === draftId);
+    if (!currentDraft) {
+      return NextResponse.json({ error: "Draft not found" }, { status: 404 });
+    }
+
+    const missingFields = validateDossierDraftFieldsForOwnerReview(currentDraft.fields);
+    if (missingFields.length > 0) {
+      return NextResponse.json({
+        error: "Draft is missing required fields for owner review",
+        code: "invalid_draft_fields",
+        missingFields,
+      }, { status: 400 });
+    }
+
+    const draft = await submitDraftForOwnerReview(draftId);
+    if (!draft) {
+      return NextResponse.json({ error: "Draft not found" }, { status: 404 });
+    }
+
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, draft, ...payload });
   }
 
   const candidateId = candidateIdFromBody(body);

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -7,6 +7,7 @@ import {
   type DossierCandidateStatus,
   type DossierDraft,
   type DossierDuplicateRisk,
+  type DossierWorkflowLink,
 } from "@/lib/dossier-workflow";
 
 export type DossierWorkflowState = {
@@ -47,6 +48,54 @@ function emptyWorkflowState(): DossierWorkflowState {
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean);
+}
+
+
+function normalizeWorkflowLink(value: unknown): DossierWorkflowLink | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const input = value as Partial<DossierWorkflowLink>;
+  if (typeof input.url !== "string" || !input.url.trim()) return undefined;
+  return {
+    label: typeof input.label === "string" && input.label.trim() ? input.label.trim() : "Featured link",
+    url: input.url.trim(),
+    type: typeof input.type === "string" && input.type.trim() ? input.type.trim() : "website",
+    selectedBy: input.selectedBy === "subject" || input.selectedBy === "legacy" ? input.selectedBy : "operator",
+    publicSafe: input.publicSafe !== false,
+  };
+}
+
+function normalizeDraftFields(fields: DossierDraft["fields"]): DossierDraft["fields"] {
+  const primaryLink = normalizeWorkflowLink(fields.primaryLink);
+  return {
+    id: typeof fields.id === "string" && fields.id.trim() ? fields.id.trim() : undefined,
+    name: typeof fields.name === "string" ? fields.name.trim() : "",
+    category: fields.category,
+    status: fields.status,
+    clearance: fields.clearance,
+    role: typeof fields.role === "string" ? fields.role.trim() : undefined,
+    origin: fields.origin,
+    summary: typeof fields.summary === "string" ? fields.summary.trim() : undefined,
+    notes: typeof fields.notes === "string" ? fields.notes.trim() : undefined,
+    tags: normalizeStringArray(fields.tags),
+    proposedTags: normalizeStringArray(fields.proposedTags),
+    primaryLink,
+    links: Array.isArray(fields.links) ? fields.links.map(normalizeWorkflowLink).filter((link): link is DossierWorkflowLink => Boolean(link)) : undefined,
+    files: [],
+  };
+}
+
+export function validateDossierDraftFieldsForOwnerReview(fields: DossierDraft["fields"]): string[] {
+  const normalized = normalizeDraftFields(fields);
+  const missing: string[] = [];
+  if (!normalized.name) missing.push("name");
+  if (!normalized.category) missing.push("category");
+  if (!normalized.status) missing.push("status");
+  if (!normalized.clearance) missing.push("clearance");
+  if (!normalized.origin) missing.push("origin");
+  if (!normalized.role) missing.push("role");
+  if (!normalized.summary) missing.push("summary");
+  if (!normalized.tags || normalized.tags.length === 0) missing.push("tags");
+  return missing;
 }
 
 function normalizeName(value: string): string {
@@ -119,6 +168,10 @@ function createCandidateId(): string {
 
 function createEvidenceId(): string {
   return `evidence_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createDraftId(): string {
+  return `dossier_draft_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export async function getDossierWorkflowState(): Promise<DossierWorkflowState> {
@@ -338,6 +391,116 @@ export async function updateDossierCandidateStatus(candidateId: string, status: 
   });
 
   return updatedCandidate;
+}
+
+export async function createDraftFromCandidate(candidateId: string): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let draft: DossierDraft | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const candidate = currentState.candidates.find((item) => item.id === candidateId);
+    if (!candidate) return currentState;
+
+    const existingDraft = currentState.drafts.find((item) => item.candidateId === candidateId && item.status !== "denied" && item.status !== "published");
+    if (existingDraft) {
+      draft = existingDraft;
+      return currentState;
+    }
+
+    const starterNotes = [
+      candidate.evidenceSummary ? `Starter evidence note: ${candidate.evidenceSummary}` : "",
+      ...(candidate.publicSafetyNotes ?? []).map((note) => `Public safety: ${note}`),
+      ...(candidate.missingInfo ?? []).map((note) => `Missing info: ${note}`),
+    ].filter(Boolean).join("\n");
+
+    draft = {
+      id: createDraftId(),
+      candidateId: candidate.id,
+      status: "draft",
+      fields: normalizeDraftFields({
+        name: candidate.name,
+        category: candidate.recommendedCategory,
+        status: candidate.recommendedStatus ?? "PENDING",
+        clearance: candidate.recommendedClearance ?? "PUBLIC",
+        origin: candidate.recommendedOrigin ?? "UNVERIFIED",
+        summary: candidate.evidenceSummary ? `Starter note only: ${candidate.evidenceSummary}` : "",
+        notes: starterNotes,
+        tags: candidate.recommendedTags ?? [],
+        proposedTags: candidate.proposedTags ?? [],
+        primaryLink: candidate.primaryLink,
+        files: [],
+      }),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return {
+      ...currentState,
+      drafts: [draft, ...currentState.drafts],
+      updatedAt: now,
+    };
+  });
+
+  return draft;
+}
+
+export async function saveDossierDraft(draftId: string, fields: DossierDraft["fields"]): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let updatedDraft: DossierDraft | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const drafts = currentState.drafts.map((draft) => {
+      if (draft.id !== draftId) return draft;
+      if (draft.status === "published") {
+        updatedDraft = null;
+        return draft;
+      }
+      updatedDraft = {
+        ...draft,
+        fields: normalizeDraftFields(fields),
+        updatedAt: now,
+      };
+      return updatedDraft;
+    });
+
+    if (!updatedDraft) return currentState;
+
+    return {
+      ...currentState,
+      drafts,
+      updatedAt: now,
+    };
+  });
+
+  return updatedDraft;
+}
+
+export async function submitDraftForOwnerReview(draftId: string): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let updatedDraft: DossierDraft | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const drafts = currentState.drafts.map((draft) => {
+      if (draft.id !== draftId) return draft;
+      if (validateDossierDraftFieldsForOwnerReview(draft.fields).length > 0) return draft;
+      updatedDraft = {
+        ...draft,
+        status: "ready_for_owner_review",
+        updatedAt: now,
+      };
+      return updatedDraft;
+    });
+
+    if (!updatedDraft) return currentState;
+
+    return {
+      ...currentState,
+      drafts,
+      updatedAt: now,
+    };
+  });
+
+  return updatedDraft;
 }
 
 export async function getDossierCandidate(candidateId: string): Promise<DossierCandidate | null> {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -55,8 +55,9 @@ export type DossierCandidateStatus =
 
 export type DossierDraftStatus =
   | "draft"
-  | "revision_requested"
-  | "approved"
+  | "ready_for_owner_review"
+  | "owner_changes_requested"
+  | "owner_approved"
   | "denied"
   | "published";
 
@@ -153,9 +154,16 @@ export type DossierWorkflowAction =
   | "createManualCandidate"
   | "selectCandidate"
   | "requestDraft"
+  | "createDraftFromCandidate"
+  | "saveDraft"
   | "saveDraftEdit"
+  | "submitDraftForOwnerReview"
   | "requestRevision"
   | "approveDraft"
+  | "ownerApproveDraft"
+  | "ownerRequestChanges"
+  | "ownerDenyDraft"
+  | "publishDraft"
   | "denyCandidate"
   | "markNeedsMoreEvidence";
 
@@ -170,9 +178,16 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "createManualCandidate",
   "selectCandidate",
   "requestDraft",
+  "createDraftFromCandidate",
+  "saveDraft",
   "saveDraftEdit",
+  "submitDraftForOwnerReview",
   "requestRevision",
   "approveDraft",
+  "ownerApproveDraft",
+  "ownerRequestChanges",
+  "ownerDenyDraft",
+  "publishDraft",
   "denyCandidate",
   "markNeedsMoreEvidence",
 ];

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -116,10 +116,10 @@ test("admin panel includes Dossier Control Center link", () => {
 
 test("admin dossier page gates workflow behind successful API payload and includes manual intake UI", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
-  for (const label of ["Dossier Control Center", "Manual Candidate Intake", "Candidate Queue", "Candidate Evidence", "Candidate Gate / Scoring", "Draft Readiness / Missing Info", "Draft Workspace", "Review Actions", "Focused BNL Assistant", "System Boundaries"]) {
+  for (const label of ["Dossier Control Center", "Manual Candidate Intake", "Candidate Queue", "Candidate Evidence", "Candidate Gate / Scoring", "Draft Readiness / Missing Info", "Draft Workspace", "Review Actions", "Owner Review Queue", "Focused BNL Assistant", "System Boundaries"]) {
     assert.match(page, new RegExp(label));
   }
-  for (const label of ["Known facts", "Missing info", "Do Not Say", "Public safety notes", "Deny", "Needs More Evidence", "Focused BNL Assistant", "Disabled placeholder only"]) {
+  for (const label of ["Known facts", "Missing info", "Do Not Say", "Public safety notes", "Deny", "Needs More Evidence", "Create Draft", "Save Draft", "Submit for Owner Review", "Manual draft only", "does not publish", "Focused BNL Assistant", "Disabled placeholder only"]) {
     assert.match(page, new RegExp(label));
   }
   assert.match(page, /\/api\/admin\/dossiers/);
@@ -131,7 +131,8 @@ test("admin dossier page gates workflow behind successful API payload and includ
   assert.match(page, /Duplicate Risk/);
   assert.match(page, /loose intake \/ strict publishing/i);
   assert.match(page, /Try Again: Too Long/);
-  assert.match(page, /Rewrite Summary Only/);
+  assert.match(page, /Owner Approve Draft/);
+  assert.match(page, /BNL generation comes later/);
 
   assert.doesNotMatch(page, /fetch\(\"\/api\/bnl/);
   assert.match(page, /if \(loading\)/);
@@ -196,6 +197,9 @@ test("authenticated GET returns workflow store, metadata, authoring guide, tag r
   assert.equal(payload.workflow.storageKey, "barcode:dossier-workflow:v1");
   assert.equal(payload.workflow.revision, 0);
   assert.ok(payload.workflow.allowedActions.includes("requestDraft"));
+  assert.ok(payload.workflow.allowedActions.includes("createDraftFromCandidate"));
+  assert.ok(payload.workflow.allowedActions.includes("saveDraft"));
+  assert.ok(payload.workflow.allowedActions.includes("submitDraftForOwnerReview"));
   assert.equal(payload.workflow.scoringPolicy.gate, "Loose intake, strict drafting/publishing.");
   assert.equal(payload.workflow.scoringPolicy.thresholds.draftReadyMin, 70);
   assert.ok(payload.workflow.candidateSourceBoundaries.some((entry) => entry.source === "queue_frequency"));
@@ -203,6 +207,11 @@ test("authenticated GET returns workflow store, metadata, authoring guide, tag r
   assert.ok(payload.authoringGuide.fieldCount > 0);
   assert.ok(payload.tagRegistry.totalUniqueTags > 0);
   assert.equal(payload.tagRegistry.creationPolicy.newTagsAllowed, "proposal_only");
+  assert.equal(payload.ownerReviewQueue.waitingCount, 0);
+  assert.equal(payload.ownerReviewQueue.draftCount, 0);
+  assert.equal(payload.ownerReviewQueue.candidateCount, 0);
+  assert.equal(payload.workflow.ownerGate.requiresOwnerSecretFuture, true);
+  assert.equal(payload.workflow.ownerGate.approvalPublishes, false);
 });
 
 test("authenticated POST creates and persists a manual candidate without publishing", async () => {
@@ -318,13 +327,113 @@ test("markNeedsMoreEvidence updates status", async () => {
 
 test("future actions stay placeholder-only and missing candidates return 404", async () => {
   await resetWorkflowStore();
-  const draftResponse = await authedPost({ action: "requestDraft", candidateId: "candidate-test" });
-  assert.equal(draftResponse.status, 501);
-  const draftPayload = await draftResponse.json();
-  assert.equal(draftPayload.code, "not_implemented_yet");
+  for (const action of ["requestDraft", "requestRevision", "ownerApproveDraft", "ownerRequestChanges", "ownerDenyDraft", "publishDraft"]) {
+    const response = await authedPost({ action, candidateId: "candidate-test", draftId: "draft-test" });
+    assert.equal(response.status, 501, `${action} should stay placeholder-only`);
+    const payload = await response.json();
+    assert.equal(payload.code, "not_implemented_yet");
+  }
 
   const missingResponse = await authedPost({ action: "denyCandidate", candidateId: "missing" });
   assert.equal(missingResponse.status, 404);
+});
+
+
+
+test("createDraftFromCandidate creates one workflow draft from candidate recommendations", async () => {
+  await resetWorkflowStore();
+  const createCandidatePayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+
+  const response = await authedPost({ action: "createDraftFromCandidate", candidateId: createCandidatePayload.candidate.id });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  const draft = payload.draft;
+
+  assert.ok(draft.id);
+  assert.equal(draft.candidateId, createCandidatePayload.candidate.id);
+  assert.equal(draft.status, "draft");
+  assert.equal(draft.fields.name, manualCandidateInput.name);
+  assert.equal(draft.fields.category, manualCandidateInput.recommendedCategory);
+  assert.equal(draft.fields.status, manualCandidateInput.recommendedStatus);
+  assert.equal(draft.fields.clearance, manualCandidateInput.recommendedClearance);
+  assert.equal(draft.fields.origin, manualCandidateInput.recommendedOrigin);
+  assert.deepEqual(draft.fields.tags, manualCandidateInput.recommendedTags);
+  assert.deepEqual(draft.fields.proposedTags, manualCandidateInput.proposedTags);
+  assert.equal(draft.fields.primaryLink.url, manualCandidateInput.primaryLink.url);
+  assert.equal(payload.candidates[0].id, createCandidatePayload.candidate.id);
+  assert.notEqual(payload.candidates[0].status, "published");
+  assert.equal(payload.drafts.length, 1);
+});
+
+test("createDraftFromCandidate returns existing active draft without duplicating", async () => {
+  await resetWorkflowStore();
+  const createCandidatePayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  const firstPayload = await (await authedPost({ action: "createDraftFromCandidate", candidateId: createCandidatePayload.candidate.id })).json();
+  const secondResponse = await authedPost({ action: "createDraftFromCandidate", candidateId: createCandidatePayload.candidate.id });
+  assert.equal(secondResponse.status, 200);
+  const secondPayload = await secondResponse.json();
+  assert.equal(secondPayload.draft.id, firstPayload.draft.id);
+  assert.equal(secondPayload.drafts.length, 1);
+});
+
+test("saveDraft updates draft fields, persists through GET, and does not mutate public content", async () => {
+  await resetWorkflowStore();
+  const databaseEntriesBefore = JSON.stringify(databasePage.entries);
+  const readModelBefore = await (await readModel.GET()).json();
+  const readModelNamesBefore = readModelBefore.sections.dossiers.items.map((entry) => entry.name).join("|");
+  const createCandidatePayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  const createDraftPayload = await (await authedPost({ action: "createDraftFromCandidate", candidateId: createCandidatePayload.candidate.id })).json();
+
+  const fields = {
+    ...createDraftPayload.draft.fields,
+    name: "Manual Candidate Alpha Draft",
+    role: "Public artist profile",
+    summary: "A saved public-safe manual draft summary.",
+    notes: "Operator edited notes.",
+    tags: ["artist", "radio", "saved-draft"],
+  };
+  const saveResponse = await authedPost({ action: "saveDraft", draftId: createDraftPayload.draft.id, fields });
+  assert.equal(saveResponse.status, 200);
+  const savePayload = await saveResponse.json();
+  assert.equal(savePayload.draft.fields.name, "Manual Candidate Alpha Draft");
+  assert.equal(savePayload.draft.fields.role, "Public artist profile");
+  assert.deepEqual(savePayload.draft.fields.tags, ["artist", "radio", "saved-draft"]);
+
+  const getPayload = await (await authedGet()).json();
+  assert.equal(getPayload.drafts[0].fields.summary, "A saved public-safe manual draft summary.");
+  assert.equal(JSON.stringify(databasePage.entries), databaseEntriesBefore);
+  const readModelAfter = await (await readModel.GET()).json();
+  assert.equal(readModelAfter.sections.dossiers.items.map((entry) => entry.name).join("|"), readModelNamesBefore);
+  assert.equal(readModelAfter.sections.dossiers.items.some((entry) => entry.name === "Manual Candidate Alpha Draft"), false);
+});
+
+test("submitDraftForOwnerReview validates required fields and updates owner queue", async () => {
+  await resetWorkflowStore();
+  const createCandidatePayload = await (await authedPost({ action: "createManualCandidate", input: manualCandidateInput })).json();
+  const createDraftPayload = await (await authedPost({ action: "createDraftFromCandidate", candidateId: createCandidatePayload.candidate.id })).json();
+
+  const invalidResponse = await authedPost({ action: "submitDraftForOwnerReview", draftId: createDraftPayload.draft.id });
+  assert.equal(invalidResponse.status, 400);
+  const invalidPayload = await invalidResponse.json();
+  assert.equal(invalidPayload.code, "invalid_draft_fields");
+  assert.ok(invalidPayload.missingFields.includes("role"));
+
+  const fields = {
+    ...createDraftPayload.draft.fields,
+    role: "Public artist profile",
+    summary: "A complete enough manual draft summary for owner review.",
+    tags: ["artist", "radio"],
+  };
+  await authedPost({ action: "saveDraft", draftId: createDraftPayload.draft.id, fields });
+  const submitResponse = await authedPost({ action: "submitDraftForOwnerReview", draftId: createDraftPayload.draft.id });
+  assert.equal(submitResponse.status, 200);
+  const submitPayload = await submitResponse.json();
+  assert.equal(submitPayload.draft.status, "ready_for_owner_review");
+  assert.equal(submitPayload.ownerReviewQueue.waitingCount, 1);
+
+  const getPayload = await (await authedGet()).json();
+  assert.equal(getPayload.ownerReviewQueue.waitingCount, 1);
+  assert.equal(getPayload.drafts[0].status, "ready_for_owner_review");
 });
 
 test("manual candidate workflow does not publish to database, read model dossiers, or tag registry", async () => {


### PR DESCRIPTION
### Motivation
- Operators need a real, manual draft layer so candidates can be turned into editable drafts and submitted for owner review without invoking BNL or publishing.
- Keep existing candidate intake, deny/needs-more-evidence, duplicate checks, and concurrency-safe store behavior from prior work intact. 
- Add only the draft/workflow plumbing and UI to let operators create, edit, save, and queue drafts for owner review while preserving privacy/system boundaries.

### Description
- Added draft statuses, actions, and owner-review states in `src/lib/dossier-workflow.ts` and extended allowed workflow actions to include `createDraftFromCandidate`, `saveDraft`, and `submitDraftForOwnerReview` while keeping owner/publish actions explicit placeholders.  
- Implemented draft helpers in `src/lib/dossier-workflow-store.ts`: `createDraftFromCandidate`, `saveDossierDraft`, `submitDraftForOwnerReview`, `validateDossierDraftFieldsForOwnerReview`, and normalization helpers; drafts are linked to candidates, prefilled, stored with timestamps, and updated with the existing concurrency-safe updater. 
- Implemented API support in `src/app/api/admin/dossiers/route.ts` for GET payloads to include `ownerReviewQueue` and owner-gate metadata and POST handlers for `createDraftFromCandidate`, `saveDraft`, and `submitDraftForOwnerReview` (with correct 400/401/404/501 behavior and `invalid_draft_fields` payload). 
- Replaced the placeholder Draft Workspace UI in `src/app/admin/dossiers/page.tsx` with: candidate-level `Create Draft` / `Open Draft` control, an editable manual draft form (fields, tags, primary link, candidate context), `Save Draft` and `Submit for Owner Review` buttons, and an Owner Review Queue display; owner approval controls are shown disabled as placeholders. 

### Testing
- Type-check and lint: ran `npx tsc --noEmit` and `npx eslint src/app/admin/dossiers/page.tsx src/app/api/admin/dossiers/route.ts src/lib/dossier-workflow.ts src/lib/dossier-workflow-store.ts` and both passed. 
- Unit/integration tests: ran `node --test tests/admin-dossiers.test.mjs` and all added/updated dossier tests passed (19 tests). 
- Full queue/read-model tests: ran `npm run test:queue` and existing queue/read-model suites passed (106 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19fc91d2648321a370c0a491036c2a)