### PR TITLE
Duplicate Candidate/Draft Merge v1 — manual duplicate detection & merge workflow

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -9,6 +9,7 @@ import {
   DOSSIER_WORKFLOW_ACTIONS,
   type DossierCandidate,
   type DossierDraft,
+  type DossierDuplicateGroup,
 } from "@/lib/dossier-workflow";
 import {
   DOSSIER_ECOSYSTEM_LANE_OPTIONS,
@@ -19,6 +20,7 @@ import {
 type WorkflowPayload = {
   candidates: DossierCandidate[];
   drafts: DossierDraft[];
+  duplicateGroups: DossierDuplicateGroup[];
   workflow: {
     status: string;
     storage: string;
@@ -275,6 +277,10 @@ export default function AdminDossiersPage() {
   const [draftForm, setDraftForm] = useState<DraftForm>(emptyDraftForm);
   const [saving, setSaving] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  const [mergePrimaryByGroup, setMergePrimaryByGroup] = useState<Record<string, string>>({});
+  const [mergeIncludedByGroup, setMergeIncludedByGroup] = useState<Record<string, string[]>>({});
+  const [mergeDraftByGroup, setMergeDraftByGroup] = useState<Record<string, boolean>>({});
+  const [mergeNoteByGroup, setMergeNoteByGroup] = useState<Record<string, string>>({});
 
   async function loadWorkflow() {
     try {
@@ -324,6 +330,10 @@ export default function AdminDossiersPage() {
     [payload?.candidates],
   );
   const drafts = useMemo(() => payload?.drafts ?? [], [payload?.drafts]);
+  const duplicateGroups = useMemo(
+    () => payload?.duplicateGroups ?? [],
+    [payload?.duplicateGroups],
+  );
   const boundaries = payload?.workflow.boundaries ?? [];
   const scoringPolicy =
     payload?.workflow.scoringPolicy ?? DOSSIER_CANDIDATE_SCORING_POLICY;
@@ -369,6 +379,10 @@ export default function AdminDossiersPage() {
         error?: string;
         message?: string;
         missingFields?: string[];
+        merge?: {
+          masterCandidate: DossierCandidate;
+          masterDraft?: DossierDraft;
+        };
       };
       if (!response.ok) {
         const missing = data.missingFields?.length
@@ -561,6 +575,51 @@ export default function AdminDossiersPage() {
     }
   }
 
+  async function mergeDuplicateGroup(group: DossierDuplicateGroup) {
+    const primaryCandidateId =
+      mergePrimaryByGroup[group.id] ??
+      group.suggestedMasterCandidateId ??
+      group.candidateIds[0];
+    const sourceCandidateIds =
+      mergeIncludedByGroup[group.id]?.length
+        ? mergeIncludedByGroup[group.id]
+        : group.candidateIds;
+    try {
+      const data = await postWorkflow({
+        action: "mergeCandidates",
+        input: {
+          primaryCandidateId,
+          sourceCandidateIds,
+          sourceDraftIds: group.draftIds,
+          createMasterDraft: Boolean(mergeDraftByGroup[group.id]),
+          mergeNote: mergeNoteByGroup[group.id] ?? "",
+        },
+      });
+      const masterCandidate = data.merge?.masterCandidate ?? data.candidate;
+      const masterDraft = data.merge?.masterDraft ?? data.draft;
+      if (masterCandidate) setSelectedCandidateId(masterCandidate.id);
+      if (masterDraft) {
+        setSelectedDraftId(masterDraft.id);
+        setDraftForm(draftFormFromDraft(masterDraft));
+      }
+      setNotice(
+        masterDraft
+          ? `Merged candidates into ${masterCandidate?.name ?? "master candidate"} and created/updated a master draft. Nothing published.`
+          : `Merged candidates into ${masterCandidate?.name ?? "master candidate"}. Source records were preserved.`,
+      );
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to merge duplicate candidates.");
+    }
+  }
+
+  function toggleMergeCandidate(group: DossierDuplicateGroup, candidateId: string) {
+    const current = mergeIncludedByGroup[group.id] ?? group.candidateIds;
+    const next = current.includes(candidateId)
+      ? current.filter((id) => id !== candidateId)
+      : [...current, candidateId];
+    setMergeIncludedByGroup({ ...mergeIncludedByGroup, [group.id]: next });
+  }
+
   if (loading) {
     return (
       <MinimalDossierAdminState
@@ -646,6 +705,172 @@ export default function AdminDossiersPage() {
             </p>
           </div>
         </div>
+
+        <section className="border border-border bg-surface p-6 space-y-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.5em] text-muted mb-3">
+                Possible Duplicates / Merge
+              </p>
+              <h2 className="text-2xl font-bold text-foreground">
+                Possible Duplicates / Merge
+              </h2>
+              <div className="text-sm text-muted mt-2 space-y-1">
+                <p>Merge is manual. Nothing auto-merges.</p>
+                <p>Source candidates are preserved and marked merged.</p>
+                <p>Source drafts are preserved and marked superseded.</p>
+                <p>Merged drafts do not publish.</p>
+                <p>BNL merge writing comes later; this PR uses deterministic field combining only.</p>
+                <p>
+                  BNL may later recommend candidates from R&amp;D, Discord-safe
+                  context, queue recurrence, and the website read model. Multiple
+                  sources may point at the same subject, so BNL should attach
+                  evidence to existing candidates or merge candidates rather
+                  than create duplicates. This page prepares for that path but
+                  does not invoke BNL.
+                </p>
+              </div>
+            </div>
+            <p className="text-xs uppercase tracking-widest text-muted">
+              {duplicateGroups.length} duplicate groups
+            </p>
+          </div>
+
+          {duplicateGroups.length === 0 ? (
+            <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+              No workflow-internal duplicate groups detected. Published database
+              duplicate checks still run during manual candidate intake.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {duplicateGroups.map((group) => {
+                const groupCandidates = group.candidateIds
+                  .map((candidateId) =>
+                    candidates.find((candidate) => candidate.id === candidateId),
+                  )
+                  .filter((candidate): candidate is DossierCandidate => Boolean(candidate));
+                const included = mergeIncludedByGroup[group.id] ?? group.candidateIds;
+                const primary =
+                  mergePrimaryByGroup[group.id] ??
+                  group.suggestedMasterCandidateId ??
+                  group.candidateIds[0];
+                const createMasterDraft = Boolean(mergeDraftByGroup[group.id]);
+                return (
+                  <article key={group.id} className="border border-border/70 bg-background/20 p-4 space-y-4">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <h3 className="text-lg font-bold text-foreground">
+                          {group.names.join(" / ") || group.normalizedName}
+                        </h3>
+                        <p className="text-xs uppercase tracking-widest text-muted">
+                          normalized: {group.normalizedName} / risk: {group.risk} /
+                          candidates: {group.candidateIds.length} / drafts: {group.draftIds.length}
+                        </p>
+                        <p className="text-sm text-muted mt-1">{group.reason}</p>
+                        {group.existingPublishedDossierMatch ? (
+                          <p className="text-xs text-accent mt-1">
+                            Existing published dossier match: {group.existingPublishedDossierMatch.id} / {group.existingPublishedDossierMatch.name} ({group.existingPublishedDossierMatch.confidence})
+                          </p>
+                        ) : null}
+                      </div>
+                      <button
+                        disabled={saving || included.length < 2}
+                        onClick={() => mergeDuplicateGroup(group)}
+                        className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                      >
+                        {createMasterDraft
+                          ? "Create Master Draft from Merge"
+                          : "Merge into Master Candidate"}
+                      </button>
+                    </div>
+
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                      {groupCandidates.map((candidate) => {
+                        const linkedDraft = drafts.find((draft) => draft.candidateId === candidate.id);
+                        return (
+                          <div key={candidate.id} className="border border-border bg-surface p-3 text-sm text-muted space-y-2">
+                            <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-widest">
+                              <label className="flex items-center gap-2">
+                                <input
+                                  type="radio"
+                                  name={`primary-${group.id}`}
+                                  checked={primary === candidate.id}
+                                  onChange={() =>
+                                    setMergePrimaryByGroup({
+                                      ...mergePrimaryByGroup,
+                                      [group.id]: candidate.id,
+                                    })
+                                  }
+                                />
+                                Master
+                              </label>
+                              <label className="flex items-center gap-2">
+                                <input
+                                  type="checkbox"
+                                  checked={included.includes(candidate.id)}
+                                  onChange={() => toggleMergeCandidate(group, candidate.id)}
+                                />
+                                Include
+                              </label>
+                            </div>
+                            <p className="text-foreground font-bold">{candidate.name}</p>
+                            <p>Status/source: {candidate.status} / {candidate.source}</p>
+                            <p>Reason: {candidate.reason || "—"}</p>
+                            <p>Why now: {candidate.whyNow || "—"}</p>
+                            <p>Evidence summary: {candidate.evidenceSummary || "—"}</p>
+                            <div><span className="text-foreground">Known facts:</span> {listOrEmpty(candidate.knownFacts, "None recorded")}</div>
+                            <div><span className="text-foreground">Missing info:</span> {listOrEmpty(candidate.missingInfo, "None recorded")}</div>
+                            <p>
+                              Recommended taxonomy: {candidate.recommendedCategory ?? "—"} / {candidate.recommendedKind ?? "—"} / {candidate.recommendedEcosystemLane ?? "—"} / {candidate.recommendedIdentityAuthority ?? "—"}
+                            </p>
+                            <p>Recommended tags: {(candidate.recommendedTags ?? []).join(", ") || "—"}</p>
+                            <p>Linked draft status: {linkedDraft?.status ?? "No linked draft"}</p>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs uppercase tracking-widest text-muted">
+                      <label className="flex items-center gap-2 border border-border bg-surface p-3">
+                        <input
+                          type="radio"
+                          checked={!createMasterDraft}
+                          onChange={() =>
+                            setMergeDraftByGroup({ ...mergeDraftByGroup, [group.id]: false })
+                          }
+                        />
+                        Merge candidates only
+                      </label>
+                      <label className="flex items-center gap-2 border border-border bg-surface p-3">
+                        <input
+                          type="radio"
+                          checked={createMasterDraft}
+                          onChange={() =>
+                            setMergeDraftByGroup({ ...mergeDraftByGroup, [group.id]: true })
+                          }
+                        />
+                        Merge candidates and create/update master draft
+                      </label>
+                      <label className="md:col-span-2 space-y-2">
+                        <span>Merge note</span>
+                        <textarea
+                          value={mergeNoteByGroup[group.id] ?? ""}
+                          onChange={(event) =>
+                            setMergeNoteByGroup({
+                              ...mergeNoteByGroup,
+                              [group.id]: event.target.value,
+                            })
+                          }
+                          className={`${textInputClass()} min-h-20`}
+                        />
+                      </label>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
 
         <section className="border border-border bg-surface p-6 space-y-5">
           <div>

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -12,13 +12,18 @@ import {
   type DossierCandidate,
   type DossierCandidateStatus,
   type DossierDraft,
+  type DossierDuplicateGroup,
   type DossierWorkflowAction,
+  type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 import {
+  buildDossierDuplicateGroups,
   createDraftFromCandidate,
   createManualDossierCandidate,
+  DossierMergeError,
   getDossierWorkflowState,
   getDossierWorkflowStorageMode,
+  mergeDossierCandidates,
   saveDossierDraft,
   submitDraftForOwnerReview,
   updateDossierCandidateStatus,
@@ -31,6 +36,7 @@ export const dynamic = "force-dynamic";
 type DossierWorkflowResponse = {
   candidates: DossierCandidate[];
   drafts: DossierDraft[];
+  duplicateGroups: DossierDuplicateGroup[];
   workflow: {
     version: 1;
     storage: "redis" | "memory_fallback";
@@ -76,6 +82,8 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "submitDraftForOwnerReview",
   "denyCandidate",
   "markNeedsMoreEvidence",
+  "detectDuplicateCandidates",
+  "mergeCandidates",
 ]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
@@ -104,6 +112,15 @@ function draftIdFromBody(body: Record<string, unknown>): string {
   return typeof body.draftId === "string" ? body.draftId.trim() : "";
 }
 
+function mergeInputFromBody(body: Record<string, unknown>): MergeDossierCandidatesInput | null {
+  const value = body.input ?? body;
+  if (!value || typeof value !== "object") return null;
+  const input = value as MergeDossierCandidatesInput;
+  if (typeof input.primaryCandidateId !== "string") return null;
+  if (!Array.isArray(input.sourceCandidateIds)) return null;
+  return input;
+}
+
 function draftFieldsFromBody(body: Record<string, unknown>): DossierDraft["fields"] | null {
   const fields = body.fields ?? body.draftFields;
   if (!fields || typeof fields !== "object") return null;
@@ -121,6 +138,7 @@ async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWor
   return {
     candidates: workflowState.candidates,
     drafts: workflowState.drafts,
+    duplicateGroups: buildDossierDuplicateGroups(workflowState),
     ownerReviewQueue: {
       waitingCount: waitingForOwnerReview.length,
       draftCount: workflowState.drafts.length,
@@ -147,6 +165,9 @@ async function workflowPayload(state?: DossierWorkflowState): Promise<DossierWor
         "This endpoint does not invoke BNL, write memory, merge Discord identity, or use payment/customer identity.",
         "Queue frequency is evidence only, not identity.",
         "Owner approval will require an owner secret in a future PR and still will not publish until a publishing workflow exists.",
+        "Workflow duplicate detection compares candidate records to each other; published database duplicate detection remains separate.",
+        "BNL may later attach evidence to existing candidates or recommend merges from R&D, Discord-safe context, queue recurrence, and the website read model, but this endpoint does not invoke BNL.",
+        "Merge actions are manual only: source candidates and drafts are preserved as merged/superseded audit records and master drafts remain unpublished drafts.",
       ],
       ownerGate: {
         status: "placeholder_only",
@@ -196,6 +217,39 @@ export async function POST(req: Request) {
       message: "Dossier drafting, approval, and publishing mutations remain intentionally disabled in this PR.",
       boundaries: (await workflowPayload()).workflow.boundaries,
     }, { status: 501 });
+  }
+
+  if (action === "detectDuplicateCandidates") {
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, ...payload });
+  }
+
+  if (action === "mergeCandidates") {
+    const input = mergeInputFromBody(body);
+    if (!input) {
+      return NextResponse.json({ error: "Valid merge input is required" }, { status: 400 });
+    }
+
+    try {
+      const merge = await mergeDossierCandidates(input);
+      if (!merge) {
+        return NextResponse.json({ error: "Merge did not update workflow state" }, { status: 400 });
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({
+        ok: true,
+        action,
+        merge,
+        candidate: merge.masterCandidate,
+        draft: merge.masterDraft,
+        ...payload,
+      });
+    } catch (error) {
+      if (error instanceof DossierMergeError) {
+        return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+      }
+      throw error;
+    }
   }
 
   if (action === "createManualCandidate") {

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6,8 +6,10 @@ import {
   type DossierCandidate,
   type DossierCandidateStatus,
   type DossierDraft,
+  type DossierDuplicateGroup,
   type DossierDuplicateRisk,
   type DossierWorkflowLink,
+  type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 
 export type DossierWorkflowState = {
@@ -164,6 +166,48 @@ function hasNearNameMatch(candidateName: string, entryName: string): boolean {
     normalizedCandidate.includes(normalizedEntry) ||
     normalizedEntry.includes(normalizedCandidate)
   );
+}
+
+
+function uniqueStrings(...groups: Array<string[] | undefined>): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const group of groups) {
+    for (const item of group ?? []) {
+      const trimmed = item.trim();
+      const key = trimmed.toLowerCase();
+      if (!trimmed || seen.has(key)) continue;
+      seen.add(key);
+      output.push(trimmed);
+    }
+  }
+  return output;
+}
+
+function combineTextValues(values: Array<string | undefined>, limit = 4): string {
+  return uniqueStrings(values.filter((value): value is string => Boolean(value))).slice(0, limit).join("\n\n");
+}
+
+function riskRank(risk: DossierDuplicateRisk): number {
+  return { none: 0, low: 1, medium: 2, high: 3 }[risk] ?? 0;
+}
+
+function confidenceRank(confidence: "low" | "medium" | "high"): number {
+  return { low: 1, medium: 2, high: 3 }[confidence];
+}
+
+function activeDraftForCandidate(drafts: DossierDraft[], candidateId: string): DossierDraft | undefined {
+  return drafts.find(
+    (draft) =>
+      draft.candidateId === candidateId &&
+      draft.status !== "denied" &&
+      draft.status !== "published" &&
+      draft.status !== "superseded",
+  );
+}
+
+function preferredValue<T>(...values: Array<T | undefined>): T | undefined {
+  return values.find((value) => value !== undefined && value !== null && value !== "");
 }
 
 function findExistingDossierMatch(name: string): {
@@ -621,6 +665,355 @@ export async function getDossierCandidate(
     currentState.candidates.find((candidate) => candidate.id === candidateId) ??
     null
   );
+}
+
+
+export function buildDossierDuplicateGroups(
+  state: DossierWorkflowState,
+): DossierDuplicateGroup[] {
+  const draftsByCandidate = new Map<string, DossierDraft[]>();
+  for (const draft of state.drafts) {
+    const list = draftsByCandidate.get(draft.candidateId) ?? [];
+    list.push(draft);
+    draftsByCandidate.set(draft.candidateId, list);
+  }
+
+  const eligible = state.candidates.filter((candidate) => {
+    if (!candidate.name?.trim()) return false;
+    if (candidate.status === "merged") return false;
+    if (candidate.status === "denied") {
+      return (draftsByCandidate.get(candidate.id) ?? []).some(
+        (draft) => draft.status !== "denied" && draft.status !== "published",
+      );
+    }
+    return true;
+  });
+
+  const candidateIdsByGroupKey = new Map<string, Set<string>>();
+  const groupRiskByKey = new Map<string, DossierDuplicateGroup["risk"]>();
+  const groupReasonByKey = new Map<string, string>();
+
+  function addPair(
+    key: string,
+    a: DossierCandidate,
+    b: DossierCandidate,
+    risk: DossierDuplicateGroup["risk"],
+    reason: string,
+  ) {
+    const ids = candidateIdsByGroupKey.get(key) ?? new Set<string>();
+    ids.add(a.id);
+    ids.add(b.id);
+    candidateIdsByGroupKey.set(key, ids);
+    const currentRisk = groupRiskByKey.get(key) ?? "low";
+    groupRiskByKey.set(key, riskRank(risk) > riskRank(currentRisk) ? risk : currentRisk);
+    if (!groupReasonByKey.has(key)) groupReasonByKey.set(key, reason);
+  }
+
+  for (let i = 0; i < eligible.length; i += 1) {
+    for (let j = i + 1; j < eligible.length; j += 1) {
+      const a = eligible[i];
+      const b = eligible[j];
+      const normalizedA = normalizeName(a.name);
+      const normalizedB = normalizeName(b.name);
+      const compactA = compactName(a.name);
+      const compactB = compactName(b.name);
+      if (!normalizedA || !normalizedB) continue;
+      if (normalizedA === normalizedB) {
+        addPair(normalizedA, a, b, "high", "Exact normalized candidate name match inside workflow store.");
+        continue;
+      }
+      if (compactA && compactA === compactB) {
+        addPair(compactA, a, b, "high", "Compact candidate names match after removing punctuation and spaces.");
+        continue;
+      }
+      if (
+        normalizedA.length >= 4 &&
+        normalizedB.length >= 4 &&
+        (normalizedA.includes(normalizedB) || normalizedB.includes(normalizedA))
+      ) {
+        const key = compactA.length <= compactB.length ? compactA : compactB;
+        addPair(key, a, b, "medium", "Candidate names appear to contain or closely overlap each other.");
+      }
+    }
+  }
+
+  return [...candidateIdsByGroupKey.entries()]
+    .map(([key, ids]) => {
+      const groupCandidates = [...ids]
+        .map((id) => eligible.find((candidate) => candidate.id === id))
+        .filter((candidate): candidate is DossierCandidate => Boolean(candidate))
+        .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+      const draftIds = groupCandidates
+        .flatMap((candidate) => draftsByCandidate.get(candidate.id) ?? [])
+        .map((draft) => draft.id)
+        .sort();
+      const existingPublishedDossierMatch = groupCandidates
+        .map((candidate) => candidate.existingDossierMatch)
+        .filter((match): match is NonNullable<DossierCandidate["existingDossierMatch"]> => Boolean(match))
+        .sort((a, b) => confidenceRank(b.confidence) - confidenceRank(a.confidence) || a.id.localeCompare(b.id))[0] ?? null;
+      return {
+        id: `workflow-duplicate-${key}`,
+        normalizedName: key,
+        candidateIds: groupCandidates.map((candidate) => candidate.id),
+        draftIds,
+        names: uniqueStrings(groupCandidates.map((candidate) => candidate.name)).sort((a, b) => a.localeCompare(b)),
+        risk: groupRiskByKey.get(key) ?? "low",
+        reason: groupReasonByKey.get(key) ?? "Possible workflow duplicate candidate names.",
+        suggestedMasterCandidateId: groupCandidates[0]?.id,
+        existingPublishedDossierMatch,
+      } satisfies DossierDuplicateGroup;
+    })
+    .filter((group) => group.candidateIds.length > 1)
+    .sort((a, b) => riskRank(b.risk) - riskRank(a.risk) || a.normalizedName.localeCompare(b.normalizedName))
+    .slice(0, 25);
+}
+
+function mergeEvidenceItems(
+  candidates: DossierCandidate[],
+): NonNullable<DossierCandidate["evidenceItems"]> {
+  const seen = new Set<string>();
+  const output: NonNullable<DossierCandidate["evidenceItems"]> = [];
+  for (const item of candidates.flatMap((candidate) => candidate.evidenceItems ?? [])) {
+    const key = `${item.id || ""}|${item.summary.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(item);
+  }
+  return output.slice(0, 20);
+}
+
+function strongestTier(candidates: DossierCandidate[]): DossierCandidate["tier"] {
+  const order: DossierCandidate["tier"][] = ["draft_ready", "review_candidate", "weak_candidate"];
+  return order.find((tier) => candidates.some((candidate) => candidate.tier === tier)) ?? "review_candidate";
+}
+
+function buildMasterDraftFields(
+  masterCandidate: DossierCandidate,
+  primaryDraft: DossierDraft | undefined,
+  sourceDrafts: DossierDraft[],
+): DossierDraft["fields"] {
+  const otherDraftFields = sourceDrafts.map((draft) => draft.fields);
+  return normalizeDraftFields({
+    name: preferredValue(primaryDraft?.fields.name, masterCandidate.name, ...otherDraftFields.map((fields) => fields.name)) ?? masterCandidate.name,
+    category: preferredValue(primaryDraft?.fields.category, masterCandidate.recommendedCategory, ...otherDraftFields.map((fields) => fields.category)),
+    kind: preferredValue(primaryDraft?.fields.kind, masterCandidate.recommendedKind, ...otherDraftFields.map((fields) => fields.kind)),
+    ecosystemLane: preferredValue(primaryDraft?.fields.ecosystemLane, masterCandidate.recommendedEcosystemLane, ...otherDraftFields.map((fields) => fields.ecosystemLane)),
+    identityAuthority: preferredValue(primaryDraft?.fields.identityAuthority, masterCandidate.recommendedIdentityAuthority, ...otherDraftFields.map((fields) => fields.identityAuthority)),
+    status: preferredValue(primaryDraft?.fields.status, masterCandidate.recommendedStatus, ...otherDraftFields.map((fields) => fields.status), "PENDING"),
+    clearance: preferredValue(primaryDraft?.fields.clearance, masterCandidate.recommendedClearance, ...otherDraftFields.map((fields) => fields.clearance), "PUBLIC"),
+    role: preferredValue(primaryDraft?.fields.role, ...otherDraftFields.map((fields) => fields.role)),
+    origin: preferredValue(primaryDraft?.fields.origin, masterCandidate.recommendedOrigin, ...otherDraftFields.map((fields) => fields.origin), "UNVERIFIED"),
+    summary: preferredValue(primaryDraft?.fields.summary, masterCandidate.evidenceSummary, ...otherDraftFields.map((fields) => fields.summary)),
+    notes: combineTextValues([
+      primaryDraft?.fields.notes,
+      masterCandidate.reason,
+      masterCandidate.whyNow,
+      ...otherDraftFields.map((fields) => fields.notes),
+    ], 8),
+    tags: uniqueStrings(primaryDraft?.fields.tags, masterCandidate.recommendedTags, ...otherDraftFields.map((fields) => fields.tags)),
+    proposedTags: uniqueStrings(primaryDraft?.fields.proposedTags, masterCandidate.proposedTags, ...otherDraftFields.map((fields) => fields.proposedTags)),
+    primaryLink: preferredValue(primaryDraft?.fields.primaryLink, masterCandidate.primaryLink, ...otherDraftFields.map((fields) => fields.primaryLink)),
+    links: [
+      ...(primaryDraft?.fields.links ?? []),
+      ...otherDraftFields.flatMap((fields) => fields.links ?? []),
+    ],
+    files: [],
+  });
+}
+
+export class DossierMergeError extends Error {
+  status: number;
+  code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.name = "DossierMergeError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export async function mergeDossierCandidates(input: MergeDossierCandidatesInput): Promise<{
+  masterCandidate: DossierCandidate;
+  masterDraft?: DossierDraft;
+  mergedCandidateIds: string[];
+  supersededDraftIds: string[];
+} | null> {
+  const now = new Date().toISOString();
+  const primaryCandidateId = input.primaryCandidateId?.trim();
+  const requestedSourceIds = uniqueStrings(input.sourceCandidateIds, [primaryCandidateId]);
+  const requestedDraftIds = new Set(uniqueStrings(input.sourceDraftIds));
+
+  if (!primaryCandidateId) {
+    throw new DossierMergeError("primaryCandidateId is required", 400, "missing_primary_candidate");
+  }
+  if (requestedSourceIds.length < 2) {
+    throw new DossierMergeError("At least two source candidates are required for merge", 400, "too_few_source_candidates");
+  }
+
+  let result: {
+    masterCandidate: DossierCandidate;
+    masterDraft?: DossierDraft;
+    mergedCandidateIds: string[];
+    supersededDraftIds: string[];
+  } | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const candidatesById = new Map(currentState.candidates.map((candidate) => [candidate.id, candidate]));
+    const primary = candidatesById.get(primaryCandidateId);
+    if (!primary) throw new DossierMergeError("Primary candidate not found", 404, "primary_candidate_not_found");
+    if (primary.status === "denied") {
+      throw new DossierMergeError("Cannot merge into a denied primary candidate", 400, "primary_candidate_denied");
+    }
+    const missingSourceId = requestedSourceIds.find((id) => !candidatesById.has(id));
+    if (missingSourceId) {
+      throw new DossierMergeError(`Source candidate not found: ${missingSourceId}`, 404, "source_candidate_not_found");
+    }
+
+    const sources = requestedSourceIds.map((id) => candidatesById.get(id)).filter((candidate): candidate is DossierCandidate => Boolean(candidate));
+    const primaryFirstSources = [primary, ...sources.filter((candidate) => candidate.id !== primary.id)];
+    const nonPrimaryIds = primaryFirstSources.filter((candidate) => candidate.id !== primary.id).map((candidate) => candidate.id);
+    const evidenceItems = mergeEvidenceItems(primaryFirstSources);
+    const highestDuplicateRisk = primaryFirstSources.map((candidate) => candidate.duplicateRisk ?? "none").sort((a, b) => riskRank(b) - riskRank(a))[0] ?? "none";
+    const existingDossierMatch = primaryFirstSources
+      .map((candidate) => candidate.existingDossierMatch)
+      .filter((match): match is NonNullable<DossierCandidate["existingDossierMatch"]> => Boolean(match))
+      .sort((a, b) => confidenceRank(b.confidence) - confidenceRank(a.confidence) || a.id.localeCompare(b.id))[0] ?? null;
+    const score = Math.min(100, Math.max(...primaryFirstSources.map((candidate) => candidate.score ?? 0)));
+    const masterCandidate: DossierCandidate = {
+      ...primary,
+      candidateType: primary.candidateType !== "unknown" ? primary.candidateType : (primaryFirstSources.find((candidate) => candidate.candidateType !== "unknown")?.candidateType ?? primary.candidateType),
+      source: primary.source ?? "combined",
+      tier: strongestTier(primaryFirstSources),
+      score,
+      reason: combineTextValues(primaryFirstSources.map((candidate) => candidate.reason), 6),
+      whyNow: combineTextValues(primaryFirstSources.map((candidate) => candidate.whyNow), 6),
+      evidenceSummary: combineTextValues(primaryFirstSources.map((candidate) => candidate.evidenceSummary), 6),
+      evidenceItems,
+      evidenceCount: evidenceItems.length,
+      knownFacts: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.knownFacts)),
+      duplicateRisk: highestDuplicateRisk,
+      existingDossierMatch,
+      recommendedCategory: preferredValue(primary.recommendedCategory, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedCategory)),
+      recommendedKind: preferredValue(primary.recommendedKind, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedKind)),
+      recommendedEcosystemLane: preferredValue(primary.recommendedEcosystemLane, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedEcosystemLane)),
+      recommendedIdentityAuthority: preferredValue(primary.recommendedIdentityAuthority, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedIdentityAuthority)),
+      recommendedStatus: preferredValue(primary.recommendedStatus, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedStatus)),
+      recommendedClearance: preferredValue(primary.recommendedClearance, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedClearance)),
+      recommendedOrigin: preferredValue(primary.recommendedOrigin, ...primaryFirstSources.slice(1).map((candidate) => candidate.recommendedOrigin)),
+      recommendedTags: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.recommendedTags)),
+      proposedTags: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.proposedTags)),
+      primaryLink: primary.primaryLink ?? primaryFirstSources.find((candidate) => candidate.primaryLink?.publicSafe !== false)?.primaryLink,
+      missingInfo: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.missingInfo)),
+      doNotSay: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.doNotSay)),
+      publicSafetyNotes: uniqueStrings(...primaryFirstSources.map((candidate) => candidate.publicSafetyNotes)),
+      status: primary.status === "draft_ready" || primary.status === "draft_requested" ? "draft_ready" : "needs_review",
+      mergeNote: input.mergeNote?.trim() || undefined,
+      mergeSourceCandidateIds: requestedSourceIds,
+      updatedAt: now,
+    };
+
+    let masterDraft: DossierDraft | undefined;
+    const supersededDraftIds: string[] = [];
+    let drafts = currentState.drafts;
+
+    if (input.createMasterDraft) {
+      const sourceDrafts = currentState.drafts.filter(
+        (draft) =>
+          requestedSourceIds.includes(draft.candidateId) || requestedDraftIds.has(draft.id),
+      );
+      const primaryDraft = activeDraftForCandidate(currentState.drafts, primary.id);
+      const nonPrimaryDrafts = sourceDrafts.filter(
+        (draft) => draft.id !== primaryDraft?.id && draft.candidateId !== primary.id && draft.status !== "published",
+      );
+      const sourceDraftIds = uniqueStrings(sourceDrafts.map((draft) => draft.id));
+
+      if (primaryDraft) {
+        masterDraft = {
+          ...primaryDraft,
+          status: primaryDraft.status === "published" ? "draft" : primaryDraft.status,
+          fields: buildMasterDraftFields(masterCandidate, primaryDraft, sourceDrafts.filter((draft) => draft.id !== primaryDraft.id)),
+          mergeNote: input.mergeNote?.trim() || undefined,
+          mergeSourceDraftIds: sourceDraftIds,
+          updatedAt: now,
+        };
+        drafts = currentState.drafts.map((draft) => {
+          if (draft.id === primaryDraft.id) return masterDraft as DossierDraft;
+          if (nonPrimaryDrafts.some((sourceDraft) => sourceDraft.id === draft.id)) {
+            supersededDraftIds.push(draft.id);
+            return {
+              ...draft,
+              status: "superseded" as const,
+              mergedIntoDraftId: primaryDraft.id,
+              mergedAt: now,
+              mergeNote: input.mergeNote?.trim() || undefined,
+              mergeSourceDraftIds: sourceDraftIds,
+              updatedAt: now,
+            };
+          }
+          return draft;
+        });
+      } else {
+        masterDraft = {
+          id: createDraftId(),
+          candidateId: primary.id,
+          status: "draft",
+          fields: buildMasterDraftFields(masterCandidate, undefined, sourceDrafts),
+          mergeNote: input.mergeNote?.trim() || undefined,
+          mergeSourceDraftIds: sourceDraftIds,
+          createdAt: now,
+          updatedAt: now,
+        };
+        drafts = [masterDraft, ...currentState.drafts.map((draft) => {
+          if (nonPrimaryDrafts.some((sourceDraft) => sourceDraft.id === draft.id)) {
+            supersededDraftIds.push(draft.id);
+            return {
+              ...draft,
+              status: "superseded" as const,
+              mergedIntoDraftId: masterDraft?.id,
+              mergedAt: now,
+              mergeNote: input.mergeNote?.trim() || undefined,
+              mergeSourceDraftIds: sourceDraftIds,
+              updatedAt: now,
+            };
+          }
+          return draft;
+        })];
+      }
+    }
+
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id === primary.id) return masterCandidate;
+      if (nonPrimaryIds.includes(candidate.id)) {
+        return {
+          ...candidate,
+          status: "merged" as const,
+          mergedIntoCandidateId: primary.id,
+          mergedAt: now,
+          mergeNote: input.mergeNote?.trim() || undefined,
+          mergeSourceCandidateIds: requestedSourceIds,
+          updatedAt: now,
+        };
+      }
+      return candidate;
+    });
+
+    result = {
+      masterCandidate,
+      masterDraft,
+      mergedCandidateIds: nonPrimaryIds,
+      supersededDraftIds,
+    };
+
+    return {
+      ...currentState,
+      candidates,
+      drafts,
+      updatedAt: now,
+    };
+  });
+
+  return result;
 }
 
 export function getDossierWorkflowStorageMode(): "redis" | "memory_fallback" {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -60,7 +60,8 @@ export type DossierCandidateStatus =
   | "needs_revision"
   | "approved"
   | "denied"
-  | "needs_more_evidence";
+  | "needs_more_evidence"
+  | "merged";
 
 export type DossierDraftStatus =
   | "draft"
@@ -68,7 +69,8 @@ export type DossierDraftStatus =
   | "owner_changes_requested"
   | "owner_approved"
   | "denied"
-  | "published";
+  | "published"
+  | "superseded";
 
 export type DossierCategory =
   | "Entity"
@@ -120,6 +122,10 @@ export type DossierCandidate = {
   missingInfo?: string[];
   doNotSay?: string[];
   publicSafetyNotes?: string[];
+  mergedIntoCandidateId?: string;
+  mergedAt?: string;
+  mergeNote?: string;
+  mergeSourceCandidateIds?: string[];
   status: DossierCandidateStatus;
   createdAt: string;
   updatedAt: string;
@@ -148,6 +154,10 @@ export type DossierDraft = {
     links?: DossierWorkflowLink[];
     files?: [];
   };
+  mergedIntoDraftId?: string;
+  mergedAt?: string;
+  mergeNote?: string;
+  mergeSourceDraftIds?: string[];
   createdAt: string;
   updatedAt: string;
 };
@@ -182,6 +192,30 @@ export type CreateManualDossierCandidateInput = {
   primaryLink?: DossierDraft["fields"]["primaryLink"];
 };
 
+export type DossierDuplicateGroup = {
+  id: string;
+  normalizedName: string;
+  candidateIds: string[];
+  draftIds: string[];
+  names: string[];
+  risk: "low" | "medium" | "high";
+  reason: string;
+  suggestedMasterCandidateId?: string;
+  existingPublishedDossierMatch?: {
+    id: string;
+    name: string;
+    confidence: "low" | "medium" | "high";
+  } | null;
+};
+
+export type MergeDossierCandidatesInput = {
+  primaryCandidateId: string;
+  sourceCandidateIds: string[];
+  sourceDraftIds?: string[];
+  createMasterDraft?: boolean;
+  mergeNote?: string;
+};
+
 export type DossierWorkflowAction =
   | "createManualCandidate"
   | "selectCandidate"
@@ -197,7 +231,10 @@ export type DossierWorkflowAction =
   | "ownerDenyDraft"
   | "publishDraft"
   | "denyCandidate"
-  | "markNeedsMoreEvidence";
+  | "markNeedsMoreEvidence"
+  | "detectDuplicateCandidates"
+  | "mergeCandidates"
+  | "createMasterDraftFromMerge";
 
 export type DossierSourceBoundary = {
   source: DossierCandidateSource;
@@ -222,6 +259,9 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "publishDraft",
   "denyCandidate",
   "markNeedsMoreEvidence",
+  "detectDuplicateCandidates",
+  "mergeCandidates",
+  "createMasterDraftFromMerge",
 ];
 
 export const DOSSIER_CANDIDATE_SCORING_POLICY = {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -930,3 +930,219 @@ test("duplicate awareness marks candidates matching existing database entries", 
     ),
   );
 });
+
+test("workflow duplicate group detection returns deterministic high-risk groups", async () => {
+  await resetWorkflowStore();
+  const first = await (await authedPost({
+    action: "createManualCandidate",
+    input: { ...manualCandidateInput, name: "Signal Witch" },
+  })).json();
+  const second = await (await authedPost({
+    action: "createManualCandidate",
+    input: { ...manualCandidateInput, name: "Signal Witch", reason: "Queue/session context." },
+  })).json();
+
+  const payload = await (await authedGet()).json();
+  assert.equal(payload.duplicateGroups.length, 1);
+  const group = payload.duplicateGroups[0];
+  assert.equal(group.risk, "high");
+  assert.deepEqual(new Set(group.candidateIds), new Set([first.candidate.id, second.candidate.id]));
+  assert.equal(group.suggestedMasterCandidateId, first.candidate.id);
+});
+
+test("workflow duplicate group detection catches compact near duplicates", async () => {
+  await resetWorkflowStore();
+  const first = await (await authedPost({
+    action: "createManualCandidate",
+    input: { ...manualCandidateInput, name: "Signal Witch" },
+  })).json();
+  const second = await (await authedPost({
+    action: "createManualCandidate",
+    input: { ...manualCandidateInput, name: "signalwitch" },
+  })).json();
+
+  const payload = await (await authedGet()).json();
+  assert.equal(payload.duplicateGroups.length, 1);
+  assert.ok(["high", "medium"].includes(payload.duplicateGroups[0].risk));
+  assert.deepEqual(new Set(payload.duplicateGroups[0].candidateIds), new Set([first.candidate.id, second.candidate.id]));
+});
+
+test("workflow duplicate group detection leaves clear non-duplicates ungrouped", async () => {
+  await resetWorkflowStore();
+  await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Signal Witch" } });
+  await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Cache Bird" } });
+  const payload = await (await authedGet()).json();
+  assert.deepEqual(payload.duplicateGroups, []);
+});
+
+test("mergeCandidates preserves sources and unions candidate review fields", async () => {
+  await resetWorkflowStore();
+  const first = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Signal Witch",
+      knownFacts: ["Fact A"],
+      missingInfo: ["Missing A"],
+      doNotSay: ["Do not say A"],
+      publicSafetyNotes: ["Safety A"],
+      recommendedTags: ["signal", "witch"],
+      proposedTags: ["draft-a"],
+    },
+  })).json();
+  const second = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Signal Witch",
+      reason: "Queue/session context.",
+      knownFacts: ["Fact B", "Fact A"],
+      missingInfo: ["Missing B"],
+      doNotSay: ["Do not say B"],
+      publicSafetyNotes: ["Safety B"],
+      recommendedTags: ["queue"],
+      proposedTags: ["draft-b"],
+    },
+  })).json();
+
+  const response = await authedPost({
+    action: "mergeCandidates",
+    input: {
+      primaryCandidateId: first.candidate.id,
+      sourceCandidateIds: [first.candidate.id, second.candidate.id],
+      mergeNote: "Manual duplicate merge test.",
+    },
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  const master = payload.candidates.find((candidate) => candidate.id === first.candidate.id);
+  const secondary = payload.candidates.find((candidate) => candidate.id === second.candidate.id);
+  assert.equal(master.status, "needs_review");
+  assert.equal(secondary.status, "merged");
+  assert.equal(secondary.mergedIntoCandidateId, first.candidate.id);
+  assert.deepEqual(new Set(master.knownFacts), new Set(["Fact A", "Fact B"]));
+  assert.deepEqual(new Set(master.missingInfo), new Set(["Missing A", "Missing B"]));
+  assert.deepEqual(new Set(master.doNotSay), new Set(["Do not say A", "Do not say B"]));
+  assert.deepEqual(new Set(master.publicSafetyNotes), new Set(["Safety A", "Safety B"]));
+  assert.deepEqual(new Set(master.recommendedTags), new Set(["signal", "witch", "queue"]));
+  assert.deepEqual(new Set(master.proposedTags), new Set(["draft-a", "draft-b"]));
+  assert.equal(payload.candidates.length, 2);
+});
+
+test("mergeCandidates prefers primary taxonomy and fills missing taxonomy from secondary", async () => {
+  await resetWorkflowStore();
+  const first = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Taxonomy Merge Subject",
+      recommendedCategory: undefined,
+      recommendedKind: undefined,
+      recommendedEcosystemLane: "radio_entity",
+      recommendedIdentityAuthority: "barcode_controlled",
+    },
+  })).json();
+  const second = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Taxonomy Merge Subject",
+      recommendedCategory: "Entity",
+      recommendedKind: "radio_entity",
+      recommendedEcosystemLane: "community_artist",
+      recommendedIdentityAuthority: "community_owned",
+    },
+  })).json();
+
+  const payload = await (await authedPost({
+    action: "mergeCandidates",
+    input: {
+      primaryCandidateId: first.candidate.id,
+      sourceCandidateIds: [first.candidate.id, second.candidate.id],
+    },
+  })).json();
+  const master = payload.merge.masterCandidate;
+  assert.equal(master.recommendedCategory, "Entity");
+  assert.equal(master.recommendedKind, "radio_entity");
+  assert.equal(master.recommendedEcosystemLane, "radio_entity");
+  assert.equal(master.recommendedIdentityAuthority, "barcode_controlled");
+});
+
+test("mergeCandidates can create/update a master draft and supersede secondary drafts", async () => {
+  await resetWorkflowStore();
+  const first = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Draft Merge Subject" } })).json();
+  const second = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Draft Merge Subject", recommendedKind: "radio_entity" } })).json();
+  const firstDraft = await (await authedPost({ action: "createDraftFromCandidate", candidateId: first.candidate.id })).json();
+  const secondDraft = await (await authedPost({ action: "createDraftFromCandidate", candidateId: second.candidate.id })).json();
+
+  const payload = await (await authedPost({
+    action: "mergeCandidates",
+    input: {
+      primaryCandidateId: first.candidate.id,
+      sourceCandidateIds: [first.candidate.id, second.candidate.id],
+      sourceDraftIds: [firstDraft.draft.id, secondDraft.draft.id],
+      createMasterDraft: true,
+    },
+  })).json();
+
+  const masterDraft = payload.merge.masterDraft;
+  const secondaryDraft = payload.drafts.find((draft) => draft.id === secondDraft.draft.id);
+  assert.equal(masterDraft.id, firstDraft.draft.id);
+  assert.equal(masterDraft.candidateId, first.candidate.id);
+  assert.equal(masterDraft.status, "draft");
+  assert.equal(secondaryDraft.status, "superseded");
+  assert.equal(secondaryDraft.mergedIntoDraftId, masterDraft.id);
+  assert.equal(masterDraft.fields.ecosystemLane, manualCandidateInput.recommendedEcosystemLane);
+  assert.equal(masterDraft.fields.identityAuthority, manualCandidateInput.recommendedIdentityAuthority);
+});
+
+test("mergeCandidates validation covers auth, missing primary, too few sources, and denied primary", async () => {
+  await resetWorkflowStore();
+  const unauthorized = await route.POST(new Request("https://example.test/api/admin/dossiers", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "mergeCandidates", input: { primaryCandidateId: "x", sourceCandidateIds: ["x", "y"] } }),
+  }));
+  assert.equal(unauthorized.status, 401);
+
+  const missing = await authedPost({ action: "mergeCandidates", input: { primaryCandidateId: "missing", sourceCandidateIds: ["missing", "also-missing"] } });
+  assert.equal(missing.status, 404);
+
+  const first = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Validation Subject" } })).json();
+  const tooFew = await authedPost({ action: "mergeCandidates", input: { primaryCandidateId: first.candidate.id, sourceCandidateIds: [first.candidate.id] } });
+  assert.equal(tooFew.status, 400);
+
+  await authedPost({ action: "denyCandidate", candidateId: first.candidate.id });
+  const second = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Validation Subject" } })).json();
+  const denied = await authedPost({ action: "mergeCandidates", input: { primaryCandidateId: first.candidate.id, sourceCandidateIds: [first.candidate.id, second.candidate.id] } });
+  assert.equal(denied.status, 400);
+});
+
+test("mergeCandidates does not mutate public database, public read model, tag registry, or publish", async () => {
+  await resetWorkflowStore();
+  const publicDossierIdsBefore = databasePage.entries.map((entry) => entry.id).join("|");
+  const tagNamesBefore = new Set(databasePage.entries.flatMap((entry) => entry.tags));
+  const readModelBefore = await (await readModel.GET()).json();
+  const publicReadModelNamesBefore = readModelBefore.sections.dossiers.items.map((entry) => entry.name).join("|");
+
+  const first = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Workflow Merge Only", recommendedTags: ["workflow-only-tag-a"] } })).json();
+  const second = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Workflow Merge Only", recommendedTags: ["workflow-only-tag-b"] } })).json();
+  await authedPost({ action: "mergeCandidates", input: { primaryCandidateId: first.candidate.id, sourceCandidateIds: [first.candidate.id, second.candidate.id], createMasterDraft: true } });
+
+  assert.equal(databasePage.entries.map((entry) => entry.id).join("|"), publicDossierIdsBefore);
+  assert.deepEqual(new Set(databasePage.entries.flatMap((entry) => entry.tags)), tagNamesBefore);
+  const readModelAfter = await (await readModel.GET()).json();
+  assert.equal(readModelAfter.sections.dossiers.items.map((entry) => entry.name).join("|"), publicReadModelNamesBefore);
+  assert.equal(readModelAfter.sections.dossiers.items.some((entry) => entry.name === "Workflow Merge Only"), false);
+});
+
+test("admin dossiers page includes duplicate merge workflow copy and controls", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  assert.match(page, /Possible Duplicates \/ Merge/);
+  assert.match(page, /Merge into Master Candidate/);
+  assert.match(page, /Create Master Draft from Merge/);
+  assert.match(page, /Merge is manual/);
+  assert.match(page, /Source candidates are preserved/);
+  assert.match(page, /Source drafts are preserved/);
+  assert.match(page, /BNL merge writing comes later/);
+});


### PR DESCRIPTION
### Motivation
- Operators can create separate workflow candidates/drafts for the same subject and need a safe, manual way to compare and combine them without publishing or invoking BNL.
- Add a deterministic, operator-driven duplicate detection + merge v1 to preserve source records for audit and support later BNL recommendations without automatic writes.

### Description
- Added new workflow types and metadata to support merges and duplicate groups and extended action names in `src/lib/dossier-workflow.ts` (adds `merged`/`superseded` statuses, merge fields, `DossierDuplicateGroup` and `MergeDossierCandidatesInput`, and merge-related actions).
- Implemented workflow-internal duplicate detection and a concurrency-safe merge helper in `src/lib/dossier-workflow-store.ts` (`buildDossierDuplicateGroups` and `mergeDossierCandidates`) that unions/dedupes review fields, validates inputs, marks non-primary candidates `merged`, and optionally creates/updates a master draft while marking source drafts `superseded`.
- Exposed duplicate groups and a `mergeCandidates` action via the authenticated admin API in `src/app/api/admin/dossiers/route.ts` (GET returns `duplicateGroups`; POST implements `mergeCandidates` with structured errors and no public mutations).
- Added a minimal admin UI section in `src/app/admin/dossiers/page.tsx` named "Possible Duplicates / Merge" to list groups, compare candidate cards, select a primary, choose included candidates, toggle draft creation, add a merge note, and run the merge action (explicit operator controls and explanatory copy about manual-only behavior and BNL boundary).
- Added comprehensive workflow tests in `tests/admin-dossiers.test.mjs` covering duplicate detection (exact/near/non-duplicates), merge field unions, taxonomy precedence, draft superseding/master draft behavior, validation, and assurance that no public database, read-model, tag registry, or publishing writes occur.
- Files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`, `src/app/admin/dossiers/page.tsx`, `tests/admin-dossiers.test.mjs`.
- Important boundaries preserved: no BNL invocation, no AI merge writing, no automatic publishing, no `src/content.ts` mutation, and no bot repo changes; existing admin routes, draft/workspace, and published duplicate checks remain intact.

### Testing
- Type-check: `npx tsc --noEmit` — succeeded.
- Lint: `npx eslint src/lib/dossier-workflow.ts src/lib/dossier-workflow-store.ts src/app/admin/dossiers/page.tsx src/app/api/admin/dossiers/route.ts` — succeeded (fixes applied where needed).
- Unit/integration tests: `node --test tests/admin-dossiers.test.mjs` — 29 tests passed (new duplicate/merge tests included).
- Queue and read-model suite: `npm run test:queue` — all existing queue/read-model tests passed (no regressions).
- Summary: all automated checks passed locally; manual post-deploy checklist is included for live verification (open `/admin/dossiers`, create duplicates, create drafts, run merge with/without master draft, and confirm preserved/superseded behavior and that `/database` and `/api/bnl/read-model` are unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a0affc1988321900006ab6fa19ab7)