### PR TITLE
BNL-Led Source File Authority: guard recommendation attachments & match helper

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -320,10 +320,11 @@ export default function CandidateReviewPage() {
             {candidate.name}
           </h1>
           <p className="text-sm text-muted mt-3 max-w-3xl">
-            Source File ID: {candidate.id}. This page collects what BNL knows
-            and what mods/admins add as source material, not the public dossier.
-            Internal workflow only; notes do not publish, create tags, or mutate
-            public records.
+            Source File ID: {candidate.id}. This BNL Source File is one
+            subject/entity source packet. Admins can add information to this
+            BNL Source File, but cannot turn this source file into another
+            subject. Internal workflow only; notes do not publish, create tags,
+            or mutate public records.
           </p>
           <div className="mt-4">
             <PhaseRail />
@@ -393,13 +394,16 @@ export default function CandidateReviewPage() {
             Add to BNL Source File
           </h2>
           <p className="text-sm text-muted">
-            This adds source material for BNL. It does not directly edit the
-            proposed dossier.
+            Admins can add information to this BNL Source File. It does not
+            directly edit the proposed dossier.
           </p>
           <p className="text-sm text-muted">
-            Add to BNL Source File = add knowledge/context for BNL. BNL Edit
-            Chat = tell BNL how to revise the proposed dossier. Advanced Manual
-            Edit = fallback direct editing of the proposed dossier fields.
+            Add to BNL Source File = add info to this subject. This source file
+            remains one subject/entity. If this information belongs to a
+            different subject, create or wait for a separate BNL recommendation.
+            BNL Edit Chat = tell BNL how to revise
+            the proposed dossier. Advanced Manual Edit = fallback direct
+            editing of the proposed dossier fields.
           </p>
           {hasOwnerReviewDraft && (
             <p className="border border-accent/60 bg-accent/10 p-3 text-sm text-accent">

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -468,6 +468,13 @@ export default function DossierControlCenterPage() {
 
   function recommendationMatchState(recommendation: DossierRecommendation) {
     const match = matchDossierRecommendationSubject({ recommendation, candidates });
+    if (match.exactMatchKind === "pre_targeted") {
+      return {
+        match,
+        state: "Pre-targeted BNL Source File",
+        nextAction: "Attach to Matched Source File",
+      };
+    }
     if (match.exactCandidateId) {
       return {
         match,
@@ -783,7 +790,16 @@ export default function DossierControlCenterPage() {
                       <p>Match state: {matchState.state}</p>
                       <p>Recommended next action: {matchState.nextAction}</p>
                       {exactCandidate && (
-                        <p>Matched subject packet: {exactCandidate.name}</p>
+                        <>
+                          <p>Matched subject packet: {exactCandidate.name}</p>
+                          {matchState.match.exactMatchKind ===
+                            "pre_targeted" && (
+                            <p>
+                              This recommendation already points to an existing
+                              source file.
+                            </p>
+                          )}
+                        </>
                       )}
                       {possibleCandidates.length > 0 && (
                         <p>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
-import type {
-  DossierCandidate,
-  DossierDraft,
-  DossierDuplicateGroup,
-  DossierRecommendation,
+import {
+  matchDossierRecommendationSubject,
+  type DossierCandidate,
+  type DossierDraft,
+  type DossierDuplicateGroup,
+  type DossierRecommendation,
 } from "@/lib/dossier-workflow";
 
 type WorkflowPayload = {
@@ -249,9 +250,6 @@ export default function DossierControlCenterPage() {
   const [form, setForm] = useState<ManualCandidateForm>(emptyForm);
   const [recommendationForm, setRecommendationForm] =
     useState<ManualRecommendationForm>(emptyRecommendationForm);
-  const [attachTargets, setAttachTargets] = useState<Record<string, string>>(
-    {},
-  );
   const [createdDraftIdByCandidate, setCreatedDraftIdByCandidate] = useState<
     Record<string, string>
   >({});
@@ -441,27 +439,54 @@ export default function DossierControlCenterPage() {
     }
   }
 
-  async function attachRecommendation(recommendationId: string) {
-    const candidateId = attachTargets[recommendationId];
-    if (!candidateId) {
-      setNotice("Choose an existing BNL Source File before attaching.");
+  async function attachRecommendationToMatchedSourceFile(
+    recommendation: DossierRecommendation,
+  ) {
+    const match = matchDossierRecommendationSubject({ recommendation, candidates });
+    if (!match.exactCandidateId) {
+      setNotice(
+        "Attach is only available after a same-subject BNL Source File match is confirmed.",
+      );
       return;
     }
     try {
       const data = await postWorkflow({
         action: "attachRecommendationToCandidate",
-        recommendationId,
-        candidateId,
+        recommendationId: recommendation.id,
+        candidateId: match.exactCandidateId,
         createSourceNote: true,
       });
       setNotice(
-        `${data.recommendation?.subjectName ?? "Recommendation"} attached to an existing BNL Source File. No draft was created.`,
+        `${data.recommendation?.subjectName ?? "Recommendation"} attached to the matched same-subject BNL Source File. No draft was created.`,
       );
     } catch (err) {
       setNotice(
         err instanceof Error ? err.message : "Failed to attach recommendation.",
       );
     }
+  }
+
+  function recommendationMatchState(recommendation: DossierRecommendation) {
+    const match = matchDossierRecommendationSubject({ recommendation, candidates });
+    if (match.exactCandidateId) {
+      return {
+        match,
+        state: "Matched existing BNL Source File",
+        nextAction: "Attach to Matched Source File",
+      };
+    }
+    if (match.possibleCandidateIds.length > 0) {
+      return {
+        match,
+        state: "Possible duplicate / identity warning",
+        nextAction: "Needs owner identity review",
+      };
+    }
+    return {
+      match,
+      state: "No BNL Source File match",
+      nextAction: "Convert to New BNL Source File",
+    };
   }
 
   async function createDraft(candidateId: string) {
@@ -630,9 +655,11 @@ export default function DossierControlCenterPage() {
           }
         >
           <p className="text-sm text-muted">
-            BNL recommendations will land here later. For now, this inbox can
-            hold manual seeds and review items. Recommendations do not publish
-            anything.
+            BNL Recommendation / Evidence Cluster records preserve BNL/manual
+            clues. A BNL Source File is one subject/entity source packet.
+            Admins can convert unmatched recommendations into new source files
+            or attach only when the system confirms a same-subject match.
+            Recommendations do not publish anything.
           </p>
           <form
             onSubmit={submitManualRecommendation}
@@ -720,7 +747,19 @@ export default function DossierControlCenterPage() {
             </p>
           ) : (
             <div className="space-y-3">
-              {activeRecommendations.map((recommendation) => (
+              {activeRecommendations.map((recommendation) => {
+                const matchState = recommendationMatchState(recommendation);
+                const exactCandidate = matchState.match.exactCandidateId
+                  ? candidates.find(
+                      (candidate) => candidate.id === matchState.match.exactCandidateId,
+                    )
+                  : null;
+                const possibleCandidates = matchState.match.possibleCandidateIds
+                  .map((candidateId) =>
+                    candidates.find((candidate) => candidate.id === candidateId),
+                  )
+                  .filter((candidate): candidate is DossierCandidate => Boolean(candidate));
+                return (
                 <article
                   key={recommendation.id}
                   className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
@@ -740,12 +779,19 @@ export default function DossierControlCenterPage() {
                       <p>
                         Source lanes: {recommendation.sourceLanes.join(", ")}
                       </p>
-                      <p>Reason: {recommendation.reason}</p>
                       <p>Status: {recommendation.status}</p>
-                      <p>
-                        Suggested action:{" "}
-                        {recommendation.suggestedAction ?? "—"}
-                      </p>
+                      <p>Match state: {matchState.state}</p>
+                      <p>Recommended next action: {matchState.nextAction}</p>
+                      {exactCandidate && (
+                        <p>Matched subject packet: {exactCandidate.name}</p>
+                      )}
+                      {possibleCandidates.length > 0 && (
+                        <p>
+                          Possible matches need owner identity review: {" "}
+                          {possibleCandidates.map((candidate) => candidate.name).join(", ")}
+                        </p>
+                      )}
+                      <p>Reason: {recommendation.reason}</p>
                     </div>
                     <div className="flex max-w-sm flex-col gap-2">
                       <Link
@@ -754,50 +800,39 @@ export default function DossierControlCenterPage() {
                       >
                         Review Recommendation
                       </Link>
-                      <button
-                        type="button"
-                        disabled={saving}
-                        onClick={() =>
-                          void updateRecommendation(
-                            recommendation.id,
-                            "convertRecommendationToCandidate",
-                          )
-                        }
-                        className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-                      >
-                        Convert to BNL Source File
-                      </button>
-                      <div className="flex gap-2">
-                        <select
-                          value={attachTargets[recommendation.id] ?? ""}
-                          onChange={(event) =>
-                            setAttachTargets({
-                              ...attachTargets,
-                              [recommendation.id]: event.target.value,
-                            })
-                          }
-                          className={textInputClass()}
-                        >
-                          <option value="">
-                            Attach to Existing Source File
-                          </option>
-                          {activeCandidates.map((candidate) => (
-                            <option key={candidate.id} value={candidate.id}>
-                              {candidate.name}
-                            </option>
-                          ))}
-                        </select>
+                      {matchState.match.exactCandidateId ? (
                         <button
                           type="button"
                           disabled={saving}
                           onClick={() =>
-                            void attachRecommendation(recommendation.id)
+                            void attachRecommendationToMatchedSourceFile(
+                              recommendation,
+                            )
                           }
                           className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
                         >
-                          Attach
+                          Attach to Matched Source File
                         </button>
-                      </div>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={saving}
+                          onClick={() =>
+                            void updateRecommendation(
+                              recommendation.id,
+                              "convertRecommendationToCandidate",
+                            )
+                          }
+                          className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+                        >
+                          Convert to New BNL Source File
+                        </button>
+                      )}
+                      {matchState.match.possibleCandidateIds.length > 0 && (
+                        <p className="border border-accent/60 bg-accent/10 p-2 text-xs text-accent">
+                          Needs owner identity review before any merge or attach.
+                        </p>
+                      )}
                       <div className="flex gap-2">
                         <button
                           type="button"
@@ -829,7 +864,8 @@ export default function DossierControlCenterPage() {
                     </div>
                   </div>
                 </article>
-              ))}
+                );
+              })}
             </div>
           )}
 

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -352,9 +352,21 @@ export default function DossierRecommendationPage() {
             </p>
             {exactCandidate ? (
               <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
-                <p className="font-bold">
-                  Exact same-subject match: {exactCandidate.name}
-                </p>
+                {subjectMatch.exactMatchKind === "pre_targeted" ? (
+                  <>
+                    <p className="font-bold">
+                      Pre-targeted BNL Source File: {exactCandidate.name}
+                    </p>
+                    <p>
+                      This recommendation already points to an existing source
+                      file.
+                    </p>
+                  </>
+                ) : (
+                  <p className="font-bold">
+                    Exact same-subject match: {exactCandidate.name}
+                  </p>
+                )}
                 <p>{subjectMatch.reason}</p>
                 <button
                   type="button"

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import type {
-  DossierCandidate,
-  DossierDraft,
-  DossierRecommendation,
+import {
+  matchDossierRecommendationSubject,
+  type DossierCandidate,
+  type DossierDraft,
+  type DossierRecommendation,
 } from "@/lib/dossier-workflow";
 
 type WorkflowPayload = {
@@ -82,7 +83,7 @@ function terminalRecommendationMessage(recommendation: DossierRecommendation) {
     return "Converted to BNL Source File.";
   }
   if (recommendation.status === "attached_to_source_file") {
-    return "Attached to existing BNL Source File.";
+    return "Attached to matched BNL Source File.";
   }
   if (recommendation.status === "ignored") {
     return "Ignored. This recommendation is closed.";
@@ -101,7 +102,6 @@ export default function DossierRecommendationPage() {
   const [saving, setSaving] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [targetCandidateId, setTargetCandidateId] = useState("");
 
   async function loadWorkflow() {
     const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
@@ -135,14 +135,6 @@ export default function DossierRecommendationPage() {
       null,
     [payload?.recommendations, recommendationId],
   );
-  const activeCandidates = useMemo(
-    () =>
-      (payload?.candidates ?? []).filter(
-        (candidate) =>
-          candidate.status !== "denied" && candidate.status !== "merged",
-      ),
-    [payload?.candidates],
-  );
   const targetCandidate = recommendation?.targetCandidateId
     ? (payload?.candidates.find(
         (candidate) => candidate.id === recommendation.targetCandidateId,
@@ -154,6 +146,22 @@ export default function DossierRecommendationPage() {
   const terminalMessage = recommendation
     ? terminalRecommendationMessage(recommendation)
     : "";
+  const subjectMatch = recommendation
+    ? matchDossierRecommendationSubject({
+        recommendation,
+        candidates: payload?.candidates ?? [],
+      })
+    : { possibleCandidateIds: [], reason: "No recommendation loaded." };
+  const exactCandidate = subjectMatch.exactCandidateId
+    ? (payload?.candidates.find(
+        (candidate) => candidate.id === subjectMatch.exactCandidateId,
+      ) ?? null)
+    : null;
+  const possibleCandidates = subjectMatch.possibleCandidateIds
+    .map((candidateId) =>
+      payload?.candidates.find((candidate) => candidate.id === candidateId),
+    )
+    .filter((candidate): candidate is DossierCandidate => Boolean(candidate));
 
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
@@ -203,20 +211,22 @@ export default function DossierRecommendationPage() {
     }
   }
 
-  async function attachRecommendation() {
-    if (!targetCandidateId) {
-      setNotice("Choose an existing BNL Source File before attaching.");
+  async function attachRecommendationToMatchedSourceFile() {
+    if (!subjectMatch.exactCandidateId) {
+      setNotice(
+        "Attach is only allowed when the system confirms an exact same-subject BNL Source File match.",
+      );
       return;
     }
     try {
       const data = await postWorkflow({
         action: "attachRecommendationToCandidate",
         recommendationId,
-        candidateId: targetCandidateId,
+        candidateId: subjectMatch.exactCandidateId,
         createSourceNote: true,
       });
       setNotice(
-        `${data.recommendation?.subjectName ?? "Recommendation"} attached as source-file context. No draft was created.`,
+        `${data.recommendation?.subjectName ?? "Recommendation"} attached to the matched BNL Source File. No draft was created.`,
       );
     } catch (err) {
       setNotice(
@@ -260,8 +270,11 @@ export default function DossierRecommendationPage() {
             {recommendation.subjectName}
           </h1>
           <p className="text-sm text-muted mt-3 max-w-3xl">
-            Recommendations are admin-only review records. They do not publish,
-            create drafts, write content files, or create tags automatically.
+            BNL Recommendation / Evidence Cluster records are admin-only
+            evidence records. They do not publish, create drafts, write content
+            files, or create tags automatically. Attach is only allowed for
+            confirmed same-subject matches; merge is owner/lead identity
+            resolution.
           </p>
           {notice && (
             <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -305,18 +318,6 @@ export default function DossierRecommendationPage() {
                   type="button"
                   disabled={saving}
                   onClick={() =>
-                    void updateRecommendation(
-                      "convertRecommendationToCandidate",
-                    )
-                  }
-                  className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-                >
-                  Convert to BNL Source File
-                </button>
-                <button
-                  type="button"
-                  disabled={saving}
-                  onClick={() =>
                     void updateRecommendation("ignoreDossierRecommendation")
                   }
                   className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
@@ -340,32 +341,73 @@ export default function DossierRecommendationPage() {
       </section>
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
         {!isTerminal && (
-          <section className="border border-border bg-surface p-5 text-sm text-muted">
-            <h2 className="text-2xl font-bold text-foreground mb-3">
-              Attach to Existing Source File
+          <section className="border border-border bg-surface p-5 text-sm text-muted space-y-4">
+            <h2 className="text-2xl font-bold text-foreground">
+              Matched BNL Source File
             </h2>
-            <div className="flex flex-col gap-3 md:flex-row">
-              <select
-                value={targetCandidateId}
-                onChange={(event) => setTargetCandidateId(event.target.value)}
-                className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
-              >
-                <option value="">Choose existing BNL Source File</option>
-                {activeCandidates.map((candidate) => (
-                  <option key={candidate.id} value={candidate.id}>
-                    {candidate.name}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                disabled={saving}
-                onClick={() => void attachRecommendation()}
-                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Attach to Existing Source File
-              </button>
-            </div>
+            <p>
+              BNL Source File = one subject/entity source packet. Admins can add
+              info to this subject, but cannot freely combine unrelated
+              recommendations with arbitrary source files.
+            </p>
+            {exactCandidate ? (
+              <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
+                <p className="font-bold">
+                  Exact same-subject match: {exactCandidate.name}
+                </p>
+                <p>{subjectMatch.reason}</p>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() => void attachRecommendationToMatchedSourceFile()}
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                >
+                  Attach to Matched BNL Source File
+                </button>
+              </div>
+            ) : possibleCandidates.length > 0 ? (
+              <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
+                <p className="font-bold">Possible duplicate / identity warning</p>
+                <p>{subjectMatch.reason}</p>
+                <ul className="list-disc pl-5">
+                  {possibleCandidates.map((candidate) => (
+                    <li key={candidate.id}>{candidate.name}</li>
+                  ))}
+                </ul>
+                <p>
+                  Owner/lead identity review is required before merge or attach.
+                  Possible existing source files found. Confirm this is a
+                  separate subject before converting.
+                </p>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() =>
+                    void updateRecommendation("convertRecommendationToCandidate")
+                  }
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                >
+                  Convert to New BNL Source File
+                </button>
+              </div>
+            ) : (
+              <div className="border border-border/70 bg-background/30 p-4 space-y-2">
+                <p className="font-bold text-foreground">
+                  No BNL Source File match
+                </p>
+                <p>{subjectMatch.reason}</p>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() =>
+                    void updateRecommendation("convertRecommendationToCandidate")
+                  }
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                >
+                  Convert to New BNL Source File
+                </button>
+              </div>
+            )}
           </section>
         )}
         <section className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -391,7 +391,7 @@ export async function POST(req: Request) {
   } catch (error) {
     if (error instanceof DossierWorkflowInputError) {
       return NextResponse.json(
-        { error: error.message, code: error.code },
+        { error: error.message, code: error.code, ...error.details },
         { status: error.status },
       );
     }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -719,13 +719,16 @@ export async function attachRecommendationToCandidate(input: {
       recommendation,
       candidates: currentState.candidates,
     });
-    if (match.exactCandidateId !== candidate.id) {
+    const preTargetedCandidateMatch =
+      recommendation.targetCandidateId === candidate.id;
+    if (match.exactCandidateId !== candidate.id && !preTargetedCandidateMatch) {
       throw new DossierWorkflowInputError(
         "Recommendation subject does not match the selected BNL Source File",
         400,
         "recommendation_subject_mismatch",
         {
           exactCandidateId: match.exactCandidateId,
+          exactMatchKind: match.exactMatchKind,
           possibleCandidateIds: match.possibleCandidateIds,
           reason: match.reason,
         },
@@ -818,6 +821,7 @@ export async function convertRecommendationToCandidate(
         "recommendation_existing_source_file_match",
         {
           exactCandidateId: match.exactCandidateId,
+          exactMatchKind: match.exactMatchKind,
           possibleCandidateIds: match.possibleCandidateIds,
           reason: match.reason,
         },

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -18,6 +18,7 @@ import {
   type DossierSourceFileNoteType,
   type DossierDuplicateRisk,
   type DossierWorkflowLink,
+  matchDossierRecommendationSubject,
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 
@@ -585,12 +586,19 @@ function recommendationSourceNoteText(
 export class DossierWorkflowInputError extends Error {
   status: number;
   code: string;
+  details?: Record<string, unknown>;
 
-  constructor(message: string, status = 400, code = "invalid_input") {
+  constructor(
+    message: string,
+    status = 400,
+    code = "invalid_input",
+    details?: Record<string, unknown>,
+  ) {
     super(message);
     this.name = "DossierWorkflowInputError";
     this.status = status;
     this.code = code;
+    this.details = details;
   }
 }
 
@@ -700,6 +708,29 @@ export async function attachRecommendationToCandidate(input: {
         "candidate_not_found",
       );
     }
+    if (candidate.status === "denied" || candidate.status === "merged") {
+      throw new DossierWorkflowInputError(
+        "Candidate is not an active BNL Source File",
+        400,
+        "candidate_not_attachable",
+      );
+    }
+    const match = matchDossierRecommendationSubject({
+      recommendation,
+      candidates: currentState.candidates,
+    });
+    if (match.exactCandidateId !== candidate.id) {
+      throw new DossierWorkflowInputError(
+        "Recommendation subject does not match the selected BNL Source File",
+        400,
+        "recommendation_subject_mismatch",
+        {
+          exactCandidateId: match.exactCandidateId,
+          possibleCandidateIds: match.possibleCandidateIds,
+          reason: match.reason,
+        },
+      );
+    }
 
     if (input.createSourceNote) {
       note = {
@@ -776,6 +807,22 @@ export async function convertRecommendationToCandidate(
       );
     }
     assertRecommendationIsOpen(recommendation);
+    const match = matchDossierRecommendationSubject({
+      recommendation,
+      candidates: currentState.candidates,
+    });
+    if (match.exactCandidateId) {
+      throw new DossierWorkflowInputError(
+        "An exact same-subject BNL Source File already exists for this recommendation",
+        400,
+        "recommendation_existing_source_file_match",
+        {
+          exactCandidateId: match.exactCandidateId,
+          possibleCandidateIds: match.possibleCandidateIds,
+          reason: match.reason,
+        },
+      );
+    }
     const duplicate = findExistingDossierMatch(recommendation.subjectName);
     const note: DossierSourceFileNote = {
       id: createSourceFileNoteId(),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -304,6 +304,7 @@ export type DossierRecommendation = {
 
 export type DossierSubjectMatchResult = {
   exactCandidateId?: string;
+  exactMatchKind?: "pre_targeted" | "subject";
   possibleCandidateIds: string[];
   reason: string;
 };
@@ -329,16 +330,23 @@ function isActiveSubjectCandidate(candidate: DossierCandidate): boolean {
   return candidate.status !== "denied" && candidate.status !== "merged";
 }
 
-function hasPossibleSubjectOverlap(subjectName: string, candidateName: string): boolean {
+function hasPossibleSubjectOverlap(
+  subjectName: string,
+  candidateName: string,
+): boolean {
   const normalizedSubject = normalizeDossierSubjectName(subjectName);
   const normalizedCandidate = normalizeDossierSubjectName(candidateName);
   const compactSubject = compactDossierSubjectName(subjectName);
   const compactCandidate = compactDossierSubjectName(candidateName);
 
   if (!normalizedSubject || !normalizedCandidate) return false;
-  if (normalizedSubject === normalizedCandidate || compactSubject === compactCandidate)
+  if (
+    normalizedSubject === normalizedCandidate ||
+    compactSubject === compactCandidate
+  )
     return false;
-  if (normalizedSubject.length < 4 || normalizedCandidate.length < 4) return false;
+  if (normalizedSubject.length < 4 || normalizedCandidate.length < 4)
+    return false;
 
   return (
     normalizedSubject.includes(normalizedCandidate) ||
@@ -349,7 +357,10 @@ function hasPossibleSubjectOverlap(subjectName: string, candidateName: string): 
 }
 
 export function matchDossierRecommendationSubject(input: {
-  recommendation: Pick<DossierRecommendation, "subjectName" | "subjectKey">;
+  recommendation: Pick<
+    DossierRecommendation,
+    "subjectName" | "subjectKey" | "targetCandidateId"
+  >;
   candidates: DossierCandidate[];
 }): DossierSubjectMatchResult {
   const activeCandidates = input.candidates.filter(isActiveSubjectCandidate);
@@ -362,6 +373,21 @@ export function matchDossierRecommendationSubject(input: {
   const compactSubjectKey = input.recommendation.subjectKey
     ? compactDossierSubjectName(input.recommendation.subjectKey)
     : "";
+  const preTargetedCandidate = input.recommendation.targetCandidateId
+    ? activeCandidates.find(
+        (candidate) => candidate.id === input.recommendation.targetCandidateId,
+      )
+    : undefined;
+
+  if (preTargetedCandidate) {
+    return {
+      exactCandidateId: preTargetedCandidate.id,
+      exactMatchKind: "pre_targeted",
+      possibleCandidateIds: [],
+      reason:
+        "Explicit pre-targeted source-file match from recommendation targetCandidateId.",
+    };
+  }
 
   const exactCandidate = activeCandidates.find((candidate) => {
     const normalizedCandidate = normalizeDossierSubjectName(candidate.name);
@@ -378,21 +404,26 @@ export function matchDossierRecommendationSubject(input: {
 
   const possibleCandidateIds = activeCandidates
     .filter((candidate) => candidate.id !== exactCandidate?.id)
-    .filter((candidate) => hasPossibleSubjectOverlap(subjectName, candidate.name))
+    .filter((candidate) =>
+      hasPossibleSubjectOverlap(subjectName, candidate.name),
+    )
     .map((candidate) => candidate.id);
 
   if (exactCandidate) {
     return {
       exactCandidateId: exactCandidate.id,
+      exactMatchKind: "subject",
       possibleCandidateIds,
-      reason: "Exact same-subject match by normalized name, compact name, or explicit subject key.",
+      reason:
+        "Exact same-subject match by normalized name, compact name, or explicit subject key.",
     };
   }
 
   if (possibleCandidateIds.length > 0) {
     return {
       possibleCandidateIds,
-      reason: "Possible duplicate / identity warning from weak partial subject similarity; owner/lead identity resolution is required before attach.",
+      reason:
+        "Possible duplicate / identity warning from weak partial subject similarity; owner/lead identity resolution is required before attach.",
     };
   }
 

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -301,6 +301,107 @@ export type DossierRecommendation = {
   createdBy?: string;
 };
 
+
+export type DossierSubjectMatchResult = {
+  exactCandidateId?: string;
+  possibleCandidateIds: string[];
+  reason: string;
+};
+
+export function normalizeDossierSubjectName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\b(the|a|an)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function compactDossierSubjectName(value: string): string {
+  return normalizeDossierSubjectName(value).replace(/\s+/g, "");
+}
+
+function isActiveSubjectCandidate(candidate: DossierCandidate): boolean {
+  return candidate.status !== "denied" && candidate.status !== "merged";
+}
+
+function hasPossibleSubjectOverlap(subjectName: string, candidateName: string): boolean {
+  const normalizedSubject = normalizeDossierSubjectName(subjectName);
+  const normalizedCandidate = normalizeDossierSubjectName(candidateName);
+  const compactSubject = compactDossierSubjectName(subjectName);
+  const compactCandidate = compactDossierSubjectName(candidateName);
+
+  if (!normalizedSubject || !normalizedCandidate) return false;
+  if (normalizedSubject === normalizedCandidate || compactSubject === compactCandidate)
+    return false;
+  if (normalizedSubject.length < 4 || normalizedCandidate.length < 4) return false;
+
+  return (
+    normalizedSubject.includes(normalizedCandidate) ||
+    normalizedCandidate.includes(normalizedSubject) ||
+    compactSubject.includes(compactCandidate) ||
+    compactCandidate.includes(compactSubject)
+  );
+}
+
+export function matchDossierRecommendationSubject(input: {
+  recommendation: Pick<DossierRecommendation, "subjectName" | "subjectKey">;
+  candidates: DossierCandidate[];
+}): DossierSubjectMatchResult {
+  const activeCandidates = input.candidates.filter(isActiveSubjectCandidate);
+  const subjectName = input.recommendation.subjectName;
+  const normalizedSubject = normalizeDossierSubjectName(subjectName);
+  const compactSubject = compactDossierSubjectName(subjectName);
+  const normalizedSubjectKey = input.recommendation.subjectKey
+    ? normalizeDossierSubjectName(input.recommendation.subjectKey)
+    : "";
+  const compactSubjectKey = input.recommendation.subjectKey
+    ? compactDossierSubjectName(input.recommendation.subjectKey)
+    : "";
+
+  const exactCandidate = activeCandidates.find((candidate) => {
+    const normalizedCandidate = normalizeDossierSubjectName(candidate.name);
+    const compactCandidate = compactDossierSubjectName(candidate.name);
+    return (
+      Boolean(normalizedSubject) &&
+      (normalizedSubject === normalizedCandidate ||
+        compactSubject === compactCandidate ||
+        (Boolean(normalizedSubjectKey) &&
+          (normalizedSubjectKey === normalizedCandidate ||
+            compactSubjectKey === compactCandidate)))
+    );
+  });
+
+  const possibleCandidateIds = activeCandidates
+    .filter((candidate) => candidate.id !== exactCandidate?.id)
+    .filter((candidate) => hasPossibleSubjectOverlap(subjectName, candidate.name))
+    .map((candidate) => candidate.id);
+
+  if (exactCandidate) {
+    return {
+      exactCandidateId: exactCandidate.id,
+      possibleCandidateIds,
+      reason: "Exact same-subject match by normalized name, compact name, or explicit subject key.",
+    };
+  }
+
+  if (possibleCandidateIds.length > 0) {
+    return {
+      possibleCandidateIds,
+      reason: "Possible duplicate / identity warning from weak partial subject similarity; owner/lead identity resolution is required before attach.",
+    };
+  }
+
+  return {
+    possibleCandidateIds: [],
+    reason: "No safe same-subject BNL Source File match found.",
+  };
+}
+
 export type CreateDossierSourceFileNoteInput = {
   candidateId: string;
   type?: DossierSourceFileNoteType;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2024,6 +2024,163 @@ test("arbitrary recommendation attach is blocked by same-subject guardrails", as
   assert.ok(["new", "reviewing"].includes(signalWitch.status));
 });
 
+
+test("pre-targeted recommendation attaches to target source file despite alias subject", async () => {
+  await resetWorkflowStore();
+  const targetPayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "modify_existing_dossier",
+        subjectName: "ShadowsPit",
+        targetCandidateId: targetPayload.candidate.id,
+        reason: "Alias evidence intentionally targets Deadite Ash.",
+        evidenceSummary: "Legacy/public name points to the canonical source file.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "attachRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+    candidateId: targetPayload.candidate.id,
+    createSourceNote: true,
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.recommendation.status, "attached_to_source_file");
+  assert.equal(payload.recommendation.targetCandidateId, targetPayload.candidate.id);
+  const target = payload.candidates.find(
+    (candidate) => candidate.id === targetPayload.candidate.id,
+  );
+  assert.equal(target.sourceFileNotes.length, 1);
+  assert.match(target.sourceFileNotes[0].text, /Alias evidence intentionally/);
+});
+
+test("pre-targeted recommendation cannot attach to a different source file", async () => {
+  await resetWorkflowStore();
+  const targetPayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const otherPayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Mac Modem" },
+    })
+  ).json();
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "modify_existing_dossier",
+        subjectName: "ShadowsPit",
+        targetCandidateId: targetPayload.candidate.id,
+        reason: "Targeted alias should not attach elsewhere.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "attachRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+    candidateId: otherPayload.candidate.id,
+    createSourceNote: true,
+  });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).code, "recommendation_subject_mismatch");
+
+  const finalPayload = await (await authedGet()).json();
+  const other = finalPayload.candidates.find(
+    (candidate) => candidate.id === otherPayload.candidate.id,
+  );
+  const recommendation = finalPayload.recommendations.find(
+    (item) => item.id === recPayload.recommendation.id,
+  );
+  assert.equal(other.sourceFileNotes.length, 0);
+  assert.equal(recommendation.status, "new");
+});
+
+test("pre-targeted recommendation cannot convert to duplicate source file", async () => {
+  await resetWorkflowStore();
+  const targetPayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "modify_existing_dossier",
+        subjectName: "ShadowsPit",
+        targetCandidateId: targetPayload.candidate.id,
+        reason: "Targeted alias should update existing source file.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "convertRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+  });
+  assert.equal(response.status, 400);
+  const errorPayload = await response.json();
+  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
+  assert.equal(errorPayload.exactCandidateId, targetPayload.candidate.id);
+  assert.equal(errorPayload.exactMatchKind, "pre_targeted");
+
+  const finalPayload = await (await authedGet()).json();
+  assert.equal(finalPayload.candidates.length, 1);
+});
+
+test("pre-targeted recommendation target must be active", async () => {
+  await resetWorkflowStore();
+  const targetPayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Closed Target" },
+    })
+  ).json();
+  await authedPost({
+    action: "denyCandidate",
+    candidateId: targetPayload.candidate.id,
+  });
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "modify_existing_dossier",
+        subjectName: "Closed Alias",
+        targetCandidateId: targetPayload.candidate.id,
+        reason: "Closed targets cannot receive pre-targeted evidence.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "attachRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+    candidateId: targetPayload.candidate.id,
+    createSourceNote: true,
+  });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).code, "candidate_not_attachable");
+});
+
 test("convert recommendation is blocked when exact source file match exists", async () => {
   await resetWorkflowStore();
   await authedPost({
@@ -2185,6 +2342,8 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Convert to New BNL Source File/);
   assert.match(dashboard, /Match state/);
   assert.match(dashboard, /Matched existing BNL Source File/);
+  assert.match(dashboard, /Pre-targeted BNL Source File/);
+  assert.match(dashboard, /This recommendation already points to an existing/);
   assert.match(dashboard, /Possible duplicate \/ identity warning/);
   assert.match(dashboard, /No BNL Source File match/);
   assert.match(dashboard, /Attach to Matched Source File/);
@@ -2224,6 +2383,8 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   );
   assert.match(recommendationPage, /!isTerminal &&/);
   assert.match(recommendationPage, /Matched BNL Source File/);
+  assert.match(recommendationPage, /Pre-targeted BNL Source File/);
+  assert.match(recommendationPage, /This recommendation already points to an existing/);
   assert.match(recommendationPage, /Attach to Matched BNL Source File/);
   assert.match(recommendationPage, /Owner\/lead identity review is required/);
   assert.doesNotMatch(recommendationPage, /Choose existing BNL Source File/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -330,9 +330,9 @@ test("dossier admin pages expose numbered dossier phases and clearer labels", ()
   assert.match(sourceFilePage, /Phase 1 — BNL Source File/);
   assertIncludesCopy(
     sourceFileCopy,
-    "This page collects what BNL knows and what mods/admins add",
+    "This BNL Source File is one subject/entity source packet",
   );
-  assertIncludesCopy(sourceFileCopy, "source material, not the public dossier");
+  assertIncludesCopy(sourceFileCopy, "Admins can add information to this BNL Source File");
 
   const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   const draftCopy = normalizedSource(
@@ -422,7 +422,8 @@ test("dedicated candidate review route contains focused evidence and action work
     "Add to BNL Source File",
     "Additional Info Added After Submission",
     "Admin Addendum",
-    "This adds source material for BNL. It does not directly edit the proposed dossier.",
+    "Admins can add information to this BNL Source File. It does not directly edit the proposed dossier.",
+    "This source file remains one subject/entity.",
     "Save Info",
     "Create / Open Proposed Dossier",
     "Open Proposed Dossier",
@@ -1675,10 +1676,19 @@ test("source file notes persist without mutating draft fields or public read mod
 
   const getPayload = await (await authedGet()).json();
   assert.equal(getPayload.candidates[0].sourceFileNotes[0].type, "correction");
+  await authedPost({
+    action: "createDossierRecommendation",
+    input: {
+      type: "new_subject",
+      subjectName: "Private Recommendation Seed",
+      reason: "This admin-only recommendation must not leak publicly.",
+      sourceLanes: ["admin_manual"],
+    },
+  });
   const publicReadModel = JSON.stringify(await (await readModel.GET()).json());
   assert.doesNotMatch(
     publicReadModel,
-    /sourceFileNotes|recommendations|Correct the public-safe spelling|admin_manual|doNotSay/,
+    /sourceFileNotes|recommendations|Correct the public-safe spelling|Private Recommendation Seed|admin_manual|doNotSay/,
   );
   assert.doesNotMatch(
     source("src/app/database/page.tsx") +
@@ -1865,7 +1875,7 @@ test("terminal recommendations cannot be attached, reattached, ignored, dismisse
   const candidatePayload = await (
     await authedPost({
       action: "createManualCandidate",
-      input: { ...manualCandidateInput, name: "Terminal Attach Target" },
+      input: { ...manualCandidateInput, name: "Already Attached" },
     })
   ).json();
 
@@ -1972,12 +1982,111 @@ test("terminal recommendations cannot be attached, reattached, ignored, dismisse
   assert.equal(finalTarget.sourceFileNotes.length, attachedNoteCount);
 });
 
-test("attach recommendation to existing candidate can create a source note and no draft", async () => {
+
+test("arbitrary recommendation attach is blocked by same-subject guardrails", async () => {
   await resetWorkflowStore();
   const candidatePayload = await (
     await authedPost({
       action: "createManualCandidate",
-      input: manualCandidateInput,
+      input: { ...manualCandidateInput, name: "Mac Modem" },
+    })
+  ).json();
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "new_subject",
+        subjectName: "Signal Witch",
+        reason: "Signal Witch evidence should not attach to Mac Modem.",
+        evidenceSummary: "Unrelated evidence cluster.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "attachRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+    candidateId: candidatePayload.candidate.id,
+    createSourceNote: true,
+  });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).code, "recommendation_subject_mismatch");
+
+  const finalPayload = await (await authedGet()).json();
+  const macModem = finalPayload.candidates.find(
+    (candidate) => candidate.id === candidatePayload.candidate.id,
+  );
+  const signalWitch = finalPayload.recommendations.find(
+    (recommendation) => recommendation.id === recPayload.recommendation.id,
+  );
+  assert.equal(macModem.sourceFileNotes.length, 0);
+  assert.ok(["new", "reviewing"].includes(signalWitch.status));
+});
+
+test("convert recommendation is blocked when exact source file match exists", async () => {
+  await resetWorkflowStore();
+  await authedPost({
+    action: "createManualCandidate",
+    input: { ...manualCandidateInput, name: "Signal Witch" },
+  });
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "new_subject",
+        subjectName: "Signal Witch",
+        reason: "Exact match should attach, not duplicate.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "convertRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+  });
+  assert.equal(response.status, 400);
+  const errorPayload = await response.json();
+  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
+  assert.ok(errorPayload.exactCandidateId);
+
+  const finalPayload = await (await authedGet()).json();
+  assert.equal(finalPayload.candidates.length, 1);
+});
+
+test("convert recommendation is allowed when no source file match exists", async () => {
+  await resetWorkflowStore();
+  const recPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "new_subject",
+        subjectName: "Antigrain",
+        reason: "No existing source file match.",
+        evidenceSummary: "Create a new one-subject packet.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "convertRecommendationToCandidate",
+    recommendationId: recPayload.recommendation.id,
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.candidate.name, "Antigrain");
+  assert.equal(payload.candidates.length, 1);
+  assert.equal(payload.recommendation.status, "converted_to_source_file");
+});
+
+test("exact match attach recommendation to existing source file creates a source note and no draft", async () => {
+  await resetWorkflowStore();
+  const candidatePayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Attach Seed" },
     })
   ).json();
   const recPayload = await (
@@ -2071,16 +2180,23 @@ test("ignore and dismiss recommendations preserve records", async () => {
 test("recommendation inbox and source note UI are present and bounded", () => {
   const dashboard = source("src/app/admin/dossiers/page.tsx");
   assert.match(dashboard, /Dossier Recommendation Inbox/);
-  assert.match(dashboard, /Recommendations do not publish anything/);
+  assert.match(dashboard, /BNL Recommendation \/ Evidence Cluster/);
   assert.match(dashboard, /Create Manual Recommendation/);
-  assert.match(dashboard, /Convert to BNL Source File/);
-  assert.match(dashboard, /Attach to Existing Source File/);
+  assert.match(dashboard, /Convert to New BNL Source File/);
+  assert.match(dashboard, /Match state/);
+  assert.match(dashboard, /Matched existing BNL Source File/);
+  assert.match(dashboard, /Possible duplicate \/ identity warning/);
+  assert.match(dashboard, /No BNL Source File match/);
+  assert.match(dashboard, /Attach to Matched Source File/);
+  assert.doesNotMatch(dashboard, /Attach to Existing Source File/);
 
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
   );
   assert.match(sourceFilePage, /Add to BNL Source File/);
-  assert.match(sourceFilePage, /does not directly edit the proposed dossier/);
+  assert.match(sourceFilePage, /Admins can add information to this BNL Source File/);
+  assert.match(sourceFilePage, /This source file[\s\S]*remains one subject\/entity/);
+  assert.match(sourceFilePage, /create or wait for a separate BNL recommendation/);
   assert.match(sourceFilePage, /Save Info/);
 
   const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
@@ -2096,17 +2212,21 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   const recommendationPage = source(recommendationPagePath);
   assert.match(
     recommendationPage,
-    /Recommendations are admin-only review records/,
+    /BNL Recommendation \/ Evidence Cluster records are admin-only/,
   );
   assert.match(recommendationPage, /terminalRecommendationStatuses/);
   assert.match(recommendationPage, /Converted to BNL Source File\./);
-  assert.match(recommendationPage, /Attached to existing BNL Source File\./);
+  assert.match(recommendationPage, /Attached to matched BNL Source File\./);
   assert.match(recommendationPage, /Ignored\. This recommendation is closed\./);
   assert.match(
     recommendationPage,
     /Dismissed\. This recommendation is closed\./,
   );
   assert.match(recommendationPage, /!isTerminal &&/);
+  assert.match(recommendationPage, /Matched BNL Source File/);
+  assert.match(recommendationPage, /Attach to Matched BNL Source File/);
+  assert.match(recommendationPage, /Owner\/lead identity review is required/);
+  assert.doesNotMatch(recommendationPage, /Choose existing BNL Source File/);
   assert.match(
     recommendationPage,
     /Terminal recommendation actions are closed/,


### PR DESCRIPTION
### Motivation

- Prevent admins from arbitrarily attaching unrelated recommendations to existing BNL Source Files and preserve a single-subject authority model for source files.
- Reframe recommendations as evidence clusters that either attach to a same-subject source file, convert to a new source file when safe, or escalate to owner/lead identity resolution for merges.
- Provide safe, deterministic subject-matching guardrails so future BNL scanning can be integrated without exposing unsafe admin merge affordances.

### Description

- Added a safe subject-matching helper and normalization utilities in `src/lib/dossier-workflow.ts` that classify `exact`, `possible`, and `no match` states and exclude denied/merged candidates (`matchDossierRecommendationSubject`, `normalizeDossierSubjectName`, `compactDossierSubjectName`).
- Enforced match-based guards in `src/lib/dossier-workflow-store.ts` so `attachRecommendationToCandidate` only succeeds for open recommendations and an exact same-subject active candidate and so `convertRecommendationToCandidate` is blocked when an exact source-file match exists; mismatch and existing-match failures surface clear error codes (`recommendation_subject_mismatch`, `recommendation_existing_source_file_match`) and safe match details.
- Updated API error handling in `src/app/api/admin/dossiers/route.ts` to include `DossierWorkflowInputError` details for admin-only responses.
- Reworked admin UI copy and flows to remove the freeform “Attach to Existing Source File” dropdown and replace it with a `Matched BNL Source File` section and match-state UX in `src/app/admin/dossiers/page.tsx` and `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, and clarified candidate/source-file copy in `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` to emphasize one-subject/source-packet authority.
- Updated tests in `tests/admin-dossiers.test.mjs` to cover: arbitrary attach being blocked, exact-match attach succeeding, convert blocked when exact match exists, convert allowed when no match exists, UI copy/flow changes, and public read-model safety.

### Testing

- Type-check and lint: ran `npx tsc --noEmit` and `npx eslint` on modified files, both passed without errors.
- Unit/integration tests: ran `node --test tests/admin-dossiers.test.mjs` and all dossier workflow tests passed (50/50).
- Queue/read-model tests: ran `npm run test:queue` and the queue + read-model suites passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b13ecb64c8321b003c0191fa0e650)