### PR TITLE
BNL dossier recommendation ingest endpoint (v1)

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -118,6 +118,15 @@ function linkedActiveDraftFor(
   );
 }
 
+function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
+    return "BNL-ingested";
+  }
+  return recommendation.createdBy
+    ? `Seeded by ${recommendation.createdBy}`
+    : "Manually seeded";
+}
+
 function StatusPill({ children }: { children: React.ReactNode }) {
   return (
     <span className="border border-border bg-background/40 px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted">
@@ -560,7 +569,9 @@ export default function DossierControlCenterPage() {
             Compact Dossier Recommendation Inbox summary. Review a record to
             convert an unmatched recommendation or attach only when the system
             confirms a same-subject BNL Source File match. No generic attach
-            dropdown is shown here.
+            dropdown is shown here. BNL-ingested recommendations are review
+            items. They do not create source files, drafts, tags, or public
+            pages until approved through the workflow.
           </p>
           {activeRecommendations.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
@@ -574,6 +585,7 @@ export default function DossierControlCenterPage() {
                   <tr>
                     <th className="py-2 pr-3">Subject</th>
                     <th className="py-2 pr-3">Match state</th>
+                    <th className="py-2 pr-3">Ingest</th>
                     <th className="py-2 pr-3">Source lanes</th>
                     <th className="py-2 pr-3">Next action</th>
                     <th className="py-2 pr-3">Review</th>
@@ -591,6 +603,12 @@ export default function DossierControlCenterPage() {
                           {recommendation.subjectName}
                         </td>
                         <td className="py-3 pr-3">{matchState.state}</td>
+                        <td className="py-3 pr-3">
+                          <p>{recommendationProvenance(recommendation)}</p>
+                          {recommendation.ingestedAt && (
+                            <p className="text-xs">{formatDate(recommendation.ingestedAt)}</p>
+                          )}
+                        </td>
                         <td className="py-3 pr-3">
                           {recommendation.sourceLanes.join(", ")}
                         </td>

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -54,6 +54,20 @@ function list(items: string[] | undefined, empty = "—") {
   );
 }
 
+function formatDate(value?: string) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
+    return "BNL-ingested";
+  }
+  return recommendation.createdBy
+    ? `Seeded by ${recommendation.createdBy}`
+    : "Manually seeded";
+}
+
 function Field({
   title,
   children,
@@ -274,7 +288,9 @@ export default function DossierRecommendationPage() {
             evidence records. They do not publish, create drafts, write content
             files, or create tags automatically. Attach is only allowed for
             confirmed same-subject matches; merge is owner/lead identity
-            resolution.
+            resolution. BNL-ingested recommendations are review items. They do
+            not create source files, drafts, tags, or public pages until
+            approved through the workflow.
           </p>
           {notice && (
             <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -430,6 +446,13 @@ export default function DossierRecommendationPage() {
             <p>
               {recommendation.type} / {recommendation.status}
             </p>
+          </Field>
+          <Field title="Ingest source">
+            <p>{recommendationProvenance(recommendation)}</p>
+            <p>Created by: {recommendation.createdBy ?? "—"}</p>
+            <p>Ingest source: {recommendation.ingestSource ?? "—"}</p>
+            <p>Ingested at: {formatDate(recommendation.ingestedAt)}</p>
+            <p>Ingest key: {recommendation.ingestKey ?? "—"}</p>
           </Field>
           <Field title="Reason">
             <p>{recommendation.reason}</p>

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -1,0 +1,226 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import {
+  databasePage,
+  type DossierEcosystemLane,
+  type DossierIdentityAuthority,
+  type PublicDossierKind,
+} from "@/content";
+import {
+  type CreateDossierRecommendationInput,
+  type DossierCategory,
+  type DossierRecommendationSourceLane,
+  type DossierRecommendationType,
+} from "@/lib/dossier-workflow";
+import {
+  createDossierRecommendationIdempotent,
+  DossierWorkflowInputError,
+} from "@/lib/dossier-workflow-store";
+
+export const dynamic = "force-dynamic";
+
+const RECOMMENDATION_TYPES = [
+  "new_subject",
+  "modify_existing_dossier",
+] as const satisfies readonly DossierRecommendationType[];
+const SOURCE_LANES = [
+  "public_discord",
+  "rd_context",
+  "broadcast_memory",
+  "queue_context",
+  "website_dossier",
+  "admin_manual",
+  "mod_manual",
+  "owner_manual",
+  "unknown",
+] as const satisfies readonly DossierRecommendationSourceLane[];
+const CATEGORIES = [
+  "Entity",
+  "Personnel",
+  "Sponsor",
+  "Interface",
+  "Production",
+] as const satisfies readonly DossierCategory[];
+const KINDS = [
+  "program",
+  "interface",
+  "platform",
+  "system",
+  "entity",
+  "artist",
+  "sponsor_character",
+  "story_arc",
+  "technical_component",
+  "archive_record",
+  "core_entity",
+  "network_operator",
+  "network_staff",
+  "moderator",
+  "collaborator",
+  "community_member",
+  "radio_regular",
+  "radio_entity",
+] as const satisfies readonly PublicDossierKind[];
+const ECOSYSTEM_LANES = [
+  "core_team",
+  "network_operator",
+  "network_staff",
+  "community_mod",
+  "radio_support",
+  "technical_operator",
+  "collaborator",
+  "community_member",
+  "radio_regular",
+  "sponsor",
+  "radio_entity",
+  "infrastructure",
+  "production",
+  "unknown",
+] as const satisfies readonly DossierEcosystemLane[];
+const IDENTITY_AUTHORITIES = [
+  "barcode_controlled",
+  "community_owned",
+  "external_system",
+  "sponsor_controlled",
+  "mixed_or_unclear",
+] as const satisfies readonly DossierIdentityAuthority[];
+const CONFIDENCES = ["low", "medium", "high"] as const;
+
+function text(value: unknown, maxLength: number): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") throw new Error("Expected text field");
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > maxLength) throw new Error("Text field is too long");
+  return trimmed;
+}
+
+function stringList(value: unknown, maxItemLength = 500): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error("Expected a list of strings");
+  if (value.length > 25) throw new Error("List field has too many items");
+  const items = value.map((item) => text(item, maxItemLength)).filter(Boolean);
+  return items.length ? (items as string[]) : [];
+}
+
+function enumValue<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+): T | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value as T;
+}
+
+function bearerToken(req: Request): string {
+  const authorization = req.headers.get("authorization") ?? "";
+  if (authorization.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+  return req.headers.get("x-bnl-ingest-token")?.trim() ?? "";
+}
+
+function tokenMatches(providedToken: string): boolean {
+  const expectedToken = process.env.BNL_DOSSIER_INGEST_TOKEN?.trim() ?? "";
+  if (!expectedToken || !providedToken) return false;
+  const expected = Buffer.from(expectedToken);
+  const provided = Buffer.from(providedToken);
+  return expected.length === provided.length && timingSafeEqual(expected, provided);
+}
+
+function normalizePayload(value: unknown): CreateDossierRecommendationInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid payload");
+  }
+  const payload = value as Record<string, unknown>;
+  if (Object.keys(payload).length === 0) throw new Error("Invalid payload");
+
+  const sourceLanesInput = payload.sourceLanes;
+  let sourceLanes: DossierRecommendationSourceLane[];
+  if (sourceLanesInput === undefined) {
+    sourceLanes = ["unknown"];
+  } else {
+    if (!Array.isArray(sourceLanesInput)) throw new Error("Invalid source lane");
+    sourceLanes = sourceLanesInput.map((lane) =>
+      enumValue(lane, SOURCE_LANES, "source lane"),
+    ) as DossierRecommendationSourceLane[];
+    sourceLanes = sourceLanes.filter(Boolean);
+    if (sourceLanes.length === 0) sourceLanes = ["unknown"];
+  }
+
+  const targetDossierId = text(payload.targetDossierId, 200);
+  if (
+    targetDossierId &&
+    !databasePage.entries.some((entry) => entry.id === targetDossierId)
+  ) {
+    throw new Error("Invalid target dossier");
+  }
+
+  const subjectName = text(payload.subjectName, 200);
+  const reason = text(payload.reason, 2000);
+  if (!subjectName) throw new Error("subjectName is required");
+  if (!reason) throw new Error("reason is required");
+
+  return {
+    type: enumValue(payload.type ?? "new_subject", RECOMMENDATION_TYPES, "type") ?? "new_subject",
+    subjectName,
+    subjectKey: text(payload.subjectKey, 200),
+    targetCandidateId: text(payload.targetCandidateId, 200),
+    targetDossierId,
+    reason,
+    evidenceSummary: text(payload.evidenceSummary, 2000),
+    confidence: enumValue(payload.confidence, CONFIDENCES, "confidence"),
+    sourceLanes,
+    suggestedAction: text(payload.suggestedAction, 500),
+    missingInfo: stringList(payload.missingInfo),
+    publicSafetyNotes: stringList(payload.publicSafetyNotes),
+    doNotSay: stringList(payload.doNotSay),
+    recommendedTags: stringList(payload.recommendedTags, 80),
+    recommendedCategory: enumValue(payload.recommendedCategory, CATEGORIES, "taxonomy"),
+    recommendedKind: enumValue(payload.recommendedKind, KINDS, "taxonomy"),
+    recommendedEcosystemLane: enumValue(
+      payload.recommendedEcosystemLane,
+      ECOSYSTEM_LANES,
+      "taxonomy",
+    ),
+    recommendedIdentityAuthority: enumValue(
+      payload.recommendedIdentityAuthority,
+      IDENTITY_AUTHORITIES,
+      "taxonomy",
+    ),
+    createdBy: text(payload.createdBy, 200) ?? "bnl",
+    ingestKey: text(payload.ingestKey, 300),
+    ingestedAt: new Date().toISOString(),
+    ingestSource: "bnl",
+  };
+}
+
+export async function POST(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let input: CreateDossierRecommendationInput;
+  try {
+    input = normalizePayload(await req.json().catch(() => null));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid payload";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    const result = await createDossierRecommendationIdempotent(input);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    if (error instanceof DossierWorkflowInputError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status },
+      );
+    }
+    throw error;
+  }
+}

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -566,7 +566,112 @@ function normalizeRecommendationInput(
     recommendedEcosystemLane: input.recommendedEcosystemLane,
     recommendedIdentityAuthority: input.recommendedIdentityAuthority,
     createdBy: boundedText(input.createdBy, 200) || undefined,
+    ingestKey: boundedText(input.ingestKey, 300) || undefined,
+    ingestedAt: boundedText(input.ingestedAt, 80) || undefined,
+    ingestSource:
+      input.ingestSource === "bnl" ||
+      input.ingestSource === "system" ||
+      input.ingestSource === "unknown"
+        ? input.ingestSource
+        : undefined,
   };
+}
+
+function isActiveRecommendation(recommendation: DossierRecommendation): boolean {
+  return !TERMINAL_RECOMMENDATION_STATUSES.has(recommendation.status);
+}
+
+function recommendationDedupeSubject(value: string): string {
+  return normalizeName(value);
+}
+
+function recommendationDedupeText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function fallbackRecommendationDedupeKey(
+  recommendation: Pick<
+    DossierRecommendation,
+    "subjectName" | "type" | "sourceLanes" | "reason"
+  >,
+): string {
+  return [
+    recommendationDedupeSubject(recommendation.subjectName),
+    recommendation.type,
+    [...recommendation.sourceLanes].sort().join("+"),
+    recommendationDedupeText(recommendation.reason),
+  ].join("|");
+}
+
+export async function createDossierRecommendationIdempotent(
+  input: CreateDossierRecommendationInput,
+): Promise<{ recommendation: DossierRecommendation; duplicate: boolean }> {
+  const normalized = normalizeRecommendationInput(input);
+  if (!normalized) {
+    throw new DossierWorkflowInputError(
+      "Recommendation requires subjectName and reason",
+    );
+  }
+  const now = new Date().toISOString();
+  const recommendation: DossierRecommendation = {
+    id: createRecommendationId(),
+    ...normalized,
+    status: "new",
+    createdAt: now,
+    updatedAt: now,
+  };
+  let savedRecommendation: DossierRecommendation = recommendation;
+  let duplicate = false;
+
+  await updateDossierWorkflowState((currentState) => {
+    if (recommendation.targetCandidateId) {
+      const candidate = currentState.candidates.find(
+        (item) => item.id === recommendation.targetCandidateId,
+      );
+      if (!candidate) {
+        throw new DossierWorkflowInputError(
+          "Target candidate not found",
+          404,
+          "target_candidate_not_found",
+        );
+      }
+      if (candidate.status === "denied" || candidate.status === "merged") {
+        throw new DossierWorkflowInputError(
+          "Target candidate is not an active BNL Source File",
+          400,
+          "target_candidate_not_active",
+        );
+      }
+    }
+
+    const existing = recommendation.ingestKey
+      ? currentState.recommendations.find(
+          (item) =>
+            isActiveRecommendation(item) &&
+            item.ingestKey === recommendation.ingestKey,
+        )
+      : currentState.recommendations.find(
+          (item) =>
+            isActiveRecommendation(item) &&
+            fallbackRecommendationDedupeKey(item) ===
+              fallbackRecommendationDedupeKey(recommendation),
+        );
+
+    if (existing) {
+      savedRecommendation = existing;
+      duplicate = true;
+      return currentState;
+    }
+
+    savedRecommendation = recommendation;
+    return {
+      ...currentState,
+      recommendations: [recommendation, ...currentState.recommendations],
+      updatedAt: now,
+    };
+  });
+
+  return { recommendation: savedRecommendation, duplicate };
 }
 
 function recommendationSourceNoteText(

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -128,6 +128,9 @@ export type DossierSourceFileNote = {
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
+  ingestKey?: string;
+  ingestedAt?: string;
+  ingestSource?: DossierRecommendationIngestSource;
 };
 
 export type DossierCandidate = {
@@ -275,6 +278,8 @@ export type DossierRecommendationSourceLane =
   | "owner_manual"
   | "unknown";
 
+export type DossierRecommendationIngestSource = "bnl" | "system" | "unknown";
+
 export type DossierRecommendation = {
   id: string;
   type: DossierRecommendationType;
@@ -299,6 +304,9 @@ export type DossierRecommendation = {
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
+  ingestKey?: string;
+  ingestedAt?: string;
+  ingestSource?: DossierRecommendationIngestSource;
 };
 
 
@@ -558,6 +566,9 @@ export type CreateDossierRecommendationInput = {
   recommendedEcosystemLane?: DossierCandidate["recommendedEcosystemLane"];
   recommendedIdentityAuthority?: DossierCandidate["recommendedIdentityAuthority"];
   createdBy?: string;
+  ingestKey?: string;
+  ingestedAt?: string;
+  ingestSource?: DossierRecommendationIngestSource;
 };
 
 export type MergeDossierCandidatesInput = {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -46,6 +46,7 @@ Module._extensions[".tsx"] = Module._extensions[".ts"];
 const require = createRequire(import.meta.url);
 const auth = require("../src/lib/auth.ts");
 const route = require("../src/app/api/admin/dossiers/route.ts");
+const bnlIngestRoute = require("../src/app/api/bnl/dossier-recommendations/route.ts");
 const workflow = require("../src/lib/dossier-workflow.ts");
 const store = require("../src/lib/dossier-workflow-store.ts");
 const { databasePage } = require("../src/content.ts");
@@ -97,6 +98,19 @@ async function authedPost(body) {
       headers: {
         "content-type": "application/json",
         cookie: await adminCookie(),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function bnlIngestPost(body, token = "test-bnl-ingest-token") {
+  return bnlIngestRoute.POST(
+    new Request("https://example.test/api/bnl/dossier-recommendations", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(body),
     }),
@@ -2456,5 +2470,224 @@ test("source note and recommendation actions enforce auth and validation", async
       })
     ).status,
     404,
+  );
+});
+
+test("BNL dossier recommendation ingest requires a private token", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const missingToken = await bnlIngestRoute.POST(
+    new Request("https://example.test/api/bnl/dossier-recommendations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ subjectName: "Signal Witch", reason: "Observed." }),
+    }),
+  );
+  assert.equal(missingToken.status, 401);
+
+  const wrongToken = await bnlIngestPost(
+    { subjectName: "Signal Witch", reason: "Observed." },
+    "wrong-token",
+  );
+  assert.equal(wrongToken.status, 401);
+
+  const validToken = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Signal Witch",
+    reason: "Signal Witch appears in multiple approved source lanes.",
+    sourceLanes: ["rd_context"],
+  });
+  assert.equal(validToken.status, 200);
+  const payload = await validToken.json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.duplicate, false);
+  assert.equal(payload.recommendation.createdBy, "bnl");
+});
+
+test("BNL ingest creates review-only recommendations visible to admin without candidates or drafts", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const response = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Signal Witch",
+    subjectKey: "signal-witch",
+    reason: "Signal Witch appears in multiple approved source lanes.",
+    evidenceSummary: "Mentioned in R&D and broadcast-memory context.",
+    confidence: "medium",
+    sourceLanes: ["rd_context", "broadcast_memory"],
+    suggestedAction: "Review source file and create or update proposed dossier.",
+    missingInfo: ["public link", "preferred display name"],
+    publicSafetyNotes: [
+      "Do not expose private Discord identity without owner approval.",
+    ],
+    doNotSay: [],
+    recommendedTags: ["artist", "broadcast-context"],
+    recommendedCategory: "Entity",
+    recommendedKind: "community_member",
+    recommendedEcosystemLane: "community_member",
+    recommendedIdentityAuthority: "community_owned",
+    ingestKey: "bnl:signal-witch:rd+broadcast:2026-05-30",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.recommendation.status, "new");
+  assert.equal(payload.recommendation.createdBy, "bnl");
+  assert.equal(payload.recommendation.ingestSource, "bnl");
+  assert.ok(payload.recommendation.ingestedAt);
+  assert.equal(payload.recommendation.ingestKey, "bnl:signal-witch:rd+broadcast:2026-05-30");
+
+  const adminResponse = await authedGet();
+  const adminPayload = await adminResponse.json();
+  assert.equal(adminPayload.recommendations.length, 1);
+  assert.equal(adminPayload.recommendations[0].subjectName, "Signal Witch");
+  assert.deepEqual(adminPayload.candidates, []);
+  assert.deepEqual(adminPayload.drafts, []);
+});
+
+test("BNL ingest dedupes active recommendations by ingestKey and fallback comparison", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const input = {
+    type: "new_subject",
+    subjectName: "Duplicate Signal",
+    reason: "The same recommendation should not be stored twice.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:duplicate-signal:2026-05-30",
+  };
+  const first = await (await bnlIngestPost(input)).json();
+  const second = await (await bnlIngestPost(input)).json();
+  assert.equal(first.duplicate, false);
+  assert.equal(second.duplicate, true);
+  assert.equal(second.recommendation.id, first.recommendation.id);
+
+  const fallbackInput = {
+    type: "new_subject",
+    subjectName: "Fallback Signal",
+    reason: "Normalize this reason for duplicate checking.",
+    sourceLanes: ["broadcast_memory", "rd_context"],
+  };
+  const fallbackFirst = await (await bnlIngestPost(fallbackInput)).json();
+  const fallbackSecond = await (await bnlIngestPost({
+    ...fallbackInput,
+    sourceLanes: ["rd_context", "broadcast_memory"],
+  })).json();
+  assert.equal(fallbackFirst.duplicate, false);
+  assert.equal(fallbackSecond.duplicate, true);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.length, 2);
+});
+
+test("BNL ingest rejects missing fields, invalid taxonomy, invalid lanes, and empty payloads", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  assert.equal((await bnlIngestPost({ reason: "Missing subject" })).status, 400);
+  assert.equal((await bnlIngestPost({ subjectName: "Missing reason" })).status, 400);
+  assert.equal((await bnlIngestPost({})).status, 400);
+  assert.equal(
+    (
+      await bnlIngestPost({
+        subjectName: "Bad Taxonomy",
+        reason: "Invalid taxonomy should fail.",
+        recommendedKind: "not_a_kind",
+        sourceLanes: ["rd_context"],
+      })
+    ).status,
+    400,
+  );
+  assert.equal(
+    (
+      await bnlIngestPost({
+        subjectName: "Bad Lane",
+        reason: "Invalid source lane should fail.",
+        sourceLanes: ["private_dm"],
+      })
+    ).status,
+    400,
+  );
+});
+
+test("BNL targeted ingest stores active targetCandidateId without attaching or mutating source files", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const candidateResponse = await authedPost({
+    action: "createManualCandidate",
+    input: manualCandidateInput,
+  });
+  const candidatePayload = await candidateResponse.json();
+  const candidateId = candidatePayload.candidate.id;
+
+  const beforeState = await store.getDossierWorkflowState();
+  const response = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: candidatePayload.candidate.name,
+    targetCandidateId: candidateId,
+    reason: "BNL found additional evidence for this source file.",
+    sourceLanes: ["rd_context"],
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.recommendation.targetCandidateId, candidateId);
+  assert.equal(payload.recommendation.status, "new");
+
+  const afterState = await store.getDossierWorkflowState();
+  assert.equal(afterState.candidates.length, beforeState.candidates.length);
+  assert.equal(afterState.drafts.length, 0);
+  assert.equal(afterState.candidates[0].sourceFileNotes.length, beforeState.candidates[0].sourceFileNotes.length);
+
+  const invalidTarget = await bnlIngestPost({
+    subjectName: "Missing Target",
+    targetCandidateId: "not-a-candidate",
+    reason: "Invalid target should fail.",
+    sourceLanes: ["rd_context"],
+  });
+  assert.equal(invalidTarget.status, 404);
+
+  await authedPost({ action: "denyCandidate", candidateId });
+  const deniedTarget = await bnlIngestPost({
+    subjectName: candidatePayload.candidate.name,
+    targetCandidateId: candidateId,
+    reason: "Denied target should fail.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:denied-target",
+  });
+  assert.equal(deniedTarget.status, 400);
+});
+
+test("BNL-ingested recommendations stay out of public read model and database pages", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Private Ingest Signal",
+    reason: "This admin-only recommendation must not leak publicly.",
+    sourceLanes: ["rd_context"],
+    publicSafetyNotes: ["Keep private until owner approval."],
+    recommendedTags: ["brand-new-private-tag"],
+  });
+
+  const readModelResponse = await readModel.GET(
+    new Request("https://example.test/api/bnl/read-model"),
+  );
+  const readModelPayload = await readModelResponse.json();
+  assert.doesNotMatch(
+    JSON.stringify(readModelPayload),
+    /Private Ingest Signal|brand-new-private-tag|recommendations|sourceFileNotes/,
+  );
+
+  assert.doesNotMatch(
+    normalizedSource("src/app/database/page.tsx"),
+    /sourceFileNotes|recommendations|Private Ingest Signal|brand-new-private-tag/,
+  );
+  assert.doesNotMatch(
+    normalizedSource("src/app/database/[slug]/page.tsx"),
+    /sourceFileNotes|recommendations|Private Ingest Signal|brand-new-private-tag/,
   );
 });


### PR DESCRIPTION
### Motivation
- Provide a safe, server-side intake for BNL to submit dossier recommendations into the existing admin review workflow without creating public content automatically.
- Enforce strict validation, provenance metadata, and idempotent deduplication so BNL cannot spam or bypass review guardrails.
- Surface BNL provenance in admin UI so operators can identify and review BNL-ingested items while keeping all sensitive data admin-only.

### Description
- Added a new authenticated ingest endpoint `POST /api/bnl/dossier-recommendations` implemented in `src/app/api/bnl/dossier-recommendations/route.ts` that requires the server-side secret `BNL_DOSSIER_INGEST_TOKEN` via `Authorization: Bearer <token>` or `x-bnl-ingest-token` and returns `401` for missing/invalid tokens.
- Extended recommendation types and inputs by adding optional ingest metadata fields `ingestKey`, `ingestedAt`, and `ingestSource` and defaulted `createdBy`/`ingestSource` to `bnl` for endpoint submissions, implemented in `src/lib/dossier-workflow.ts` and `src/lib/dossier-workflow-store.ts`.
- Implemented strict payload validation (required `subjectName` and `reason`, text/list length limits, allowed source lanes, allowed taxonomy values, optional `targetDossierId` validation against `databasePage.entries`, and defaulting source lane to `unknown` only when needed) in the new route; invalid payloads return `400`.
- Added idempotent creation `createDossierRecommendationIdempotent` that dedupes active recommendations by `ingestKey` (if provided) or by deterministic fallback key (normalized subjectName + type + sorted sourceLanes + normalized reason) and returns `{ ok: true, recommendation, duplicate }` without creating duplicates, implemented in `src/lib/dossier-workflow-store.ts`.
- Validated `targetCandidateId` when provided to ensure the candidate exists and is active (not `denied` or `merged`) and stored it as metadata without attaching/mutating source files, with `targetDossierId` validated against known public dossier ids when present.
- Updated admin UI to expose ingest provenance and safety copy without enlarging the control center: `src/app/admin/dossiers/page.tsx` shows ingest provenance and time in the compact inbox, and `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx` shows `createdBy`, `ingestSource`, `ingestedAt`, and `ingestKey` on the recommendation detail page.
- Tests: added focused API/end-to-end tests to `tests/admin-dossiers.test.mjs` covering auth, valid ingest, admin visibility, dedupe by `ingestKey` and fallback, invalid payloads, targeted recommendation safety, and public read-model/database non-leakage.
- Files changed:
  - `src/app/api/bnl/dossier-recommendations/route.ts` (new)
  - `src/lib/dossier-workflow.ts` (recommendation types/input extended)
  - `src/lib/dossier-workflow-store.ts` (idempotent create, dedupe, validation)
  - `src/app/admin/dossiers/page.tsx` (UI: inbox ingest column & copy)
  - `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx` (UI: ingest metadata)
  - `tests/admin-dossiers.test.mjs` (tests added/updated)
- Safety boundaries preserved: no bot repo changes, no automatic draft/source-file creation/attach/publish/tag creation, no image upload, no writes to `src/content.ts`, and no exposure of admin-only data to public read-models or `/database` pages.
- Backlog left for future PRs: admin-only `Preview Dossier Page` and dossier image upload/validation remain unimplemented.

### Testing
- Type-check: ran `npx tsc --noEmit` and it passed.
- Lint: ran `npx eslint` on the modified files and it passed.
- Unit/integration: ran `node --test tests/admin-dossiers.test.mjs` and all new and existing tests passed (61 tests total reported by that run).
- Queue/read-model suite: ran `npm run test:queue` and all queue/read-model tests passed (107 tests total reported by that run).
- Summary: compilation, linting, and the full test suites executed during the rollout all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b2760e2208321b194b71fbcc5bb37)