### PR TITLE
PR #139 — Dossier Identity / Alias Link Foundation v1

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -8,6 +8,9 @@ import {
   type DossierCandidate,
   type DossierDraft,
   type DossierDuplicateGroup,
+  type DossierIdentityLinkSource,
+  type DossierIdentityLinkType,
+  type DossierIdentityLinkVisibility,
   type DossierRecommendation,
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
@@ -24,6 +27,15 @@ type SourceNoteForm = {
   type: DossierSourceFileNoteType;
   text: string;
   publicSafe: boolean;
+};
+
+type IdentityLinkForm = {
+  label: string;
+  type: DossierIdentityLinkType;
+  visibility: DossierIdentityLinkVisibility;
+  source: DossierIdentityLinkSource;
+  note: string;
+  useForMatching: boolean;
 };
 
 const activeDraftStatuses = new Set<DossierDraft["status"]>([
@@ -45,6 +57,35 @@ const emptyNoteForm: SourceNoteForm = {
   type: "fact",
   text: "",
   publicSafe: true,
+};
+const identityLinkTypes: DossierIdentityLinkType[] = [
+  "alias",
+  "artist_name",
+  "discord_handle",
+  "operator_name",
+  "public_persona",
+  "previous_name",
+  "alternate_spelling",
+  "related_label",
+  "unknown",
+];
+const identityLinkSources: DossierIdentityLinkSource[] = [
+  "owner_confirmed",
+  "admin_manual",
+  "mod_manual",
+  "bnl_recommendation",
+  "rd_context",
+  "broadcast_memory",
+  "website_dossier",
+  "unknown",
+];
+const emptyIdentityLinkForm: IdentityLinkForm = {
+  label: "",
+  type: "alias",
+  visibility: "internal_only",
+  source: "admin_manual",
+  note: "",
+  useForMatching: false,
 };
 
 function routeParam(value: string | string[] | undefined) {
@@ -147,6 +188,8 @@ export default function CandidateReviewPage() {
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [noteForm, setNoteForm] = useState<SourceNoteForm>(emptyNoteForm);
+  const [identityLinkForm, setIdentityLinkForm] =
+    useState<IdentityLinkForm>(emptyIdentityLinkForm);
 
   async function loadWorkflow() {
     const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
@@ -209,6 +252,12 @@ export default function CandidateReviewPage() {
     : null;
   const attachedRecommendations = (payload?.recommendations ?? []).filter(
     (recommendation) => recommendation.targetCandidateId === candidate?.id,
+  );
+  const identityLinks = [...(candidate?.identityLinks ?? [])].sort(
+    (a, b) =>
+      (a.status === "proposed" ? -1 : 1) -
+        (b.status === "proposed" ? -1 : 1) ||
+      b.updatedAt.localeCompare(a.updatedAt),
   );
   const nextRecommendedAction = sourceMetrics?.unappliedSourceNotesCount
     ? "Review source updates in proposed dossier"
@@ -305,6 +354,56 @@ export default function CandidateReviewPage() {
     }
   }
 
+
+  async function addIdentityLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      await postWorkflow({
+        action: "addDossierIdentityLink",
+        candidateId,
+        input: {
+          label: identityLinkForm.label,
+          type: identityLinkForm.type,
+          visibility: identityLinkForm.visibility,
+          source: identityLinkForm.source,
+          note: identityLinkForm.note,
+          useForMatching: identityLinkForm.useForMatching,
+        },
+      });
+      setIdentityLinkForm(emptyIdentityLinkForm);
+      setNotice(
+        "Identity link proposed. It will not route recommendations until confirmed.",
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error ? err.message : "Failed to save identity link.",
+      );
+    }
+  }
+
+  async function reviewIdentityLink(
+    identityLinkId: string,
+    action:
+      | "confirmDossierIdentityLink"
+      | "rejectDossierIdentityLink"
+      | "retireDossierIdentityLink",
+    useForMatching = false,
+  ) {
+    try {
+      await postWorkflow({
+        action,
+        candidateId,
+        identityLinkId,
+        useForMatching,
+      });
+      setNotice("Identity link updated. No public dossier text was changed.");
+    } catch (err) {
+      setNotice(
+        err instanceof Error ? err.message : "Failed to update identity link.",
+      );
+    }
+  }
+
   if (loading)
     return (
       <MinimalState
@@ -365,6 +464,10 @@ export default function CandidateReviewPage() {
             <div className="border border-border bg-background/30 p-3">
               <p className="uppercase tracking-widest text-accent">Source notes</p>
               <p>{sourceMetrics?.sourceNotesCount ?? 0}</p>
+            </div>
+            <div className="border border-border bg-background/30 p-3">
+              <p className="uppercase tracking-widest text-accent">Aliases</p>
+              <p>{identityLinks.length}</p>
             </div>
             <div className="border border-border bg-background/30 p-3">
               <p className="uppercase tracking-widest text-accent">Unapplied notes</p>
@@ -560,6 +663,212 @@ export default function CandidateReviewPage() {
               ))}
             </div>
           )}
+        </Section>
+
+        <Section title="Identity / Aliases">
+          <div className="space-y-4">
+            <p>
+              Aliases help BNL route future recommendations to the right source
+              file. Internal aliases are not public dossier text. Public-safe
+              visibility does not publish anything yet.
+            </p>
+            {identityLinks.length === 0 ? (
+              <p>No identity links saved yet.</p>
+            ) : (
+              <div className="space-y-3">
+                {identityLinks.map((identityLink) => (
+                  <article
+                    key={identityLink.id}
+                    className="border border-border/70 bg-background/20 p-3 space-y-2"
+                  >
+                    <p className="text-foreground font-semibold">
+                      {identityLink.label}
+                    </p>
+                    <p>
+                      Type: {identityLink.type} / Visibility: {identityLink.visibility} / Status: {identityLink.status}
+                    </p>
+                    <p>
+                      Confidence: {identityLink.confidence ?? "—"} / Source: {identityLink.source}
+                    </p>
+                    <p>
+                      Use for matching: {String(identityLink.useForMatching)} / Use in public dossier: {String(identityLink.useInPublicDossier)}
+                    </p>
+                    <p className="whitespace-pre-wrap">Note: {identityLink.note ?? "—"}</p>
+                    <p>
+                      Created: {formatDate(identityLink.createdAt)} by {identityLink.createdBy ?? "—"} / Confirmed: {formatDate(identityLink.confirmedAt)} by {identityLink.confirmedBy ?? "—"}
+                    </p>
+                    <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+                      <button
+                        type="button"
+                        disabled={saving || identityLink.status === "confirmed"}
+                        onClick={() =>
+                          void reviewIdentityLink(
+                            identityLink.id,
+                            "confirmDossierIdentityLink",
+                            true,
+                          )
+                        }
+                        className="border border-accent px-3 py-1.5 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        type="button"
+                        disabled={saving || identityLink.status === "rejected"}
+                        onClick={() =>
+                          void reviewIdentityLink(
+                            identityLink.id,
+                            "rejectDossierIdentityLink",
+                          )
+                        }
+                        className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:opacity-50"
+                      >
+                        Reject
+                      </button>
+                      <button
+                        type="button"
+                        disabled={saving || identityLink.status === "retired"}
+                        onClick={() =>
+                          void reviewIdentityLink(
+                            identityLink.id,
+                            "retireDossierIdentityLink",
+                          )
+                        }
+                        className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:opacity-50"
+                      >
+                        Retire
+                      </button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+            <form
+              onSubmit={addIdentityLink}
+              className="grid grid-cols-1 md:grid-cols-4 gap-3 text-xs uppercase tracking-widest text-muted"
+            >
+              <label className="space-y-2">
+                <span>Label</span>
+                <input
+                  required
+                  maxLength={120}
+                  value={identityLinkForm.label}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      label: event.target.value,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="space-y-2">
+                <span>Type</span>
+                <select
+                  value={identityLinkForm.type}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      type: event.target.value as DossierIdentityLinkType,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {identityLinkTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="space-y-2">
+                <span>Visibility</span>
+                <select
+                  value={identityLinkForm.visibility}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      visibility: event.target.value as DossierIdentityLinkVisibility,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  <option value="internal_only">internal_only</option>
+                  <option value="public_safe">public_safe</option>
+                </select>
+              </label>
+              <label className="space-y-2">
+                <span>Source</span>
+                <select
+                  value={identityLinkForm.source}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      source: event.target.value as DossierIdentityLinkSource,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {identityLinkSources.map((source) => (
+                    <option key={source} value={source}>
+                      {source}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="md:col-span-4 space-y-2">
+                <span>Note</span>
+                <textarea
+                  maxLength={1000}
+                  value={identityLinkForm.note}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      note: event.target.value,
+                    })
+                  }
+                  className="w-full min-h-20 bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="md:col-span-2 flex items-center gap-2 normal-case tracking-normal text-sm">
+                <input
+                  type="checkbox"
+                  checked={identityLinkForm.useForMatching}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      useForMatching: event.target.checked,
+                    })
+                  }
+                />{" "}
+                Use for future matching after confirmation
+              </label>
+              <label className="md:col-span-2 flex items-center gap-2 normal-case tracking-normal text-sm">
+                <input
+                  type="checkbox"
+                  checked={identityLinkForm.visibility === "public_safe"}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      visibility: event.target.checked
+                        ? "public_safe"
+                        : "internal_only",
+                    })
+                  }
+                />{" "}
+                Public-safe label (does not publish yet)
+              </label>
+              <div className="md:col-span-4">
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                >
+                  Add Identity Link
+                </button>
+              </div>
+            </form>
+          </div>
         </Section>
 
         <Section title="Proposed Dossier">

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -745,6 +745,7 @@ export default function DossierControlCenterPage() {
                     <th className="py-2 pr-3">Recommendation/evidence count</th>
                     <th className="py-2 pr-3">Proposed dossier status</th>
                     <th className="py-2 pr-3">Unapplied source notes count</th>
+                    <th className="py-2 pr-3">Identity links</th>
                     <th className="py-2 pr-3">Duplicate/identity warning</th>
                     <th className="py-2 pr-3">Last updated</th>
                     <th className="py-2 pr-3">Next recommended action</th>
@@ -769,6 +770,10 @@ export default function DossierControlCenterPage() {
                       : openDraftId
                         ? "draft just created"
                         : "No proposed dossier";
+                    const identityLinks = candidate.identityLinks ?? [];
+                    const proposedIdentityLinks = identityLinks.filter(
+                      (identityLink) => identityLink.status === "proposed",
+                    );
                     const nextAction =
                       (metrics?.unappliedSourceNotesCount ?? 0) > 0
                         ? "Review source updates in proposed dossier"
@@ -802,6 +807,12 @@ export default function DossierControlCenterPage() {
                         <td className="py-3 pr-3">{proposedStatus}</td>
                         <td className="py-3 pr-3">
                           Unapplied notes: {metrics?.unappliedSourceNotesCount ?? 0}
+                        </td>
+                        <td className="py-3 pr-3">
+                          Aliases: {identityLinks.length}
+                          {proposedIdentityLinks.length > 0 && (
+                            <p className="text-xs text-accent">Identity warnings</p>
+                          )}
                         </td>
                         <td className="py-3 pr-3">
                           {candidate.duplicateRisk ?? "none"}

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   matchDossierRecommendationSubject,
+  normalizeDossierSubjectName,
   type DossierCandidate,
   type DossierDraft,
   type DossierRecommendation,
@@ -171,6 +172,26 @@ export default function DossierRecommendationPage() {
         (candidate) => candidate.id === subjectMatch.exactCandidateId,
       ) ?? null)
     : null;
+  const confirmedAliasLink =
+    subjectMatch.exactMatchKind === "confirmed_alias" && exactCandidate
+      ? (exactCandidate.identityLinks ?? []).find(
+          (identityLink) =>
+            identityLink.status === "confirmed" &&
+            identityLink.useForMatching &&
+            identityLink.normalizedLabel ===
+              normalizeDossierSubjectName(recommendation?.subjectName ?? ""),
+        )
+      : undefined;
+  const possibleAliasConflictCandidates = recommendation
+    ? (payload?.candidates ?? []).filter((candidate) =>
+        (candidate.identityLinks ?? []).some(
+          (identityLink) =>
+            identityLink.status === "proposed" &&
+            identityLink.normalizedLabel ===
+              normalizeDossierSubjectName(recommendation.subjectName),
+        ),
+      )
+    : [];
   const possibleCandidates = subjectMatch.possibleCandidateIds
     .map((candidateId) =>
       payload?.candidates.find((candidate) => candidate.id === candidateId),
@@ -368,7 +389,18 @@ export default function DossierRecommendationPage() {
             </p>
             {exactCandidate ? (
               <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
-                {subjectMatch.exactMatchKind === "pre_targeted" ? (
+                {subjectMatch.exactMatchKind === "confirmed_alias" ? (
+                  <>
+                    <p className="font-bold">
+                      Matched by confirmed alias: {confirmedAliasLink?.label ?? subjectMatch.aliasLabel ?? recommendation.subjectName}
+                    </p>
+                    <p>Source file name: {exactCandidate.name}</p>
+                    <p>
+                      This alias is used for internal matching only unless public
+                      use is later approved.
+                    </p>
+                  </>
+                ) : subjectMatch.exactMatchKind === "pre_targeted" ? (
                   <>
                     <p className="font-bold">
                       Pre-targeted BNL Source File: {exactCandidate.name}
@@ -392,6 +424,19 @@ export default function DossierRecommendationPage() {
                 >
                   Attach to Matched BNL Source File
                 </button>
+              </div>
+            ) : possibleAliasConflictCandidates.length > 0 ? (
+              <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
+                <p className="font-bold">Possible alias conflict</p>
+                <p>
+                  A proposed identity link uses this subject label, but proposed
+                  aliases do not auto-match, attach, or merge source files.
+                </p>
+                <ul className="list-disc pl-5">
+                  {possibleAliasConflictCandidates.map((candidate) => (
+                    <li key={candidate.id}>{candidate.name}</li>
+                  ))}
+                </ul>
               </div>
             ) : possibleCandidates.length > 0 ? (
               <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -10,6 +10,10 @@ import {
   DOSSIER_WORKFLOW_RULES,
   type CreateManualDossierCandidateInput,
   type DossierCandidate,
+  type DossierIdentityLink,
+  type DossierIdentityLinkSource,
+  type DossierIdentityLinkType,
+  type DossierIdentityLinkVisibility,
   type CreateDossierRecommendationInput,
   type CreateDossierSourceFileNoteInput,
   type DossierCandidateStatus,
@@ -20,8 +24,10 @@ import {
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 import {
+  addDossierIdentityLink,
   addDossierSourceFileNote,
   attachRecommendationToCandidate,
+  confirmDossierIdentityLink,
   buildDossierDuplicateGroups,
   convertRecommendationToCandidate,
   createDossierRecommendation,
@@ -33,10 +39,13 @@ import {
   getDossierWorkflowState,
   getDossierWorkflowStorageMode,
   ignoreDossierRecommendation,
+  rejectDossierIdentityLink,
+  retireDossierIdentityLink,
   mergeDossierCandidates,
   saveDossierDraft,
   submitDraftForOwnerReview,
   updateDossierCandidateStatus,
+  updateDossierIdentityLink,
   validateDossierDraftFieldsForOwnerReview,
   type DossierWorkflowState,
 } from "@/lib/dossier-workflow-store";
@@ -98,6 +107,11 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "detectDuplicateCandidates",
   "mergeCandidates",
   "addSourceFileNote",
+  "addDossierIdentityLink",
+  "updateDossierIdentityLink",
+  "confirmDossierIdentityLink",
+  "rejectDossierIdentityLink",
+  "retireDossierIdentityLink",
   "createDossierRecommendation",
   "attachRecommendationToCandidate",
   "convertRecommendationToCandidate",
@@ -157,6 +171,59 @@ function sourceFileNoteInputFromBody(
     publicSafe: input.publicSafe === true,
     appliesToDraftId: input.appliesToDraftId,
     createdBy: input.createdBy,
+  };
+}
+
+
+function identityLinkIdFromBody(body: Record<string, unknown>): string {
+  return typeof body.identityLinkId === "string"
+    ? body.identityLinkId.trim()
+    : "";
+}
+
+function identityLinkInputFromBody(
+  body: Record<string, unknown>,
+): {
+  candidateId: string;
+  label: string;
+  type?: DossierIdentityLinkType;
+  visibility?: DossierIdentityLinkVisibility;
+  source?: DossierIdentityLinkSource;
+  confidence?: DossierIdentityLink["confidence"];
+  useForMatching?: boolean;
+  useInPublicDossier?: boolean;
+  note?: string;
+  createdBy?: string;
+} | null {
+  const candidateId = candidateIdFromBody(body);
+  const value = body.input;
+  if (!candidateId || !value || typeof value !== "object") return null;
+  const input = value as Partial<DossierIdentityLink>;
+  if (typeof input.label !== "string" || !input.label.trim()) return null;
+  return {
+    candidateId,
+    label: input.label,
+    type: input.type,
+    visibility: input.visibility,
+    source: input.source,
+    confidence: input.confidence,
+    useForMatching: input.useForMatching === true,
+    useInPublicDossier: input.useInPublicDossier === true,
+    note: input.note,
+    createdBy: input.createdBy,
+  };
+}
+
+function identityLinkReviewInputFromBody(body: Record<string, unknown>) {
+  const candidateId = candidateIdFromBody(body);
+  const identityLinkId = identityLinkIdFromBody(body);
+  if (!candidateId || !identityLinkId) return null;
+  return {
+    candidateId,
+    identityLinkId,
+    reviewedBy: typeof body.reviewedBy === "string" ? body.reviewedBy : undefined,
+    useForMatching: body.useForMatching === true,
+    useInPublicDossier: body.useInPublicDossier === true,
   };
 }
 
@@ -313,6 +380,59 @@ export async function POST(req: Request) {
       const note = await addDossierSourceFileNote(input);
       const payload = await workflowPayload();
       return NextResponse.json({ ok: true, action, note, ...payload });
+    }
+
+
+    if (action === "addDossierIdentityLink") {
+      const input = identityLinkInputFromBody(body);
+      if (!input) {
+        return NextResponse.json(
+          { error: "Valid candidateId and identity link label are required" },
+          { status: 400 },
+        );
+      }
+      const identityLink = await addDossierIdentityLink(input);
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, identityLink, ...payload });
+    }
+
+    if (action === "updateDossierIdentityLink") {
+      const input = identityLinkInputFromBody(body);
+      const identityLinkId = identityLinkIdFromBody(body);
+      if (!input || !identityLinkId) {
+        return NextResponse.json(
+          { error: "Valid candidateId, identityLinkId, and identity link label are required" },
+          { status: 400 },
+        );
+      }
+      const identityLink = await updateDossierIdentityLink({
+        ...input,
+        identityLinkId,
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, identityLink, ...payload });
+    }
+
+    if (
+      action === "confirmDossierIdentityLink" ||
+      action === "rejectDossierIdentityLink" ||
+      action === "retireDossierIdentityLink"
+    ) {
+      const input = identityLinkReviewInputFromBody(body);
+      if (!input) {
+        return NextResponse.json(
+          { error: "candidateId and identityLinkId are required" },
+          { status: 400 },
+        );
+      }
+      const identityLink =
+        action === "confirmDossierIdentityLink"
+          ? await confirmDossierIdentityLink(input)
+          : action === "rejectDossierIdentityLink"
+            ? await rejectDossierIdentityLink(input)
+            : await retireDossierIdentityLink(input);
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, identityLink, ...payload });
     }
 
     if (action === "createDossierRecommendation") {

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -7,6 +7,11 @@ import {
   type CreateManualDossierCandidateInput,
   type DossierCandidate,
   type DossierCandidateStatus,
+  type DossierIdentityLink,
+  type DossierIdentityLinkSource,
+  type DossierIdentityLinkStatus,
+  type DossierIdentityLinkType,
+  type DossierIdentityLinkVisibility,
   type DossierDraft,
   type DossierDuplicateGroup,
   type DossierRecommendation,
@@ -276,6 +281,9 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
           sourceFileNotes: Array.isArray(candidate.sourceFileNotes)
             ? candidate.sourceFileNotes
             : [],
+          identityLinks: Array.isArray(candidate.identityLinks)
+            ? candidate.identityLinks
+            : [],
         }))
       : [],
     drafts: Array.isArray(candidateState.drafts) ? candidateState.drafts : [],
@@ -303,6 +311,10 @@ function createRecommendationId(): string {
 
 function createSourceFileNoteId(): string {
   return `source_file_note_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createIdentityLinkId(): string {
+  return `identity_link_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function createDraftId(): string {
@@ -465,6 +477,7 @@ const SOURCE_NOTE_SOURCES: DossierSourceFileNoteSource[] = [
 const RECOMMENDATION_TYPES: DossierRecommendationType[] = [
   "new_subject",
   "modify_existing_dossier",
+  "identity_link",
 ];
 const RECOMMENDATION_SOURCE_LANES: DossierRecommendationSourceLane[] = [
   "public_discord",
@@ -477,6 +490,65 @@ const RECOMMENDATION_SOURCE_LANES: DossierRecommendationSourceLane[] = [
   "owner_manual",
   "unknown",
 ];
+
+
+const IDENTITY_LINK_TYPES: DossierIdentityLinkType[] = [
+  "alias",
+  "artist_name",
+  "discord_handle",
+  "operator_name",
+  "public_persona",
+  "previous_name",
+  "alternate_spelling",
+  "related_label",
+  "unknown",
+];
+const IDENTITY_LINK_VISIBILITIES: DossierIdentityLinkVisibility[] = [
+  "internal_only",
+  "public_safe",
+];
+const IDENTITY_LINK_SOURCES: DossierIdentityLinkSource[] = [
+  "owner_confirmed",
+  "admin_manual",
+  "mod_manual",
+  "bnl_recommendation",
+  "rd_context",
+  "broadcast_memory",
+  "website_dossier",
+  "unknown",
+];
+const ACTIVE_IDENTITY_LINK_STATUSES = new Set<DossierIdentityLinkStatus>([
+  "proposed",
+  "confirmed",
+]);
+
+export type CreateDossierIdentityLinkInput = {
+  candidateId: string;
+  label: string;
+  type?: DossierIdentityLinkType;
+  visibility?: DossierIdentityLinkVisibility;
+  source?: DossierIdentityLinkSource;
+  confidence?: "low" | "medium" | "high" | "confirmed";
+  useForMatching?: boolean;
+  useInPublicDossier?: boolean;
+  note?: string;
+  createdBy?: string;
+};
+
+export type UpdateDossierIdentityLinkInput = Partial<
+  Omit<CreateDossierIdentityLinkInput, "candidateId">
+> & {
+  candidateId: string;
+  identityLinkId: string;
+};
+
+export type ReviewDossierIdentityLinkInput = {
+  candidateId: string;
+  identityLinkId: string;
+  reviewedBy?: string;
+  useForMatching?: boolean;
+  useInPublicDossier?: boolean;
+};
 
 const TERMINAL_RECOMMENDATION_STATUSES = new Set<DossierRecommendationStatus>([
   "attached_to_source_file",
@@ -705,6 +777,297 @@ export class DossierWorkflowInputError extends Error {
     this.code = code;
     this.details = details;
   }
+}
+
+
+function normalizeIdentityLinkInput(
+  input: CreateDossierIdentityLinkInput,
+): Omit<
+  DossierIdentityLink,
+  "id" | "normalizedLabel" | "status" | "createdAt" | "updatedAt"
+> | null {
+  const candidateId = boundedText(input.candidateId, 200);
+  const label = boundedText(input.label, 120);
+  if (!candidateId || !label) return null;
+  const type = IDENTITY_LINK_TYPES.includes(input.type ?? "alias")
+    ? (input.type ?? "alias")
+    : "alias";
+  const visibility = IDENTITY_LINK_VISIBILITIES.includes(
+    input.visibility ?? "internal_only",
+  )
+    ? (input.visibility ?? "internal_only")
+    : "internal_only";
+  const source = IDENTITY_LINK_SOURCES.includes(input.source ?? "admin_manual")
+    ? (input.source ?? "admin_manual")
+    : "admin_manual";
+  const confidence = ["low", "medium", "high", "confirmed"].includes(
+    input.confidence ?? "",
+  )
+    ? input.confidence
+    : undefined;
+  return {
+    candidateId,
+    label,
+    type,
+    visibility,
+    source,
+    confidence,
+    useForMatching: input.useForMatching === true,
+    useInPublicDossier: input.useInPublicDossier === true,
+    note: boundedText(input.note, 1000) || undefined,
+    createdBy: boundedText(input.createdBy, 200) || undefined,
+  };
+}
+
+function assertNoDuplicateActiveIdentityLink(input: {
+  candidate: DossierCandidate;
+  normalizedLabel: string;
+  exceptIdentityLinkId?: string;
+}) {
+  const duplicate = (input.candidate.identityLinks ?? []).find(
+    (identityLink) =>
+      identityLink.id !== input.exceptIdentityLinkId &&
+      ACTIVE_IDENTITY_LINK_STATUSES.has(identityLink.status) &&
+      identityLink.normalizedLabel === input.normalizedLabel,
+  );
+  if (!duplicate) return;
+  throw new DossierWorkflowInputError(
+    "An active identity link with this label already exists on this BNL Source File",
+    400,
+    "duplicate_identity_link",
+    { identityLinkId: duplicate.id },
+  );
+}
+
+export async function addDossierIdentityLink(
+  input: CreateDossierIdentityLinkInput,
+): Promise<DossierIdentityLink> {
+  const normalized = normalizeIdentityLinkInput(input);
+  if (!normalized) {
+    throw new DossierWorkflowInputError(
+      "Identity link requires candidateId and a non-empty label",
+      400,
+      "invalid_identity_link",
+    );
+  }
+
+  const now = new Date().toISOString();
+  const identityLink: DossierIdentityLink = {
+    id: createIdentityLinkId(),
+    ...normalized,
+    normalizedLabel: normalizeName(normalized.label),
+    status: "proposed",
+    useForMatching: false,
+    useInPublicDossier: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+  let saved: DossierIdentityLink | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    let found = false;
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== identityLink.candidateId) return candidate;
+      found = true;
+      assertNoDuplicateActiveIdentityLink({
+        candidate,
+        normalizedLabel: identityLink.normalizedLabel,
+      });
+      saved = identityLink;
+      return {
+        ...candidate,
+        identityLinks: [identityLink, ...(candidate.identityLinks ?? [])],
+        updatedAt: now,
+      };
+    });
+    if (!found) {
+      throw new DossierWorkflowInputError(
+        "Candidate not found",
+        404,
+        "candidate_not_found",
+      );
+    }
+    return { ...currentState, candidates, updatedAt: now };
+  });
+
+  return saved ?? identityLink;
+}
+
+export async function updateDossierIdentityLink(
+  input: UpdateDossierIdentityLinkInput,
+): Promise<DossierIdentityLink> {
+  const now = new Date().toISOString();
+  const candidateId = boundedText(input.candidateId, 200);
+  const identityLinkId = boundedText(input.identityLinkId, 200);
+  if (!candidateId || !identityLinkId) {
+    throw new DossierWorkflowInputError(
+      "Identity link update requires candidateId and identityLinkId",
+      400,
+      "invalid_identity_link",
+    );
+  }
+  let updatedLink: DossierIdentityLink | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    let foundCandidate = false;
+    let foundLink = false;
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== candidateId) return candidate;
+      foundCandidate = true;
+      const currentLinks = candidate.identityLinks ?? [];
+      const identityLinks = currentLinks.map((identityLink) => {
+        if (identityLink.id !== identityLinkId) return identityLink;
+        foundLink = true;
+        const label =
+          typeof input.label === "string"
+            ? boundedText(input.label, 120)
+            : identityLink.label;
+        if (!label) {
+          throw new DossierWorkflowInputError(
+            "Identity link label cannot be empty",
+            400,
+            "invalid_identity_link",
+          );
+        }
+        const normalizedLabel = normalizeName(label);
+        assertNoDuplicateActiveIdentityLink({
+          candidate,
+          normalizedLabel,
+          exceptIdentityLinkId: identityLink.id,
+        });
+        updatedLink = {
+          ...identityLink,
+          label,
+          normalizedLabel,
+          type:
+            input.type && IDENTITY_LINK_TYPES.includes(input.type)
+              ? input.type
+              : identityLink.type,
+          visibility:
+            input.visibility &&
+            IDENTITY_LINK_VISIBILITIES.includes(input.visibility)
+              ? input.visibility
+              : identityLink.visibility,
+          source:
+            input.source && IDENTITY_LINK_SOURCES.includes(input.source)
+              ? input.source
+              : identityLink.source,
+          confidence: ["low", "medium", "high", "confirmed"].includes(
+            input.confidence ?? "",
+          )
+            ? input.confidence
+            : identityLink.confidence,
+          useForMatching:
+            identityLink.status === "confirmed"
+              ? input.useForMatching === true
+              : false,
+          useInPublicDossier: input.useInPublicDossier === true,
+          note:
+            typeof input.note === "string"
+              ? boundedText(input.note, 1000) || undefined
+              : identityLink.note,
+          updatedAt: now,
+        };
+        return updatedLink;
+      });
+      return { ...candidate, identityLinks, updatedAt: foundLink ? now : candidate.updatedAt };
+    });
+    if (!foundCandidate) {
+      throw new DossierWorkflowInputError(
+        "Candidate not found",
+        404,
+        "candidate_not_found",
+      );
+    }
+    if (!foundLink) {
+      throw new DossierWorkflowInputError(
+        "Identity link not found",
+        404,
+        "identity_link_not_found",
+      );
+    }
+    return { ...currentState, candidates, updatedAt: now };
+  });
+
+  return updatedLink!;
+}
+
+async function setDossierIdentityLinkStatus(
+  input: ReviewDossierIdentityLinkInput,
+  status: Exclude<DossierIdentityLinkStatus, "proposed">,
+): Promise<DossierIdentityLink> {
+  const now = new Date().toISOString();
+  const candidateId = boundedText(input.candidateId, 200);
+  const identityLinkId = boundedText(input.identityLinkId, 200);
+  let updatedLink: DossierIdentityLink | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    let foundCandidate = false;
+    let foundLink = false;
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== candidateId) return candidate;
+      foundCandidate = true;
+      const identityLinks = (candidate.identityLinks ?? []).map((identityLink) => {
+        if (identityLink.id !== identityLinkId) return identityLink;
+        foundLink = true;
+        updatedLink = {
+          ...identityLink,
+          status,
+          confidence: status === "confirmed" ? "confirmed" : identityLink.confidence,
+          useForMatching: status === "confirmed" && input.useForMatching === true,
+          useInPublicDossier:
+            status === "confirmed" && input.useInPublicDossier === true,
+          confirmedBy:
+            status === "confirmed"
+              ? boundedText(input.reviewedBy, 200) || identityLink.confirmedBy
+              : identityLink.confirmedBy,
+          confirmedAt: status === "confirmed" ? now : identityLink.confirmedAt,
+          updatedAt: now,
+        };
+        if (status !== "confirmed") {
+          updatedLink.useForMatching = false;
+          updatedLink.useInPublicDossier = false;
+        }
+        return updatedLink;
+      });
+      return { ...candidate, identityLinks, updatedAt: foundLink ? now : candidate.updatedAt };
+    });
+    if (!foundCandidate) {
+      throw new DossierWorkflowInputError(
+        "Candidate not found",
+        404,
+        "candidate_not_found",
+      );
+    }
+    if (!foundLink) {
+      throw new DossierWorkflowInputError(
+        "Identity link not found",
+        404,
+        "identity_link_not_found",
+      );
+    }
+    return { ...currentState, candidates, updatedAt: now };
+  });
+
+  return updatedLink!;
+}
+
+export function confirmDossierIdentityLink(
+  input: ReviewDossierIdentityLinkInput,
+): Promise<DossierIdentityLink> {
+  return setDossierIdentityLinkStatus(input, "confirmed");
+}
+
+export function rejectDossierIdentityLink(
+  input: ReviewDossierIdentityLinkInput,
+): Promise<DossierIdentityLink> {
+  return setDossierIdentityLinkStatus(input, "rejected");
+}
+
+export function retireDossierIdentityLink(
+  input: ReviewDossierIdentityLinkInput,
+): Promise<DossierIdentityLink> {
+  return setDossierIdentityLinkStatus(input, "retired");
 }
 
 export async function addDossierSourceFileNote(
@@ -994,6 +1357,7 @@ export async function convertRecommendationToCandidate(
       doNotSay: recommendation.doNotSay ?? [],
       publicSafetyNotes: recommendation.publicSafetyNotes ?? [],
       sourceFileNotes: [{ ...note, candidateId: "" }],
+      identityLinks: [],
       status: "needs_review",
       createdAt: now,
       updatedAt: now,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -133,6 +133,58 @@ export type DossierSourceFileNote = {
   ingestSource?: DossierRecommendationIngestSource;
 };
 
+
+export type DossierIdentityLinkType =
+  | "alias"
+  | "artist_name"
+  | "discord_handle"
+  | "operator_name"
+  | "public_persona"
+  | "previous_name"
+  | "alternate_spelling"
+  | "related_label"
+  | "unknown";
+
+export type DossierIdentityLinkVisibility =
+  | "internal_only"
+  | "public_safe";
+
+export type DossierIdentityLinkStatus =
+  | "proposed"
+  | "confirmed"
+  | "rejected"
+  | "retired";
+
+export type DossierIdentityLinkSource =
+  | "owner_confirmed"
+  | "admin_manual"
+  | "mod_manual"
+  | "bnl_recommendation"
+  | "rd_context"
+  | "broadcast_memory"
+  | "website_dossier"
+  | "unknown";
+
+export type DossierIdentityLink = {
+  id: string;
+  candidateId: string;
+  label: string;
+  normalizedLabel: string;
+  type: DossierIdentityLinkType;
+  visibility: DossierIdentityLinkVisibility;
+  status: DossierIdentityLinkStatus;
+  source: DossierIdentityLinkSource;
+  confidence?: "low" | "medium" | "high" | "confirmed";
+  useForMatching: boolean;
+  useInPublicDossier: boolean;
+  note?: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  confirmedBy?: string;
+  confirmedAt?: string;
+};
+
 export type DossierCandidate = {
   id: string;
   name: string;
@@ -169,6 +221,7 @@ export type DossierCandidate = {
   doNotSay?: string[];
   publicSafetyNotes?: string[];
   sourceFileNotes?: DossierSourceFileNote[];
+  identityLinks?: DossierIdentityLink[];
   mergedIntoCandidateId?: string;
   mergedAt?: string;
   mergeNote?: string;
@@ -257,7 +310,8 @@ export type DossierDuplicateGroup = {
 
 export type DossierRecommendationType =
   | "new_subject"
-  | "modify_existing_dossier";
+  | "modify_existing_dossier"
+  | "identity_link";
 
 export type DossierRecommendationStatus =
   | "new"
@@ -407,7 +461,13 @@ export function getDossierSourceFileMetrics(input: {
 
 export type DossierSubjectMatchResult = {
   exactCandidateId?: string;
-  exactMatchKind?: "pre_targeted" | "subject";
+  exactMatchKind?:
+    | "pre_targeted"
+    | "name"
+    | "compact_name"
+    | "subject_key"
+    | "confirmed_alias";
+  aliasLabel?: string;
   possibleCandidateIds: string[];
   reason: string;
 };
@@ -492,33 +552,63 @@ export function matchDossierRecommendationSubject(input: {
     };
   }
 
+  let exactMatchKind: DossierSubjectMatchResult["exactMatchKind"];
   const exactCandidate = activeCandidates.find((candidate) => {
     const normalizedCandidate = normalizeDossierSubjectName(candidate.name);
     const compactCandidate = compactDossierSubjectName(candidate.name);
-    return (
-      Boolean(normalizedSubject) &&
-      (normalizedSubject === normalizedCandidate ||
-        compactSubject === compactCandidate ||
-        (Boolean(normalizedSubjectKey) &&
-          (normalizedSubjectKey === normalizedCandidate ||
-            compactSubjectKey === compactCandidate)))
-    );
+    if (!normalizedSubject) return false;
+    if (normalizedSubject === normalizedCandidate) {
+      exactMatchKind = "name";
+      return true;
+    }
+    if (compactSubject === compactCandidate) {
+      exactMatchKind = "compact_name";
+      return true;
+    }
+    if (
+      Boolean(normalizedSubjectKey) &&
+      (normalizedSubjectKey === normalizedCandidate ||
+        compactSubjectKey === compactCandidate)
+    ) {
+      exactMatchKind = "subject_key";
+      return true;
+    }
+    return false;
   });
 
+  let exactAliasCandidate: DossierCandidate | undefined;
+  let exactAliasLabel: string | undefined;
+  if (!exactCandidate && normalizedSubject) {
+    exactAliasCandidate = activeCandidates.find((candidate) => {
+      const link = (candidate.identityLinks ?? []).find(
+        (identityLink) =>
+          identityLink.status === "confirmed" &&
+          identityLink.useForMatching === true &&
+          identityLink.normalizedLabel === normalizedSubject,
+      );
+      if (!link) return false;
+      exactAliasLabel = link.label;
+      return true;
+    });
+  }
+  const safeExactCandidate = exactCandidate ?? exactAliasCandidate;
+
   const possibleCandidateIds = activeCandidates
-    .filter((candidate) => candidate.id !== exactCandidate?.id)
+    .filter((candidate) => candidate.id !== safeExactCandidate?.id)
     .filter((candidate) =>
       hasPossibleSubjectOverlap(subjectName, candidate.name),
     )
     .map((candidate) => candidate.id);
 
-  if (exactCandidate) {
+  if (safeExactCandidate) {
     return {
-      exactCandidateId: exactCandidate.id,
-      exactMatchKind: "subject",
+      exactCandidateId: safeExactCandidate.id,
+      exactMatchKind: exactAliasCandidate ? "confirmed_alias" : exactMatchKind,
+      aliasLabel: exactAliasCandidate ? exactAliasLabel : undefined,
       possibleCandidateIds,
-      reason:
-        "Exact same-subject match by normalized name, compact name, or explicit subject key.",
+      reason: exactAliasCandidate
+        ? "Confirmed identity link / alias match."
+        : "Exact same-subject match by normalized name, compact name, or explicit subject key.",
     };
   }
 
@@ -596,6 +686,11 @@ export type DossierWorkflowAction =
   | "denyCandidate"
   | "markNeedsMoreEvidence"
   | "addSourceFileNote"
+  | "addDossierIdentityLink"
+  | "updateDossierIdentityLink"
+  | "confirmDossierIdentityLink"
+  | "rejectDossierIdentityLink"
+  | "retireDossierIdentityLink"
   | "createDossierRecommendation"
   | "attachRecommendationToCandidate"
   | "convertRecommendationToCandidate"
@@ -629,6 +724,11 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "denyCandidate",
   "markNeedsMoreEvidence",
   "addSourceFileNote",
+  "addDossierIdentityLink",
+  "updateDossierIdentityLink",
+  "confirmDossierIdentityLink",
+  "rejectDossierIdentityLink",
+  "retireDossierIdentityLink",
   "createDossierRecommendation",
   "attachRecommendationToCandidate",
   "convertRecommendationToCandidate",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1594,6 +1594,7 @@ test("workflow state defaults recommendations and source notes for older stores"
   const payload = await (await authedGet()).json();
   assert.deepEqual(payload.recommendations, []);
   assert.deepEqual(payload.candidates[0].sourceFileNotes, []);
+  assert.deepEqual(payload.candidates[0].identityLinks, []);
 });
 
 test("source file notes persist without mutating draft fields or public read model", async () => {
@@ -1660,6 +1661,215 @@ test("source file notes persist without mutating draft fields or public read mod
   );
 });
 
+
+
+test("identity links default, persist safely, and never publish", async () => {
+  await resetWorkflowStore();
+  const created = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const draft = await (
+    await authedPost({
+      action: "createDraftFromCandidate",
+      candidateId: created.candidate.id,
+    })
+  ).json();
+  const draftFields = JSON.stringify(draft.draft.fields);
+
+  const addResponse = await authedPost({
+    action: "addDossierIdentityLink",
+    candidateId: created.candidate.id,
+    input: {
+      label: "  ShadowsPit  ",
+      type: "discord_handle",
+      visibility: "internal_only",
+      source: "owner_confirmed",
+      note: "Internal identity link for routing future recommendations.",
+      useForMatching: true,
+      useInPublicDossier: true,
+    },
+  });
+  assert.equal(addResponse.status, 200);
+  const addPayload = await addResponse.json();
+  assert.equal(addPayload.identityLink.label, "ShadowsPit");
+  assert.equal(addPayload.identityLink.normalizedLabel, "shadowspit");
+  assert.equal(addPayload.identityLink.status, "proposed");
+  assert.equal(addPayload.identityLink.visibility, "internal_only");
+  assert.equal(addPayload.identityLink.useForMatching, false);
+  assert.equal(addPayload.identityLink.useInPublicDossier, false);
+  assert.equal(JSON.stringify(addPayload.drafts[0].fields), draftFields);
+  assert.equal(addPayload.drafts[0].fields.name, "Deadite Ash");
+  assert.deepEqual(addPayload.drafts[0].fields.tags, manualCandidateInput.recommendedTags);
+
+  const duplicateResponse = await authedPost({
+    action: "addDossierIdentityLink",
+    candidateId: created.candidate.id,
+    input: { label: "shadowspit", type: "alias" },
+  });
+  assert.equal(duplicateResponse.status, 400);
+  assert.equal((await duplicateResponse.json()).code, "duplicate_identity_link");
+
+  const publicReadModel = JSON.stringify(await (await readModel.GET()).json());
+  assert.doesNotMatch(publicReadModel, /ShadowsPit|identityLinks/);
+  assert.doesNotMatch(
+    normalizedSource("src/app/database/page.tsx") +
+      normalizedSource("src/app/database/[slug]/page.tsx"),
+    /identityLinks|ShadowsPit/,
+  );
+});
+
+test("identity link review statuses control alias matching", async () => {
+  await resetWorkflowStore();
+  const created = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const candidateId = created.candidate.id;
+
+  const proposed = await (
+    await authedPost({
+      action: "addDossierIdentityLink",
+      candidateId,
+      input: { label: "ShadowsPit", type: "discord_handle" },
+    })
+  ).json();
+  const proposedMatch = workflow.matchDossierRecommendationSubject({
+    recommendation: { subjectName: "ShadowsPit" },
+    candidates: (await (await authedGet()).json()).candidates,
+  });
+  assert.equal(proposedMatch.exactCandidateId, undefined);
+
+  const confirmed = await (
+    await authedPost({
+      action: "confirmDossierIdentityLink",
+      candidateId,
+      identityLinkId: proposed.identityLink.id,
+      reviewedBy: "admin-test",
+      useForMatching: true,
+    })
+  ).json();
+  assert.equal(confirmed.identityLink.status, "confirmed");
+  assert.equal(confirmed.identityLink.confidence, "confirmed");
+  assert.ok(confirmed.identityLink.confirmedAt);
+  assert.equal(confirmed.identityLink.useForMatching, true);
+
+  const confirmedMatch = workflow.matchDossierRecommendationSubject({
+    recommendation: { subjectName: "ShadowsPit" },
+    candidates: confirmed.candidates,
+  });
+  assert.equal(confirmedMatch.exactCandidateId, candidateId);
+  assert.equal(confirmedMatch.exactMatchKind, "confirmed_alias");
+  assert.equal(confirmedMatch.aliasLabel, "ShadowsPit");
+  assert.equal(confirmedMatch.reason, "Confirmed identity link / alias match.");
+
+  const retired = await (
+    await authedPost({
+      action: "retireDossierIdentityLink",
+      candidateId,
+      identityLinkId: proposed.identityLink.id,
+    })
+  ).json();
+  const retiredMatch = workflow.matchDossierRecommendationSubject({
+    recommendation: { subjectName: "ShadowsPit" },
+    candidates: retired.candidates,
+  });
+  assert.equal(retired.identityLink.status, "retired");
+  assert.equal(retiredMatch.exactCandidateId, undefined);
+
+  const rejectedLink = await (
+    await authedPost({
+      action: "addDossierIdentityLink",
+      candidateId,
+      input: { label: "Ash Old Name", type: "previous_name" },
+    })
+  ).json();
+  const rejected = await (
+    await authedPost({
+      action: "rejectDossierIdentityLink",
+      candidateId,
+      identityLinkId: rejectedLink.identityLink.id,
+    })
+  ).json();
+  const rejectedMatch = workflow.matchDossierRecommendationSubject({
+    recommendation: { subjectName: "Ash Old Name" },
+    candidates: rejected.candidates,
+  });
+  assert.equal(rejected.identityLink.status, "rejected");
+  assert.equal(rejectedMatch.exactCandidateId, undefined);
+});
+
+test("confirmed alias match allows attach and blocks duplicate conversion", async () => {
+  await resetWorkflowStore();
+  const created = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const candidateId = created.candidate.id;
+  const alias = await (
+    await authedPost({
+      action: "addDossierIdentityLink",
+      candidateId,
+      input: { label: "ShadowsPit", type: "discord_handle" },
+    })
+  ).json();
+  await authedPost({
+    action: "confirmDossierIdentityLink",
+    candidateId,
+    identityLinkId: alias.identityLink.id,
+    useForMatching: true,
+  });
+  const rec = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "identity_link",
+        subjectName: "ShadowsPit",
+        reason: "Review identity link.",
+        evidenceSummary: "ShadowsPit may be an alternate identity label.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+
+  const attachResponse = await authedPost({
+    action: "attachRecommendationToCandidate",
+    recommendationId: rec.recommendation.id,
+    candidateId,
+    createSourceNote: true,
+  });
+  assert.equal(attachResponse.status, 200);
+  const attached = await attachResponse.json();
+  assert.equal(attached.recommendation.status, "attached_to_source_file");
+  assert.equal(attached.drafts.length, 0);
+  assert.equal(attached.candidates.length, 1);
+
+  const secondRec = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "identity_link",
+        subjectName: "ShadowsPit",
+        reason: "Exact alias match should not duplicate source file.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+  const convertResponse = await authedPost({
+    action: "convertRecommendationToCandidate",
+    recommendationId: secondRec.recommendation.id,
+  });
+  assert.equal(convertResponse.status, 400);
+  const errorPayload = await convertResponse.json();
+  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
+  assert.equal(errorPayload.exactMatchKind, "confirmed_alias");
+});
 
 test("unapplied source notes count after draft creation without mutating draft fields", async () => {
   await resetWorkflowStore();
@@ -2370,6 +2580,12 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(sourceFilePage, /This source file[\s\S]*remains one subject\/entity/);
   assert.match(sourceFilePage, /create or wait for a separate BNL recommendation/);
   assert.match(sourceFilePage, /Save Info/);
+  assert.match(sourceFilePage, /Identity \/ Aliases/);
+  assert.match(sourceFilePage, /Aliases help BNL route future recommendations/);
+  assert.match(sourceFilePage, /Internal aliases are not public dossier text/);
+  assert.match(sourceFilePage, /Add Identity Link/);
+  assert.match(dashboard, /Aliases: /);
+  assert.match(dashboard, /Identity warnings/);
 
   const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   assert.match(draftPage, /Unapplied Source Notes/);
@@ -2397,6 +2613,9 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(recommendationPage, /Pre-targeted BNL Source File/);
   assert.match(recommendationPage, /This recommendation already points to an existing/);
   assert.match(recommendationPage, /Attach to Matched BNL Source File/);
+  assert.match(recommendationPage, /Matched by confirmed alias/);
+  assert.match(recommendationPage, /This alias is used for internal matching only/);
+  assert.match(recommendationPage, /Possible alias conflict/);
   assert.match(recommendationPage, /Owner\/lead identity review is required/);
   assert.doesNotMatch(recommendationPage, /Choose existing BNL Source File/);
   assert.match(recommendationPage, /Terminal recommendation actions are closed/);
@@ -2679,15 +2898,15 @@ test("BNL-ingested recommendations stay out of public read model and database pa
   const readModelPayload = await readModelResponse.json();
   assert.doesNotMatch(
     JSON.stringify(readModelPayload),
-    /Private Ingest Signal|brand-new-private-tag|recommendations|sourceFileNotes/,
+    /Private Ingest Signal|brand-new-private-tag|recommendations|sourceFileNotes|identityLinks/,
   );
 
   assert.doesNotMatch(
     normalizedSource("src/app/database/page.tsx"),
-    /sourceFileNotes|recommendations|Private Ingest Signal|brand-new-private-tag/,
+    /sourceFileNotes|recommendations|identityLinks|Private Ingest Signal|brand-new-private-tag/,
   );
   assert.doesNotMatch(
     normalizedSource("src/app/database/[slug]/page.tsx"),
-    /sourceFileNotes|recommendations|Private Ingest Signal|brand-new-private-tag/,
+    /sourceFileNotes|recommendations|identityLinks|Private Ingest Signal|brand-new-private-tag/,
   );
 });


### PR DESCRIPTION
### Motivation
- BNL is beginning to recommend source-packets using alternate labels and the site needs a safe admin-only way to record aliases without enabling unsafe automatic merges or public exposure. 
- The change must let confirmed internal aliases route future recommendations while preserving existing same-subject guardrails and public read-model safety.

### Description
- Add a Dossier Identity Link model and candidate field: introduced `DossierIdentityLink` types (`type`, `visibility`, `status`, `source`, normalized label, `useForMatching`, `useInPublicDossier`, audit fields) and made `identityLinks?: DossierIdentityLink[]` part of `DossierCandidate`. (Files: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`.)
- Store helpers and API actions: implemented store helpers `addDossierIdentityLink`, `updateDossierIdentityLink`, `confirmDossierIdentityLink`, `rejectDossierIdentityLink`, `retireDossierIdentityLink` with validation, duplicate-active-alias blocking, and safe defaulting; wired admin actions in the workflow API (`/api/admin/dossiers`). (Files: `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`.)
- Matching and recommendation support: added optional `identity_link` recommendation type and extended `matchDossierRecommendationSubject` to consider confirmed aliases only when `status === "confirmed"`, `useForMatching === true`, and the normalized subject equals the alias; alias matches surface `exactMatchKind: "confirmed_alias"` and the reason text. (File: `src/lib/dossier-workflow.ts`.)
- Admin UI: added a compact `Identity / Aliases` section to candidate pages with a simple Add Identity Link form and Confirm/Reject/Retire actions, dashboard alias counts and identity-warning indicators, and recommendation detail copy that explains confirmed-alias matches and proposed-alias conflict warnings. (Files: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`.)
- Tests and safety: extended `tests/admin-dossiers.test.mjs` to cover migration defaults, add/duplicate blocking, confirm/reject/retire flows, confirmed-alias matching and attach/convert guardrails, UI copy, and public/read-model safety; code keeps identity links admin-only and does not publish or mutate drafts/content. (File: `tests/admin-dossiers.test.mjs`.)
- Intentional exclusions: no bot repo changes, no automatic inference/fuzzy matching, no auto-merges, no public alias publishing, and no writes to `src/content.ts` or automatic dossier generation in this PR.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it passed.
- Lint: ran `npx eslint` against the modified files and reported no blocking issues after a small cleanup; lint passed for the targeted files (`src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`).
- Unit/integration tests: ran `node --test tests/admin-dossiers.test.mjs` and the suite passed (64 tests).
- Queue/read-model tests: ran `npm run test:queue` and the queue/read-model suites passed (107 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b3e10e4308321be79b871d9c5586e)