### PR TITLE
Identity / Alias Confirmation UX Cleanup

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -8,7 +8,9 @@ import {
   type DossierCandidate,
   type DossierDraft,
   type DossierDuplicateGroup,
+  type DossierIdentityLink,
   type DossierIdentityLinkSource,
+  type DossierIdentityLinkStatus,
   type DossierIdentityLinkType,
   type DossierIdentityLinkVisibility,
   type DossierRecommendation,
@@ -88,6 +90,34 @@ const emptyIdentityLinkForm: IdentityLinkForm = {
   useForMatching: false,
 };
 
+const identityLinkStatusLabels: Record<DossierIdentityLinkStatus, string> = {
+  proposed: "Proposed",
+  confirmed: "Confirmed",
+  rejected: "Rejected",
+  retired: "Retired",
+};
+
+const identityLinkStatusCopy: Record<DossierIdentityLinkStatus, string> = {
+  proposed:
+    "This alias is waiting for review. It will not affect matching until confirmed.",
+  confirmed:
+    "This alias is confirmed and can route future recommendations to this BNL Source File when matching is enabled.",
+  rejected: "This alias was rejected and will not be used for matching.",
+  retired: "This alias is retired and no longer used for matching.",
+};
+
+const identityReviewNotice: Record<
+  "confirmDossierIdentityLink" | "rejectDossierIdentityLink" | "retireDossierIdentityLink",
+  string
+> = {
+  confirmDossierIdentityLink:
+    "Identity link confirmed. Future recommendations can now match this alias if matching is enabled.",
+  rejectDossierIdentityLink:
+    "Identity link rejected. It will not be used for matching.",
+  retireDossierIdentityLink:
+    "Identity link retired. It is no longer active.",
+};
+
 function routeParam(value: string | string[] | undefined) {
   const raw = Array.isArray(value) ? value[0] : value;
   return raw ? decodeURIComponent(raw) : "";
@@ -137,6 +167,126 @@ function Section({
       <h2 className="font-bold text-foreground mb-2">{title}</h2>
       {children}
     </section>
+  );
+}
+
+function StatusBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex border border-border bg-background/40 px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted">
+      {children}
+    </span>
+  );
+}
+
+function IdentityLinkCard({
+  identityLink,
+  saving,
+  onReview,
+}: {
+  identityLink: DossierIdentityLink;
+  saving: boolean;
+  onReview: (
+    identityLinkId: string,
+    action:
+      | "confirmDossierIdentityLink"
+      | "rejectDossierIdentityLink"
+      | "retireDossierIdentityLink",
+    useForMatching?: boolean,
+  ) => void;
+}) {
+  const isProposed = identityLink.status === "proposed";
+  const isConfirmed = identityLink.status === "confirmed";
+  const isRetired = identityLink.status === "retired";
+
+  return (
+    <article className="border border-border/70 bg-background/20 p-3 space-y-3">
+      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-foreground font-semibold">{identityLink.label}</p>
+          <p className="mt-1">{identityLinkStatusCopy[identityLink.status]}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusBadge>{identityLinkStatusLabels[identityLink.status]}</StatusBadge>
+          {isConfirmed && (
+            <>
+              <StatusBadge>
+                {identityLink.useForMatching
+                  ? "Active for matching"
+                  : "Not used for matching"}
+              </StatusBadge>
+              <StatusBadge>
+                {identityLink.visibility === "public_safe"
+                  ? "Public-safe label"
+                  : "Internal only"}
+              </StatusBadge>
+              <StatusBadge>
+                {identityLink.useInPublicDossier
+                  ? "Approved for public dossier text"
+                  : "Not public dossier text"}
+              </StatusBadge>
+            </>
+          )}
+          {!isConfirmed && !isRetired && (
+            <StatusBadge>Not used for matching</StatusBadge>
+          )}
+        </div>
+      </div>
+      <p>
+        Type: {identityLink.type} / Visibility: {identityLink.visibility} /
+        Source: {identityLink.source}
+      </p>
+      <p>Confidence: {identityLink.confidence ?? "—"}</p>
+      <p className="whitespace-pre-wrap">Note: {identityLink.note ?? "—"}</p>
+      <p>
+        Created: {formatDate(identityLink.createdAt)} by{" "}
+        {identityLink.createdBy ?? "—"} / Confirmed: {" "}
+        {formatDate(identityLink.confirmedAt)} by {identityLink.confirmedBy ?? "—"}
+      </p>
+      {(isProposed || isConfirmed) && (
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+          {isProposed && (
+            <>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() =>
+                  onReview(
+                    identityLink.id,
+                    "confirmDossierIdentityLink",
+                    true,
+                  )
+                }
+                className="border border-accent px-3 py-1.5 text-accent hover:bg-accent hover:text-background disabled:pointer-events-none disabled:opacity-50"
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() =>
+                  onReview(identityLink.id, "rejectDossierIdentityLink")
+                }
+                className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-50"
+              >
+                Reject
+              </button>
+            </>
+          )}
+          {isConfirmed && (
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() =>
+                onReview(identityLink.id, "retireDossierIdentityLink")
+              }
+              className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-50"
+            >
+              Retire
+            </button>
+          )}
+        </div>
+      )}
+    </article>
   );
 }
 
@@ -258,6 +408,16 @@ export default function CandidateReviewPage() {
       (a.status === "proposed" ? -1 : 1) -
         (b.status === "proposed" ? -1 : 1) ||
       b.updatedAt.localeCompare(a.updatedAt),
+  );
+  const proposedIdentityLinks = identityLinks.filter(
+    (identityLink) => identityLink.status === "proposed",
+  );
+  const confirmedIdentityLinks = identityLinks.filter(
+    (identityLink) => identityLink.status === "confirmed",
+  );
+  const closedIdentityLinks = identityLinks.filter(
+    (identityLink) =>
+      identityLink.status === "rejected" || identityLink.status === "retired",
   );
   const nextRecommendedAction = sourceMetrics?.unappliedSourceNotesCount
     ? "Review source updates in proposed dossier"
@@ -396,7 +556,7 @@ export default function CandidateReviewPage() {
         identityLinkId,
         useForMatching,
       });
-      setNotice("Identity link updated. No public dossier text was changed.");
+      setNotice(identityReviewNotice[action]);
     } catch (err) {
       setNotice(
         err instanceof Error ? err.message : "Failed to update identity link.",
@@ -666,80 +826,75 @@ export default function CandidateReviewPage() {
         </Section>
 
         <Section title="Identity / Aliases">
-          <div className="space-y-4">
-            <p>
-              Aliases help BNL route future recommendations to the right source
-              file. Internal aliases are not public dossier text. Public-safe
-              visibility does not publish anything yet.
-            </p>
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <p>
+                Aliases help BNL route future recommendations to the right source
+                file. Internal aliases are not public dossier text. Public-safe
+                visibility does not publish anything yet.
+              </p>
+              <p className="border border-border/70 bg-background/20 p-3">
+                Adding an alias does not make it public and does not affect
+                matching until confirmed. If an alias is created as proposed,
+                matching is not active yet.
+              </p>
+            </div>
+
             {identityLinks.length === 0 ? (
               <p>No identity links saved yet.</p>
             ) : (
-              <div className="space-y-3">
-                {identityLinks.map((identityLink) => (
-                  <article
-                    key={identityLink.id}
-                    className="border border-border/70 bg-background/20 p-3 space-y-2"
+              <div className="space-y-4">
+                {[
+                  {
+                    title: "Pending Review",
+                    empty: "No pending aliases.",
+                    links: proposedIdentityLinks,
+                  },
+                  {
+                    title: "Confirmed Aliases",
+                    empty: "No confirmed aliases.",
+                    links: confirmedIdentityLinks,
+                  },
+                  {
+                    title: "Closed / Inactive",
+                    empty: "No closed aliases.",
+                    links: closedIdentityLinks,
+                  },
+                ].map((group) => (
+                  <section
+                    key={group.title}
+                    className="border border-border/60 bg-background/10 p-3 space-y-3"
                   >
-                    <p className="text-foreground font-semibold">
-                      {identityLink.label}
-                    </p>
-                    <p>
-                      Type: {identityLink.type} / Visibility: {identityLink.visibility} / Status: {identityLink.status}
-                    </p>
-                    <p>
-                      Confidence: {identityLink.confidence ?? "—"} / Source: {identityLink.source}
-                    </p>
-                    <p>
-                      Use for matching: {String(identityLink.useForMatching)} / Use in public dossier: {String(identityLink.useInPublicDossier)}
-                    </p>
-                    <p className="whitespace-pre-wrap">Note: {identityLink.note ?? "—"}</p>
-                    <p>
-                      Created: {formatDate(identityLink.createdAt)} by {identityLink.createdBy ?? "—"} / Confirmed: {formatDate(identityLink.confirmedAt)} by {identityLink.confirmedBy ?? "—"}
-                    </p>
-                    <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
-                      <button
-                        type="button"
-                        disabled={saving || identityLink.status === "confirmed"}
-                        onClick={() =>
-                          void reviewIdentityLink(
-                            identityLink.id,
-                            "confirmDossierIdentityLink",
-                            true,
-                          )
-                        }
-                        className="border border-accent px-3 py-1.5 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-                      >
-                        Confirm
-                      </button>
-                      <button
-                        type="button"
-                        disabled={saving || identityLink.status === "rejected"}
-                        onClick={() =>
-                          void reviewIdentityLink(
-                            identityLink.id,
-                            "rejectDossierIdentityLink",
-                          )
-                        }
-                        className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:opacity-50"
-                      >
-                        Reject
-                      </button>
-                      <button
-                        type="button"
-                        disabled={saving || identityLink.status === "retired"}
-                        onClick={() =>
-                          void reviewIdentityLink(
-                            identityLink.id,
-                            "retireDossierIdentityLink",
-                          )
-                        }
-                        className="border border-border px-3 py-1.5 hover:border-accent hover:text-accent disabled:opacity-50"
-                      >
-                        Retire
-                      </button>
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-sm font-bold uppercase tracking-widest text-foreground">
+                        {group.title}
+                      </h3>
+                      <span className="text-xs text-muted">
+                        {group.links.length} alias
+                        {group.links.length === 1 ? "" : "es"}
+                      </span>
                     </div>
-                  </article>
+                    {group.links.length === 0 ? (
+                      <p className="text-xs">{group.empty}</p>
+                    ) : (
+                      <div className="space-y-3">
+                        {group.links.map((identityLink) => (
+                          <IdentityLinkCard
+                            key={identityLink.id}
+                            identityLink={identityLink}
+                            saving={saving}
+                            onReview={(identityLinkId, action, useForMatching) =>
+                              void reviewIdentityLink(
+                                identityLinkId,
+                                action,
+                                useForMatching,
+                              )
+                            }
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </section>
                 ))}
               </div>
             )}
@@ -862,7 +1017,7 @@ export default function CandidateReviewPage() {
                 <button
                   type="submit"
                   disabled={saving}
-                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:pointer-events-none disabled:opacity-50"
                 >
                   Add Identity Link
                 </button>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -771,6 +771,9 @@ export default function DossierControlCenterPage() {
                         ? "draft just created"
                         : "No proposed dossier";
                     const identityLinks = candidate.identityLinks ?? [];
+                    const confirmedIdentityLinks = identityLinks.filter(
+                      (identityLink) => identityLink.status === "confirmed",
+                    );
                     const proposedIdentityLinks = identityLinks.filter(
                       (identityLink) => identityLink.status === "proposed",
                     );
@@ -809,9 +812,12 @@ export default function DossierControlCenterPage() {
                           Unapplied notes: {metrics?.unappliedSourceNotesCount ?? 0}
                         </td>
                         <td className="py-3 pr-3">
-                          Aliases: {identityLinks.length}
+                          Aliases: {confirmedIdentityLinks.length} confirmed
                           {proposedIdentityLinks.length > 0 && (
-                            <p className="text-xs text-accent">Identity warnings</p>
+                            <p className="text-xs text-accent">
+                              Pending aliases: {proposedIdentityLinks.length} —
+                              Identity warnings
+                            </p>
                           )}
                         </td>
                         <td className="py-3 pr-3">

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -394,9 +394,9 @@ export default function DossierRecommendationPage() {
                     <p className="font-bold">
                       Matched by confirmed alias: {confirmedAliasLink?.label ?? subjectMatch.aliasLabel ?? recommendation.subjectName}
                     </p>
-                    <p>Source file name: {exactCandidate.name}</p>
+                    <p>Target source file: {exactCandidate.name}</p>
                     <p>
-                      This alias is used for internal matching only unless public
+                      This alias is used for internal routing only unless public
                       use is later approved.
                     </p>
                   </>
@@ -427,10 +427,11 @@ export default function DossierRecommendationPage() {
               </div>
             ) : possibleAliasConflictCandidates.length > 0 ? (
               <div className="border border-accent/60 bg-accent/10 p-4 text-accent space-y-2">
-                <p className="font-bold">Possible alias conflict</p>
+                <p className="font-bold">Possible identity review needed</p>
                 <p>
                   A proposed identity link uses this subject label, but proposed
-                  aliases do not auto-match, attach, or merge source files.
+                  aliases do not count as exact confirmed matches, auto-match,
+                  attach, or merge source files.
                 </p>
                 <ul className="list-disc pl-5">
                   {possibleAliasConflictCandidates.map((candidate) => (

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1803,6 +1803,98 @@ test("identity link review statuses control alias matching", async () => {
   assert.equal(rejectedMatch.exactCandidateId, undefined);
 });
 
+test("identity alias review UX is grouped, status-aware, and public-safe", () => {
+  const dashboard = source("src/app/admin/dossiers/page.tsx");
+  const sourceFilePage = source(
+    "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
+  );
+  const recommendationPage = source(
+    "src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx",
+  );
+
+  for (const label of ["Proposed", "Confirmed", "Rejected", "Retired"]) {
+    assert.match(sourceFilePage, new RegExp(label));
+  }
+  for (const group of [
+    "Pending Review",
+    "Confirmed Aliases",
+    "Closed / Inactive",
+  ]) {
+    assert.match(sourceFilePage, new RegExp(group));
+  }
+  assert.match(
+    sourceFilePage,
+    /This alias is waiting for review\. It will not affect matching until confirmed\./,
+  );
+  assert.match(
+    sourceFilePage,
+    /This alias is confirmed and can route future recommendations to this BNL Source File when matching is enabled\./,
+  );
+  assert.match(
+    sourceFilePage,
+    /This alias was rejected and will not be used for matching\./,
+  );
+  assert.match(
+    sourceFilePage,
+    /This alias is retired and no longer used for matching\./,
+  );
+  assert.match(sourceFilePage, /Active for matching/);
+  assert.match(sourceFilePage, /Not used for matching/);
+  assert.match(sourceFilePage, /Internal only/);
+  assert.match(sourceFilePage, /Public-safe label/);
+  assert.match(sourceFilePage, /Not public dossier text/);
+  assert.match(
+    sourceFilePage,
+    /Adding an alias does not make it public and does not affect\s+matching until confirmed/,
+  );
+  assert.match(sourceFilePage, /Use for future matching after confirmation/);
+  assert.match(sourceFilePage, /identityLink\.status === "proposed"/);
+  assert.match(sourceFilePage, /identityLink\.status === "confirmed"/);
+  assert.match(sourceFilePage, /identityLink\.status === "rejected" \|\| identityLink\.status === "retired"/);
+  assert.match(sourceFilePage, /\{isProposed && \(/);
+  assert.match(sourceFilePage, /Confirm/);
+  assert.match(sourceFilePage, /Reject/);
+  assert.match(sourceFilePage, /\{isConfirmed && \(/);
+  assert.match(sourceFilePage, /Retire/);
+  assert.match(sourceFilePage, /disabled:pointer-events-none/);
+  assert.match(
+    sourceFilePage,
+    /Identity link confirmed\. Future recommendations can now match this alias if matching is enabled\./,
+  );
+  assert.match(
+    sourceFilePage,
+    /Identity link rejected\. It will not be used for matching\./,
+  );
+  assert.match(
+    sourceFilePage,
+    /Identity link retired\. It is no longer active\./,
+  );
+
+  assert.match(dashboard, /Aliases: \{confirmedIdentityLinks\.length\} confirmed/);
+  assert.match(dashboard, /Pending aliases: \{proposedIdentityLinks\.length\}/);
+  assert.match(dashboard, /identityLink\.status === "confirmed"/);
+  assert.match(dashboard, /identityLink\.status === "proposed"/);
+
+  assert.match(recommendationPage, /Matched by confirmed alias/);
+  assert.match(recommendationPage, /Target source file/);
+  assert.match(
+    recommendationPage,
+    /This alias is used for internal routing only unless public\s+use is later approved\./,
+  );
+  assert.match(recommendationPage, /Possible identity review needed/);
+  assert.doesNotMatch(
+    recommendationPage,
+    /Possible alias conflict[\s\S]*exact confirmed match/,
+  );
+
+  assert.doesNotMatch(
+    source("src/app/api/bnl/read-model/route.ts") +
+      source("src/app/database/page.tsx") +
+      source("src/app/database/[slug]/page.tsx"),
+    /identityLinks|publishDraft|automatic merge/i,
+  );
+});
+
 test("confirmed alias match allows attach and blocks duplicate conversion", async () => {
   await resetWorkflowStore();
   const created = await (
@@ -2614,8 +2706,8 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(recommendationPage, /This recommendation already points to an existing/);
   assert.match(recommendationPage, /Attach to Matched BNL Source File/);
   assert.match(recommendationPage, /Matched by confirmed alias/);
-  assert.match(recommendationPage, /This alias is used for internal matching only/);
-  assert.match(recommendationPage, /Possible alias conflict/);
+  assert.match(recommendationPage, /This alias is used for internal routing only/);
+  assert.match(recommendationPage, /Possible identity review needed/);
   assert.match(recommendationPage, /Owner\/lead identity review is required/);
   assert.doesNotMatch(recommendationPage, /Choose existing BNL Source File/);
   assert.match(recommendationPage, /Terminal recommendation actions are closed/);


### PR DESCRIPTION
### Motivation
- Make Identity / Aliases review behavior visually obvious so confirm/reject/retire flows feel complete and prevent operators from taking stale actions.
- Keep existing matching and public-safety behavior intact while clarifying UI copy and grouping for admin reviewers.

### Description
- Files changed: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, `tests/admin-dossiers.test.mjs`.
- Identity link cards now show explicit status badges and explanatory copy for `Proposed`, `Confirmed`, `Rejected`, and `Retired`, and confirmed aliases surface `Active for matching` / `Not used for matching`, visibility, and public-dossier safety labels; the Add form now reminds that aliases do not affect matching until confirmed.
- Aliases are grouped into `Pending Review`, `Confirmed Aliases`, and `Closed / Inactive`; action buttons are status-aware (proposed: Confirm/Reject; confirmed: Retire; rejected/retired: no active decision buttons) and buttons disable pointer events while saving to reduce double-submit confusion.
- Recommendation detail copy and dashboard rows updated to distinguish `Matched by confirmed alias` vs proposed alias review warnings and to count only confirmed aliases as active while showing pending alias counts as identity warnings.
- Kept public-safety and workflow invariants: no publishing, no automatic merges/inference, no changes to API or backend matching logic — only admin UI/UX and tests were changed.

### Testing
- Ran typecheck: `npx tsc --noEmit` — passed.
- Ran lint: `npx eslint` on affected files — passed.
- Ran unit/integration tests: `node --test tests/admin-dossiers.test.mjs` — all tests passed (including new UX assertions added in `tests/admin-dossiers.test.mjs`).
- Ran queue/read-model tests: `npm run test:queue` — passed.
- Summary: all automated checks and updated test suite passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b43ecd68083218956afded99e757c)