### PR TITLE
Add admin flow to apply BNL identity-link recommendations

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -182,9 +182,11 @@ function IdentityLinkCard({
   identityLink,
   saving,
   onReview,
+  recommendation,
 }: {
   identityLink: DossierIdentityLink;
   saving: boolean;
+  recommendation?: DossierRecommendation;
   onReview: (
     identityLinkId: string,
     action:
@@ -236,6 +238,20 @@ function IdentityLinkCard({
         Source: {identityLink.source}
       </p>
       <p>Confidence: {identityLink.confidence ?? "—"}</p>
+      {identityLink.createdFromRecommendationId && (
+        <div className="border border-border/70 bg-background/30 p-3 space-y-1">
+          <p className="font-semibold text-foreground">Created from recommendation</p>
+          <p>Recommendation subject: {identityLink.createdFromRecommendationSubject ?? recommendation?.subjectName ?? "—"}</p>
+          <p>Source lanes: {recommendation?.sourceLanes.join(", ") ?? "—"}</p>
+          <p>Ingest source: {recommendation?.ingestSource ?? recommendation?.createdBy ?? "—"}</p>
+          <Link
+            href={`/admin/dossiers/recommendations/${identityLink.createdFromRecommendationId}`}
+            className="inline-flex text-accent hover:underline"
+          >
+            Open recommendation
+          </Link>
+        </div>
+      )}
       <p className="whitespace-pre-wrap">Note: {identityLink.note ?? "—"}</p>
       <p>
         Created: {formatDate(identityLink.createdAt)} by{" "}
@@ -418,6 +434,12 @@ export default function CandidateReviewPage() {
   const closedIdentityLinks = identityLinks.filter(
     (identityLink) =>
       identityLink.status === "rejected" || identityLink.status === "retired",
+  );
+  const recommendationById = new Map(
+    (payload?.recommendations ?? []).map((recommendation) => [
+      recommendation.id,
+      recommendation,
+    ]),
   );
   const nextRecommendedAction = sourceMetrics?.unappliedSourceNotesCount
     ? "Review source updates in proposed dossier"
@@ -883,6 +905,11 @@ export default function CandidateReviewPage() {
                             key={identityLink.id}
                             identityLink={identityLink}
                             saving={saving}
+                            recommendation={
+                              identityLink.createdFromRecommendationId
+                                ? recommendationById.get(identityLink.createdFromRecommendationId)
+                                : undefined
+                            }
                             onReview={(identityLinkId, action, useForMatching) =>
                               void reviewIdentityLink(
                                 identityLinkId,

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -259,6 +259,7 @@ export default function DossierControlCenterPage() {
     [
       "attached_to_source_file",
       "converted_to_source_file",
+      "identity_link_created",
       "ignored",
       "dismissed",
     ].includes(recommendation.status),
@@ -952,6 +953,33 @@ export default function DossierControlCenterPage() {
               {" "}{resolvedDuplicateGroups.length} resolved duplicate groups.
             </p>
           </div>
+          {terminalRecommendations.length > 0 && (
+            <div className="mt-4 space-y-2 text-sm text-muted">
+              {terminalRecommendations.slice(0, 5).map((recommendation) => (
+                <article
+                  key={recommendation.id}
+                  className="border border-border/70 bg-background/20 p-3"
+                >
+                  <p className="font-semibold text-foreground">
+                    {recommendation.subjectName}
+                  </p>
+                  <p>
+                    Status: {recommendation.status === "identity_link_created"
+                      ? "Identity link created — proposed, not confirmed"
+                      : recommendation.status}
+                  </p>
+                  {recommendation.targetCandidateId && (
+                    <Link
+                      href={`/admin/dossiers/candidates/${recommendation.targetCandidateId}`}
+                      className="text-accent hover:underline"
+                    >
+                      Open related BNL Source File
+                    </Link>
+                  )}
+                </article>
+              ))}
+            </div>
+          )}
         </details>
 
         <DashboardCard eyebrow="Boundaries" title="System Boundaries">

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -2,12 +2,15 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
   matchDossierRecommendationSubject,
   normalizeDossierSubjectName,
   type DossierCandidate,
   type DossierDraft,
+  type DossierIdentityLinkSource,
+  type DossierIdentityLinkType,
+  type DossierIdentityLinkVisibility,
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
 
@@ -17,6 +20,57 @@ type WorkflowPayload = {
   recommendations: DossierRecommendation[];
   workflow: { status: string };
 };
+
+type IdentityLinkRecommendationForm = {
+  candidateId: string;
+  label: string;
+  type: DossierIdentityLinkType;
+  visibility: DossierIdentityLinkVisibility;
+  source: DossierIdentityLinkSource;
+  note: string;
+  useForMatchingAfterConfirmation: boolean;
+  useInPublicDossier: boolean;
+};
+
+const identityLinkTypes: DossierIdentityLinkType[] = [
+  "alias",
+  "artist_name",
+  "discord_handle",
+  "operator_name",
+  "public_persona",
+  "previous_name",
+  "alternate_spelling",
+  "related_label",
+  "unknown",
+];
+const identityLinkSources: DossierIdentityLinkSource[] = [
+  "bnl_recommendation",
+  "admin_manual",
+  "mod_manual",
+  "owner_confirmed",
+  "rd_context",
+  "broadcast_memory",
+  "website_dossier",
+  "unknown",
+];
+
+function identityLinkDefaults(
+  recommendation?: DossierRecommendation | null,
+  candidateId = "",
+): IdentityLinkRecommendationForm {
+  return {
+    candidateId,
+    label: recommendation?.subjectName ?? "",
+    type: "alias",
+    visibility: "internal_only",
+    source: "bnl_recommendation",
+    note: recommendation
+      ? `Created from recommendation ${recommendation.id}.`
+      : "",
+    useForMatchingAfterConfirmation: true,
+    useInPublicDossier: false,
+  };
+}
 
 function routeParam(value: string | string[] | undefined) {
   const raw = Array.isArray(value) ? value[0] : value;
@@ -88,6 +142,7 @@ const terminalRecommendationStatuses = new Set<DossierRecommendation["status"]>(
   [
     "attached_to_source_file",
     "converted_to_source_file",
+    "identity_link_created",
     "ignored",
     "dismissed",
   ],
@@ -99,6 +154,9 @@ function terminalRecommendationMessage(recommendation: DossierRecommendation) {
   }
   if (recommendation.status === "attached_to_source_file") {
     return "Attached to matched BNL Source File.";
+  }
+  if (recommendation.status === "identity_link_created") {
+    return "Proposed identity link created. Confirm it from the BNL Source File when ready.";
   }
   if (recommendation.status === "ignored") {
     return "Ignored. This recommendation is closed.";
@@ -117,8 +175,10 @@ export default function DossierRecommendationPage() {
   const [saving, setSaving] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [identityLinkForm, setIdentityLinkForm] =
+    useState<IdentityLinkRecommendationForm>(() => identityLinkDefaults());
 
-  async function loadWorkflow() {
+  const loadWorkflow = useCallback(async function loadWorkflow() {
     const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
     if (!response.ok)
       throw new Error(
@@ -126,8 +186,28 @@ export default function DossierRecommendationPage() {
           ? "Admin authentication required"
           : `Workflow API returned ${response.status}.`,
       );
-    setPayload((await response.json()) as WorkflowPayload);
-  }
+    const nextPayload = (await response.json()) as WorkflowPayload;
+    const nextRecommendation = nextPayload.recommendations.find(
+      (item) => item.id === recommendationId,
+    );
+    if (nextRecommendation) {
+      const nextMatch = matchDossierRecommendationSubject({
+        recommendation: nextRecommendation,
+        candidates: nextPayload.candidates,
+      });
+      const nextCandidateId =
+        nextRecommendation.targetCandidateId ??
+        nextMatch.exactCandidateId ??
+        nextMatch.possibleCandidateIds[0] ??
+        "";
+      setIdentityLinkForm((current) =>
+        current.label || current.candidateId
+          ? current
+          : identityLinkDefaults(nextRecommendation, nextCandidateId),
+      );
+    }
+    setPayload(nextPayload);
+  }, [recommendationId]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -142,7 +222,7 @@ export default function DossierRecommendationPage() {
         .finally(() => setLoading(false));
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [recommendationId]);
+  }, [loadWorkflow]);
 
   const recommendation = useMemo(
     () =>
@@ -197,7 +277,11 @@ export default function DossierRecommendationPage() {
       payload?.candidates.find((candidate) => candidate.id === candidateId),
     )
     .filter((candidate): candidate is DossierCandidate => Boolean(candidate));
-
+  const activeCandidates = (payload?.candidates ?? []).filter(
+    (candidate) => candidate.status !== "denied" && candidate.status !== "merged",
+  );
+  const preselectedCandidateId =
+    targetCandidate?.id ?? exactCandidate?.id ?? possibleCandidates[0]?.id ?? "";
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
     setNotice(null);
@@ -266,6 +350,37 @@ export default function DossierRecommendationPage() {
     } catch (err) {
       setNotice(
         err instanceof Error ? err.message : "Failed to attach recommendation.",
+      );
+    }
+  }
+
+
+  async function createIdentityLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      await postWorkflow({
+        action: "createIdentityLinkFromRecommendation",
+        recommendationId,
+        candidateId: identityLinkForm.candidateId,
+        input: {
+          label: identityLinkForm.label,
+          type: identityLinkForm.type,
+          visibility: identityLinkForm.visibility,
+          source: identityLinkForm.source,
+          note: identityLinkForm.note,
+          useForMatchingAfterConfirmation:
+            identityLinkForm.useForMatchingAfterConfirmation,
+          useInPublicDossier: identityLinkForm.useInPublicDossier,
+        },
+      });
+      setNotice(
+        "Proposed identity link created. Confirm it from the BNL Source File when ready.",
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error
+          ? err.message
+          : "Failed to create proposed identity link.",
       );
     }
   }
@@ -482,6 +597,170 @@ export default function DossierRecommendationPage() {
                 </button>
               </div>
             )}
+          </section>
+        )}
+
+        {!isTerminal && (
+          <section className="border border-border bg-surface p-5 space-y-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.45em] text-muted mb-2">
+                Create Identity Link
+              </p>
+              <h2 className="text-xl font-bold text-foreground">
+                Create proposed identity link
+              </h2>
+              <p className="text-sm text-muted mt-2">
+                Recommendation subject: {recommendation.subjectName}. This creates
+                a proposed alias on the selected BNL Source File only. It does not
+                confirm the alias, publish, merge source files, create a draft, or
+                create tags.
+              </p>
+              {preselectedCandidateId && (
+                <p className="mt-2 text-sm text-accent">
+                  Matched/pre-targeted BNL Source File: {targetCandidate?.name ?? exactCandidate?.name ?? possibleCandidates[0]?.name}
+                </p>
+              )}
+            </div>
+            <form
+              onSubmit={createIdentityLink}
+              className="grid grid-cols-1 md:grid-cols-4 gap-3 text-xs uppercase tracking-widest text-muted"
+            >
+              <label className="space-y-2 md:col-span-2">
+                <span>BNL Source File</span>
+                <select
+                  required
+                  value={identityLinkForm.candidateId}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      candidateId: event.target.value,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  <option value="">Select BNL Source File</option>
+                  {activeCandidates.map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="space-y-2 md:col-span-2">
+                <span>Alias label</span>
+                <input
+                  required
+                  maxLength={120}
+                  value={identityLinkForm.label}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      label: event.target.value,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="space-y-2">
+                <span>Identity link type</span>
+                <select
+                  value={identityLinkForm.type}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      type: event.target.value as DossierIdentityLinkType,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {identityLinkTypes.map((type) => (
+                    <option key={type} value={type}>{type}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="space-y-2">
+                <span>Visibility</span>
+                <select
+                  value={identityLinkForm.visibility}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      visibility: event.target.value as DossierIdentityLinkVisibility,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  <option value="internal_only">internal_only</option>
+                  <option value="public_safe">public_safe</option>
+                </select>
+              </label>
+              <label className="space-y-2">
+                <span>Source</span>
+                <select
+                  value={identityLinkForm.source}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      source: event.target.value as DossierIdentityLinkSource,
+                    })
+                  }
+                  className="w-full bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {identityLinkSources.map((source) => (
+                    <option key={source} value={source}>{source}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="md:col-span-4 space-y-2">
+                <span>Note</span>
+                <textarea
+                  maxLength={1000}
+                  value={identityLinkForm.note}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      note: event.target.value,
+                    })
+                  }
+                  className="w-full min-h-20 bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="md:col-span-2 flex items-center gap-2 normal-case tracking-normal text-sm">
+                <input
+                  type="checkbox"
+                  checked={identityLinkForm.useForMatchingAfterConfirmation}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      useForMatchingAfterConfirmation: event.target.checked,
+                    })
+                  }
+                />
+                Use for future matching after confirmation
+              </label>
+              <label className="md:col-span-2 flex items-center gap-2 normal-case tracking-normal text-sm">
+                <input
+                  type="checkbox"
+                  checked={identityLinkForm.useInPublicDossier}
+                  onChange={(event) =>
+                    setIdentityLinkForm({
+                      ...identityLinkForm,
+                      useInPublicDossier: event.target.checked,
+                    })
+                  }
+                />
+                Use in public dossier later
+              </label>
+              <div className="md:col-span-4">
+                <button
+                  type="submit"
+                  disabled={saving || !identityLinkForm.candidateId}
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:pointer-events-none disabled:opacity-50"
+                >
+                  Create Proposed Identity Link
+                </button>
+              </div>
+            </form>
           </section>
         )}
         <section className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -27,6 +27,7 @@ import {
   addDossierIdentityLink,
   addDossierSourceFileNote,
   attachRecommendationToCandidate,
+  createIdentityLinkFromRecommendation,
   confirmDossierIdentityLink,
   buildDossierDuplicateGroups,
   convertRecommendationToCandidate,
@@ -108,6 +109,7 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "mergeCandidates",
   "addSourceFileNote",
   "addDossierIdentityLink",
+  "createIdentityLinkFromRecommendation",
   "updateDossierIdentityLink",
   "confirmDossierIdentityLink",
   "rejectDossierIdentityLink",
@@ -451,6 +453,36 @@ export async function POST(req: Request) {
         recommendation,
         ...payload,
       });
+    }
+
+    if (action === "createIdentityLinkFromRecommendation") {
+      const input = identityLinkInputFromBody(body);
+      const recommendationId = recommendationIdFromBody(body);
+      if (!input || !recommendationId) {
+        return NextResponse.json(
+          { error: "recommendationId, candidateId, and identity link label are required" },
+          { status: 400 },
+        );
+      }
+      const result = await createIdentityLinkFromRecommendation({
+        recommendationId,
+        candidateId: input.candidateId,
+        label: input.label,
+        type: input.type,
+        visibility: input.visibility,
+        source: input.source,
+        note: input.note,
+        useForMatchingAfterConfirmation:
+          body.useForMatchingAfterConfirmation === false ||
+          (body.input as Record<string, unknown> | undefined)
+            ?.useForMatchingAfterConfirmation === false
+            ? false
+            : true,
+        useInPublicDossier: input.useInPublicDossier,
+        createdBy: input.createdBy,
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, ...result, ...payload });
     }
 
     if (action === "attachRecommendationToCandidate") {

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -533,6 +533,22 @@ export type CreateDossierIdentityLinkInput = {
   useInPublicDossier?: boolean;
   note?: string;
   createdBy?: string;
+  useForMatchingAfterConfirmation?: boolean;
+  createdFromRecommendationId?: string;
+  createdFromRecommendationSubject?: string;
+};
+
+export type CreateIdentityLinkFromRecommendationInput = {
+  recommendationId: string;
+  candidateId: string;
+  label: string;
+  type?: DossierIdentityLinkType;
+  visibility?: DossierIdentityLinkVisibility;
+  source?: DossierIdentityLinkSource;
+  note?: string;
+  useForMatchingAfterConfirmation?: boolean;
+  useInPublicDossier?: boolean;
+  createdBy?: string;
 };
 
 export type UpdateDossierIdentityLinkInput = Partial<
@@ -553,6 +569,7 @@ export type ReviewDossierIdentityLinkInput = {
 const TERMINAL_RECOMMENDATION_STATUSES = new Set<DossierRecommendationStatus>([
   "attached_to_source_file",
   "converted_to_source_file",
+  "identity_link_created",
   "ignored",
   "dismissed",
 ]);
@@ -816,6 +833,12 @@ function normalizeIdentityLinkInput(
     useInPublicDossier: input.useInPublicDossier === true,
     note: boundedText(input.note, 1000) || undefined,
     createdBy: boundedText(input.createdBy, 200) || undefined,
+    useForMatchingAfterConfirmation:
+      input.useForMatchingAfterConfirmation === true || input.useForMatching === true,
+    createdFromRecommendationId:
+      boundedText(input.createdFromRecommendationId, 200) || undefined,
+    createdFromRecommendationSubject:
+      boundedText(input.createdFromRecommendationSubject, 200) || undefined,
   };
 }
 
@@ -893,6 +916,142 @@ export async function addDossierIdentityLink(
   return saved ?? identityLink;
 }
 
+export async function createIdentityLinkFromRecommendation(
+  input: CreateIdentityLinkFromRecommendationInput,
+): Promise<{
+  recommendation: DossierRecommendation;
+  identityLink: DossierIdentityLink;
+}> {
+  const recommendationId = boundedText(input.recommendationId, 200);
+  const candidateId = boundedText(input.candidateId, 200);
+  const label = boundedText(input.label, 120);
+  if (!recommendationId || !candidateId || !label) {
+    throw new DossierWorkflowInputError(
+      "recommendationId, candidateId, and label are required",
+      400,
+      "invalid_identity_link_recommendation",
+    );
+  }
+
+  const now = new Date().toISOString();
+  let result:
+    | { recommendation: DossierRecommendation; identityLink: DossierIdentityLink }
+    | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const recommendation = currentState.recommendations.find(
+      (item) => item.id === recommendationId,
+    );
+    if (!recommendation) {
+      throw new DossierWorkflowInputError(
+        "Recommendation not found",
+        404,
+        "recommendation_not_found",
+      );
+    }
+    assertRecommendationIsOpen(recommendation);
+
+    const candidate = currentState.candidates.find((item) => item.id === candidateId);
+    if (!candidate) {
+      throw new DossierWorkflowInputError(
+        "Candidate not found",
+        404,
+        "candidate_not_found",
+      );
+    }
+    if (candidate.status === "denied" || candidate.status === "merged") {
+      throw new DossierWorkflowInputError(
+        "Candidate is not an active BNL Source File",
+        400,
+        "candidate_not_attachable",
+      );
+    }
+    if (
+      recommendation.targetCandidateId &&
+      recommendation.targetCandidateId !== candidate.id
+    ) {
+      throw new DossierWorkflowInputError(
+        "Recommendation is pre-targeted to a different BNL Source File",
+        400,
+        "recommendation_target_mismatch",
+        { targetCandidateId: recommendation.targetCandidateId },
+      );
+    }
+
+    const normalized = normalizeIdentityLinkInput({
+      candidateId,
+      label,
+      type: input.type ?? "alias",
+      visibility: input.visibility ?? "internal_only",
+      source: input.source ?? "bnl_recommendation",
+      note: input.note,
+      useForMatchingAfterConfirmation:
+        input.useForMatchingAfterConfirmation !== false,
+      useInPublicDossier: input.useInPublicDossier === true,
+      createdBy: input.createdBy,
+      createdFromRecommendationId: recommendation.id,
+      createdFromRecommendationSubject: recommendation.subjectName,
+    });
+    if (!normalized) {
+      throw new DossierWorkflowInputError(
+        "Identity link requires candidateId and a non-empty label",
+        400,
+        "invalid_identity_link",
+      );
+    }
+
+    const identityLink: DossierIdentityLink = {
+      id: createIdentityLinkId(),
+      ...normalized,
+      normalizedLabel: normalizeName(normalized.label),
+      status: "proposed",
+      useForMatching: false,
+      useInPublicDossier: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    assertNoDuplicateActiveIdentityLink({
+      candidate,
+      normalizedLabel: identityLink.normalizedLabel,
+    });
+
+    const updatedRecommendation: DossierRecommendation = {
+      ...recommendation,
+      status: "identity_link_created",
+      targetCandidateId: candidate.id,
+      updatedAt: now,
+    };
+    result = { recommendation: updatedRecommendation, identityLink };
+
+    return {
+      ...currentState,
+      recommendations: currentState.recommendations.map((item) =>
+        item.id === recommendation.id ? updatedRecommendation : item,
+      ),
+      candidates: currentState.candidates.map((item) =>
+        item.id === candidate.id
+          ? {
+              ...item,
+              identityLinks: [identityLink, ...(item.identityLinks ?? [])],
+              updatedAt: now,
+            }
+          : item,
+      ),
+      updatedAt: now,
+    };
+  });
+
+  if (!result) {
+    throw new DossierWorkflowInputError(
+      "Recommendation not found",
+      404,
+      "recommendation_not_found",
+    );
+  }
+  return result;
+}
+
 export async function updateDossierIdentityLink(
   input: UpdateDossierIdentityLinkInput,
 ): Promise<DossierIdentityLink> {
@@ -961,7 +1120,10 @@ export async function updateDossierIdentityLink(
             identityLink.status === "confirmed"
               ? input.useForMatching === true
               : false,
-          useInPublicDossier: input.useInPublicDossier === true,
+          useInPublicDossier:
+            identityLink.status === "confirmed" && input.useInPublicDossier === true,
+          useForMatchingAfterConfirmation:
+            input.useForMatching === true || identityLink.useForMatchingAfterConfirmation,
           note:
             typeof input.note === "string"
               ? boundedText(input.note, 1000) || undefined
@@ -1014,7 +1176,9 @@ async function setDossierIdentityLinkStatus(
           ...identityLink,
           status,
           confidence: status === "confirmed" ? "confirmed" : identityLink.confidence,
-          useForMatching: status === "confirmed" && input.useForMatching === true,
+          useForMatching:
+            status === "confirmed" &&
+            (input.useForMatching ?? identityLink.useForMatchingAfterConfirmation) === true,
           useInPublicDossier:
             status === "confirmed" && input.useInPublicDossier === true,
           confirmedBy:

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -183,6 +183,9 @@ export type DossierIdentityLink = {
   createdBy?: string;
   confirmedBy?: string;
   confirmedAt?: string;
+  useForMatchingAfterConfirmation?: boolean;
+  createdFromRecommendationId?: string;
+  createdFromRecommendationSubject?: string;
 };
 
 export type DossierCandidate = {
@@ -318,6 +321,7 @@ export type DossierRecommendationStatus =
   | "reviewing"
   | "attached_to_source_file"
   | "converted_to_source_file"
+  | "identity_link_created"
   | "ignored"
   | "dismissed";
 
@@ -687,6 +691,7 @@ export type DossierWorkflowAction =
   | "markNeedsMoreEvidence"
   | "addSourceFileNote"
   | "addDossierIdentityLink"
+  | "createIdentityLinkFromRecommendation"
   | "updateDossierIdentityLink"
   | "confirmDossierIdentityLink"
   | "rejectDossierIdentityLink"
@@ -725,6 +730,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "markNeedsMoreEvidence",
   "addSourceFileNote",
   "addDossierIdentityLink",
+  "createIdentityLinkFromRecommendation",
   "updateDossierIdentityLink",
   "confirmDossierIdentityLink",
   "rejectDossierIdentityLink",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1803,6 +1803,156 @@ test("identity link review statuses control alias matching", async () => {
   assert.equal(rejectedMatch.exactCandidateId, undefined);
 });
 
+
+test("identity link recommendations create proposed aliases safely", async () => {
+  await resetWorkflowStore();
+  const publicEntriesBefore = JSON.stringify(databasePage.entries);
+
+  const candidatePayload = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const candidateId = candidatePayload.candidate.id;
+  const recommendationPayload = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "identity_link",
+        subjectName: "ShadowsPit",
+        targetCandidateId: candidateId,
+        reason: "BNL recommends reviewing this as an identity label.",
+        evidenceSummary: "Observed in admin-safe source lanes.",
+        sourceLanes: ["rd_context", "broadcast_memory"],
+        ingestSource: "bnl",
+        createdBy: "bnl",
+      },
+    })
+  ).json();
+
+  const response = await authedPost({
+    action: "createIdentityLinkFromRecommendation",
+    recommendationId: recommendationPayload.recommendation.id,
+    candidateId,
+    input: {
+      label: "ShadowsPit",
+      note: "Review before matching.",
+    },
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.identityLink.label, "ShadowsPit");
+  assert.equal(payload.identityLink.type, "alias");
+  assert.equal(payload.identityLink.visibility, "internal_only");
+  assert.equal(payload.identityLink.source, "bnl_recommendation");
+  assert.equal(payload.identityLink.status, "proposed");
+  assert.equal(payload.identityLink.useForMatchingAfterConfirmation, true);
+  assert.equal(payload.identityLink.useForMatching, false);
+  assert.equal(payload.identityLink.useInPublicDossier, false);
+  assert.equal(
+    payload.identityLink.createdFromRecommendationId,
+    recommendationPayload.recommendation.id,
+  );
+  assert.equal(payload.identityLink.createdFromRecommendationSubject, "ShadowsPit");
+  assert.equal(payload.recommendation.status, "identity_link_created");
+  assert.equal(payload.recommendation.targetCandidateId, candidateId);
+  assert.equal(payload.drafts.length, 0);
+  assert.equal(payload.candidates.length, 1);
+  assert.equal(JSON.stringify(databasePage.entries), publicEntriesBefore);
+  assert.doesNotMatch(
+    JSON.stringify(await (await readModel.GET()).json()),
+    /ShadowsPit|identityLinks|identity_link_created/,
+  );
+
+  const proposedMatch = workflow.matchDossierRecommendationSubject({
+    recommendation: { subjectName: "ShadowsPit" },
+    candidates: payload.candidates,
+  });
+  assert.equal(proposedMatch.exactCandidateId, undefined);
+
+  const staleResponse = await authedPost({
+    action: "createIdentityLinkFromRecommendation",
+    recommendationId: recommendationPayload.recommendation.id,
+    candidateId,
+    input: { label: "Shadow Pit Duplicate" },
+  });
+  assert.equal(staleResponse.status, 400);
+  assert.equal((await staleResponse.json()).code, "recommendation_already_terminal");
+});
+
+test("identity link recommendation duplicate, invalid, and target mismatch cases fail safely", async () => {
+  await resetWorkflowStore();
+  const first = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Deadite Ash" },
+    })
+  ).json();
+  const second = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Other Source File" },
+    })
+  ).json();
+  const candidateId = first.candidate.id;
+
+  await authedPost({
+    action: "addDossierIdentityLink",
+    candidateId,
+    input: { label: "ShadowsPit" },
+  });
+  const duplicateRec = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "identity_link",
+        subjectName: "ShadowsPit",
+        reason: "Duplicate label should fail.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+  const duplicateResponse = await authedPost({
+    action: "createIdentityLinkFromRecommendation",
+    recommendationId: duplicateRec.recommendation.id,
+    candidateId,
+    input: { label: "shadowspit" },
+  });
+  assert.equal(duplicateResponse.status, 400);
+  assert.equal((await duplicateResponse.json()).code, "duplicate_identity_link");
+
+  const invalidResponse = await authedPost({
+    action: "createIdentityLinkFromRecommendation",
+    recommendationId: duplicateRec.recommendation.id,
+    candidateId: "missing-candidate",
+    input: { label: "Missing Candidate Alias" },
+  });
+  assert.equal(invalidResponse.status, 404);
+  assert.equal((await invalidResponse.json()).code, "candidate_not_found");
+
+  const targeted = await (
+    await authedPost({
+      action: "createDossierRecommendation",
+      input: {
+        type: "identity_link",
+        subjectName: "Wrong Target Label",
+        targetCandidateId: candidateId,
+        reason: "Target mismatch should fail.",
+        sourceLanes: ["admin_manual"],
+      },
+    })
+  ).json();
+  const mismatch = await authedPost({
+    action: "createIdentityLinkFromRecommendation",
+    recommendationId: targeted.recommendation.id,
+    candidateId: second.candidate.id,
+    input: { label: "Wrong Target Label" },
+  });
+  assert.equal(mismatch.status, 400);
+  assert.equal((await mismatch.json()).code, "recommendation_target_mismatch");
+});
+
 test("identity alias review UX is grouped, status-aware, and public-safe", () => {
   const dashboard = source("src/app/admin/dossiers/page.tsx");
   const sourceFilePage = source(
@@ -1856,6 +2006,9 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   assert.match(sourceFilePage, /Reject/);
   assert.match(sourceFilePage, /\{isConfirmed && \(/);
   assert.match(sourceFilePage, /Retire/);
+  assert.match(sourceFilePage, /Created from recommendation/);
+  assert.match(sourceFilePage, /Recommendation subject:/);
+  assert.match(sourceFilePage, /Open recommendation/);
   assert.match(sourceFilePage, /disabled:pointer-events-none/);
   assert.match(
     sourceFilePage,
@@ -1874,8 +2027,14 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   assert.match(dashboard, /Pending aliases: \{proposedIdentityLinks\.length\}/);
   assert.match(dashboard, /identityLink\.status === "confirmed"/);
   assert.match(dashboard, /identityLink\.status === "proposed"/);
+  assert.match(dashboard, /identity_link_created/);
 
   assert.match(recommendationPage, /Matched by confirmed alias/);
+  assert.match(recommendationPage, /Create Identity Link/);
+  assert.match(recommendationPage, /Create Proposed Identity Link/);
+  assert.match(recommendationPage, /Use for future matching after confirmation/);
+  assert.match(recommendationPage, /Use in public dossier later/);
+  assert.match(recommendationPage, /Proposed identity link created\. Confirm it from the BNL Source File when ready\./);
   assert.match(recommendationPage, /Target source file/);
   assert.match(
     recommendationPage,
@@ -2706,6 +2865,11 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(recommendationPage, /This recommendation already points to an existing/);
   assert.match(recommendationPage, /Attach to Matched BNL Source File/);
   assert.match(recommendationPage, /Matched by confirmed alias/);
+  assert.match(recommendationPage, /Create Identity Link/);
+  assert.match(recommendationPage, /Create Proposed Identity Link/);
+  assert.match(recommendationPage, /Use for future matching after confirmation/);
+  assert.match(recommendationPage, /Use in public dossier later/);
+  assert.match(recommendationPage, /Proposed identity link created\. Confirm it from the BNL Source File when ready\./);
   assert.match(recommendationPage, /This alias is used for internal routing only/);
   assert.match(recommendationPage, /Possible identity review needed/);
   assert.match(recommendationPage, /Owner\/lead identity review is required/);


### PR DESCRIPTION
### Motivation
- Allow admins to turn a BNL identity-link recommendation into a proposed alias on a chosen BNL Source File without auto-confirming or publishing.
- Provide a focused, safe UI on the Recommendation detail page so operators can select the correct Source File and configure alias metadata before proposal.
- Preserve existing safety boundaries: no auto-confirm, no merges, no drafts, and no public exposure unless later explicitly approved.

### Description
- Added a new workflow action and store helper `createIdentityLinkFromRecommendation` that validates an open recommendation, creates a `proposed` identity link on the selected candidate, records provenance fields (`createdFromRecommendationId`, `createdFromRecommendationSubject`), and marks the recommendation `identity_link_created` without creating drafts or publishing.
- Exposed the new admin API action in `/api/admin/dossiers` as `createIdentityLinkFromRecommendation` and mapped request inputs to `CreateIdentityLinkFromRecommendationInput` with defaults: `type=alias`, `visibility=internal_only`, `source=bnl_recommendation`, `status=proposed`, `useForMatchingAfterConfirmation=true`, and `useInPublicDossier=false`.
- Implemented a Recommendation detail UI section that shows the recommendation subject, a candidate/source-file selector (preselected when possible), inputs for label/type/visibility/source/note, checkboxes for `Use for future matching after confirmation` and `Use in public dossier later`, and a `Create Proposed Identity Link` button that calls the API and shows the success notice: “Proposed identity link created. Confirm it from the BNL Source File when ready.”
- Surface provenance on the BNL Source File page for identity links created from recommendations (recommendation subject, ingest/source lanes, link back to recommendation) and update dashboard/history listings to include `identity_link_created` recommendation status as a closed/proposed record.
- Added input validation and safe failure modes for duplicate labels, missing/stale/target-mismatch recommendations, candidate not found, and terminal recommendation states, and extended tests and UI text to reflect the new flow.

### Testing
- Ran `npx eslint` on changed files and fixed warnings/errors; lint passed.
- Ran `npx tsc --noEmit` to check types; type check passed.
- Ran unit/workflow tests with `node --test tests/admin-dossiers.test.mjs` which passed (new tests cover creation defaults, no-public exposure, non-matching until confirmation, duplicate/invalid/target-mismatch cases, and stale handling).
- Ran integration/queue tests with `npm run test:queue` which passed; total test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b4e0259c88321ac6e91c512eeea0d)