### PR TITLE
Website PR #142 — BNL Dynamic Recommendations Become Regular Source File Candidates

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -119,12 +119,22 @@ function linkedActiveDraftFor(
 }
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
+    return "BNL dynamic discovery";
+  }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
     return "BNL-ingested";
   }
   return recommendation.createdBy
     ? `Seeded by ${recommendation.createdBy}`
     : "Manually seeded";
+}
+
+function candidateProvenance(candidate: DossierCandidate) {
+  if (candidate.source === "bnl_dynamic_candidate_discovery") {
+    return `BNL dynamic discovery${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+  }
+  return candidate.source;
 }
 
 function StatusPill({ children }: { children: React.ReactNode }) {
@@ -570,9 +580,10 @@ export default function DossierControlCenterPage() {
             Compact Dossier Recommendation Inbox summary. Review a record to
             convert an unmatched recommendation or attach only when the system
             confirms a same-subject BNL Source File match. No generic attach
-            dropdown is shown here. BNL-ingested recommendations are review
-            items. They do not create source files, drafts, tags, or public
-            pages until approved through the workflow.
+            dropdown is shown here. BNL dynamic discovery can create an
+            internal source file only when no exact or possible existing source
+            file match is found; identity and duplicate recommendations remain
+            review-only.
           </p>
           {activeRecommendations.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
@@ -740,6 +751,7 @@ export default function DossierControlCenterPage() {
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
                     <th className="py-2 pr-3">BNL Source File</th>
+                    <th className="py-2 pr-3">Provenance</th>
                     <th className="py-2 pr-3">Current phase</th>
                     <th className="py-2 pr-3">Source depth / info strength</th>
                     <th className="py-2 pr-3">Source notes count</th>
@@ -793,6 +805,15 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 text-foreground font-semibold">
                           {candidate.name}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <p>{candidateProvenance(candidate)}</p>
+                          {candidate.ingestKey && (
+                            <p className="text-xs">Ingest key: {candidate.ingestKey}</p>
+                          )}
+                          {candidate.createdFromRecommendationId && (
+                            <p className="text-xs">From recommendation: {candidate.createdFromRecommendationId}</p>
+                          )}
                         </td>
                         <td className="py-3 pr-3">
                           <StatusPill>{currentPhase}</StatusPill>

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -115,6 +115,9 @@ function formatDate(value?: string) {
 }
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
+    return "BNL dynamic discovery";
+  }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
     return "BNL-ingested";
   }
@@ -424,9 +427,10 @@ export default function DossierRecommendationPage() {
             evidence records. They do not publish, create drafts, write content
             files, or create tags automatically. Attach is only allowed for
             confirmed same-subject matches; merge is owner/lead identity
-            resolution. BNL-ingested recommendations are review items. They do
-            not create source files, drafts, tags, or public pages until
-            approved through the workflow.
+            resolution. BNL dynamic discovery can create an internal source
+            file only when no exact or possible existing source-file match is
+            found. Identity/alias and duplicate recommendations remain review
+            items; no drafts, tags, or public pages are created automatically.
           </p>
           {notice && (
             <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -436,6 +440,10 @@ export default function DossierRecommendationPage() {
           {isTerminal && (
             <div className="mt-4 border border-border/70 bg-background/30 p-4 text-sm text-muted">
               <p className="font-bold text-foreground">{terminalMessage}</p>
+              <p>Ingest: {recommendationProvenance(recommendation)}</p>
+              {recommendation.ingestKey && (
+                <p>Ingest key: {recommendation.ingestKey}</p>
+              )}
               {targetCandidate ? (
                 <Link
                   href={`/admin/dossiers/candidates/${targetCandidate.id}`}

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -22,6 +22,7 @@ export const dynamic = "force-dynamic";
 const RECOMMENDATION_TYPES = [
   "new_subject",
   "modify_existing_dossier",
+  "identity_link",
 ] as const satisfies readonly DossierRecommendationType[];
 const SOURCE_LANES = [
   "public_discord",
@@ -194,7 +195,10 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     createdBy: text(payload.createdBy, 200) ?? "bnl",
     ingestKey: text(payload.ingestKey, 300),
     ingestedAt: new Date().toISOString(),
-    ingestSource: "bnl",
+    ingestSource:
+      text(payload.ingestSource, 80) === "bnl_dynamic_candidate_discovery"
+        ? "bnl_dynamic_candidate_discovery"
+        : "bnl",
   };
 }
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -659,11 +659,162 @@ function normalizeRecommendationInput(
     ingestedAt: boundedText(input.ingestedAt, 80) || undefined,
     ingestSource:
       input.ingestSource === "bnl" ||
+      input.ingestSource === "bnl_dynamic_candidate_discovery" ||
       input.ingestSource === "system" ||
       input.ingestSource === "unknown"
         ? input.ingestSource
         : undefined,
   };
+}
+
+function isBnlDynamicCandidateDiscovery(
+  recommendation: Pick<DossierRecommendation, "ingestSource" | "type">,
+): boolean {
+  return (
+    recommendation.ingestSource === "bnl_dynamic_candidate_discovery" &&
+    recommendation.type === "new_subject"
+  );
+}
+
+function candidateTypeFromRecommendation(
+  recommendation: Pick<
+    DossierRecommendation,
+    "recommendedCategory" | "recommendedKind"
+  >,
+): DossierCandidate["candidateType"] {
+  if (recommendation.recommendedKind === "artist") return "artist";
+  if (recommendation.recommendedKind === "community_member") {
+    return "community_member";
+  }
+  if (recommendation.recommendedCategory === "Production") return "production";
+  if (recommendation.recommendedCategory === "Interface") return "interface";
+  if (recommendation.recommendedCategory === "Sponsor") return "sponsor";
+  if (recommendation.recommendedCategory === "Entity") return "entity";
+  return "unknown";
+}
+
+function recommendationCandidateScore(
+  recommendation: Pick<DossierRecommendation, "confidence">,
+): number {
+  return recommendation.confidence === "high"
+    ? 70
+    : recommendation.confidence === "medium"
+      ? 55
+      : 40;
+}
+
+function bnlDynamicDiscoveryNoteText(
+  recommendation: DossierRecommendation,
+): string {
+  return [
+    recommendationSourceNoteText(recommendation),
+    `BNL dynamic discovery source lanes: ${recommendation.sourceLanes.join(", ")}`,
+    recommendation.ingestKey ? `BNL dynamic ingest key: ${recommendation.ingestKey}` : "",
+    recommendation.confidence ? `BNL confidence: ${recommendation.confidence}` : "",
+    recommendation.recommendedCategory || recommendation.recommendedKind
+      ? `BNL category metadata: ${[
+          recommendation.recommendedCategory,
+          recommendation.recommendedKind,
+          recommendation.recommendedEcosystemLane,
+          recommendation.recommendedIdentityAuthority,
+        ]
+          .filter(Boolean)
+          .join(" / ")}`
+      : "",
+    ...(recommendation.publicSafetyNotes ?? []).map(
+      (note) => `Safety note: ${note}`,
+    ),
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+    .slice(0, 2000);
+}
+
+function buildCandidateFromRecommendation(input: {
+  recommendation: DossierRecommendation;
+  now: string;
+  source: DossierCandidate["source"];
+  noteText: string;
+}): DossierCandidate {
+  const { recommendation, now, source, noteText } = input;
+  const duplicate = findExistingDossierMatch(recommendation.subjectName);
+  const note: DossierSourceFileNote = {
+    id: createSourceFileNoteId(),
+    candidateId: "",
+    type: "general_note",
+    text: noteText,
+    source: "bnl_recommendation",
+    status: "active",
+    publicSafe: false,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: recommendation.createdBy,
+    ingestKey: recommendation.ingestKey,
+    ingestedAt: recommendation.ingestedAt,
+    ingestSource: recommendation.ingestSource,
+  };
+  const candidate: DossierCandidate = {
+    id: createCandidateId(),
+    name: recommendation.subjectName,
+    candidateType: candidateTypeFromRecommendation(recommendation),
+    source,
+    tier: "review_candidate",
+    score: recommendationCandidateScore(recommendation),
+    whyNow:
+      recommendation.suggestedAction ??
+      (source === "bnl_dynamic_candidate_discovery"
+        ? "BNL dynamic candidate discovery."
+        : "Recommendation inbox conversion."),
+    reason: recommendation.reason,
+    firstSeenAt: recommendation.ingestedAt ?? now,
+    lastSeenAt: now,
+    evidenceSummary: recommendation.evidenceSummary ?? recommendation.reason,
+    evidenceItems: recommendation.evidenceSummary
+      ? [
+          {
+            id: createEvidenceId(),
+            type: "operator_note",
+            label:
+              source === "bnl_dynamic_candidate_discovery"
+                ? "BNL dynamic discovery evidence"
+                : "Recommendation inbox evidence",
+            summary: recommendation.evidenceSummary,
+            count: 1,
+            firstSeenAt: recommendation.ingestedAt ?? now,
+            lastSeenAt: now,
+            publicSafe: false,
+          },
+        ]
+      : [],
+    evidenceCount: recommendation.evidenceSummary ? 1 : 0,
+    knownFacts: [],
+    confidence: recommendation.confidence ?? "low",
+    duplicateRisk: duplicate.risk,
+    existingDossierMatch: duplicate.match,
+    recommendedCategory: recommendation.recommendedCategory,
+    recommendedKind: recommendation.recommendedKind,
+    recommendedEcosystemLane: recommendation.recommendedEcosystemLane,
+    recommendedIdentityAuthority: recommendation.recommendedIdentityAuthority,
+    recommendedStatus: "PENDING",
+    recommendedClearance: "PUBLIC",
+    recommendedOrigin: "UNVERIFIED",
+    recommendedTags: recommendation.recommendedTags ?? [],
+    proposedTags: [],
+    missingInfo: recommendation.missingInfo ?? [],
+    doNotSay: recommendation.doNotSay ?? [],
+    publicSafetyNotes: recommendation.publicSafetyNotes ?? [],
+    sourceFileNotes: [{ ...note, candidateId: "" }],
+    identityLinks: [],
+    sourceLanes: recommendation.sourceLanes,
+    ingestKey: recommendation.ingestKey,
+    ingestSource: recommendation.ingestSource,
+    createdFromRecommendationId: recommendation.id,
+    status: "needs_review",
+    createdAt: now,
+    updatedAt: now,
+  };
+  candidate.sourceFileNotes = [{ ...note, candidateId: candidate.id }];
+  return candidate;
 }
 
 function isActiveRecommendation(recommendation: DossierRecommendation): boolean {
@@ -694,7 +845,12 @@ function fallbackRecommendationDedupeKey(
 
 export async function createDossierRecommendationIdempotent(
   input: CreateDossierRecommendationInput,
-): Promise<{ recommendation: DossierRecommendation; duplicate: boolean }> {
+): Promise<{
+  recommendation: DossierRecommendation;
+  duplicate: boolean;
+  candidate?: DossierCandidate;
+  autoAction?: "created_candidate" | "attached_existing" | "left_for_review";
+}> {
   const normalized = normalizeRecommendationInput(input);
   if (!normalized) {
     throw new DossierWorkflowInputError(
@@ -710,7 +866,9 @@ export async function createDossierRecommendationIdempotent(
     updatedAt: now,
   };
   let savedRecommendation: DossierRecommendation = recommendation;
+  let savedCandidate: DossierCandidate | undefined;
   let duplicate = false;
+  let autoAction: "created_candidate" | "attached_existing" | "left_for_review" | undefined;
 
   await updateDossierWorkflowState((currentState) => {
     if (recommendation.targetCandidateId) {
@@ -735,9 +893,7 @@ export async function createDossierRecommendationIdempotent(
 
     const existing = recommendation.ingestKey
       ? currentState.recommendations.find(
-          (item) =>
-            isActiveRecommendation(item) &&
-            item.ingestKey === recommendation.ingestKey,
+          (item) => item.ingestKey === recommendation.ingestKey,
         )
       : currentState.recommendations.find(
           (item) =>
@@ -752,6 +908,123 @@ export async function createDossierRecommendationIdempotent(
       return currentState;
     }
 
+    if (isBnlDynamicCandidateDiscovery(recommendation)) {
+      const ingestKeyCandidate = recommendation.ingestKey
+        ? currentState.candidates.find(
+            (candidate) =>
+              candidate.ingestKey === recommendation.ingestKey &&
+              candidate.status !== "denied" &&
+              candidate.status !== "merged",
+          )
+        : undefined;
+      if (ingestKeyCandidate) {
+        const updatedRecommendation: DossierRecommendation = {
+          ...recommendation,
+          status: "attached_to_source_file",
+          targetCandidateId: ingestKeyCandidate.id,
+          publicSafetyNotes: [
+            ...(recommendation.publicSafetyNotes ?? []),
+            "BNL dynamic discovery ingest key already exists on a source file; linked without creating a duplicate candidate.",
+          ],
+          updatedAt: now,
+        };
+        savedRecommendation = updatedRecommendation;
+        autoAction = "attached_existing";
+        return {
+          ...currentState,
+          recommendations: [updatedRecommendation, ...currentState.recommendations],
+          updatedAt: now,
+        };
+      }
+
+      const match = matchDossierRecommendationSubject({
+        recommendation,
+        candidates: currentState.candidates,
+      });
+
+      if (match.exactCandidateId) {
+        const note: DossierSourceFileNote = {
+          id: createSourceFileNoteId(),
+          candidateId: match.exactCandidateId,
+          type: "general_note",
+          text: bnlDynamicDiscoveryNoteText(recommendation),
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        };
+        const updatedRecommendation: DossierRecommendation = {
+          ...recommendation,
+          status: "attached_to_source_file",
+          targetCandidateId: match.exactCandidateId,
+          publicSafetyNotes: [
+            ...(recommendation.publicSafetyNotes ?? []),
+            "BNL dynamic discovery matched an existing exact same-subject source file and was attached without creating a duplicate candidate.",
+          ],
+          updatedAt: now,
+        };
+        savedRecommendation = updatedRecommendation;
+        autoAction = "attached_existing";
+        return {
+          ...currentState,
+          recommendations: [updatedRecommendation, ...currentState.recommendations],
+          candidates: currentState.candidates.map((candidate) =>
+            candidate.id === match.exactCandidateId
+              ? {
+                  ...candidate,
+                  sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+                  updatedAt: now,
+                }
+              : candidate,
+          ),
+          updatedAt: now,
+        };
+      }
+
+      if (match.possibleCandidateIds.length === 0) {
+        const candidate = buildCandidateFromRecommendation({
+          recommendation,
+          now,
+          source: "bnl_dynamic_candidate_discovery",
+          noteText: bnlDynamicDiscoveryNoteText(recommendation),
+        });
+        const updatedRecommendation: DossierRecommendation = {
+          ...recommendation,
+          status: "converted_to_source_file",
+          targetCandidateId: candidate.id,
+          updatedAt: now,
+        };
+        savedRecommendation = updatedRecommendation;
+        savedCandidate = candidate;
+        autoAction = "created_candidate";
+        return {
+          ...currentState,
+          candidates: [candidate, ...currentState.candidates],
+          recommendations: [updatedRecommendation, ...currentState.recommendations],
+          updatedAt: now,
+        };
+      }
+
+      savedRecommendation = {
+        ...recommendation,
+        publicSafetyNotes: [
+          ...(recommendation.publicSafetyNotes ?? []),
+          "BNL dynamic discovery found possible existing source files; left in Recommendation Inbox for owner/lead duplicate or identity review.",
+        ],
+      };
+      autoAction = "left_for_review";
+      return {
+        ...currentState,
+        recommendations: [savedRecommendation, ...currentState.recommendations],
+        updatedAt: now,
+      };
+    }
+
     savedRecommendation = recommendation;
     return {
       ...currentState,
@@ -760,7 +1033,12 @@ export async function createDossierRecommendationIdempotent(
     };
   });
 
-  return { recommendation: savedRecommendation, duplicate };
+  return {
+    recommendation: savedRecommendation,
+    duplicate,
+    candidate: savedCandidate,
+    autoAction,
+  };
 }
 
 function recommendationSourceNoteText(
@@ -1459,74 +1737,18 @@ export async function convertRecommendationToCandidate(
         },
       );
     }
-    const duplicate = findExistingDossierMatch(recommendation.subjectName);
-    const note: DossierSourceFileNote = {
-      id: createSourceFileNoteId(),
-      candidateId: "",
-      type: "general_note",
-      text: recommendationSourceNoteText(recommendation),
-      source: "bnl_recommendation",
-      status: "active",
-      publicSafe: false,
-      createdAt: now,
-      updatedAt: now,
-    };
-    const candidate: DossierCandidate = {
-      id: createCandidateId(),
-      name: recommendation.subjectName,
-      candidateType: "unknown",
-      source: "manual",
-      tier: "review_candidate",
-      score:
-        recommendation.confidence === "high"
-          ? 70
-          : recommendation.confidence === "medium"
-            ? 55
-            : 40,
-      whyNow:
-        recommendation.suggestedAction ?? "Recommendation inbox conversion.",
-      reason: recommendation.reason,
-      firstSeenAt: now,
-      lastSeenAt: now,
-      evidenceSummary: recommendation.evidenceSummary ?? recommendation.reason,
-      evidenceItems: recommendation.evidenceSummary
-        ? [
-            {
-              id: createEvidenceId(),
-              type: "operator_note",
-              label: "Recommendation inbox evidence",
-              summary: recommendation.evidenceSummary,
-              count: 1,
-              firstSeenAt: now,
-              lastSeenAt: now,
-              publicSafe: false,
-            },
-          ]
-        : [],
-      evidenceCount: recommendation.evidenceSummary ? 1 : 0,
-      knownFacts: [],
-      confidence: recommendation.confidence ?? "low",
-      duplicateRisk: duplicate.risk,
-      existingDossierMatch: duplicate.match,
-      recommendedCategory: recommendation.recommendedCategory,
-      recommendedKind: recommendation.recommendedKind,
-      recommendedEcosystemLane: recommendation.recommendedEcosystemLane,
-      recommendedIdentityAuthority: recommendation.recommendedIdentityAuthority,
-      recommendedStatus: "PENDING",
-      recommendedClearance: "PUBLIC",
-      recommendedOrigin: "UNVERIFIED",
-      recommendedTags: recommendation.recommendedTags ?? [],
-      proposedTags: [],
-      missingInfo: recommendation.missingInfo ?? [],
-      doNotSay: recommendation.doNotSay ?? [],
-      publicSafetyNotes: recommendation.publicSafetyNotes ?? [],
-      sourceFileNotes: [{ ...note, candidateId: "" }],
-      identityLinks: [],
-      status: "needs_review",
-      createdAt: now,
-      updatedAt: now,
-    };
-    candidate.sourceFileNotes = [{ ...note, candidateId: candidate.id }];
+    const candidate = buildCandidateFromRecommendation({
+      recommendation,
+      now,
+      source:
+        recommendation.ingestSource === "bnl_dynamic_candidate_discovery"
+          ? "bnl_dynamic_candidate_discovery"
+          : "manual",
+      noteText:
+        recommendation.ingestSource === "bnl_dynamic_candidate_discovery"
+          ? bnlDynamicDiscoveryNoteText(recommendation)
+          : recommendationSourceNoteText(recommendation),
+    });
     const updatedRecommendation: DossierRecommendation = {
       ...recommendation,
       status: "converted_to_source_file",

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -10,6 +10,7 @@ export type DossierCandidateSource =
   | "queue_frequency"
   | "discord_context"
   | "website_read_model"
+  | "bnl_dynamic_candidate_discovery"
   | "combined";
 
 export type DossierCandidateType =
@@ -225,6 +226,10 @@ export type DossierCandidate = {
   publicSafetyNotes?: string[];
   sourceFileNotes?: DossierSourceFileNote[];
   identityLinks?: DossierIdentityLink[];
+  sourceLanes?: DossierRecommendationSourceLane[];
+  ingestKey?: string;
+  ingestSource?: DossierRecommendationIngestSource;
+  createdFromRecommendationId?: string;
   mergedIntoCandidateId?: string;
   mergedAt?: string;
   mergeNote?: string;
@@ -336,7 +341,11 @@ export type DossierRecommendationSourceLane =
   | "owner_manual"
   | "unknown";
 
-export type DossierRecommendationIngestSource = "bnl" | "system" | "unknown";
+export type DossierRecommendationIngestSource =
+  | "bnl"
+  | "bnl_dynamic_candidate_discovery"
+  | "system"
+  | "unknown";
 
 export type DossierRecommendation = {
   id: string;
@@ -922,6 +931,14 @@ export const DOSSIER_SOURCE_BOUNDARIES: DossierSourceBoundary[] = [
       "Public site state may include existing public-page dossiers and tags only.",
     allowedUse:
       "May help compare candidates against existing public database records.",
+  },
+  {
+    source: "bnl_dynamic_candidate_discovery",
+    label: "BNL dynamic candidate discovery",
+    boundary:
+      "BNL dynamic discovery creates internal source-file candidates only; it never publishes, drafts, confirms aliases, or creates tags automatically.",
+    allowedUse:
+      "May create an admin-only candidate when no exact or possible existing source-file match is found.",
   },
   {
     source: "combined",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -3022,6 +3022,153 @@ test("BNL ingest creates review-only recommendations visible to admin without ca
   assert.deepEqual(adminPayload.drafts, []);
 });
 
+
+test("BNL dynamic discovery creates a normal source-file candidate with provenance and no public side effects", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const beforePublicTagCount = databasePage.entries.flatMap((entry) => entry.tags).length;
+
+  const response = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Dynamic Signal System",
+    subjectKey: "dynamic-signal-system",
+    reason: "BNL discovered a source-file subject from approved lanes.",
+    evidenceSummary: "R&D context and broadcast memory both mention the system.",
+    confidence: "high",
+    sourceLanes: ["rd_context", "broadcast_memory"],
+    publicSafetyNotes: ["Keep internal until reviewed."],
+    missingInfo: ["Confirm public-safe label."],
+    recommendedCategory: "Interface",
+    recommendedKind: "system",
+    recommendedEcosystemLane: "infrastructure",
+    recommendedIdentityAuthority: "barcode_controlled",
+    recommendedTags: ["dynamic-private-tag"],
+    ingestKey: "bnl:dynamic-signal-system:2026-05-30",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.autoAction, "created_candidate");
+  assert.equal(payload.duplicate, false);
+  assert.equal(payload.recommendation.status, "converted_to_source_file");
+  assert.equal(payload.recommendation.ingestSource, "bnl_dynamic_candidate_discovery");
+  assert.ok(payload.candidate.id);
+  assert.equal(payload.candidate.name, "Dynamic Signal System");
+  assert.equal(payload.candidate.source, "bnl_dynamic_candidate_discovery");
+  assert.deepEqual(payload.candidate.sourceLanes, ["rd_context", "broadcast_memory"]);
+  assert.equal(payload.candidate.ingestKey, "bnl:dynamic-signal-system:2026-05-30");
+  assert.equal(payload.candidate.createdFromRecommendationId, payload.recommendation.id);
+  assert.equal(payload.candidate.reason, "BNL discovered a source-file subject from approved lanes.");
+  assert.equal(payload.candidate.evidenceSummary, "R&D context and broadcast memory both mention the system.");
+  assert.deepEqual(payload.candidate.publicSafetyNotes, ["Keep internal until reviewed."]);
+  assert.equal(payload.candidate.confidence, "high");
+  assert.equal(payload.candidate.recommendedCategory, "Interface");
+  assert.equal(payload.candidate.recommendedKind, "system");
+  assert.equal(payload.candidate.status, "needs_review");
+  assert.equal(payload.candidate.sourceFileNotes.length, 1);
+  assert.match(payload.candidate.sourceFileNotes[0].text, /BNL dynamic discovery source lanes: rd_context, broadcast_memory/);
+  assert.equal(payload.candidate.sourceFileNotes[0].ingestSource, "bnl_dynamic_candidate_discovery");
+
+  const adminPayload = await (await authedGet()).json();
+  assert.equal(adminPayload.candidates.length, 1);
+  assert.equal(adminPayload.candidates[0].id, payload.candidate.id);
+  assert.equal(adminPayload.recommendations.length, 1);
+  assert.equal(adminPayload.drafts.length, 0);
+  assert.equal(databasePage.entries.flatMap((entry) => entry.tags).length, beforePublicTagCount);
+  assert.doesNotMatch(JSON.stringify(databasePage.entries), /Dynamic Signal System|dynamic-private-tag/);
+
+  const readModelResponse = await readModel.GET(
+    new Request("https://example.test/api/bnl/read-model"),
+  );
+  const readModelPayload = await readModelResponse.json();
+  assert.doesNotMatch(JSON.stringify(readModelPayload), /Dynamic Signal System|dynamic-private-tag/);
+});
+
+test("BNL dynamic discovery dedupes by ingestKey and exact subject candidate", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const input = {
+    type: "new_subject",
+    subjectName: "Deduped Dynamic System",
+    reason: "BNL found a system candidate.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:deduped-dynamic-system",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  };
+  const first = await (await bnlIngestPost(input)).json();
+  const second = await (await bnlIngestPost(input)).json();
+  assert.equal(first.autoAction, "created_candidate");
+  assert.equal(second.duplicate, true);
+  assert.equal(second.recommendation.id, first.recommendation.id);
+
+  const sameSubject = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "The Deduped Dynamic System",
+    reason: "BNL found the same normalized subject under a different ingest key.",
+    sourceLanes: ["broadcast_memory"],
+    ingestKey: "bnl:deduped-dynamic-system:second-key",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  assert.equal(sameSubject.autoAction, "attached_existing");
+  assert.equal(sameSubject.recommendation.status, "attached_to_source_file");
+  assert.equal(sameSubject.recommendation.targetCandidateId, first.candidate.id);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.equal(state.recommendations.length, 2);
+  assert.equal(state.candidates[0].sourceFileNotes.length, 2);
+  assert.equal(state.drafts.length, 0);
+});
+
+test("BNL dynamic identity and possible duplicate recommendations remain review-only", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const existing = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Signal Archive",
+      reason: "Existing candidate for duplicate review.",
+    },
+  })).json();
+
+  const identity = await (await bnlIngestPost({
+    type: "identity_link",
+    subjectName: "Signal Alias",
+    targetCandidateId: existing.candidate.id,
+    reason: "BNL found a possible alias for review.",
+    sourceLanes: ["public_discord"],
+    ingestKey: "bnl:identity-link-review",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  assert.equal(identity.recommendation.status, "new");
+  assert.equal(identity.autoAction, undefined);
+
+  const possibleDuplicate = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Signal Archive Annex",
+    reason: "BNL found a nearby source-file subject that may be a duplicate.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:possible-duplicate-review",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  assert.equal(possibleDuplicate.autoAction, "left_for_review");
+  assert.equal(possibleDuplicate.recommendation.status, "new");
+  assert.match(
+    possibleDuplicate.recommendation.publicSafetyNotes.join(" "),
+    /possible existing source files/,
+  );
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.equal(state.drafts.length, 0);
+  assert.equal(state.recommendations.length, 2);
+  assert.equal(state.candidates[0].identityLinks?.length ?? 0, 0);
+});
+
 test("BNL ingest dedupes active recommendations by ingestKey and fallback comparison", async () => {
   await resetWorkflowStore();
   process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";


### PR DESCRIPTION
### Motivation
- BNL dynamic discovery currently creates only review recommendations; high-confidence new-subject discoveries should become normal internal BNL Source File candidates so admins can work with them in the standard workflow. 
- Preserve full BNL provenance (source lanes, ingestKey, ingestSource, evidence/reason, safety notes, confidence, taxonomy) on any auto-created candidate for audit and traceability. 
- Maintain safety boundaries: identity/alias recommendations and possible-duplicate recommendations must remain review-only and no public-sided effects (drafts, publishes, tags, content.ts writes) should occur automatically.

### Description
- Accept `ingestSource: "bnl_dynamic_candidate_discovery"` and `identity_link` recommendation type in the BNL ingest route and preserve the ingest source when normalizing payloads in `src/app/api/bnl/dossier-recommendations/route.ts`.
- Implemented auto-conversion flow inside the dossier workflow store so a `new_subject` recommendation with `ingestSource === "bnl_dynamic_candidate_discovery"` will: if no exact or possible existing candidate match exists, create a normal internal `DossierCandidate` (source=`bnl_dynamic_candidate_discovery`) using `buildCandidateFromRecommendation` and attach provenance; if an exact candidate or ingest-key match exists, attach as a source-file note instead; otherwise leave the recommendation in the inbox for owner/lead review.
- Added helpers to preserve provenance and scoring when converting: `bnlDynamicDiscoveryNoteText`, `buildCandidateFromRecommendation`, `candidateTypeFromRecommendation`, and `recommendationCandidateScore` inside `src/lib/dossier-workflow-store.ts` and extended types to carry `ingestKey`, `ingestSource`, `sourceLanes`, and `createdFromRecommendationId` in `src/lib/dossier-workflow.ts`.
- Updated admin UI copy and existing Candidates table to surface BNL dynamic provenance without adding new menus/lanes: display provenance, `ingestKey`, and originating recommendation id in the normal BNL Source Files view and show ingest provenance on recommendation detail pages (`src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`).
- Tests: added targeted tests to `tests/admin-dossiers.test.mjs` covering: successful dynamic conversion into a normal candidate, provenance preserved on candidate and source-file note, ingestKey and subject dedupe behavior, attach-to-existing behavior, identity/possible-duplicate recommendations remain review-only, and no public/read-model/tag/draft side effects. 
- Files changed (key): `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-workflow.ts`, `src/app/api/bnl/dossier-recommendations/route.ts`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, `tests/admin-dossiers.test.mjs`.

### Testing
- Type check: `npx tsc --noEmit` — succeeded.
- ESLint: targeted lint run over changed files — succeeded (no blocking errors reported).
- Workflow unit tests: `node --test tests/admin-dossiers.test.mjs` — all tests passed (new coverage added for dynamic discovery cases).
- Full queue/read-model tests: `npm run test:queue` (runs `tests/queue-playback.test.mjs` and `tests/bnl-read-model.test.mjs`) — all tests passed.

All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5521e9a88321899f8f505ef74bb2)