### PR TITLE
Website PR #143 — BNL Source File Read Model v1

### DIFF
--- a/src/app/api/bnl/source-files/route.ts
+++ b/src/app/api/bnl/source-files/route.ts
@@ -1,0 +1,562 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import {
+  compactDossierSubjectName,
+  normalizeDossierSubjectName,
+  type DossierCandidate,
+  type DossierDraft,
+  type DossierIdentityLink,
+  type DossierRecommendation,
+  type DossierSourceFileNote,
+} from "@/lib/dossier-workflow";
+import { getDossierWorkflowState } from "@/lib/dossier-workflow-store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const CACHE_CONTROL = "private, no-store";
+const MAX_NOTE_LENGTH = 700;
+const MAX_RECOMMENDATIONS = 8;
+const MAX_POSSIBLE_MATCHES = 8;
+
+const VISIBILITY_BOUNDARY = {
+  visibility: "internal_bnl_source_file" as const,
+  publicUse: false,
+  publicSummaryAllowed:
+    "only when a field is explicitly publicSafe or already published elsewhere" as const,
+  identityWarning:
+    "identity links and aliases are workflow/routing context, not public identity proof" as const,
+  publishWarning: "BNL Source Files are not public dossiers" as const,
+  draftWarning:
+    "proposed dossiers/drafts are not public until owner-approved and published" as const,
+  allowedUse: [
+    "internal/operator source-file retrieval",
+    "same-subject routing and review context",
+    "draft preparation context inside the authenticated BNL boundary",
+  ],
+  disallowedUse: [
+    "public repetition unless a field is explicitly public-safe or already published elsewhere",
+    "claiming aliases prove public identity",
+    "publishing or mutating source files, drafts, recommendations, or content.ts",
+    "exposing private payment, customer, account, upload, contact, token, or raw transcript data",
+  ],
+};
+
+type MatchKind =
+  | "candidate_id"
+  | "name"
+  | "compact_name"
+  | "normalized_name"
+  | "confirmed_alias";
+
+type PossibleMatchKind =
+  | "same_name"
+  | "compact_name"
+  | "unconfirmed_alias"
+  | "partial_name";
+
+type QueryMode = "candidateId" | "subject" | "alias" | "normalizedName";
+
+type ResolvedMatch =
+  | { candidate: DossierCandidate; matchKind: Exclude<MatchKind, "confirmed_alias"> }
+  | {
+      candidate: DossierCandidate;
+      alias: DossierIdentityLink;
+      matchKind: "confirmed_alias";
+    };
+
+type SourceFileSummary = {
+  candidateId: string;
+  id: string;
+  name: string;
+  normalizedName: string;
+  candidateType: DossierCandidate["candidateType"];
+  status: DossierCandidate["status"];
+  tier: DossierCandidate["tier"];
+  score: number;
+  confidence: DossierCandidate["confidence"] | null;
+  source: DossierCandidate["source"];
+  sourceLanes: DossierCandidate["sourceLanes"];
+  ingestSource: DossierCandidate["ingestSource"] | null;
+  ingestKey: string | null;
+  createdFromRecommendationId: string | null;
+  reason: string;
+  whyNow: string;
+  evidenceSummary: string;
+  knownFacts: string[];
+  missingInfo: string[];
+  doNotSay: string[];
+  publicSafetyNotes: string[];
+  recommendedTaxonomy: {
+    category: DossierCandidate["recommendedCategory"] | null;
+    kind: DossierCandidate["recommendedKind"] | null;
+    ecosystemLane: DossierCandidate["recommendedEcosystemLane"] | null;
+    identityAuthority: DossierCandidate["recommendedIdentityAuthority"] | null;
+    status: DossierCandidate["recommendedStatus"] | null;
+    clearance: DossierCandidate["recommendedClearance"] | null;
+    origin: DossierCandidate["recommendedOrigin"] | null;
+    tags: string[];
+    proposedTags: string[];
+  };
+  sourceFileNotes: Array<{
+    id: string;
+    type: DossierSourceFileNote["type"];
+    summary: string;
+    source: DossierSourceFileNote["source"];
+    status: DossierSourceFileNote["status"];
+    publicSafe: boolean;
+    appliesToDraftId: string | null;
+    incorporatedIntoDraftId: string | null;
+    ingestSource: DossierSourceFileNote["ingestSource"] | null;
+    ingestKey: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  identityLinks: Array<{
+    id: string;
+    label: string;
+    normalizedLabel: string;
+    type: DossierIdentityLink["type"];
+    visibility: DossierIdentityLink["visibility"];
+    status: DossierIdentityLink["status"];
+    source: DossierIdentityLink["source"];
+    confidence: DossierIdentityLink["confidence"] | null;
+    useForMatching: boolean;
+    useInPublicDossier: boolean;
+    note: string | null;
+    createdFromRecommendationId: string | null;
+    createdFromRecommendationSubject: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  attachedRecommendations: Array<{
+    id: string;
+    type: DossierRecommendation["type"];
+    subjectName: string;
+    status: DossierRecommendation["status"];
+    confidence: DossierRecommendation["confidence"] | null;
+    sourceLanes: DossierRecommendation["sourceLanes"];
+    ingestSource: DossierRecommendation["ingestSource"] | null;
+    ingestKey: string | null;
+    reason: string;
+    evidenceSummary: string | null;
+    updatedAt: string;
+    createdAt: string;
+  }>;
+  activeDraft: {
+    id: string;
+    status: DossierDraft["status"];
+    updatedAt: string;
+    createdAt: string;
+  } | null;
+  ownerReview: {
+    status: "waiting" | "changes_requested" | "approved" | "not_in_owner_review";
+    draftId: string | null;
+  };
+  duplicateWarnings: {
+    duplicateRisk: DossierCandidate["duplicateRisk"] | null;
+    existingDossierMatch: DossierCandidate["existingDossierMatch"] | null;
+    mergedIntoCandidateId: string | null;
+    mergeSourceCandidateIds: string[];
+  };
+  visibility: typeof VISIBILITY_BOUNDARY;
+  updatedAt: string;
+  createdAt: string;
+};
+
+function bearerToken(req: Request): string {
+  const authorization = req.headers.get("authorization") ?? "";
+  if (authorization.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+  return req.headers.get("x-bnl-source-file-read-token")?.trim() ?? "";
+}
+
+function tokenMatches(providedToken: string): boolean {
+  const expectedToken = process.env.BNL_SOURCE_FILE_READ_TOKEN?.trim() ?? "";
+  if (!expectedToken || !providedToken) return false;
+  const expected = Buffer.from(expectedToken);
+  const provided = Buffer.from(providedToken);
+  return expected.length === provided.length && timingSafeEqual(expected, provided);
+}
+
+function cleanQueryValue(value: string | null): string {
+  return (value ?? "").trim().slice(0, 200);
+}
+
+function queryFrom(req: Request): { mode: QueryMode; value: string } | null {
+  const url = new URL(req.url);
+  const candidateId = cleanQueryValue(url.searchParams.get("candidateId"));
+  if (candidateId) return { mode: "candidateId", value: candidateId };
+  const alias = cleanQueryValue(url.searchParams.get("alias"));
+  if (alias) return { mode: "alias", value: alias };
+  const normalizedName = cleanQueryValue(url.searchParams.get("normalizedName"));
+  if (normalizedName) return { mode: "normalizedName", value: normalizedName };
+  const subject = cleanQueryValue(url.searchParams.get("subject"));
+  if (subject) return { mode: "subject", value: subject };
+  return null;
+}
+
+function isActiveCandidate(candidate: DossierCandidate): boolean {
+  return candidate.status !== "denied" && candidate.status !== "merged";
+}
+
+function noteSummary(note: DossierSourceFileNote): string {
+  const text = note.text.trim().replace(/\s+/g, " ");
+  if (text.length <= MAX_NOTE_LENGTH) return text;
+  return `${text.slice(0, MAX_NOTE_LENGTH - 1).trim()}…`;
+}
+
+function hasPartialNameOverlap(query: string, name: string): boolean {
+  const normalizedQuery = normalizeDossierSubjectName(query);
+  const normalizedName = normalizeDossierSubjectName(name);
+  const compactQuery = compactDossierSubjectName(query);
+  const compactName = compactDossierSubjectName(name);
+  if (!normalizedQuery || !normalizedName) return false;
+  if (normalizedQuery === normalizedName || compactQuery === compactName) return false;
+  if (normalizedQuery.length < 4 || normalizedName.length < 4) return false;
+  return (
+    normalizedQuery.includes(normalizedName) ||
+    normalizedName.includes(normalizedQuery) ||
+    compactQuery.includes(compactName) ||
+    compactName.includes(compactQuery)
+  );
+}
+
+function possibleMatchSummary(
+  candidate: DossierCandidate,
+  matchKind: PossibleMatchKind,
+  alias?: DossierIdentityLink,
+) {
+  return {
+    candidateId: candidate.id,
+    name: candidate.name,
+    normalizedName: normalizeDossierSubjectName(candidate.name),
+    status: candidate.status,
+    candidateType: candidate.candidateType,
+    source: candidate.source,
+    confidence: candidate.confidence ?? null,
+    matchKind,
+    reviewRequired: true,
+    alias: alias
+      ? {
+          id: alias.id,
+          label: alias.label,
+          normalizedLabel: alias.normalizedLabel,
+          status: alias.status,
+          type: alias.type,
+          visibility: alias.visibility,
+          useForMatching: alias.useForMatching,
+          useInPublicDossier: alias.useInPublicDossier,
+        }
+      : null,
+    warning:
+      matchKind === "unconfirmed_alias"
+        ? "Alias is not confirmed for matching; owner/operator review is required."
+        : "Possible same-subject match; owner/operator review is required.",
+  };
+}
+
+function findActiveDraft(drafts: DossierDraft[], candidateId: string): DossierDraft | null {
+  return (
+    drafts.find(
+      (draft) =>
+        draft.candidateId === candidateId &&
+        draft.status !== "denied" &&
+        draft.status !== "published" &&
+        draft.status !== "superseded",
+    ) ?? null
+  );
+}
+
+function ownerReviewStatus(draft: DossierDraft | null): SourceFileSummary["ownerReview"] {
+  if (!draft) return { status: "not_in_owner_review", draftId: null };
+  if (draft.status === "ready_for_owner_review") return { status: "waiting", draftId: draft.id };
+  if (draft.status === "owner_changes_requested") {
+    return { status: "changes_requested", draftId: draft.id };
+  }
+  if (draft.status === "owner_approved") return { status: "approved", draftId: draft.id };
+  return { status: "not_in_owner_review", draftId: draft.id };
+}
+
+function sourceFileReadModel(input: {
+  candidate: DossierCandidate;
+  drafts: DossierDraft[];
+  recommendations: DossierRecommendation[];
+}): SourceFileSummary {
+  const activeDraft = findActiveDraft(input.drafts, input.candidate.id);
+  const attachedRecommendations = input.recommendations
+    .filter((recommendation) => recommendation.targetCandidateId === input.candidate.id)
+    .slice(0, MAX_RECOMMENDATIONS)
+    .map((recommendation) => ({
+      id: recommendation.id,
+      type: recommendation.type,
+      subjectName: recommendation.subjectName,
+      status: recommendation.status,
+      confidence: recommendation.confidence ?? null,
+      sourceLanes: recommendation.sourceLanes,
+      ingestSource: recommendation.ingestSource ?? null,
+      ingestKey: recommendation.ingestKey ?? null,
+      reason: recommendation.reason,
+      evidenceSummary: recommendation.evidenceSummary ?? null,
+      updatedAt: recommendation.updatedAt,
+      createdAt: recommendation.createdAt,
+    }));
+
+  return {
+    candidateId: input.candidate.id,
+    id: input.candidate.id,
+    name: input.candidate.name,
+    normalizedName: normalizeDossierSubjectName(input.candidate.name),
+    candidateType: input.candidate.candidateType,
+    status: input.candidate.status,
+    tier: input.candidate.tier,
+    score: input.candidate.score,
+    confidence: input.candidate.confidence ?? null,
+    source: input.candidate.source,
+    sourceLanes: input.candidate.sourceLanes ?? [],
+    ingestSource: input.candidate.ingestSource ?? null,
+    ingestKey: input.candidate.ingestKey ?? null,
+    createdFromRecommendationId: input.candidate.createdFromRecommendationId ?? null,
+    reason: input.candidate.reason,
+    whyNow: input.candidate.whyNow,
+    evidenceSummary: input.candidate.evidenceSummary,
+    knownFacts: input.candidate.knownFacts ?? [],
+    missingInfo: input.candidate.missingInfo ?? [],
+    doNotSay: input.candidate.doNotSay ?? [],
+    publicSafetyNotes: input.candidate.publicSafetyNotes ?? [],
+    recommendedTaxonomy: {
+      category: input.candidate.recommendedCategory ?? null,
+      kind: input.candidate.recommendedKind ?? null,
+      ecosystemLane: input.candidate.recommendedEcosystemLane ?? null,
+      identityAuthority: input.candidate.recommendedIdentityAuthority ?? null,
+      status: input.candidate.recommendedStatus ?? null,
+      clearance: input.candidate.recommendedClearance ?? null,
+      origin: input.candidate.recommendedOrigin ?? null,
+      tags: input.candidate.recommendedTags ?? [],
+      proposedTags: input.candidate.proposedTags ?? [],
+    },
+    sourceFileNotes: (input.candidate.sourceFileNotes ?? []).map((note) => ({
+      id: note.id,
+      type: note.type,
+      summary: noteSummary(note),
+      source: note.source,
+      status: note.status,
+      publicSafe: note.publicSafe === true,
+      appliesToDraftId: note.appliesToDraftId ?? null,
+      incorporatedIntoDraftId: note.incorporatedIntoDraftId ?? null,
+      ingestSource: note.ingestSource ?? null,
+      ingestKey: note.ingestKey ?? null,
+      createdAt: note.createdAt,
+      updatedAt: note.updatedAt,
+    })),
+    identityLinks: (input.candidate.identityLinks ?? []).map((identityLink) => ({
+      id: identityLink.id,
+      label: identityLink.label,
+      normalizedLabel: identityLink.normalizedLabel,
+      type: identityLink.type,
+      visibility: identityLink.visibility,
+      status: identityLink.status,
+      source: identityLink.source,
+      confidence: identityLink.confidence ?? null,
+      useForMatching: identityLink.useForMatching,
+      useInPublicDossier: identityLink.useInPublicDossier,
+      note: identityLink.note ?? null,
+      createdFromRecommendationId: identityLink.createdFromRecommendationId ?? null,
+      createdFromRecommendationSubject:
+        identityLink.createdFromRecommendationSubject ?? null,
+      createdAt: identityLink.createdAt,
+      updatedAt: identityLink.updatedAt,
+    })),
+    attachedRecommendations,
+    activeDraft: activeDraft
+      ? {
+          id: activeDraft.id,
+          status: activeDraft.status,
+          updatedAt: activeDraft.updatedAt,
+          createdAt: activeDraft.createdAt,
+        }
+      : null,
+    ownerReview: ownerReviewStatus(activeDraft),
+    duplicateWarnings: {
+      duplicateRisk: input.candidate.duplicateRisk ?? null,
+      existingDossierMatch: input.candidate.existingDossierMatch ?? null,
+      mergedIntoCandidateId: input.candidate.mergedIntoCandidateId ?? null,
+      mergeSourceCandidateIds: input.candidate.mergeSourceCandidateIds ?? [],
+    },
+    visibility: VISIBILITY_BOUNDARY,
+    updatedAt: input.candidate.updatedAt,
+    createdAt: input.candidate.createdAt,
+  };
+}
+
+function resolveSourceFile(input: {
+  mode: QueryMode;
+  value: string;
+  candidates: DossierCandidate[];
+}) {
+  const activeCandidates = input.candidates.filter(isActiveCandidate);
+  const normalizedValue = normalizeDossierSubjectName(input.value);
+  const compactValue = compactDossierSubjectName(input.value);
+
+  if (input.mode === "candidateId") {
+    const exact = activeCandidates.find((candidate) => candidate.id === input.value);
+    return {
+      matches: exact ? [{ candidate: exact, matchKind: "candidate_id" as const }] : [],
+      possibleMatches: [],
+    };
+  }
+
+  const directMatches: ResolvedMatch[] = activeCandidates
+    .map((candidate): ResolvedMatch | null => {
+      const normalizedName = normalizeDossierSubjectName(candidate.name);
+      const compactName = compactDossierSubjectName(candidate.name);
+      if (input.mode === "normalizedName" && normalizedValue === normalizedName) {
+        return { candidate, matchKind: "normalized_name" as const };
+      }
+      if (input.mode === "subject" && normalizedValue === normalizedName) {
+        return { candidate, matchKind: "name" as const };
+      }
+      if (input.mode === "subject" && compactValue === compactName) {
+        return { candidate, matchKind: "compact_name" as const };
+      }
+      return null;
+    })
+    .filter((match): match is ResolvedMatch => Boolean(match));
+
+  const confirmedAliasMatches: ResolvedMatch[] = activeCandidates
+    .map((candidate): ResolvedMatch | null => {
+      const alias = (candidate.identityLinks ?? []).find(
+        (identityLink) =>
+          identityLink.status === "confirmed" &&
+          identityLink.useForMatching === true &&
+          identityLink.normalizedLabel === normalizedValue,
+      );
+      return alias ? { candidate, alias, matchKind: "confirmed_alias" as const } : null;
+    })
+    .filter((match): match is ResolvedMatch => Boolean(match));
+
+  const matches = input.mode === "alias" ? confirmedAliasMatches : directMatches;
+  const matchedIds = new Set(matches.map((match) => match.candidate.id));
+
+  const possibleMatches = activeCandidates
+    .filter((candidate) => !matchedIds.has(candidate.id))
+    .flatMap((candidate) => {
+      const alias = (candidate.identityLinks ?? []).find(
+        (identityLink) =>
+          identityLink.normalizedLabel === normalizedValue &&
+          (identityLink.status !== "confirmed" || identityLink.useForMatching !== true),
+      );
+      if (alias) return [possibleMatchSummary(candidate, "unconfirmed_alias", alias)];
+      const normalizedName = normalizeDossierSubjectName(candidate.name);
+      const compactName = compactDossierSubjectName(candidate.name);
+      if (normalizedValue === normalizedName) {
+        return [possibleMatchSummary(candidate, "same_name")];
+      }
+      if (compactValue === compactName) {
+        return [possibleMatchSummary(candidate, "compact_name")];
+      }
+      if (input.mode !== "alias" && hasPartialNameOverlap(input.value, candidate.name)) {
+        return [possibleMatchSummary(candidate, "partial_name")];
+      }
+      return [];
+    })
+    .slice(0, MAX_POSSIBLE_MATCHES);
+
+  return { matches, possibleMatches };
+}
+
+export async function GET(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const query = queryFrom(req);
+  if (!query) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "Provide one lookup query parameter: candidateId, subject, alias, or normalizedName.",
+      },
+      { status: 400, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const state = await getDossierWorkflowState();
+  const { matches, possibleMatches } = resolveSourceFile({
+    mode: query.mode,
+    value: query.value,
+    candidates: state.candidates,
+  });
+
+  if (matches.length === 1) {
+    const match = matches[0];
+    return NextResponse.json(
+      {
+        ok: true,
+        found: true,
+        scope: "bnl_internal_source_file_read_model",
+        auth: "BNL_SOURCE_FILE_READ_TOKEN",
+        mutation: false,
+        query,
+        matchKind: match.matchKind,
+        matchedAlias:
+          "alias" in match
+            ? {
+                id: match.alias.id,
+                label: match.alias.label,
+                normalizedLabel: match.alias.normalizedLabel,
+                status: match.alias.status,
+                type: match.alias.type,
+                visibility: match.alias.visibility,
+                useForMatching: match.alias.useForMatching,
+                useInPublicDossier: match.alias.useInPublicDossier,
+              }
+            : null,
+        sourceFile: sourceFileReadModel({
+          candidate: match.candidate,
+          drafts: state.drafts,
+          recommendations: state.recommendations,
+        }),
+        possibleMatches,
+        readModelBoundary: VISIBILITY_BOUNDARY,
+        generatedAt: new Date().toISOString(),
+      },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const multipleMatches = matches.map((match) =>
+    possibleMatchSummary(
+      match.candidate,
+      match.matchKind === "confirmed_alias" ? "unconfirmed_alias" : "same_name",
+      "alias" in match ? match.alias : undefined,
+    ),
+  );
+
+  return NextResponse.json(
+    {
+      ok: true,
+      found: false,
+      scope: "bnl_internal_source_file_read_model",
+      auth: "BNL_SOURCE_FILE_READ_TOKEN",
+      mutation: false,
+      query,
+      reviewRequired: matches.length > 1 || possibleMatches.length > 0,
+      possibleMatches: [...multipleMatches, ...possibleMatches].slice(
+        0,
+        MAX_POSSIBLE_MATCHES,
+      ),
+      reason:
+        matches.length > 1
+          ? "Multiple exact BNL Source File matches found; owner/operator review is required."
+          : possibleMatches.length > 0
+            ? "Only possible BNL Source File matches found; no confirmed match was resolved."
+            : "No BNL Source File match found.",
+      readModelBoundary: VISIBILITY_BOUNDARY,
+      generatedAt: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -45,6 +45,9 @@ const { getDossierPrimaryLink, getDossierPublicLinks, legacyDossierLink } = requ
 const { buildDossierTagRegistry, resolveDossierTagCanonical } = require("../src/lib/dossier-tags.ts");
 const { isBnlReadModelDossierVisible, isPublicDatabasePageVisible } = require("../src/lib/database-visibility.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
+const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
+const workflowStore = require("../src/lib/dossier-workflow-store.ts");
+const workflow = require("../src/lib/dossier-workflow.ts");
 
 const forbiddenKeys = [
   "contactEmail",
@@ -67,6 +70,25 @@ const forbiddenKeys = [
 ];
 
 let sequence = 0;
+
+async function resetDossierWorkflowStore() {
+  await workflowStore.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [],
+    drafts: [],
+    recommendations: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+}
+
+async function sourceFilesGet(query, token = "test-source-file-read-token") {
+  return sourceFilesReadModel.GET(
+    new Request(`https://example.test/api/bnl/source-files${query}`, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    }),
+  );
+}
 
 async function freshReadModelSession() {
   sequence += 1;
@@ -662,4 +684,270 @@ test("BNL read model keeps normal queue items out of broadcast memory candidates
   const artist = model.sections.artists.find((entry) => entry.normalizedName === "memory-queue-artist");
   assert.equal(artist.bnlContext.profileStatus, "not_profile");
   assert.equal(artist.bnlContext.identityStatus, "not_discord_or_account_identity");
+});
+
+function sourceFileCandidate(overrides = {}) {
+  const now = "2026-05-30T00:00:00.000Z";
+  const id = overrides.id ?? "candidate_signal_witch";
+  const name = overrides.name ?? "Signal Witch";
+  return {
+    id,
+    name,
+    candidateType: overrides.candidateType ?? "artist",
+    source: overrides.source ?? "bnl_dynamic_candidate_discovery",
+    tier: overrides.tier ?? "draft_ready",
+    score: overrides.score ?? 82,
+    whyNow: overrides.whyNow ?? "BNL found approved source-lane momentum.",
+    reason: overrides.reason ?? "Approved source lanes point to a stable subject.",
+    evidenceSummary: overrides.evidenceSummary ?? "Public show context plus operator-approved evidence.",
+    knownFacts: overrides.knownFacts ?? ["Appeared in public show context"],
+    missingInfo: overrides.missingInfo ?? ["Confirm preferred role"],
+    doNotSay: overrides.doNotSay ?? ["Do not imply private Discord identity"],
+    publicSafetyNotes: overrides.publicSafetyNotes ?? ["Use only public-safe phrasing"],
+    confidence: overrides.confidence ?? "high",
+    duplicateRisk: overrides.duplicateRisk ?? "low",
+    existingDossierMatch: overrides.existingDossierMatch ?? null,
+    recommendedCategory: overrides.recommendedCategory ?? "Personnel",
+    recommendedKind: overrides.recommendedKind ?? "radio_regular",
+    recommendedEcosystemLane: overrides.recommendedEcosystemLane ?? "radio_regular",
+    recommendedIdentityAuthority: overrides.recommendedIdentityAuthority ?? "community_owned",
+    recommendedStatus: overrides.recommendedStatus ?? "PENDING",
+    recommendedClearance: overrides.recommendedClearance ?? "PUBLIC",
+    recommendedOrigin: overrides.recommendedOrigin ?? "UNVERIFIED",
+    recommendedTags: overrides.recommendedTags ?? ["radio", "artist"],
+    proposedTags: overrides.proposedTags ?? ["bnl-discovered"],
+    sourceLanes: overrides.sourceLanes ?? ["rd_context", "broadcast_memory"],
+    ingestSource: overrides.ingestSource ?? "bnl_dynamic_candidate_discovery",
+    ingestKey: overrides.ingestKey ?? "bnl:signal-witch:read-model-test",
+    createdFromRecommendationId: overrides.createdFromRecommendationId ?? "rec_signal_witch",
+    sourceFileNotes: overrides.sourceFileNotes ?? [
+      {
+        id: "note_signal_witch",
+        candidateId: id,
+        type: "fact",
+        text: "BNL internal source summary from approved lanes; keep context bounded.",
+        source: "bnl_recommendation",
+        status: "active",
+        publicSafe: false,
+        ingestSource: "bnl_dynamic_candidate_discovery",
+        ingestKey: "bnl:signal-witch:read-model-test",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    identityLinks: overrides.identityLinks ?? [
+      {
+        id: "alias_shadowspit",
+        candidateId: id,
+        label: "ShadowsPit",
+        normalizedLabel: workflow.normalizeDossierSubjectName("ShadowsPit"),
+        type: "alias",
+        visibility: "internal_only",
+        status: "confirmed",
+        source: "owner_confirmed",
+        confidence: "confirmed",
+        useForMatching: true,
+        useInPublicDossier: false,
+        note: "Internal routing alias only.",
+        createdFromRecommendationId: "rec_alias_shadowspit",
+        createdFromRecommendationSubject: "ShadowsPit",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    status: overrides.status ?? "needs_review",
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+async function seedSourceFileReadModelState(extra = {}) {
+  const now = "2026-05-30T00:00:00.000Z";
+  const candidate = sourceFileCandidate(extra.candidate ?? {});
+  await workflowStore.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [candidate, ...(extra.candidates ?? [])],
+    drafts: extra.drafts ?? [
+      {
+        id: "draft_signal_witch",
+        candidateId: candidate.id,
+        status: "ready_for_owner_review",
+        fields: { name: candidate.name },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    recommendations: extra.recommendations ?? [
+      {
+        id: "rec_signal_witch",
+        type: "new_subject",
+        subjectName: candidate.name,
+        targetCandidateId: candidate.id,
+        status: "converted_to_source_file",
+        reason: "BNL dynamic candidate discovery converted this recommendation.",
+        evidenceSummary: "Approved source lanes found the subject.",
+        confidence: "high",
+        sourceLanes: ["rd_context", "broadcast_memory"],
+        ingestKey: "bnl:signal-witch:read-model-test",
+        ingestSource: "bnl_dynamic_candidate_discovery",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    updatedAt: now,
+  });
+  return candidate;
+}
+
+test("BNL source file read model requires the private read token", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+
+  assert.equal((await sourceFilesGet("?subject=Signal%20Witch", "")).status, 401);
+  assert.equal((await sourceFilesGet("?subject=Signal%20Witch", "wrong-token")).status, 401);
+});
+
+test("BNL source file read model resolves subject and returns bounded provenance and safety metadata", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState();
+  const before = await workflowStore.getDossierWorkflowState();
+
+  const response = await sourceFilesGet("?subject=Signal%20Witch");
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+
+  assert.equal(payload.ok, true);
+  assert.equal(payload.found, true);
+  assert.equal(payload.mutation, false);
+  assert.equal(payload.matchKind, "name");
+  assert.equal(payload.sourceFile.candidateId, candidate.id);
+  assert.equal(payload.sourceFile.name, "Signal Witch");
+  assert.equal(payload.sourceFile.normalizedName, "signal witch");
+  assert.equal(payload.sourceFile.source, "bnl_dynamic_candidate_discovery");
+  assert.deepEqual(payload.sourceFile.sourceLanes, ["rd_context", "broadcast_memory"]);
+  assert.equal(payload.sourceFile.ingestSource, "bnl_dynamic_candidate_discovery");
+  assert.equal(payload.sourceFile.ingestKey, "bnl:signal-witch:read-model-test");
+  assert.equal(payload.sourceFile.createdFromRecommendationId, "rec_signal_witch");
+  assert.equal(payload.sourceFile.sourceFileNotes[0].summary.includes("BNL internal source summary"), true);
+  assert.equal(payload.sourceFile.sourceFileNotes[0].publicSafe, false);
+  assert.equal(payload.sourceFile.identityLinks[0].label, "ShadowsPit");
+  assert.equal(payload.sourceFile.identityLinks[0].status, "confirmed");
+  assert.equal(payload.sourceFile.identityLinks[0].useForMatching, true);
+  assert.equal(payload.sourceFile.attachedRecommendations[0].id, "rec_signal_witch");
+  assert.equal(payload.sourceFile.activeDraft.status, "ready_for_owner_review");
+  assert.equal(payload.sourceFile.ownerReview.status, "waiting");
+  assert.equal(payload.sourceFile.visibility.visibility, "internal_bnl_source_file");
+  assert.equal(payload.sourceFile.visibility.publicUse, false);
+  assert.match(payload.sourceFile.visibility.identityWarning, /not public identity proof/);
+  assert.match(payload.sourceFile.visibility.publishWarning, /not public dossiers/);
+  assert.match(payload.sourceFile.visibility.draftWarning, /not public/);
+  assert.equal(payload.sourceFile.recommendedTaxonomy.kind, "radio_regular");
+  assert.equal(payload.sourceFile.duplicateWarnings.duplicateRisk, "low");
+
+  const after = await workflowStore.getDossierWorkflowState();
+  assert.deepEqual(after, before);
+});
+
+test("BNL source file read model resolves candidateId and normalizedName lookups", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState();
+
+  const byId = await (await sourceFilesGet(`?candidateId=${candidate.id}`)).json();
+  assert.equal(byId.found, true);
+  assert.equal(byId.matchKind, "candidate_id");
+
+  const byNormalizedName = await (await sourceFilesGet("?normalizedName=signal%20witch")).json();
+  assert.equal(byNormalizedName.found, true);
+  assert.equal(byNormalizedName.matchKind, "normalized_name");
+});
+
+test("BNL source file read model resolves confirmed aliases only", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  await seedSourceFileReadModelState();
+
+  const payload = await (await sourceFilesGet("?alias=ShadowsPit")).json();
+  assert.equal(payload.found, true);
+  assert.equal(payload.matchKind, "confirmed_alias");
+  assert.equal(payload.matchedAlias.label, "ShadowsPit");
+  assert.equal(payload.sourceFile.name, "Signal Witch");
+});
+
+test("BNL source file read model does not confirm proposed, rejected, or retired aliases", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const now = "2026-05-30T00:00:00.000Z";
+
+  for (const status of ["proposed", "rejected", "retired"]) {
+    await resetDossierWorkflowStore();
+    await seedSourceFileReadModelState({
+      candidate: {
+        identityLinks: [
+          {
+            id: `alias_${status}`,
+            candidateId: "candidate_signal_witch",
+            label: "Soft Alias",
+            normalizedLabel: workflow.normalizeDossierSubjectName("Soft Alias"),
+            type: "alias",
+            visibility: "internal_only",
+            status,
+            source: "bnl_recommendation",
+            confidence: "medium",
+            useForMatching: true,
+            useInPublicDossier: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      },
+    });
+
+    const payload = await (await sourceFilesGet("?alias=Soft%20Alias")).json();
+    assert.equal(payload.found, false);
+    assert.equal(payload.reviewRequired, true);
+    assert.equal(payload.possibleMatches.length, 1);
+    assert.equal(payload.possibleMatches[0].matchKind, "unconfirmed_alias");
+    assert.equal(payload.possibleMatches[0].alias.status, status);
+  }
+});
+
+test("BNL source file read model returns found=false without mutation for no-match", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  await seedSourceFileReadModelState();
+  const before = await workflowStore.getDossierWorkflowState();
+
+  const response = await sourceFilesGet("?subject=Missing%20Subject");
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.found, false);
+  assert.equal(payload.reviewRequired, false);
+  assert.deepEqual(payload.possibleMatches, []);
+  assert.match(payload.reason, /No BNL Source File match/);
+
+  const after = await workflowStore.getDossierWorkflowState();
+  assert.deepEqual(after, before);
+});
+
+test("BNL source file read model keeps public endpoint separate and does not expose private keys", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  await seedSourceFileReadModelState();
+
+  const unauthorized = await sourceFilesGet("?subject=Signal%20Witch", "");
+  assert.equal(unauthorized.status, 401);
+  assert.doesNotMatch(JSON.stringify(await unauthorized.json()), /Signal Witch|sourceFileNotes|identityLinks/);
+
+  const publicPayload = await modelJson();
+  assert.doesNotMatch(
+    JSON.stringify(publicPayload),
+    /Signal Witch|sourceFileNotes|identityLinks|bnl:signal-witch:read-model-test/,
+  );
+
+  const internalPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();
+  assert.deepEqual(findForbiddenKeys(internalPayload), []);
+  assert.doesNotMatch(JSON.stringify(internalPayload), /test-source-file-read-token|stripeSessionId|customerId|accountId|paymentIntent|submitterToken|fileUrl|contactEmail/);
 });


### PR DESCRIPTION
### Motivation
- Provide BNL a safe, authenticated, read-only way to fetch internal BNL Source File context by subject/name/alias/id without exposing internal admin fields on the public read model. 
- Preserve existing public `/api/bnl/read-model` semantics while giving operators a compact, provenance-aware view BNL can use for routing, review, and draft preparation. 
- Ensure alias matching follows workflow rules (only confirmed aliases with `useForMatching=true` resolve) and avoid making any mutations or automatic confirmations. 

### Description
- Added a new token-protected endpoint `GET /api/bnl/source-files` implemented in `src/app/api/bnl/source-files/route.ts` using `BNL_SOURCE_FILE_READ_TOKEN` (bearer or `x-bnl-source-file-read-token`) to return an internal BNL source-file read model. 
- Supported lookup modes: `candidateId`, `subject`, `alias`, and `normalizedName`, with exact match, confirmed-alias match (returns `matchKind: confirmed_alias`), and safe `possibleMatches` for unconfirmed/proposed/rejected/retired aliases or partial-name overlaps. 
- Response shape returns a compact `SourceFileSummary` (id, name, normalized name, candidate type/status/tier/score/confidence, source/sourceLanes/ingestSource/ingestKey, createdFromRecommendationId, reason/evidenceSummary/knownFacts/missingInfo/doNotSay/publicSafetyNotes, recommended taxonomy, safe `sourceFileNotes` summaries, `identityLinks` with visibility and matching flags, attached recommendation summaries, active draft/ownerReview state, duplicate warnings, updatedAt/createdAt, and an explicit `visibility` block labeling the data `internal_bnl_source_file`). 
- Added tests and fixtures in `tests/bnl-read-model.test.mjs` to cover auth failures (401), subject/id/normalized-name/confirmed-alias lookup, proposed/rejected/retired alias non-resolution, no-match behavior (`found:false`), read-model separation, and that no mutation occurs; public read-model behavior remains unchanged. 

### Testing
- Type-check and lint: `npx tsc --noEmit` and `npx eslint src/app/api/bnl/source-files/route.ts tests/bnl-read-model.test.mjs` both passed. 
- Unit and integration test runs: `node --test tests/admin-dossiers.test.mjs`, `node --test tests/bnl-read-model.test.mjs`, and `npm run test:queue` completed with all tests passing. 
- Manual verification guidance: unauthenticated requests return `401`, authenticated calls with `BNL_SOURCE_FILE_READ_TOKEN` return `found:true` for exact matches, `confirmed_alias` matches only when `useForMatching=true`, and proposed/rejected/retired aliases surface as `possibleMatches` and `reviewRequired` without resolving; the endpoint never mutates workflow state or exposes private tokens/payment/account/contact data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b615a54808321b56e352cf2f73431)