### PR TITLE
Surface BNL Source Knowledge Bridge candidates

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -193,9 +193,11 @@ function sourceWarningLabels(input: {
   return uniqueLabels([
     lanes.has("broadcast_memory") ? "Source-blind memory trace" : "",
     input.candidate.ingestSource === "bnl_dynamic_candidate_discovery" ||
+    input.candidate.ingestSource === "bnl_source_knowledge_bridge" ||
     input.recommendations.some(
       (recommendation) =>
-        recommendation.ingestSource === "bnl_dynamic_candidate_discovery",
+        recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
+        recommendation.ingestSource === "bnl_source_knowledge_bridge",
     )
       ? "Internal/private review required"
       : "",

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -122,6 +122,9 @@ function recommendationProvenance(recommendation: DossierRecommendation) {
   if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
     return "BNL dynamic discovery";
   }
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
+    return "BNL Source Knowledge Bridge";
+  }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
     return "BNL-ingested";
   }
@@ -133,6 +136,9 @@ function recommendationProvenance(recommendation: DossierRecommendation) {
 function candidateProvenance(candidate: DossierCandidate) {
   if (candidate.source === "bnl_dynamic_candidate_discovery") {
     return `BNL dynamic discovery${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+  }
+  if (candidate.source === "bnl_source_knowledge_bridge") {
+    return `BNL Source Knowledge Bridge${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
   }
   return candidate.source;
 }

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -23,6 +23,7 @@ const RECOMMENDATION_TYPES = [
   "new_subject",
   "modify_existing_dossier",
   "identity_link",
+  "possible_connection_review",
 ] as const satisfies readonly DossierRecommendationType[];
 const SOURCE_LANES = [
   "public_discord",
@@ -132,6 +133,46 @@ function tokenMatches(providedToken: string): boolean {
   return expected.length === provided.length && timingSafeEqual(expected, provided);
 }
 
+function supportedIngestSource(value: unknown): CreateDossierRecommendationInput["ingestSource"] {
+  const normalized = text(value, 80);
+  if (
+    normalized === "bnl_dynamic_candidate_discovery" ||
+    normalized === "bnl_source_knowledge_bridge"
+  ) {
+    return normalized;
+  }
+  return "bnl";
+}
+
+function normalizeBridgeSourceLane(value: unknown): {
+  lane: DossierRecommendationSourceLane;
+  original?: string;
+} {
+  if (typeof value !== "string") throw new Error("Invalid source lane");
+  if (SOURCE_LANES.includes(value as DossierRecommendationSourceLane)) {
+    return { lane: value as DossierRecommendationSourceLane };
+  }
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const mapped: Record<string, DossierRecommendationSourceLane> = {
+    source_blind_memory_trace: "broadcast_memory",
+    memory_trace: "broadcast_memory",
+    broadcast_trace: "broadcast_memory",
+    local_broadcast_memory: "broadcast_memory",
+    rd_knowledge_store: "rd_context",
+    r_d_knowledge_store: "rd_context",
+    local_rd_context: "rd_context",
+    website_read_model: "website_dossier",
+    existing_dossier: "website_dossier",
+    source_file: "admin_manual",
+    source_files: "admin_manual",
+    source_knowledge_bridge: "admin_manual",
+    bnl_source_knowledge_bridge: "admin_manual",
+    local_knowledge_store: "admin_manual",
+    operator_notes: "admin_manual",
+  };
+  return { lane: mapped[normalized] ?? "unknown", original: value.trim() };
+}
+
 function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Invalid payload");
@@ -139,16 +180,29 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   const payload = value as Record<string, unknown>;
   if (Object.keys(payload).length === 0) throw new Error("Invalid payload");
 
+  const ingestSource = supportedIngestSource(payload.ingestSource);
+  const isBridgeIngest = ingestSource === "bnl_source_knowledge_bridge";
   const sourceLanesInput = payload.sourceLanes;
   let sourceLanes: DossierRecommendationSourceLane[];
+  const bridgeSourceLaneDetails: string[] = [];
   if (sourceLanesInput === undefined) {
     sourceLanes = ["unknown"];
   } else {
     if (!Array.isArray(sourceLanesInput)) throw new Error("Invalid source lane");
-    sourceLanes = sourceLanesInput.map((lane) =>
-      enumValue(lane, SOURCE_LANES, "source lane"),
-    ) as DossierRecommendationSourceLane[];
-    sourceLanes = sourceLanes.filter(Boolean);
+    if (isBridgeIngest) {
+      const normalized = sourceLanesInput.map(normalizeBridgeSourceLane);
+      sourceLanes = normalized.map((item) => item.lane);
+      bridgeSourceLaneDetails.push(
+        ...normalized
+          .filter((item) => item.original)
+          .map((item) => `${item.original} -> ${item.lane}`),
+      );
+    } else {
+      sourceLanes = sourceLanesInput.map((lane) =>
+        enumValue(lane, SOURCE_LANES, "source lane"),
+      ) as DossierRecommendationSourceLane[];
+    }
+    sourceLanes = Array.from(new Set(sourceLanes.filter(Boolean)));
     if (sourceLanes.length === 0) sourceLanes = ["unknown"];
   }
 
@@ -162,6 +216,16 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
 
   const subjectName = text(payload.subjectName, 200);
   const reason = text(payload.reason, 2000);
+  const evidenceSummary = text(payload.evidenceSummary, 2000);
+  const bridgeEvidenceSummary = bridgeSourceLaneDetails.length
+    ? [
+        evidenceSummary,
+        `Bridge source lane mapping: ${bridgeSourceLaneDetails.join(", ")}`,
+      ]
+        .filter(Boolean)
+        .join("\n\n")
+        .slice(0, 2000)
+    : evidenceSummary;
   if (!subjectName) throw new Error("subjectName is required");
   if (!reason) throw new Error("reason is required");
 
@@ -172,7 +236,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     targetCandidateId: text(payload.targetCandidateId, 200),
     targetDossierId,
     reason,
-    evidenceSummary: text(payload.evidenceSummary, 2000),
+    evidenceSummary: bridgeEvidenceSummary,
     confidence: enumValue(payload.confidence, CONFIDENCES, "confidence"),
     sourceLanes,
     suggestedAction: text(payload.suggestedAction, 500),
@@ -195,10 +259,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     createdBy: text(payload.createdBy, 200) ?? "bnl",
     ingestKey: text(payload.ingestKey, 300),
     ingestedAt: new Date().toISOString(),
-    ingestSource:
-      text(payload.ingestSource, 80) === "bnl_dynamic_candidate_discovery"
-        ? "bnl_dynamic_candidate_discovery"
-        : "bnl",
+    ingestSource,
   };
 }
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -478,6 +478,7 @@ const RECOMMENDATION_TYPES: DossierRecommendationType[] = [
   "new_subject",
   "modify_existing_dossier",
   "identity_link",
+  "possible_connection_review",
 ];
 const RECOMMENDATION_SOURCE_LANES: DossierRecommendationSourceLane[] = [
   "public_discord",
@@ -660,6 +661,7 @@ function normalizeRecommendationInput(
     ingestSource:
       input.ingestSource === "bnl" ||
       input.ingestSource === "bnl_dynamic_candidate_discovery" ||
+      input.ingestSource === "bnl_source_knowledge_bridge" ||
       input.ingestSource === "system" ||
       input.ingestSource === "unknown"
         ? input.ingestSource
@@ -667,13 +669,34 @@ function normalizeRecommendationInput(
   };
 }
 
-function isBnlDynamicCandidateDiscovery(
+function isAutoConvertibleBnlSourceRecommendation(
   recommendation: Pick<DossierRecommendation, "ingestSource" | "type">,
 ): boolean {
   return (
-    recommendation.ingestSource === "bnl_dynamic_candidate_discovery" &&
+    (recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
+      recommendation.ingestSource === "bnl_source_knowledge_bridge") &&
     recommendation.type === "new_subject"
   );
+}
+
+function bnlIngestLabel(
+  recommendation: Pick<DossierRecommendation, "ingestSource">,
+): string {
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
+    return "BNL Source Knowledge Bridge";
+  }
+  if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
+    return "BNL dynamic discovery";
+  }
+  return "BNL recommendation";
+}
+
+function bnlIngestCandidateSource(
+  recommendation: Pick<DossierRecommendation, "ingestSource">,
+): DossierCandidate["source"] {
+  return recommendation.ingestSource === "bnl_source_knowledge_bridge"
+    ? "bnl_source_knowledge_bridge"
+    : "bnl_dynamic_candidate_discovery";
 }
 
 function candidateTypeFromRecommendation(
@@ -703,16 +726,32 @@ function recommendationCandidateScore(
       : 40;
 }
 
-function bnlDynamicDiscoveryNoteText(
+function bnlAutoCandidateSourceNotes(
+  recommendation: Pick<DossierRecommendation, "ingestSource">,
+): string[] {
+  return recommendation.ingestSource === "bnl_source_knowledge_bridge"
+    ? [
+        "Source Knowledge Bridge origin: BNL local knowledge stores.",
+        "Public use requires review before any public dossier copy is written.",
+        "Internal/private review required for bridge-derived context.",
+      ]
+    : [];
+}
+
+function bnlAutoCandidateNoteText(
   recommendation: DossierRecommendation,
 ): string {
+  const label = bnlIngestLabel(recommendation);
   return [
     recommendationSourceNoteText(recommendation),
-    `BNL dynamic discovery source lanes: ${recommendation.sourceLanes.join(", ")}`,
-    recommendation.ingestKey ? `BNL dynamic ingest key: ${recommendation.ingestKey}` : "",
-    recommendation.confidence ? `BNL confidence: ${recommendation.confidence}` : "",
+    `${label} origin.`,
+    recommendation.ingestSource === "bnl_source_knowledge_bridge"
+      ? `${label} source lanes/types summary: ${recommendation.sourceLanes.join(", ")}`
+      : `${label} source lanes: ${recommendation.sourceLanes.join(", ")}`,
+    recommendation.ingestKey ? `${label} ingest key: ${recommendation.ingestKey}` : "",
+    recommendation.confidence ? `${label} confidence: ${recommendation.confidence}` : "",
     recommendation.recommendedCategory || recommendation.recommendedKind
-      ? `BNL category metadata: ${[
+      ? `${label} taxonomy metadata: ${[
           recommendation.recommendedCategory,
           recommendation.recommendedKind,
           recommendation.recommendedEcosystemLane,
@@ -721,9 +760,12 @@ function bnlDynamicDiscoveryNoteText(
           .filter(Boolean)
           .join(" / ")}`
       : "",
+    ...bnlAutoCandidateSourceNotes(recommendation),
     ...(recommendation.publicSafetyNotes ?? []).map(
       (note) => `Safety note: ${note}`,
     ),
+    ...(recommendation.doNotSay ?? []).map((note) => `Do not say: ${note}`),
+    ...(recommendation.missingInfo ?? []).map((note) => `Missing info: ${note}`),
   ]
     .filter(Boolean)
     .join("\n\n")
@@ -764,7 +806,9 @@ function buildCandidateFromRecommendation(input: {
       recommendation.suggestedAction ??
       (source === "bnl_dynamic_candidate_discovery"
         ? "BNL dynamic candidate discovery."
-        : "Recommendation inbox conversion."),
+        : source === "bnl_source_knowledge_bridge"
+          ? "BNL Source Knowledge Bridge."
+          : "Recommendation inbox conversion."),
     reason: recommendation.reason,
     firstSeenAt: recommendation.ingestedAt ?? now,
     lastSeenAt: now,
@@ -777,7 +821,9 @@ function buildCandidateFromRecommendation(input: {
             label:
               source === "bnl_dynamic_candidate_discovery"
                 ? "BNL dynamic discovery evidence"
-                : "Recommendation inbox evidence",
+                : source === "bnl_source_knowledge_bridge"
+                  ? "BNL Source Knowledge Bridge evidence"
+                  : "Recommendation inbox evidence",
             summary: recommendation.evidenceSummary,
             count: 1,
             firstSeenAt: recommendation.ingestedAt ?? now,
@@ -802,7 +848,10 @@ function buildCandidateFromRecommendation(input: {
     proposedTags: [],
     missingInfo: recommendation.missingInfo ?? [],
     doNotSay: recommendation.doNotSay ?? [],
-    publicSafetyNotes: recommendation.publicSafetyNotes ?? [],
+    publicSafetyNotes: uniqueStrings(
+      recommendation.publicSafetyNotes,
+      bnlAutoCandidateSourceNotes(recommendation),
+    ),
     sourceFileNotes: [{ ...note, candidateId: "" }],
     identityLinks: [],
     sourceLanes: recommendation.sourceLanes,
@@ -908,7 +957,7 @@ export async function createDossierRecommendationIdempotent(
       return currentState;
     }
 
-    if (isBnlDynamicCandidateDiscovery(recommendation)) {
+    if (isAutoConvertibleBnlSourceRecommendation(recommendation)) {
       const ingestKeyCandidate = recommendation.ingestKey
         ? currentState.candidates.find(
             (candidate) =>
@@ -918,13 +967,28 @@ export async function createDossierRecommendationIdempotent(
           )
         : undefined;
       if (ingestKeyCandidate) {
+        const note: DossierSourceFileNote = {
+          id: createSourceFileNoteId(),
+          candidateId: ingestKeyCandidate.id,
+          type: "general_note",
+          text: bnlAutoCandidateNoteText(recommendation),
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        };
         const updatedRecommendation: DossierRecommendation = {
           ...recommendation,
           status: "attached_to_source_file",
           targetCandidateId: ingestKeyCandidate.id,
           publicSafetyNotes: [
             ...(recommendation.publicSafetyNotes ?? []),
-            "BNL dynamic discovery ingest key already exists on a source file; linked without creating a duplicate candidate.",
+            `${bnlIngestLabel(recommendation)} ingest key already exists on a source file; linked without creating a duplicate candidate.`,
           ],
           updatedAt: now,
         };
@@ -933,6 +997,15 @@ export async function createDossierRecommendationIdempotent(
         return {
           ...currentState,
           recommendations: [updatedRecommendation, ...currentState.recommendations],
+          candidates: currentState.candidates.map((candidate) =>
+            candidate.id === ingestKeyCandidate.id
+              ? {
+                  ...candidate,
+                  sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+                  updatedAt: now,
+                }
+              : candidate,
+          ),
           updatedAt: now,
         };
       }
@@ -947,7 +1020,7 @@ export async function createDossierRecommendationIdempotent(
           id: createSourceFileNoteId(),
           candidateId: match.exactCandidateId,
           type: "general_note",
-          text: bnlDynamicDiscoveryNoteText(recommendation),
+          text: bnlAutoCandidateNoteText(recommendation),
           source: "bnl_recommendation",
           status: "active",
           publicSafe: false,
@@ -964,7 +1037,7 @@ export async function createDossierRecommendationIdempotent(
           targetCandidateId: match.exactCandidateId,
           publicSafetyNotes: [
             ...(recommendation.publicSafetyNotes ?? []),
-            "BNL dynamic discovery matched an existing exact same-subject source file and was attached without creating a duplicate candidate.",
+            `${bnlIngestLabel(recommendation)} matched an existing exact same-subject source file and was attached without creating a duplicate candidate.`,
           ],
           updatedAt: now,
         };
@@ -990,8 +1063,8 @@ export async function createDossierRecommendationIdempotent(
         const candidate = buildCandidateFromRecommendation({
           recommendation,
           now,
-          source: "bnl_dynamic_candidate_discovery",
-          noteText: bnlDynamicDiscoveryNoteText(recommendation),
+          source: bnlIngestCandidateSource(recommendation),
+          noteText: bnlAutoCandidateNoteText(recommendation),
         });
         const updatedRecommendation: DossierRecommendation = {
           ...recommendation,
@@ -1014,7 +1087,7 @@ export async function createDossierRecommendationIdempotent(
         ...recommendation,
         publicSafetyNotes: [
           ...(recommendation.publicSafetyNotes ?? []),
-          "BNL dynamic discovery found possible existing source files; left in Recommendation Inbox for owner/lead duplicate or identity review.",
+          `${bnlIngestLabel(recommendation)} found possible existing source files; left in Recommendation Inbox for owner/lead duplicate or identity review.`,
         ],
       };
       autoAction = "left_for_review";
@@ -1741,12 +1814,14 @@ export async function convertRecommendationToCandidate(
       recommendation,
       now,
       source:
-        recommendation.ingestSource === "bnl_dynamic_candidate_discovery"
-          ? "bnl_dynamic_candidate_discovery"
+        recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
+        recommendation.ingestSource === "bnl_source_knowledge_bridge"
+          ? bnlIngestCandidateSource(recommendation)
           : "manual",
       noteText:
-        recommendation.ingestSource === "bnl_dynamic_candidate_discovery"
-          ? bnlDynamicDiscoveryNoteText(recommendation)
+        recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
+        recommendation.ingestSource === "bnl_source_knowledge_bridge"
+          ? bnlAutoCandidateNoteText(recommendation)
           : recommendationSourceNoteText(recommendation),
     });
     const updatedRecommendation: DossierRecommendation = {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -11,6 +11,7 @@ export type DossierCandidateSource =
   | "discord_context"
   | "website_read_model"
   | "bnl_dynamic_candidate_discovery"
+  | "bnl_source_knowledge_bridge"
   | "combined";
 
 export type DossierCandidateType =
@@ -319,7 +320,8 @@ export type DossierDuplicateGroup = {
 export type DossierRecommendationType =
   | "new_subject"
   | "modify_existing_dossier"
-  | "identity_link";
+  | "identity_link"
+  | "possible_connection_review";
 
 export type DossierRecommendationStatus =
   | "new"
@@ -344,6 +346,7 @@ export type DossierRecommendationSourceLane =
 export type DossierRecommendationIngestSource =
   | "bnl"
   | "bnl_dynamic_candidate_discovery"
+  | "bnl_source_knowledge_bridge"
   | "system"
   | "unknown";
 

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -51,6 +51,7 @@ const workflow = require("../src/lib/dossier-workflow.ts");
 const store = require("../src/lib/dossier-workflow-store.ts");
 const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
+const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -100,6 +101,14 @@ async function authedPost(body) {
         cookie: await adminCookie(),
       },
       body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function sourceFilesGet(query, token = "test-source-file-read-token") {
+  return sourceFilesReadModel.GET(
+    new Request(`https://example.test/api/bnl/source-files${query}`, {
+      headers: { authorization: `Bearer ${token}` },
     }),
   );
 }
@@ -3225,6 +3234,157 @@ test("BNL dynamic identity and possible duplicate recommendations remain review-
   assert.equal(state.candidates.length, 1);
   assert.equal(state.drafts.length, 0);
   assert.equal(state.recommendations.length, 2);
+  assert.equal(state.candidates[0].identityLinks?.length ?? 0, 0);
+});
+
+
+
+test("BNL Source Knowledge Bridge new-subject recommendations create source-file candidates with warnings", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const beforePublicTagCount = databasePage.entries.flatMap((entry) => entry.tags).length;
+
+  const response = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Bridge Memory Subject",
+    subjectKey: "bridge-memory-subject",
+    reason: "Source Knowledge Bridge found an older known subject in local stores.",
+    evidenceSummary: "Older source-file knowledge mentions the subject repeatedly.",
+    confidence: "medium",
+    sourceLanes: ["source_blind_memory_trace", "local_knowledge_store"],
+    suggestedAction: "Create an internal source file only; review before public use.",
+    missingInfo: ["Confirm public-safe name."],
+    publicSafetyNotes: ["source-blind memory trace", "public use requires review"],
+    doNotSay: ["Do not expose internal alias material."],
+    recommendedTags: ["bridge-private-tag"],
+    recommendedCategory: "Entity",
+    recommendedKind: "entity",
+    recommendedEcosystemLane: "unknown",
+    recommendedIdentityAuthority: "mixed_or_unclear",
+    ingestKey: "bnl:bridge-memory-subject",
+    ingestSource: "bnl_source_knowledge_bridge",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.autoAction, "created_candidate");
+  assert.equal(payload.duplicate, false);
+  assert.equal(payload.recommendation.status, "converted_to_source_file");
+  assert.equal(payload.recommendation.ingestSource, "bnl_source_knowledge_bridge");
+  assert.deepEqual(payload.recommendation.sourceLanes, ["broadcast_memory", "admin_manual"]);
+  assert.match(payload.recommendation.evidenceSummary, /Bridge source lane mapping: source_blind_memory_trace -> broadcast_memory, local_knowledge_store -> admin_manual/);
+  assert.equal(payload.candidate.name, "Bridge Memory Subject");
+  assert.equal(payload.candidate.source, "bnl_source_knowledge_bridge");
+  assert.equal(payload.candidate.ingestSource, "bnl_source_knowledge_bridge");
+  assert.equal(payload.candidate.status, "needs_review");
+  assert.equal(payload.candidate.recommendedKind, "entity");
+  assert.deepEqual(payload.candidate.sourceLanes, ["broadcast_memory", "admin_manual"]);
+  assert.match(payload.candidate.publicSafetyNotes.join(" "), /Source Knowledge Bridge origin|Public use requires review|Internal\/private review required|source-blind memory trace/);
+  assert.match(payload.candidate.sourceFileNotes[0].text, /BNL Source Knowledge Bridge origin/);
+  assert.match(payload.candidate.sourceFileNotes[0].text, /source lanes\/types summary: broadcast_memory, admin_manual/);
+  assert.match(payload.candidate.sourceFileNotes[0].text, /source-blind memory trace/);
+  assert.match(payload.candidate.sourceFileNotes[0].text, /public use requires review/i);
+  assert.equal(payload.candidate.sourceFileNotes[0].ingestSource, "bnl_source_knowledge_bridge");
+
+  const adminPayload = await (await authedGet()).json();
+  assert.equal(adminPayload.candidates.length, 1);
+  assert.equal(adminPayload.candidates[0].id, payload.candidate.id);
+  assert.equal(adminPayload.recommendations.length, 1);
+  assert.equal(adminPayload.drafts.length, 0);
+
+  const protectedPayload = await (await sourceFilesGet("?subject=Bridge%20Memory%20Subject")).json();
+  assert.equal(protectedPayload.sourceFile.source, "bnl_source_knowledge_bridge");
+  assert.equal(protectedPayload.sourceFile.ingestSource, "bnl_source_knowledge_bridge");
+  assert.match(protectedPayload.sourceFile.visibility.boundaryLabel, /internal working case file; not a public dossier/);
+  assert.equal(protectedPayload.sourceFile.visibility.publicUseReviewRequired, true);
+  assert.match(JSON.stringify(protectedPayload.sourceFile), /Source Knowledge Bridge origin|public use requires review|source-blind memory trace/);
+
+  const publicReadModelPayload = await (await readModel.GET(
+    new Request("https://example.test/api/bnl/read-model"),
+  )).json();
+  assert.equal(databasePage.entries.flatMap((entry) => entry.tags).length, beforePublicTagCount);
+  assert.doesNotMatch(JSON.stringify(publicReadModelPayload), /Bridge Memory Subject|bridge-private-tag|Source Knowledge Bridge/);
+});
+
+test("BNL Source Knowledge Bridge attach, duplicate, possible-match, and identity recommendations stay bounded", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const first = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Bridge Deduped Subject",
+    reason: "Bridge found an older known subject.",
+    sourceLanes: ["broadcast_memory"],
+    publicSafetyNotes: ["source-blind memory trace"],
+    ingestKey: "bnl:bridge-deduped-subject",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(first.autoAction, "created_candidate");
+
+  const duplicate = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Bridge Deduped Subject",
+    reason: "Bridge found an older known subject.",
+    sourceLanes: ["broadcast_memory"],
+    ingestKey: "bnl:bridge-deduped-subject",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(duplicate.duplicate, true);
+  assert.equal(duplicate.recommendation.id, first.recommendation.id);
+
+  const sameSubject = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "The Bridge Deduped Subject",
+    reason: "Bridge found the same subject under a separate ingest key.",
+    sourceLanes: ["local_source_file"],
+    ingestKey: "bnl:bridge-deduped-subject:second",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(sameSubject.autoAction, "attached_existing");
+  assert.equal(sameSubject.recommendation.status, "attached_to_source_file");
+  assert.equal(sameSubject.recommendation.targetCandidateId, first.candidate.id);
+
+  const possible = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Bridge Deduped Subject Annex",
+    reason: "Bridge found a nearby source-file subject that may be a duplicate.",
+    sourceLanes: ["local_knowledge_store"],
+    ingestKey: "bnl:bridge-possible-duplicate",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(possible.autoAction, "left_for_review");
+  assert.equal(possible.recommendation.status, "new");
+  assert.match(possible.recommendation.publicSafetyNotes.join(" "), /possible existing source files/);
+
+  const identity = await (await bnlIngestPost({
+    type: "identity_link",
+    subjectName: "Bridge Alias",
+    targetCandidateId: first.candidate.id,
+    reason: "Bridge found a possible alias for review only.",
+    sourceLanes: ["source_blind_memory_trace"],
+    ingestKey: "bnl:bridge-identity-review",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(identity.recommendation.status, "new");
+  assert.equal(identity.autoAction, undefined);
+
+  const connection = await (await bnlIngestPost({
+    type: "possible_connection_review",
+    subjectName: "Bridge Connection",
+    reason: "Bridge found a possible connection for human review only.",
+    sourceLanes: ["local_knowledge_store"],
+    ingestKey: "bnl:bridge-connection-review",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(connection.recommendation.status, "new");
+  assert.equal(connection.autoAction, undefined);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.equal(state.drafts.length, 0);
+  assert.equal(state.recommendations.length, 5);
+  assert.equal(state.candidates[0].sourceFileNotes.length, 2);
   assert.equal(state.candidates[0].identityLinks?.length ?? 0, 0);
 });
 

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -853,6 +853,77 @@ test("BNL source file read model resolves subject and returns bounded provenance
   assert.deepEqual(after, before);
 });
 
+
+
+test("BNL source file read model includes Source Knowledge Bridge candidates with boundary warnings", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState({
+    candidate: {
+      id: "candidate_bridge_subject",
+      name: "Bridge Known Subject",
+      source: "bnl_source_knowledge_bridge",
+      ingestSource: "bnl_source_knowledge_bridge",
+      ingestKey: "bnl:bridge-known-subject",
+      createdFromRecommendationId: "rec_bridge_subject",
+      sourceLanes: ["broadcast_memory", "admin_manual"],
+      publicSafetyNotes: [
+        "Source Knowledge Bridge origin: BNL local knowledge stores.",
+        "Public use requires review before any public dossier copy is written.",
+        "source-blind memory trace",
+      ],
+      sourceFileNotes: [
+        {
+          id: "note_bridge_subject",
+          candidateId: "candidate_bridge_subject",
+          type: "general_note",
+          text: "BNL Source Knowledge Bridge origin. Source Knowledge Bridge source lanes/types summary: broadcast_memory, admin_manual. Public use requires review before any public dossier copy is written. source-blind memory trace.",
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          ingestSource: "bnl_source_knowledge_bridge",
+          ingestKey: "bnl:bridge-known-subject",
+          createdAt: "2026-05-30T00:00:00.000Z",
+          updatedAt: "2026-05-30T00:00:00.000Z",
+        },
+      ],
+    },
+    recommendations: [
+      {
+        id: "rec_bridge_subject",
+        type: "new_subject",
+        subjectName: "Bridge Known Subject",
+        targetCandidateId: "candidate_bridge_subject",
+        status: "converted_to_source_file",
+        reason: "Bridge recommendation converted into an internal source file.",
+        evidenceSummary: "Bridge local knowledge stores found the subject.",
+        confidence: "medium",
+        sourceLanes: ["broadcast_memory", "admin_manual"],
+        ingestKey: "bnl:bridge-known-subject",
+        ingestSource: "bnl_source_knowledge_bridge",
+        createdAt: "2026-05-30T00:00:00.000Z",
+        updatedAt: "2026-05-30T00:00:00.000Z",
+      },
+    ],
+  });
+
+  const payload = await (await sourceFilesGet("?subject=Bridge%20Known%20Subject")).json();
+  assert.equal(payload.found, true);
+  assert.equal(payload.sourceFile.candidateId, candidate.id);
+  assert.equal(payload.sourceFile.source, "bnl_source_knowledge_bridge");
+  assert.equal(payload.sourceFile.ingestSource, "bnl_source_knowledge_bridge");
+  assert.deepEqual(payload.sourceFile.sourceLanes, ["broadcast_memory", "admin_manual"]);
+  assert.match(payload.sourceFile.visibility.boundaryLabel, /internal working case file; not a public dossier/);
+  assert.equal(payload.sourceFile.visibility.publicUseReviewRequired, true);
+  assert.match(JSON.stringify(payload.sourceFile), /Source Knowledge Bridge origin|Public use requires review|source-blind memory trace/);
+
+  const publicPayload = await modelJson();
+  assert.doesNotMatch(
+    JSON.stringify(publicPayload),
+    /Bridge Known Subject|bnl:bridge-known-subject|Source Knowledge Bridge/,
+  );
+});
+
 test("BNL source file read model resolves candidateId and normalizedName lookups", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";


### PR DESCRIPTION
### Motivation
- Bridge-origin recommendations with `ingestSource = bnl_source_knowledge_bridge` were being normalized to plain `bnl` and not auto-converted into internal BNL Source File candidates like `bnl_dynamic_candidate_discovery`, so older known subjects from the knowledge bridge did not surface on the admin candidate dashboard. 
- The change preserves bridge provenance and safety warnings while keeping the existing case-file / proposed-dossier boundary intact and preventing any automatic public publishing, alias confirmation, or merges.

### Description
- Preserve `bnl_source_knowledge_bridge` as a first-class `ingestSource` and add `possible_connection_review` as a review-only `DossierRecommendationType`, with the ingest normalizer updated to retain the value instead of collapsing it to `bnl` and to accept bridge-specific lane inputs. (files changed: `src/app/api/bnl/dossier-recommendations/route.ts`, `src/lib/dossier-workflow.ts`)
- Normalize bridge-provided source lanes into existing allowed lanes (mapping unknown bridge labels into supported lanes) while capturing the original mappings in the recommendation `evidenceSummary` so internal bridge context is preserved for reviewers. (file changed: `src/app/api/bnl/dossier-recommendations/route.ts`)
- Extend the workflow auto-conversion logic to treat `bnl_source_knowledge_bridge` like `bnl_dynamic_candidate_discovery` for `type = new_subject` with the same safe boundaries: attach to exact matches or ingestKey matches, leave possible matches for review, and create a new internal Source File candidate only when no safe match exists; bridge identity/connection recommendations remain review-only. (file changed: `src/lib/dossier-workflow-store.ts`)
- Add bridge-aware candidate/source-note text and safety labels so bridge-created notes include origin, source-lane/type summaries, ingestKey, confidence, public-review warnings, and internal/private review cues; admin UI and protected read-model surfaces were updated to show bridge provenance and warnings while public read-models remain unaffected. (files changed: `src/lib/dossier-workflow-store.ts`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/api/bnl/source-files/route.ts`)
- Tests added/updated to cover bridge ingest preservation and behavior: ingest preservation, candidate creation, ingestKey dedupe/attach, possible-match review, identity/connection review-only behavior, source-blind/public-safety warning preservation, admin dashboard visibility/counts, and protected read-model coverage. (files changed: `tests/admin-dossiers.test.mjs`, `tests/bnl-read-model.test.mjs`)
- Files changed: `src/app/api/bnl/dossier-recommendations/route.ts`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/api/bnl/source-files/route.ts`, `tests/admin-dossiers.test.mjs`, `tests/bnl-read-model.test.mjs`.

### Testing
- Typecheck and lint: ran `npx tsc --noEmit` and `npx eslint` on changed files with no errors. (success)
- Unit/integration test suites: ran `node --test tests/admin-dossiers.test.mjs` and `node --test tests/bnl-read-model.test.mjs` and the combined queue test `npm run test:queue`, and all tests passed after the changes. (success)
- Targeted runtime checks: exercised the BNL ingest POST (`/api/bnl/dossier-recommendations`) and protected source-file GET (`/api/bnl/source-files`) flows via tests that assert bridge recommendations create/attach internal candidates, preserve warnings, and do not leak bridge material into the public read model. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b7f8641a48321990afac32e51f2e7)