### PR TITLE
Add active source file cleanup controls

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -439,13 +439,25 @@ export default function CandidateReviewPage() {
   const hasOwnerReviewDraft = linkedDrafts.some(
     (draft) => draft.status === "ready_for_owner_review",
   );
+  const isArchivedCandidate = candidate?.status === "archived";
+  const isCandidateIntake = candidate?.status === "candidate_intake";
+  const canPromoteCandidate = Boolean(candidate && isCandidateIntake);
+  const canArchiveCandidate = Boolean(
+    candidate && !isCandidateClosed(candidate) && !isArchivedCandidate,
+  );
+  const canRestoreCandidate = Boolean(candidate && isArchivedCandidate);
+  const canPermanentlyDeleteCandidate = Boolean(
+    candidate && !isCandidateClosed(candidate),
+  );
   const canCreateDraft = Boolean(
     candidate &&
     !isCandidateClosed(candidate) &&
+    !isArchivedCandidate &&
+    !isCandidateIntake &&
     !linkedDrafts.some((draft) => isDraftActive(draft)),
   );
   const canUpdateCandidate = Boolean(
-    candidate && !isCandidateClosed(candidate),
+    candidate && !isCandidateClosed(candidate) && !isArchivedCandidate,
   );
   const sourceMetrics = candidate
     ? getDossierSourceFileMetrics({
@@ -543,6 +555,46 @@ export default function CandidateReviewPage() {
     } catch (err) {
       setNotice(
         err instanceof Error ? err.message : "Failed to update candidate.",
+      );
+    }
+  }
+
+  async function candidateLifecycleAction(
+    action:
+      | "promoteCandidateToSourceFile"
+      | "archiveCandidate"
+      | "restoreCandidate"
+      | "permanentlyDeleteCandidate",
+  ) {
+    if (!candidate) return;
+    try {
+      const body: Record<string, unknown> = { action, candidateId };
+      if (action === "permanentlyDeleteCandidate") {
+        const confirmation = window.prompt(
+          `Permanent delete removes this unpublished workflow item${
+            linkedDrafts.length > 0
+              ? ` and ${linkedDrafts.length} linked unpublished proposed dossier draft${linkedDrafts.length === 1 ? "" : "s"}`
+              : ""
+          }. Public dossiers and published data are not deleted. Type "DELETE SOURCE FILE" to confirm.`,
+        );
+        if (confirmation !== "DELETE SOURCE FILE") return;
+        body.confirmation = confirmation;
+      }
+      await postWorkflow(body);
+      setNotice(
+        action === "archiveCandidate"
+          ? "Source file archived. It is removed from active dashboard lanes without deleting public dossiers or published data."
+          : action === "restoreCandidate"
+            ? "Source file restored to Candidate Intake so it can be reviewed and promoted again if needed."
+            : action === "permanentlyDeleteCandidate"
+              ? "Source file permanently deleted from unpublished workflow records. Public dossiers were not changed."
+              : "Candidate promoted to an Active BNL Source File. Public dossiers were not changed.",
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error
+          ? err.message
+          : "Failed to update source file lifecycle.",
       );
     }
   }
@@ -760,6 +812,52 @@ export default function CandidateReviewPage() {
             >
               Mark Needs Info
             </button>
+            {canPromoteCandidate && (
+              <button
+                type="button"
+                onClick={() =>
+                  void candidateLifecycleAction("promoteCandidateToSourceFile")
+                }
+                disabled={saving}
+                className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+              >
+                Promote to Source File
+              </button>
+            )}
+            {canArchiveCandidate && (
+              <button
+                type="button"
+                onClick={() => void candidateLifecycleAction("archiveCandidate")}
+                disabled={saving}
+                className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+                title="Safe cleanup: removes this source file from active dashboard lanes without deleting public dossiers or published data."
+              >
+                Archive
+              </button>
+            )}
+            {canRestoreCandidate && (
+              <button
+                type="button"
+                onClick={() => void candidateLifecycleAction("restoreCandidate")}
+                disabled={saving}
+                className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+              >
+                Restore
+              </button>
+            )}
+            {canPermanentlyDeleteCandidate && (
+              <button
+                type="button"
+                onClick={() =>
+                  void candidateLifecycleAction("permanentlyDeleteCandidate")
+                }
+                disabled={saving}
+                className="border border-red-500/70 px-4 py-2 text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+                title='Requires typing "DELETE SOURCE FILE". Does not delete public dossiers or published data.'
+              >
+                Delete Permanently
+              </button>
+            )}
           </div>
           {notice && (
             <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -520,16 +520,29 @@ export default function DossierControlCenterPage() {
     try {
       const body: Record<string, unknown> = { action, candidateId };
       if (action === "permanentlyDeleteCandidate") {
+        const linkedDrafts = drafts.filter(
+          (draft) => draft.candidateId === candidateId,
+        );
         const confirmation = window.prompt(
-          'Permanent delete removes this workflow item and linked unpublished drafts. Type "DELETE SOURCE FILE" to confirm.',
+          `Permanent delete removes the unpublished workflow item${
+            linkedDrafts.length > 0
+              ? ` and ${linkedDrafts.length} linked unpublished proposed dossier draft${linkedDrafts.length === 1 ? "" : "s"}`
+              : ""
+          }. Public dossiers and published data are not deleted. Type "DELETE SOURCE FILE" to confirm.`,
         );
         if (confirmation !== "DELETE SOURCE FILE") return;
         body.confirmation = confirmation;
       }
       const data = await postWorkflow(body);
-      setNotice(
-        `${candidate.name} updated via ${action}. Public dossiers were not changed.`,
-      );
+      const actionNotice =
+        action === "archiveCandidate"
+          ? `${candidate.name} archived. It moved out of active dashboard lanes and public dossiers were not changed.`
+          : action === "restoreCandidate"
+            ? `${candidate.name} restored to Candidate Intake. Public dossiers were not changed.`
+            : action === "permanentlyDeleteCandidate"
+              ? `${candidate.name} permanently deleted from unpublished workflow records. Public dossiers were not changed.`
+              : `${candidate.name} promoted to an Active BNL Source File. Public dossiers were not changed.`;
+      setNotice(actionNotice);
       if (data.candidates && data.drafts && data.workflow) {
         setPayload(data as WorkflowPayload);
       }
@@ -976,7 +989,7 @@ export default function DossierControlCenterPage() {
                     <th className="py-2 pr-3">Case file indicators</th>
                     <th className="py-2 pr-3">Last updated</th>
                     <th className="py-2 pr-3">Next recommended action</th>
-                    <th className="py-2 pr-3">Open</th>
+                    <th className="py-2 pr-3">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1138,6 +1151,31 @@ export default function DossierControlCenterPage() {
                               className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest hover:border-accent hover:text-accent disabled:opacity-50"
                             >
                               Mark Needs Info
+                            </button>
+                            <button
+                              type="button"
+                              disabled={saving || !canUpdateCandidate}
+                              onClick={() =>
+                                void candidateAction(candidate.id, "archiveCandidate")
+                              }
+                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+                              title="Safe cleanup: move this source file out of active dashboard lanes without deleting public dossiers or published data."
+                            >
+                              Archive
+                            </button>
+                            <button
+                              type="button"
+                              disabled={saving}
+                              onClick={() =>
+                                void candidateAction(
+                                  candidate.id,
+                                  "permanentlyDeleteCandidate",
+                                )
+                              }
+                              className="border border-red-500/70 px-3 py-1.5 text-xs uppercase tracking-widest text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+                              title='Requires typing "DELETE SOURCE FILE". Does not delete public dossiers or published data.'
+                            >
+                              Delete Permanently
                             </button>
                           </div>
                         </td>

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -280,6 +280,10 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
     "Source depth / info strength",
     "Unapplied notes:",
     "Open Source File",
+    "Archive",
+    "Delete Permanently",
+    "DELETE SOURCE FILE",
+    "Safe cleanup: move this source file out of active dashboard lanes without deleting public dossiers or published data.",
     "case file has warnings",
     "case file has source-blind material",
     "case file has public-safe facts",
@@ -300,6 +304,8 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
+  assert.match(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
+  assert.match(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
   assert.doesNotMatch(page, /eyebrow="Lane 2"/);
   assert.doesNotMatch(page, /title="Proposed Dossiers"/);
   assert.doesNotMatch(page, /title="Final Admin Drafts"/);
@@ -332,6 +338,12 @@ test("dossier admin pages expose the control-center/source-hub/draft-workspace m
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
   );
   assertIncludesCopy(sourceFileCopy, "Case File Summary");
+  assertIncludesCopy(sourceFileCopy, "Archive");
+  assertIncludesCopy(sourceFileCopy, "Delete Permanently");
+  assertIncludesCopy(sourceFileCopy, "Restore");
+  assertIncludesCopy(sourceFileCopy, "Promote to Source File");
+  assertIncludesCopy(sourceFileCopy, "DELETE SOURCE FILE");
+  assertIncludesCopy(sourceFileCopy, "Public dossiers and published data are not deleted");
   assertIncludesCopy(sourceFileCopy, "Ready for Proposed Dossier: the proposed dossier should be written from reviewed, public-safe Source File material, not copied wholesale from this working case file.");
 
   const draftCopy = normalizedSource(
@@ -3411,6 +3423,95 @@ test("BNL Source Knowledge Bridge attach, duplicate, possible-match, and identit
   assert.equal(state.candidates[0].identityLinks?.length ?? 0, 0);
 });
 
+
+
+test("active source file cleanup controls archive, restore, and delete without public data mutation", async () => {
+  await resetWorkflowStore();
+  const publicDossierBefore = JSON.stringify(databasePage.entries);
+  const publicReadModelBefore = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Active Cleanup Source",
+      reason: "Operator needs to clean an active source file.",
+    },
+  })).json();
+
+  const promoted = await (await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(promoted.candidate.status, "active_source_file");
+
+  const draft = await (await authedPost({
+    action: "createDraftFromCandidate",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(draft.draft.candidateId, created.candidate.id);
+
+  const activeRead = await (await sourceFilesGet("?subject=Active%20Cleanup%20Source")).json();
+  assert.equal(activeRead.found, true);
+
+  const archived = await (await authedPost({
+    action: "archiveCandidate",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(archived.candidate.status, "archived");
+  assert.equal(
+    archived.candidates.some((candidate) =>
+      candidate.id === created.candidate.id && candidate.status === "active_source_file",
+    ),
+    false,
+  );
+  assert.equal(
+    archived.candidates.some((candidate) =>
+      candidate.id === created.candidate.id && candidate.status === "archived",
+    ),
+    true,
+  );
+  const archivedRead = await (await sourceFilesGet("?subject=Active%20Cleanup%20Source")).json();
+  assert.equal(archivedRead.found, false);
+
+  const restored = await (await authedPost({
+    action: "restoreCandidate",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(restored.candidate.status, "candidate_intake");
+
+  const blockedDelete = await authedPost({
+    action: "permanentlyDeleteCandidate",
+    candidateId: created.candidate.id,
+    confirmation: "DELETE",
+  });
+  assert.equal(blockedDelete.status, 400);
+  assert.equal(
+    (await store.getDossierWorkflowState()).candidates.some(
+      (candidate) => candidate.id === created.candidate.id,
+    ),
+    true,
+  );
+
+  const deleted = await (await authedPost({
+    action: "permanentlyDeleteCandidate",
+    candidateId: created.candidate.id,
+    confirmation: "DELETE SOURCE FILE",
+  })).json();
+  assert.equal(deleted.deletion.deleted, true);
+  assert.equal(
+    deleted.candidates.some((candidate) => candidate.id === created.candidate.id),
+    false,
+  );
+  assert.equal(
+    deleted.drafts.some((item) => item.candidateId === created.candidate.id),
+    false,
+  );
+
+  const publicReadModelAfter = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.equal(JSON.stringify(databasePage.entries), publicDossierBefore);
+  assert.deepEqual(publicReadModelAfter.sections.dossiers, publicReadModelBefore.sections.dossiers);
+});
 
 test("Candidate Intake promotion, archive/restore, and protected delete keep source warnings bounded", async () => {
   await resetWorkflowStore();

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -988,6 +988,31 @@ test("BNL source file read model does not confirm proposed, rejected, or retired
   }
 });
 
+
+test("BNL source file read model does not return archived or denied workflow records", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  await seedSourceFileReadModelState({
+    candidate: {
+      status: "archived",
+    },
+    drafts: [],
+  });
+
+  const archivedPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();
+  assert.equal(archivedPayload.found, false);
+
+  await seedSourceFileReadModelState({
+    candidate: {
+      status: "denied",
+    },
+    drafts: [],
+  });
+
+  const deniedPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();
+  assert.equal(deniedPayload.found, false);
+});
+
 test("BNL source file read model returns found=false without mutation for no-match", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";


### PR DESCRIPTION
### Motivation
- Provide explicit, safe cleanup controls for Active BNL Source Files so operators can archive or permanently remove junk/test/error active workflow records that cannot be cleaned up from the dashboard today.

### Description
- Add visible `Archive` and `Delete Permanently` action buttons to each Active Source File row on `/admin/dossiers` and add status-aware lifecycle controls (`Promote`, `Archive`, `Restore`, `Delete Permanently`) to `/admin/dossiers/candidates/[candidateId]` so only valid actions show for the current candidate status.
- Improve permanent-delete confirmation text to require typing `DELETE SOURCE FILE`, warn when linked unpublished proposed-dossier drafts exist, and clarify that public dossiers and published data are not deleted.
- Hook the UI to existing workflow API actions (`archiveCandidate`, `restoreCandidate`, `permanentlyDeleteCandidate`, `promoteCandidateToSourceFile`) and update displayed notices after actions complete.
- Files changed: `src/app/admin/dossiers/page.tsx` (add Archive/Delete buttons in Active Source Files table and enhanced delete confirmation handling), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (add lifecycle action buttons and client-side checks for status), `tests/admin-dossiers.test.mjs` (add render and workflow regression tests for archive/restore/delete scenarios), and `tests/bnl-read-model.test.mjs` (add read-model test ensuring archived/denied workflow records are not returned).

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed with no errors.
- Ran `npx eslint` targeted to changed files and no lint failures were reported.
- Ran `node --test tests/admin-dossiers.test.mjs` and `node --test tests/bnl-read-model.test.mjs`, and all new and existing assertions passed (test suites succeeded).
- Ran `npm run test:queue` (targeted queue/read-model tests) and the test grouping passed, including the new regression that verifies archive/restore/delete do not mutate public dossiers or the public read model.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8fcbf71c83218c73a7e843d23643)