### PR TITLE
Existing Dossier — admin reclassification & attach tools (Existing Dossier Update lane)

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -23,6 +23,7 @@ type WorkflowPayload = {
   duplicateGroups: DossierDuplicateGroup[];
   recommendations: DossierRecommendation[];
   workflow: { status: string };
+  publicDossiers?: Array<{ id: string; name: string }>;
 };
 
 type SourceNoteForm = {
@@ -394,6 +395,8 @@ export default function CandidateReviewPage() {
   const [noteForm, setNoteForm] = useState<SourceNoteForm>(emptyNoteForm);
   const [identityLinkForm, setIdentityLinkForm] =
     useState<IdentityLinkForm>(emptyIdentityLinkForm);
+  const [selectedExistingDossierId, setSelectedExistingDossierId] =
+    useState("");
 
   async function loadWorkflow() {
     const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
@@ -481,6 +484,10 @@ export default function CandidateReviewPage() {
   const confirmedIdentityLinks = identityLinks.filter(
     (identityLink) => identityLink.status === "confirmed",
   );
+  const publicDossiers = payload?.publicDossiers ?? [];
+  const existingDossierSelection =
+    selectedExistingDossierId || candidate?.existingDossierMatch?.id || "";
+  const isExistingDossierUpdate = candidate?.status === "existing_dossier_update";
   const closedIdentityLinks = identityLinks.filter(
     (identityLink) =>
       identityLink.status === "rejected" || identityLink.status === "retired",
@@ -564,11 +571,22 @@ export default function CandidateReviewPage() {
       | "promoteCandidateToSourceFile"
       | "archiveCandidate"
       | "restoreCandidate"
-      | "permanentlyDeleteCandidate",
+      | "permanentlyDeleteCandidate"
+      | "attachCandidateToExistingDossier"
+      | "markCandidateAsExistingDossierUpdate",
   ) {
     if (!candidate) return;
     try {
       const body: Record<string, unknown> = { action, candidateId };
+      if (
+        action === "attachCandidateToExistingDossier" ||
+        action === "markCandidateAsExistingDossierUpdate"
+      ) {
+        if (existingDossierSelection) {
+          body.dossierId = existingDossierSelection;
+          body.confidence = selectedExistingDossierId ? "high" : candidate.existingDossierMatch?.confidence;
+        }
+      }
       if (action === "permanentlyDeleteCandidate") {
         const confirmation = window.prompt(
           `Permanent delete removes this unpublished workflow item${
@@ -588,7 +606,11 @@ export default function CandidateReviewPage() {
             ? "Source file restored to Candidate Intake so it can be reviewed and promoted again if needed."
             : action === "permanentlyDeleteCandidate"
               ? "Source file permanently deleted from unpublished workflow records. Public dossiers were not changed."
-              : "Candidate promoted to an Active BNL Source File. Public dossiers were not changed.",
+              : action === "attachCandidateToExistingDossier"
+                ? "Existing public dossier target attached. Public dossier content was not changed."
+                : action === "markCandidateAsExistingDossierUpdate"
+                  ? "Source file moved to Existing Dossier Updates / Enrichment. Public dossier content was not changed."
+                  : "Candidate promoted to an Active BNL Source File. Public dossiers were not changed.",
       );
     } catch (err) {
       setNotice(
@@ -718,6 +740,11 @@ export default function CandidateReviewPage() {
             source file into another subject. Notes do not publish, create tags,
             or mutate public records.
           </p>
+          {isExistingDossierUpdate && (
+            <p className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
+              This is not a new dossier candidate. This is review material for an existing public dossier.
+            </p>
+          )}
           <div className="mt-4">
             <PhaseRail />
           </div>
@@ -812,6 +839,29 @@ export default function CandidateReviewPage() {
             >
               Mark Needs Info
             </button>
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction("markCandidateAsExistingDossierUpdate")
+              }
+              disabled={saving || !canUpdateCandidate || !existingDossierSelection}
+              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+              title="Reclassify this record as update/enrichment material for the attached public dossier. Does not publish or edit public content."
+            >
+              Move to Existing Dossier Update
+            </button>
+            {isExistingDossierUpdate && (
+              <button
+                type="button"
+                onClick={() =>
+                  void candidateLifecycleAction("promoteCandidateToSourceFile")
+                }
+                disabled={saving}
+                className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+              >
+                Move Back to Active Source File
+              </button>
+            )}
             {canPromoteCandidate && (
               <button
                 type="button"
@@ -887,6 +937,63 @@ export default function CandidateReviewPage() {
             {sourceWarningLabels({ candidate, recommendations: attachedRecommendations }).map((label) => (
               <StatusBadge key={label}>{label}</StatusBadge>
             ))}
+          </div>
+        </section>
+
+        <section className="border border-border bg-surface p-5 space-y-4">
+          <h2 className="text-2xl font-bold text-foreground">
+            Existing Public Dossier Match
+          </h2>
+          {candidate.existingDossierMatch ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
+              <p>Matched public dossier name: {candidate.existingDossierMatch.name}</p>
+              <p>Match confidence: {candidate.existingDossierMatch.confidence}</p>
+              <p>Public dossier id/slug: {candidate.existingDossierMatch.id}</p>
+              <p>Current workflow state: {candidate.status}</p>
+            </div>
+          ) : (
+            <p className="text-sm text-muted">
+              No existing public dossier match currently attached.
+            </p>
+          )}
+          <label className="block space-y-2 text-xs uppercase tracking-widest text-muted">
+            Attach to Existing Public Dossier
+            <select
+              value={existingDossierSelection}
+              onChange={(event) => setSelectedExistingDossierId(event.target.value)}
+              className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+            >
+              <option value="">Choose public dossier…</option>
+              {publicDossiers.map((dossier) => (
+                <option key={dossier.id} value={dossier.id}>
+                  {dossier.name} ({dossier.id})
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction("attachCandidateToExistingDossier")
+              }
+              disabled={saving || !existingDossierSelection}
+              className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              Attach to Existing Public Dossier
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction("markCandidateAsExistingDossierUpdate")
+              }
+              disabled={saving || !canUpdateCandidate || !existingDossierSelection}
+              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+            >
+              {isExistingDossierUpdate
+                ? "Mark as Enrichment for Existing Dossier"
+                : "Move to Existing Dossier Update"}
+            </button>
           </div>
         </section>
 

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -29,6 +29,7 @@ type WorkflowPayload = {
   };
   authoringGuide?: { version: string };
   tagRegistry?: { totalUniqueTags: number; totalTagAssignments: number };
+  publicDossiers?: Array<{ id: string; name: string }>;
 };
 
 type ManualRecommendationForm = {
@@ -229,6 +230,9 @@ export default function DossierControlCenterPage() {
   const [createdDraftIdByCandidate, setCreatedDraftIdByCandidate] = useState<
     Record<string, string>
   >({});
+  const [selectedDossierByCandidate, setSelectedDossierByCandidate] = useState<
+    Record<string, string>
+  >({});
 
   async function loadWorkflow() {
     setError(null);
@@ -270,6 +274,10 @@ export default function DossierControlCenterPage() {
   const recommendations = useMemo(
     () => payload?.recommendations ?? [],
     [payload?.recommendations],
+  );
+  const publicDossiers = useMemo(
+    () => payload?.publicDossiers ?? [],
+    [payload?.publicDossiers],
   );
   const activeRecommendations = recommendations.filter((recommendation) =>
     ["new", "reviewing"].includes(recommendation.status),
@@ -512,13 +520,26 @@ export default function DossierControlCenterPage() {
       | "promoteCandidateToSourceFile"
       | "archiveCandidate"
       | "restoreCandidate"
-      | "permanentlyDeleteCandidate",
+      | "permanentlyDeleteCandidate"
+      | "attachCandidateToExistingDossier"
+      | "markCandidateAsExistingDossierUpdate",
   ) {
     const candidate = candidates.find((item) => item.id === candidateId);
     if (!candidate) return;
 
     try {
       const body: Record<string, unknown> = { action, candidateId };
+      if (
+        action === "attachCandidateToExistingDossier" ||
+        action === "markCandidateAsExistingDossierUpdate"
+      ) {
+        const selectedDossierId =
+          selectedDossierByCandidate[candidateId] || candidate.existingDossierMatch?.id || "";
+        if (selectedDossierId) {
+          body.dossierId = selectedDossierId;
+          body.confidence = selectedDossierByCandidate[candidateId] ? "high" : candidate.existingDossierMatch?.confidence;
+        }
+      }
       if (action === "permanentlyDeleteCandidate") {
         const linkedDrafts = drafts.filter(
           (draft) => draft.candidateId === candidateId,
@@ -541,7 +562,11 @@ export default function DossierControlCenterPage() {
             ? `${candidate.name} restored to Candidate Intake. Public dossiers were not changed.`
             : action === "permanentlyDeleteCandidate"
               ? `${candidate.name} permanently deleted from unpublished workflow records. Public dossiers were not changed.`
-              : `${candidate.name} promoted to an Active BNL Source File. Public dossiers were not changed.`;
+              : action === "attachCandidateToExistingDossier"
+                ? `${candidate.name} attached to an existing public dossier target. Public dossier content was not changed.`
+                : action === "markCandidateAsExistingDossierUpdate"
+                  ? `${candidate.name} moved to Existing Dossier Updates / Enrichment. Public dossier content was not changed.`
+                  : `${candidate.name} promoted to an Active BNL Source File. Public dossiers were not changed.`;
       setNotice(actionNotice);
       if (data.candidates && data.drafts && data.workflow) {
         setPayload(data as WorkflowPayload);
@@ -936,8 +961,11 @@ export default function DossierControlCenterPage() {
                       <p className="font-bold text-foreground">Existing Dossier Update: {candidate.existingDossierMatch?.name ?? candidate.name}</p>
                       <p>Recommendation subject: {candidate.name}</p>
                       <p>Matched public dossier: {candidate.existingDossierMatch?.name ?? "—"}</p>
+                      <p>Public dossier target id: {candidate.existingDossierMatch?.id ?? "—"}</p>
+                      <p>Match confidence: {candidate.existingDossierMatch?.confidence ?? "—"}</p>
                       <p>Evidence/source notes: {(candidate.sourceFileNotes ?? []).length} notes preserved</p>
-                      <p>Proposed action: Review as update to existing dossier; owner approval required before public changes.</p>
+                      <p>Source warnings: {(candidate.publicSafetyNotes ?? []).length} public-safety notes / {(candidate.doNotSay ?? []).length} do-not-say notes / {(candidate.missingInfo ?? []).length} missing-info notes</p>
+                      <p>Proposed action: review update/enrichment; owner approval required before public changes.</p>
                     </div>
                     <div className="flex flex-wrap gap-2">
                       <Link href={`/admin/dossiers/candidates/${candidate.id}`} className="border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
@@ -1090,6 +1118,11 @@ export default function DossierControlCenterPage() {
                             <p>ready for draft/review</p>
                           )}
                           <p>Duplicate risk: {candidate.duplicateRisk ?? "none"}</p>
+                          {candidate.existingDossierMatch && (
+                            <p className="text-accent">
+                              Existing public dossier match: {candidate.existingDossierMatch.name} ({candidate.existingDossierMatch.confidence})
+                            </p>
+                          )}
                         </td>
                         <td className="py-3 pr-3">
                           {formatDate(candidate.updatedAt)}
@@ -1110,6 +1143,66 @@ export default function DossierControlCenterPage() {
                             >
                               Open Source File
                             </Link>
+                            {candidate.existingDossierMatch && (
+                              <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() =>
+                                  void candidateAction(
+                                    candidate.id,
+                                    "markCandidateAsExistingDossierUpdate",
+                                  )
+                                }
+                                className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                                title="Reclassify this active Source File as update/enrichment material for the matched public dossier. Does not publish or edit public content."
+                              >
+                                Move to Existing Dossier Update
+                              </button>
+                            )}
+                            <label className="flex flex-col gap-1 text-[0.65rem] uppercase tracking-widest text-muted">
+                              Attach to Existing Public Dossier
+                              <select
+                                value={
+                                  selectedDossierByCandidate[candidate.id] ??
+                                  candidate.existingDossierMatch?.id ??
+                                  ""
+                                }
+                                onChange={(event) =>
+                                  setSelectedDossierByCandidate((current) => ({
+                                    ...current,
+                                    [candidate.id]: event.target.value,
+                                  }))
+                                }
+                                className="max-w-[14rem] bg-background border border-border px-2 py-1.5 text-xs normal-case tracking-normal text-foreground"
+                              >
+                                <option value="">Choose public dossier…</option>
+                                {publicDossiers.map((dossier) => (
+                                  <option key={dossier.id} value={dossier.id}>
+                                    {dossier.name}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <button
+                              type="button"
+                              disabled={
+                                saving ||
+                                !(
+                                  selectedDossierByCandidate[candidate.id] ||
+                                  candidate.existingDossierMatch?.id
+                                )
+                              }
+                              onClick={() =>
+                                void candidateAction(
+                                  candidate.id,
+                                  "attachCandidateToExistingDossier",
+                                )
+                              }
+                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+                              title="Store the confirmed existing public dossier target without publishing or changing public dossier content."
+                            >
+                              Attach
+                            </button>
                             {openDraftId && (
                               <Link
                                 href={`/admin/dossiers/drafts/${openDraftId}`}

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -28,6 +28,7 @@ import {
   addDossierSourceFileNote,
   archiveDossierCandidate,
   archiveDossierRecommendation,
+  attachCandidateToExistingDossier,
   attachRecommendationToCandidate,
   createIdentityLinkFromRecommendation,
   confirmDossierIdentityLink,
@@ -45,6 +46,7 @@ import {
   rejectDossierIdentityLink,
   retireDossierIdentityLink,
   mergeDossierCandidates,
+  markCandidateAsExistingDossierUpdate,
   permanentlyDeleteDossierCandidate,
   promoteCandidateToSourceFile,
   restoreDossierCandidate,
@@ -101,6 +103,7 @@ type DossierWorkflowResponse = {
       typeof buildDossierTagRegistry
     >["creationPolicy"];
   };
+  publicDossiers: Array<{ id: string; name: string }>;
 };
 
 const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
@@ -129,6 +132,8 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "ignoreDossierRecommendation",
   "dismissDossierRecommendation",
   "archiveDossierRecommendation",
+  "attachCandidateToExistingDossier",
+  "markCandidateAsExistingDossierUpdate",
 ]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
@@ -335,6 +340,10 @@ async function workflowPayload(
       totalTagAssignments: tagRegistry.totalTagAssignments,
       creationPolicy: tagRegistry.creationPolicy,
     },
+    publicDossiers: databasePage.entries.map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+    })),
   };
 }
 
@@ -527,6 +536,57 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true, action, ...conversion, ...payload });
     }
 
+
+    if (
+      action === "attachCandidateToExistingDossier" ||
+      action === "markCandidateAsExistingDossierUpdate"
+    ) {
+      const candidateId = candidateIdFromBody(body);
+      const dossierId =
+        typeof body.dossierId === "string"
+          ? body.dossierId.trim()
+          : typeof (body.input as Record<string, unknown> | undefined)?.dossierId === "string"
+            ? String((body.input as Record<string, unknown>).dossierId).trim()
+            : "";
+      const confidenceValue =
+        typeof body.confidence === "string"
+          ? body.confidence
+          : (body.input as Record<string, unknown> | undefined)?.confidence;
+      const confidence =
+        confidenceValue === "low" ||
+        confidenceValue === "medium" ||
+        confidenceValue === "high"
+          ? confidenceValue
+          : undefined;
+      if (!candidateId) {
+        return NextResponse.json(
+          { error: "candidateId is required" },
+          { status: 400 },
+        );
+      }
+      const candidate =
+        action === "attachCandidateToExistingDossier"
+          ? dossierId
+            ? await attachCandidateToExistingDossier({
+                candidateId,
+                dossierId,
+                confidence,
+              })
+            : null
+          : await markCandidateAsExistingDossierUpdate({
+              candidateId,
+              dossierId: dossierId || undefined,
+              confidence,
+            });
+      if (!candidate) {
+        return NextResponse.json(
+          { error: dossierId ? "Candidate not found" : "dossierId is required" },
+          { status: dossierId ? 404 : 400 },
+        );
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, candidate, ...payload });
+    }
 
     if (
       action === "promoteCandidateToSourceFile" ||

--- a/src/app/api/bnl/source-files/route.ts
+++ b/src/app/api/bnl/source-files/route.ts
@@ -77,8 +77,9 @@ type SourceFileSummary = {
   normalizedName: string;
   candidateType: DossierCandidate["candidateType"];
   status: DossierCandidate["status"];
-  workflowLane: "active_source_file";
-  sourceFileActive: true;
+  workflowLane: "active_source_file" | "existing_dossier_update";
+  sourceFileActive: boolean;
+  laneDescription: string;
   tier: DossierCandidate["tier"];
   score: number;
   confidence: DossierCandidate["confidence"] | null;
@@ -317,8 +318,15 @@ function sourceFileReadModel(input: {
     normalizedName: normalizeDossierSubjectName(input.candidate.name),
     candidateType: input.candidate.candidateType,
     status: input.candidate.status,
-    workflowLane: "active_source_file",
-    sourceFileActive: true,
+    workflowLane:
+      input.candidate.status === "existing_dossier_update"
+        ? "existing_dossier_update"
+        : "active_source_file",
+    sourceFileActive: input.candidate.status !== "existing_dossier_update",
+    laneDescription:
+      input.candidate.status === "existing_dossier_update"
+        ? "Update/enrichment material for an existing public dossier; not a new public dossier candidate."
+        : "Active BNL Source File / internal working case file.",
     tier: input.candidate.tier,
     score: input.candidate.score,
     confidence: input.candidate.confidence ?? null,
@@ -409,11 +417,14 @@ function resolveSourceFile(input: {
   const compactValue = compactDossierSubjectName(input.value);
 
   if (input.mode === "candidateId") {
-    const exact = activeCandidates.find((candidate) => candidate.id === input.value);
-    return {
-      matches: exact ? [{ candidate: exact, matchKind: "candidate_id" as const }] : [],
-      possibleMatches: [],
-    };
+    const exact = input.candidates.find((candidate) => candidate.id === input.value);
+    if (exact && (isActiveCandidate(exact) || exact.status === "existing_dossier_update")) {
+      return {
+        matches: [{ candidate: exact, matchKind: "candidate_id" as const }],
+        possibleMatches: [],
+      };
+    }
+    return { matches: [], possibleMatches: [] };
   }
 
   const directMatches: ResolvedMatch[] = activeCandidates

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -2032,6 +2032,104 @@ export async function promoteCandidateToSourceFile(
   return updatedCandidate;
 }
 
+function publicDossierMatchForId(
+  dossierId: string,
+  confidence: NonNullable<DossierCandidate["existingDossierMatch"]>["confidence"] = "high",
+): NonNullable<DossierCandidate["existingDossierMatch"]> {
+  const entry = databasePage.entries.find((item) => item.id === dossierId);
+  if (!entry) {
+    throw new DossierWorkflowInputError(
+      "Existing public dossier target was not found",
+      400,
+      "existing_dossier_not_found",
+    );
+  }
+  return { id: entry.id, name: entry.name, confidence };
+}
+
+export async function attachCandidateToExistingDossier(input: {
+  candidateId: string;
+  dossierId: string;
+  confidence?: NonNullable<DossierCandidate["existingDossierMatch"]>["confidence"];
+}): Promise<DossierCandidate | null> {
+  const now = new Date().toISOString();
+  const existingDossierMatch = publicDossierMatchForId(
+    input.dossierId,
+    input.confidence ?? "high",
+  );
+  let updatedCandidate: DossierCandidate | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== input.candidateId) return candidate;
+      if (candidate.status === "denied" || candidate.status === "merged") {
+        throw new DossierWorkflowInputError(
+          "Closed candidates cannot be attached to an existing public dossier",
+          400,
+          "candidate_closed",
+        );
+      }
+      updatedCandidate = {
+        ...candidate,
+        existingDossierMatch,
+        duplicateRisk: candidate.duplicateRisk === "high" ? "high" : "medium",
+        updatedAt: now,
+      };
+      return updatedCandidate;
+    });
+
+    if (!updatedCandidate) return currentState;
+    return { ...currentState, candidates, updatedAt: now };
+  });
+
+  return updatedCandidate;
+}
+
+export async function markCandidateAsExistingDossierUpdate(input: {
+  candidateId: string;
+  dossierId?: string;
+  confidence?: NonNullable<DossierCandidate["existingDossierMatch"]>["confidence"];
+}): Promise<DossierCandidate | null> {
+  const now = new Date().toISOString();
+  let updatedCandidate: DossierCandidate | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== input.candidateId) return candidate;
+      if (candidate.status === "denied" || candidate.status === "merged") {
+        throw new DossierWorkflowInputError(
+          "Closed candidates cannot be reclassified as existing dossier updates",
+          400,
+          "candidate_closed",
+        );
+      }
+      const existingDossierMatch = input.dossierId
+        ? publicDossierMatchForId(input.dossierId, input.confidence ?? "high")
+        : candidate.existingDossierMatch;
+      if (!existingDossierMatch) {
+        throw new DossierWorkflowInputError(
+          "Attach an existing public dossier target before moving this source file to Existing Dossier Updates",
+          400,
+          "existing_dossier_match_required",
+        );
+      }
+      updatedCandidate = {
+        ...candidate,
+        existingDossierMatch,
+        duplicateRisk: candidate.duplicateRisk === "high" ? "high" : "medium",
+        status: "existing_dossier_update",
+        updatedAt: now,
+      };
+      return updatedCandidate;
+    });
+
+    if (!updatedCandidate) return currentState;
+    return { ...currentState, candidates, updatedAt: now };
+  });
+
+  return updatedCandidate;
+}
+
 export async function archiveDossierCandidate(
   candidateId: string,
 ): Promise<DossierCandidate | null> {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -733,6 +733,8 @@ export type DossierWorkflowAction =
   | "ignoreDossierRecommendation"
   | "dismissDossierRecommendation"
   | "archiveDossierRecommendation"
+  | "attachCandidateToExistingDossier"
+  | "markCandidateAsExistingDossierUpdate"
   | "detectDuplicateCandidates"
   | "mergeCandidates"
   | "createMasterDraftFromMerge";
@@ -777,6 +779,8 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "ignoreDossierRecommendation",
   "dismissDossierRecommendation",
   "archiveDossierRecommendation",
+  "attachCandidateToExistingDossier",
+  "markCandidateAsExistingDossierUpdate",
   "detectDuplicateCandidates",
   "mergeCandidates",
   "createMasterDraftFromMerge",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -282,6 +282,10 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
     "Open Source File",
     "Archive",
     "Delete Permanently",
+    "Move to Existing Dossier Update",
+    "Attach to Existing Public Dossier",
+    "Existing Dossier Updates / Enrichment Candidates",
+    "owner approval required before public changes",
     "DELETE SOURCE FILE",
     "Safe cleanup: move this source file out of active dashboard lanes without deleting public dossiers or published data.",
     "case file has warnings",
@@ -306,6 +310,8 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
   assert.match(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
   assert.match(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
   assert.match(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
+  assert.match(page, /markCandidateAsExistingDossierUpdate/);
+  assert.match(page, /attachCandidateToExistingDossier/);
   assert.doesNotMatch(page, /eyebrow="Lane 2"/);
   assert.doesNotMatch(page, /title="Proposed Dossiers"/);
   assert.doesNotMatch(page, /title="Final Admin Drafts"/);
@@ -506,6 +512,10 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Public use not allowed until review",
     "Owner review required",
     "Possible connection, not confirmed identity",
+    "Existing Public Dossier Match",
+    "No existing public dossier match currently attached.",
+    "This is not a new dossier candidate. This is review material for an existing public dossier.",
+    "Move Back to Active Source File",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -525,6 +535,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   assert.match(page, /routeParam\(params\?\.candidateId\)/);
   assert.match(page, /action: "createDraftFromCandidate"/);
   assert.match(page, /action: "addSourceFileNote"/);
+  assert.match(page, /attachCandidateToExistingDossier/);
+  assert.match(page, /markCandidateAsExistingDossierUpdate/);
   assert.doesNotMatch(page, />Deny<|>Deny<\/button>/);
   assert.doesNotMatch(page, />Final Approve<|>Publish<|>Delete<|>Final Merge</);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
@@ -3606,6 +3618,98 @@ test("exact existing public dossier matches route to Existing Dossier Update wit
   const adminPayload = await (await authedGet()).json();
   assert.equal(adminPayload.candidates[0].status, "existing_dossier_update");
   assert.equal(adminPayload.drafts.length, 0);
+});
+
+test("active Source File with an existing public dossier match reclassifies to Existing Dossier Update safely", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const publicBefore = JSON.stringify(databasePage.entries.find((entry) => entry.name === "Mac Modem"));
+
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const created = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Mac Modem",
+    reason: "Existing public dossier has enrichment material to review.",
+    evidenceSummary: "Existing public dossier enrichment evidence.",
+    sourceLanes: ["website_dossier", "rd_context"],
+    missingInfo: ["Confirm whether this belongs in the public dossier."],
+    doNotSay: ["Do not publish internal modem lore note."],
+    publicSafetyNotes: ["Owner approval required before public copy changes."],
+    ingestKey: "bnl:mac-modem-existing-update",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(created.candidate.existingDossierMatch.name, "Mac Modem");
+
+  const promoted = await (await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(promoted.candidate.status, "active_source_file");
+
+  await (await authedPost({
+    action: "addSourceFileNote",
+    candidateId: created.candidate.id,
+    input: {
+      type: "correction",
+      text: "Preserve this enrichment note during reclassification.",
+      source: "bnl_recommendation",
+      publicSafe: false,
+    },
+  })).json();
+
+  const activeRead = await (await sourceFilesGet(`?subject=${encodeURIComponent("Mac Modem")}`)).json();
+  assert.equal(activeRead.found, true);
+  assert.equal(activeRead.sourceFile.workflowLane, "active_source_file");
+  assert.equal(activeRead.sourceFile.sourceFileActive, true);
+
+  const reclassified = await (await authedPost({
+    action: "markCandidateAsExistingDossierUpdate",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(reclassified.candidate.status, "existing_dossier_update");
+  assert.equal(reclassified.candidate.existingDossierMatch.name, "Mac Modem");
+  assert.equal(reclassified.candidate.ingestKey, "bnl:mac-modem-existing-update");
+  assert.equal(reclassified.candidate.ingestSource, "bnl_source_knowledge_bridge");
+  assert.deepEqual(reclassified.candidate.missingInfo, ["Confirm whether this belongs in the public dossier."]);
+  assert.deepEqual(reclassified.candidate.doNotSay, ["Do not publish internal modem lore note."]);
+  assert.ok(reclassified.candidate.publicSafetyNotes.includes("Owner approval required before public copy changes."));
+  assert.match(reclassified.candidate.publicSafetyNotes.join(" "), /Source Knowledge Bridge origin|Public use requires review/);
+  assert.match(JSON.stringify(reclassified.candidate.sourceFileNotes), /Preserve this enrichment note/);
+  assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.name === "Mac Modem")), publicBefore);
+
+  const adminPayload = await (await authedGet()).json();
+  const updateLaneCandidate = adminPayload.candidates.find((candidate) => candidate.id === created.candidate.id);
+  assert.equal(updateLaneCandidate.status, "existing_dossier_update");
+  assert.equal(updateLaneCandidate.existingDossierMatch.name, "Mac Modem");
+
+  const subjectRead = await (await sourceFilesGet(`?subject=${encodeURIComponent("Mac Modem")}`)).json();
+  assert.equal(subjectRead.found, false);
+  assert.match(subjectRead.reason, /No BNL Source File match found/);
+
+  const candidateRead = await (await sourceFilesGet(`?candidateId=${encodeURIComponent(created.candidate.id)}`)).json();
+  assert.equal(candidateRead.found, true);
+  assert.equal(candidateRead.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(candidateRead.sourceFile.sourceFileActive, false);
+  assert.match(candidateRead.sourceFile.laneDescription, /update\/enrichment material/i);
+  assert.equal(candidateRead.sourceFile.duplicateWarnings.existingDossierMatch.name, "Mac Modem");
+
+  const publicReadModelPayload = await (await readModel.GET(
+    new Request("https://example.test/api/bnl/read-model"),
+  )).json();
+  assert.doesNotMatch(JSON.stringify(publicReadModelPayload), /Preserve this enrichment note|bnl:mac-modem-existing-update|Existing public dossier enrichment evidence/);
+
+  const archived = await (await authedPost({
+    action: "archiveCandidate",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(archived.candidate.status, "archived");
+
+  const restoredActive = await (await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: created.candidate.id,
+  })).json();
+  assert.equal(restoredActive.candidate.status, "active_source_file");
+  assert.equal(restoredActive.candidate.existingDossierMatch.name, "Mac Modem");
 });
 
 test("BNL ingest dedupes active recommendations by ingestKey and fallback comparison", async () => {

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -1013,6 +1013,29 @@ test("BNL source file read model does not return archived or denied workflow rec
   assert.equal(deniedPayload.found, false);
 });
 
+test("BNL source file read model labels Existing Dossier Updates only on explicit candidateId lookup", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState({
+    candidate: {
+      status: "existing_dossier_update",
+      existingDossierMatch: { id: "mac-modem", name: "Mac Modem", confidence: "high" },
+    },
+    drafts: [],
+  });
+
+  const subjectPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();
+  assert.equal(subjectPayload.found, false);
+  assert.match(subjectPayload.reason, /No BNL Source File match found/);
+
+  const candidatePayload = await (await sourceFilesGet(`?candidateId=${candidate.id}`)).json();
+  assert.equal(candidatePayload.found, true);
+  assert.equal(candidatePayload.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(candidatePayload.sourceFile.sourceFileActive, false);
+  assert.match(candidatePayload.sourceFile.laneDescription, /update\/enrichment material/i);
+  assert.equal(candidatePayload.sourceFile.duplicateWarnings.existingDossierMatch.name, "Mac Modem");
+});
+
 test("BNL source file read model returns found=false without mutation for no-match", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";


### PR DESCRIPTION
### Motivation
- Provide administrators a safe way to reclassify active BNL Source Files that match existing public dossiers into an "Existing Dossier Update" / enrichment lane so real public dossiers are not treated as new candidates or accidentally removed. 
- Preserve all internal metadata (notes, evidence, warnings, ingest keys, identity links) while preventing any automated publishing or edits to public content.

### Description
- Added two new workflow actions and store helpers: `attachCandidateToExistingDossier` and `markCandidateAsExistingDossierUpdate` that attach a public dossier target and/or move a candidate into `existing_dossier_update` while preserving all source-file metadata and not publishing anything. (store: `src/lib/dossier-workflow-store.ts`, types: `src/lib/dossier-workflow.ts`)
- Exposed an admin-only list of public dossier targets on the admin workflow payload (`publicDossiers`) and wired `attachCandidateToExistingDossier` / `markCandidateAsExistingDossierUpdate` handling in the admin API endpoint (`src/app/api/admin/dossiers/route.ts`).
- Admin UI changes: dashboard rows now surface match context and actions (Move to Existing Dossier Update, Attach to Existing Public Dossier, Archive, Delete); candidate detail page adds an "Existing Public Dossier Match" section, attach/reclassify controls, explicit notice that update-lane items are enrichment not new dossiers, and a move-back control to restore Active Source File status. (UI: `src/app/admin/dossiers/page.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Protected read model (`/api/bnl/source-files`) updated to: exclude `existing_dossier_update` records from active subject/name lookups, and return them only for explicit `candidateId` lookups with `workflowLane: "existing_dossier_update"`, `sourceFileActive: false`, and a `laneDescription` explaining they are update/enrichment material. (`src/app/api/bnl/source-files/route.ts`)
- Tests added/updated to cover reclassification behavior, metadata preservation, read-model labeling, archive/restore, and public-read-model safety. (tests: `tests/admin-dossiers.test.mjs`, `tests/bnl-read-model.test.mjs`)

Files changed (key):
- src/lib/dossier-workflow-store.ts — added `attachCandidateToExistingDossier`, `markCandidateAsExistingDossierUpdate`, and helper `publicDossierMatchForId`.
- src/lib/dossier-workflow.ts — added workflow action names for the two new actions and related type usage.
- src/app/api/admin/dossiers/route.ts — expose `publicDossiers` in payload and handle new POST actions.
- src/app/api/bnl/source-files/route.ts — read-model labeling/lane changes for Existing Dossier Updates.
- src/app/admin/dossiers/page.tsx — dashboard: attach/reclassify controls and Existing Dossier Updates display.
- src/app/admin/dossiers/candidates/[candidateId]/page.tsx — candidate detail: Existing Public Dossier Match UI, attach/reclassify/move-back buttons.
- tests/admin-dossiers.test.mjs, tests/bnl-read-model.test.mjs — added/updated tests for reclassification and read-model behavior.

Anything intentionally left untouched: public content in `src/content.ts` and all publishing flows, alias auto-confirmation, identity merges, queue/payment/relay behavior, and BNL bot code are unchanged.

Follow-up risks/manual checks: ensure operators understand the difference between "Attach" (stores a target) and "Move to Existing Dossier Update" (reclassifies workflow lane); owner-approval and publishing flows remain future work.

### Testing
- Type-check: `npx tsc --noEmit` — succeeded.
- Lint: targeted `eslint` on changed files — succeeded.
- Unit / endpoint tests: `node --test tests/admin-dossiers.test.mjs` and `node --test tests/bnl-read-model.test.mjs` — all tests passed after updates.
- Integration/queue tests: `npm run test:queue` (runs the read-model + queue playback tests) — succeeded.

All automated checks described in the task were executed in this environment and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9c085acc83219d40c3fb4b6639d6)