### PR TITLE
Add first-class BNL Source File enrichment ingest

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -194,10 +194,12 @@ function sourceWarningLabels(input: {
     lanes.has("broadcast_memory") ? "Source-blind memory trace" : "",
     input.candidate.ingestSource === "bnl_dynamic_candidate_discovery" ||
     input.candidate.ingestSource === "bnl_source_knowledge_bridge" ||
+    input.candidate.ingestSource === "bnl_source_file_enrichment" ||
     input.recommendations.some(
       (recommendation) =>
         recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
-        recommendation.ingestSource === "bnl_source_knowledge_bridge",
+        recommendation.ingestSource === "bnl_source_knowledge_bridge" ||
+        recommendation.ingestSource === "bnl_source_file_enrichment",
     )
       ? "Internal/private review required"
       : "",
@@ -1250,17 +1252,28 @@ export default function CandidateReviewPage() {
             <p>No saved source notes yet.</p>
           ) : (
             <div className="space-y-3">
-              {sourceNotes.map((note) => (
+              {sourceNotes.map((note) => {
+                const isEnrichmentNote =
+                  note.ingestSource === "bnl_source_file_enrichment";
+                return (
                 <article
                   key={note.id}
                   className="border border-border/70 bg-background/20 p-3"
                 >
                   <p className="text-foreground font-semibold">
-                    {note.type} / {note.status}
+                    {isEnrichmentNote ? "BNL Source File Enrichment" : note.type} / {note.status}
                   </p>
+                  {isEnrichmentNote && (
+                    <div className="mb-2 flex flex-wrap gap-2">
+                      <StatusBadge>Review-only</StatusBadge>
+                      <StatusBadge>Internal case-file material</StatusBadge>
+                      <StatusBadge>Not public copy</StatusBadge>
+                      <StatusBadge>Owner/admin review required</StatusBadge>
+                    </div>
+                  )}
                   <p className="whitespace-pre-wrap">{note.text}</p>
                   <p>
-                    Source: {note.source} / Public safe:{" "}
+                    Source: {note.source} / Ingest source: {note.ingestSource ?? "—"} / Public safe:{" "}
                     {String(note.publicSafe)} / Created:{" "}
                     {formatDate(note.createdAt)}
                   </p>
@@ -1278,7 +1291,8 @@ export default function CandidateReviewPage() {
                     )}
                   </p>
                 </article>
-              ))}
+              );
+              })}
             </div>
           )}
         </Section>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -120,6 +120,9 @@ function linkedActiveDraftFor(
 }
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+    return "BNL Source File Enrichment";
+  }
   if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
     return "BNL dynamic discovery";
   }
@@ -135,6 +138,9 @@ function recommendationProvenance(recommendation: DossierRecommendation) {
 }
 
 function candidateProvenance(candidate: DossierCandidate) {
+  if (candidate.source === "bnl_source_file_enrichment") {
+    return `BNL Source File Enrichment${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+  }
   if (candidate.source === "bnl_dynamic_candidate_discovery") {
     return `BNL dynamic discovery${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
   }
@@ -405,6 +411,22 @@ export default function DossierControlCenterPage() {
 
   function recommendationMatchState(recommendation: DossierRecommendation) {
     const match = matchDossierRecommendationSubject({ recommendation, candidates });
+    if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+      const target = recommendation.targetCandidateId
+        ? candidates.find((candidate) => candidate.id === recommendation.targetCandidateId)
+        : null;
+      return {
+        match,
+        state: target?.status === "active_source_file"
+          ? "BNL Source File Enrichment / Active Source File"
+          : target?.status === "candidate_intake"
+            ? "BNL Source File Enrichment / Candidate Intake"
+            : target?.status === "existing_dossier_update"
+              ? "BNL Source File Enrichment / Existing Dossier Update"
+              : "BNL Source File Enrichment / Recommendation Inbox",
+        nextAction: "Review-only internal case-file material; not public copy",
+      };
+    }
     if (match.exactMatchKind === "pre_targeted") {
       return {
         match,

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -115,8 +115,14 @@ function formatDate(value?: string) {
 }
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+    return "BNL Source File Enrichment";
+  }
   if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
     return "BNL dynamic discovery";
+  }
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
+    return "BNL Source Knowledge Bridge";
   }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
     return "BNL-ingested";
@@ -144,6 +150,8 @@ function Field({
 const terminalRecommendationStatuses = new Set<DossierRecommendation["status"]>(
   [
     "attached_to_source_file",
+    "attached_to_candidate_intake",
+    "attached_to_existing_dossier_update",
     "converted_to_source_file",
     "identity_link_created",
     "ignored",
@@ -157,6 +165,12 @@ function terminalRecommendationMessage(recommendation: DossierRecommendation) {
   }
   if (recommendation.status === "attached_to_source_file") {
     return "Attached to matched BNL Source File.";
+  }
+  if (recommendation.status === "attached_to_candidate_intake") {
+    return "Attached to Candidate Intake as review-only enrichment.";
+  }
+  if (recommendation.status === "attached_to_existing_dossier_update") {
+    return "Attached to Existing Dossier Update as review-only enrichment.";
   }
   if (recommendation.status === "identity_link_created") {
     return "Proposed identity link created. Confirm it from the BNL Source File when ready.";
@@ -283,6 +297,17 @@ export default function DossierRecommendationPage() {
   const activeCandidates = (payload?.candidates ?? []).filter(
     (candidate) => candidate.status !== "denied" && candidate.status !== "merged",
   );
+  const enrichmentLane =
+    recommendation?.ingestSource === "bnl_source_file_enrichment"
+      ? targetCandidate?.status === "active_source_file"
+        ? "Active Source File"
+        : targetCandidate?.status === "candidate_intake"
+          ? "Candidate Intake"
+          : targetCandidate?.status === "existing_dossier_update"
+            ? "Existing Dossier Update"
+            : "Recommendation Inbox"
+      : null;
+  const isEnrichmentRecommendation = enrichmentLane !== null;
   const preselectedCandidateId =
     targetCandidate?.id ?? exactCandidate?.id ?? possibleCandidates[0]?.id ?? "";
   async function postWorkflow(body: Record<string, unknown>) {
@@ -502,7 +527,25 @@ export default function DossierRecommendationPage() {
         </div>
       </section>
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
-        {!isTerminal && (
+        {isEnrichmentRecommendation && (
+          <section className="border border-accent/60 bg-accent/10 p-5 text-sm text-accent space-y-3">
+            <p className="text-xs uppercase tracking-[0.45em]">BNL Source File Enrichment</p>
+            <h2 className="text-2xl font-bold">Review-only internal case-file material</h2>
+            <p>
+              This packet is BNL-generated enrichment, not candidate discovery,
+              not raw bridge intake, not public copy, and not publication approval.
+              Owner/admin review is required before any public use.
+            </p>
+            <p>Enrichment target lane: {enrichmentLane}</p>
+            {targetCandidate ? (
+              <p>Target record: {targetCandidate.name} ({targetCandidate.status})</p>
+            ) : (
+              <p>No target candidate is set; this remains in the Recommendation Inbox.</p>
+            )}
+            <p>Allowed actions: review, dismiss, ignore, or attach only through the matched target lane. No public dossier, alias confirmation, merge, or Proposed Dossier is created automatically.</p>
+          </section>
+        )}
+        {!isTerminal && !isEnrichmentRecommendation && (
           <section className="border border-border bg-surface p-5 text-sm text-muted space-y-4">
             <h2 className="text-2xl font-bold text-foreground">
               Matched BNL Source File
@@ -802,6 +845,9 @@ export default function DossierRecommendationPage() {
           <Field title="Source lanes">
             <p>{recommendation.sourceLanes.join(", ")}</p>
           </Field>
+          <Field title="Source types">
+            <p>{recommendation.sourceTypes?.join(", ") || "—"}</p>
+          </Field>
           <Field title="Confidence">
             <p>{recommendation.confidence ?? "—"}</p>
           </Field>
@@ -826,8 +872,15 @@ export default function DossierRecommendationPage() {
               {recommendation.ingestSource?.startsWith("bnl") && (
                 <li>Internal/private review required</li>
               )}
+              {recommendation.ingestSource === "bnl_source_file_enrichment" && (
+                <>
+                  <li>Review-only BNL-generated enrichment</li>
+                  <li>Internal case-file material; not public copy</li>
+                  <li>Does not publish or create Proposed Dossiers</li>
+                </>
+              )}
               <li>Public use not allowed until review</li>
-              <li>Owner review required</li>
+              <li>Owner/admin review required</li>
               {recommendation.type === "identity_link" && (
                 <li>Possible connection, not confirmed identity</li>
               )}

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -137,7 +137,8 @@ function supportedIngestSource(value: unknown): CreateDossierRecommendationInput
   const normalized = text(value, 80);
   if (
     normalized === "bnl_dynamic_candidate_discovery" ||
-    normalized === "bnl_source_knowledge_bridge"
+    normalized === "bnl_source_knowledge_bridge" ||
+    normalized === "bnl_source_file_enrichment"
   ) {
     return normalized;
   }
@@ -167,6 +168,11 @@ function normalizeBridgeSourceLane(value: unknown): {
     source_files: "admin_manual",
     source_knowledge_bridge: "admin_manual",
     bnl_source_knowledge_bridge: "admin_manual",
+    bnl_source_file_enrichment: "admin_manual",
+    source_file_enrichment: "admin_manual",
+    active_source_file: "admin_manual",
+    candidate_intake: "admin_manual",
+    existing_dossier_update: "website_dossier",
     local_knowledge_store: "admin_manual",
     operator_notes: "admin_manual",
   };
@@ -182,6 +188,8 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
 
   const ingestSource = supportedIngestSource(payload.ingestSource);
   const isBridgeIngest = ingestSource === "bnl_source_knowledge_bridge";
+  const isStructuredBnlSourceIngest =
+    isBridgeIngest || ingestSource === "bnl_source_file_enrichment";
   const sourceLanesInput = payload.sourceLanes;
   let sourceLanes: DossierRecommendationSourceLane[];
   const bridgeSourceLaneDetails: string[] = [];
@@ -189,7 +197,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     sourceLanes = ["unknown"];
   } else {
     if (!Array.isArray(sourceLanesInput)) throw new Error("Invalid source lane");
-    if (isBridgeIngest) {
+    if (isStructuredBnlSourceIngest) {
       const normalized = sourceLanesInput.map(normalizeBridgeSourceLane);
       sourceLanes = normalized.map((item) => item.lane);
       bridgeSourceLaneDetails.push(
@@ -216,7 +224,12 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
 
   const subjectName = text(payload.subjectName, 200);
   const reason = text(payload.reason, 2000);
-  const evidenceSummary = text(payload.evidenceSummary, 2000);
+  const evidenceSummary =
+    payload.evidenceSummary &&
+    typeof payload.evidenceSummary === "object" &&
+    !Array.isArray(payload.evidenceSummary)
+      ? JSON.stringify(payload.evidenceSummary).slice(0, 2000)
+      : text(payload.evidenceSummary, 2000);
   const bridgeEvidenceSummary = bridgeSourceLaneDetails.length
     ? [
         evidenceSummary,
@@ -239,6 +252,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     evidenceSummary: bridgeEvidenceSummary,
     confidence: enumValue(payload.confidence, CONFIDENCES, "confidence"),
     sourceLanes,
+    sourceTypes: stringList(payload.sourceTypes, 120),
     suggestedAction: text(payload.suggestedAction, 500),
     missingInfo: stringList(payload.missingInfo),
     publicSafetyNotes: stringList(payload.publicSafetyNotes),

--- a/src/app/api/bnl/source-files/route.ts
+++ b/src/app/api/bnl/source-files/route.ts
@@ -143,6 +143,7 @@ type SourceFileSummary = {
     status: DossierRecommendation["status"];
     confidence: DossierRecommendation["confidence"] | null;
     sourceLanes: DossierRecommendation["sourceLanes"];
+    sourceTypes: string[];
     ingestSource: DossierRecommendation["ingestSource"] | null;
     ingestKey: string | null;
     reason: string;
@@ -302,6 +303,7 @@ function sourceFileReadModel(input: {
       status: recommendation.status,
       confidence: recommendation.confidence ?? null,
       sourceLanes: recommendation.sourceLanes,
+      sourceTypes: recommendation.sourceTypes ?? [],
       ingestSource: recommendation.ingestSource ?? null,
       ingestKey: recommendation.ingestKey ?? null,
       reason: recommendation.reason,

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -570,6 +570,8 @@ export type ReviewDossierIdentityLinkInput = {
 
 const TERMINAL_RECOMMENDATION_STATUSES = new Set<DossierRecommendationStatus>([
   "attached_to_source_file",
+  "attached_to_candidate_intake",
+  "attached_to_existing_dossier_update",
   "converted_to_source_file",
   "identity_link_created",
   "ignored",
@@ -648,6 +650,7 @@ function normalizeRecommendationInput(
     evidenceSummary: boundedText(input.evidenceSummary) || undefined,
     confidence,
     sourceLanes: sourceLanes.length ? sourceLanes : ["admin_manual"],
+    sourceTypes: normalizeStringArray(input.sourceTypes).slice(0, 25),
     suggestedAction: boundedText(input.suggestedAction, 500) || undefined,
     missingInfo: normalizeStringArray(input.missingInfo),
     publicSafetyNotes: normalizeStringArray(input.publicSafetyNotes),
@@ -664,6 +667,7 @@ function normalizeRecommendationInput(
       input.ingestSource === "bnl" ||
       input.ingestSource === "bnl_dynamic_candidate_discovery" ||
       input.ingestSource === "bnl_source_knowledge_bridge" ||
+      input.ingestSource === "bnl_source_file_enrichment" ||
       input.ingestSource === "system" ||
       input.ingestSource === "unknown"
         ? input.ingestSource
@@ -684,6 +688,9 @@ function isAutoConvertibleBnlSourceRecommendation(
 function bnlIngestLabel(
   recommendation: Pick<DossierRecommendation, "ingestSource">,
 ): string {
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+    return "BNL Source File Enrichment";
+  }
   if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
     return "BNL Source Knowledge Bridge";
   }
@@ -696,9 +703,13 @@ function bnlIngestLabel(
 function bnlIngestCandidateSource(
   recommendation: Pick<DossierRecommendation, "ingestSource">,
 ): DossierCandidate["source"] {
-  return recommendation.ingestSource === "bnl_source_knowledge_bridge"
-    ? "bnl_source_knowledge_bridge"
-    : "bnl_dynamic_candidate_discovery";
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
+    return "bnl_source_knowledge_bridge";
+  }
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+    return "bnl_source_file_enrichment";
+  }
+  return "bnl_dynamic_candidate_discovery";
 }
 
 function candidateTypeFromRecommendation(
@@ -731,13 +742,21 @@ function recommendationCandidateScore(
 function bnlAutoCandidateSourceNotes(
   recommendation: Pick<DossierRecommendation, "ingestSource">,
 ): string[] {
-  return recommendation.ingestSource === "bnl_source_knowledge_bridge"
-    ? [
-        "Source Knowledge Bridge origin: BNL local knowledge stores.",
-        "Public use requires review before any public dossier copy is written.",
-        "Internal/private review required for bridge-derived context.",
-      ]
-    : [];
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
+    return [
+      "Source Knowledge Bridge origin: BNL local knowledge stores.",
+      "Public use requires review before any public dossier copy is written.",
+      "Internal/private review required for bridge-derived context.",
+    ];
+  }
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+    return [
+      "BNL Source File Enrichment origin: BNL-generated enrichment.",
+      "Review-only internal case-file material; not public copy.",
+      "Owner/admin review required before any public use.",
+    ];
+  }
+  return [];
 }
 
 function bnlAutoCandidateNoteText(
@@ -747,8 +766,14 @@ function bnlAutoCandidateNoteText(
   return [
     recommendationSourceNoteText(recommendation),
     `${label} origin.`,
-    recommendation.ingestSource === "bnl_source_knowledge_bridge"
-      ? `${label} source lanes/types summary: ${recommendation.sourceLanes.join(", ")}`
+    recommendation.ingestSource === "bnl_source_knowledge_bridge" ||
+    recommendation.ingestSource === "bnl_source_file_enrichment"
+      ? `${label} source lanes/types summary: ${[
+          recommendation.sourceLanes.join(", "),
+          recommendation.sourceTypes?.length ? `source types: ${recommendation.sourceTypes.join(", ")}` : "",
+        ]
+          .filter(Boolean)
+          .join(" / ")}`
       : `${label} source lanes: ${recommendation.sourceLanes.join(", ")}`,
     recommendation.ingestKey ? `${label} ingest key: ${recommendation.ingestKey}` : "",
     recommendation.confidence ? `${label} confidence: ${recommendation.confidence}` : "",
@@ -920,6 +945,8 @@ export async function createDossierRecommendationIdempotent(
   let savedCandidate: DossierCandidate | undefined;
   let duplicate = false;
   let autoAction: "created_candidate" | "attached_existing" | "left_for_review" | undefined;
+  const isEnrichmentIngest =
+    recommendation.ingestSource === "bnl_source_file_enrichment";
 
   await updateDossierWorkflowState((currentState) => {
     if (recommendation.targetCandidateId) {
@@ -933,7 +960,7 @@ export async function createDossierRecommendationIdempotent(
           "target_candidate_not_found",
         );
       }
-      if (!isActiveSourceFileCandidate(candidate)) {
+      if (!isActiveSourceFileCandidate(candidate) && !isEnrichmentIngest) {
         throw new DossierWorkflowInputError(
           "Target candidate is not an active BNL Source File",
           400,
@@ -957,6 +984,101 @@ export async function createDossierRecommendationIdempotent(
       savedRecommendation = existing;
       duplicate = true;
       return currentState;
+    }
+
+    if (isEnrichmentIngest) {
+      if (recommendation.targetCandidateId) {
+        const targetCandidate = currentState.candidates.find(
+          (candidate) => candidate.id === recommendation.targetCandidateId,
+        );
+        if (!targetCandidate) {
+          throw new DossierWorkflowInputError(
+            "Target candidate not found",
+            404,
+            "target_candidate_not_found",
+          );
+        }
+        if (
+          targetCandidate.status !== "active_source_file" &&
+          targetCandidate.status !== "candidate_intake" &&
+          targetCandidate.status !== "existing_dossier_update"
+        ) {
+          throw new DossierWorkflowInputError(
+            "BNL Source File Enrichment target is not an attachable workflow lane",
+            400,
+            "enrichment_target_not_attachable",
+          );
+        }
+        const targetStatusNote =
+          targetCandidate.status === "active_source_file"
+            ? "attached to an Active BNL Source File for review only; no public dossier was changed."
+            : targetCandidate.status === "candidate_intake"
+              ? "attached to Candidate Intake as enrichment, not active case-file fact; no promotion occurred."
+              : targetCandidate.status === "existing_dossier_update"
+                ? "attached as Existing Dossier Update enrichment; public dossier content was not edited."
+                : "attached to the targeted workflow record for review only; no public content changed.";
+        const updatedStatus: DossierRecommendationStatus =
+          targetCandidate.status === "candidate_intake"
+            ? "attached_to_candidate_intake"
+            : targetCandidate.status === "existing_dossier_update"
+              ? "attached_to_existing_dossier_update"
+              : "attached_to_source_file";
+        const note: DossierSourceFileNote = {
+          id: createSourceFileNoteId(),
+          candidateId: targetCandidate.id,
+          type: "general_note",
+          text: bnlAutoCandidateNoteText(recommendation),
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        };
+        const updatedRecommendation: DossierRecommendation = {
+          ...recommendation,
+          status: updatedStatus,
+          targetCandidateId: targetCandidate.id,
+          publicSafetyNotes: [
+            ...(recommendation.publicSafetyNotes ?? []),
+            `${bnlIngestLabel(recommendation)} ${targetStatusNote}`,
+          ],
+          updatedAt: now,
+        };
+        savedRecommendation = updatedRecommendation;
+        autoAction = "attached_existing";
+        return {
+          ...currentState,
+          recommendations: [updatedRecommendation, ...currentState.recommendations],
+          candidates: currentState.candidates.map((candidate) =>
+            candidate.id === targetCandidate.id
+              ? {
+                  ...candidate,
+                  sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+                  updatedAt: now,
+                }
+              : candidate,
+          ),
+          updatedAt: now,
+        };
+      }
+
+      savedRecommendation = {
+        ...recommendation,
+        publicSafetyNotes: [
+          ...(recommendation.publicSafetyNotes ?? []),
+          `${bnlIngestLabel(recommendation)} has no target; left in Recommendation Inbox for owner/admin review. No Candidate Intake, Source File, Proposed Dossier, alias, merge, or public content was created.`,
+        ],
+      };
+      autoAction = "left_for_review";
+      return {
+        ...currentState,
+        recommendations: [savedRecommendation, ...currentState.recommendations],
+        updatedAt: now,
+      };
     }
 
     if (isAutoConvertibleBnlSourceRecommendation(recommendation)) {
@@ -1730,12 +1852,18 @@ export async function attachRecommendationToCandidate(input: {
         id: createSourceFileNoteId(),
         candidateId: candidate.id,
         type: "general_note",
-        text: recommendationSourceNoteText(recommendation),
+        text: recommendation.ingestSource?.startsWith("bnl")
+          ? bnlAutoCandidateNoteText(recommendation)
+          : recommendationSourceNoteText(recommendation),
         source: "bnl_recommendation",
         status: "active",
         publicSafe: false,
         createdAt: now,
         updatedAt: now,
+        createdBy: recommendation.createdBy,
+        ingestKey: recommendation.ingestKey,
+        ingestedAt: recommendation.ingestedAt,
+        ingestSource: recommendation.ingestSource,
       };
     }
 
@@ -1800,6 +1928,13 @@ export async function convertRecommendationToCandidate(
       );
     }
     assertRecommendationIsOpen(recommendation);
+    if (recommendation.ingestSource === "bnl_source_file_enrichment") {
+      throw new DossierWorkflowInputError(
+        "BNL Source File Enrichment cannot create a new candidate automatically",
+        400,
+        "enrichment_cannot_create_candidate",
+      );
+    }
     const match = matchDossierRecommendationSubject({
       recommendation,
       candidates: currentState.candidates,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -12,6 +12,7 @@ export type DossierCandidateSource =
   | "website_read_model"
   | "bnl_dynamic_candidate_discovery"
   | "bnl_source_knowledge_bridge"
+  | "bnl_source_file_enrichment"
   | "combined";
 
 export type DossierCandidateType =
@@ -331,6 +332,8 @@ export type DossierRecommendationStatus =
   | "new"
   | "reviewing"
   | "attached_to_source_file"
+  | "attached_to_candidate_intake"
+  | "attached_to_existing_dossier_update"
   | "converted_to_source_file"
   | "identity_link_created"
   | "ignored"
@@ -352,6 +355,7 @@ export type DossierRecommendationIngestSource =
   | "bnl"
   | "bnl_dynamic_candidate_discovery"
   | "bnl_source_knowledge_bridge"
+  | "bnl_source_file_enrichment"
   | "system"
   | "unknown";
 
@@ -367,6 +371,7 @@ export type DossierRecommendation = {
   evidenceSummary?: string;
   confidence?: "low" | "medium" | "high";
   sourceLanes: DossierRecommendationSourceLane[];
+  sourceTypes?: string[];
   suggestedAction?: string;
   missingInfo?: string[];
   publicSafetyNotes?: string[];
@@ -677,6 +682,7 @@ export type CreateDossierRecommendationInput = {
   evidenceSummary?: string;
   confidence?: "low" | "medium" | "high";
   sourceLanes?: DossierRecommendationSourceLane[];
+  sourceTypes?: string[];
   suggestedAction?: string;
   missingInfo?: string[];
   publicSafetyNotes?: string[];
@@ -967,6 +973,14 @@ export const DOSSIER_SOURCE_BOUNDARIES: DossierSourceBoundary[] = [
       "BNL dynamic discovery creates Candidate Intake records first; it never publishes, drafts, confirms aliases, creates tags, or opens active Source Files automatically.",
     allowedUse:
       "May create an admin-only Candidate Intake record when no exact or possible existing source-file match is found; admin promotion is required before active source-file work.",
+  },
+  {
+    source: "bnl_source_file_enrichment",
+    label: "BNL Source File Enrichment",
+    boundary:
+      "BNL-generated enrichment is review-only internal case-file material; it is not discovery, public copy, or publication approval.",
+    allowedUse:
+      "May attach to an existing workflow lane for owner/admin review; it never creates public dossiers, confirms aliases, merges identities, or publishes by itself.",
   },
   {
     source: "combined",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -3752,3 +3752,204 @@ test("BNL-ingested recommendations stay out of public read model and database pa
     /sourceFileNotes|recommendations|identityLinks|Private Ingest Signal|brand-new-private-tag/,
   );
 });
+
+test("BNL Source File enrichment preserves provenance and attaches to an active Source File without public side effects", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const beforePublic = JSON.stringify(databasePage.entries);
+
+  const intake = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Enrichment Active Subject",
+    reason: "BNL dynamic discovery found the active subject.",
+    evidenceSummary: "Starter evidence.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:enrichment-active-subject:discovery",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  const promoted = await (await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: intake.candidate.id,
+  })).json();
+  assert.equal(promoted.candidate.status, "active_source_file");
+
+  const response = await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "Enrichment Active Subject",
+    targetCandidateId: intake.candidate.id,
+    reason: "BNL generated source-file enrichment for review.",
+    evidenceSummary: {
+      observedFacts: ["Active source enrichment fact."],
+      warnings: ["Needs owner review."],
+      missingInfo: ["Confirm public-safe source."],
+      doNotSay: ["Do not publish internal language."],
+    },
+    confidence: "medium",
+    sourceLanes: ["active_source_file", "rd_knowledge_store"],
+    sourceTypes: ["source_file_note", "public_safety_note"],
+    missingInfo: ["Confirm public-safe source."],
+    publicSafetyNotes: ["Review-only; not public copy."],
+    doNotSay: ["Do not publish internal language."],
+    ingestKey: "bnl:enrichment-active-subject:enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.autoAction, "attached_existing");
+  assert.equal(payload.candidate, undefined);
+  assert.equal(payload.recommendation.ingestSource, "bnl_source_file_enrichment");
+  assert.equal(payload.recommendation.ingestKey, "bnl:enrichment-active-subject:enrichment");
+  assert.equal(payload.recommendation.status, "attached_to_source_file");
+  assert.equal(payload.recommendation.targetCandidateId, intake.candidate.id);
+  assert.deepEqual(payload.recommendation.sourceLanes, ["admin_manual", "rd_context"]);
+  assert.deepEqual(payload.recommendation.sourceTypes, ["source_file_note", "public_safety_note"]);
+  assert.match(payload.recommendation.evidenceSummary, /observedFacts/);
+  assert.deepEqual(payload.recommendation.missingInfo, ["Confirm public-safe source."]);
+  assert.deepEqual(payload.recommendation.doNotSay, ["Do not publish internal language."]);
+  assert.deepEqual(payload.recommendation.publicSafetyNotes.slice(0, 1), ["Review-only; not public copy."]);
+  assert.match(payload.recommendation.publicSafetyNotes.join(" "), /Active BNL Source File/);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  const active = state.candidates[0];
+  assert.equal(active.status, "active_source_file");
+  assert.equal(active.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(active.sourceFileNotes[0].ingestKey, "bnl:enrichment-active-subject:enrichment");
+  assert.equal(active.sourceFileNotes[0].publicSafe, false);
+  assert.match(active.sourceFileNotes[0].text, /BNL Source File Enrichment/);
+  assert.match(active.sourceFileNotes[0].text, /source_file_note, public_safety_note/);
+  assert.equal(state.drafts.length, 0);
+
+  const protectedPayload = await (await sourceFilesGet("?candidateId=" + encodeURIComponent(intake.candidate.id))).json();
+  assert.equal(protectedPayload.found, true);
+  assert.equal(protectedPayload.sourceFile.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(protectedPayload.sourceFile.attachedRecommendations[0].ingestSource, "bnl_source_file_enrichment");
+  assert.deepEqual(protectedPayload.sourceFile.attachedRecommendations[0].sourceTypes, ["source_file_note", "public_safety_note"]);
+  assert.equal(protectedPayload.sourceFile.visibility.publicUse, false);
+  assert.equal(protectedPayload.sourceFile.visibility.publicUseReviewRequired, true);
+
+  const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  assert.doesNotMatch(JSON.stringify(publicPayload), /Enrichment Active Subject|bnl_source_file_enrichment|source_file_note/);
+});
+
+test("BNL Source File enrichment attaches to Candidate Intake and Existing Dossier Update without promotion or public edits", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const beforePublic = JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit"));
+
+  const intake = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Enrichment Intake Subject",
+    reason: "BNL discovered an intake subject.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:enrichment-intake-subject:discovery",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  assert.equal(intake.candidate.status, "candidate_intake");
+
+  const intakeEnrichment = await (await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "Enrichment Intake Subject",
+    targetCandidateId: intake.candidate.id,
+    reason: "BNL generated intake enrichment for review.",
+    evidenceSummary: "Candidate Intake enrichment only.",
+    sourceLanes: ["candidate_intake"],
+    sourceTypes: ["intake_enrichment"],
+    ingestKey: "bnl:enrichment-intake-subject:enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+  })).json();
+  assert.equal(intakeEnrichment.autoAction, "attached_existing");
+  assert.equal(intakeEnrichment.recommendation.status, "attached_to_candidate_intake");
+  assert.equal(intakeEnrichment.recommendation.ingestSource, "bnl_source_file_enrichment");
+  let state = await store.getDossierWorkflowState();
+  let intakeCandidate = state.candidates.find((candidate) => candidate.id === intake.candidate.id);
+  assert.equal(intakeCandidate.status, "candidate_intake");
+  assert.equal(intakeCandidate.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+
+  const existingUpdate = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "6 Bit",
+    reason: "Bridge found an existing public dossier update lane.",
+    sourceLanes: ["website_dossier"],
+    ingestKey: "bnl:enrichment-existing-update:bridge",
+    ingestSource: "bnl_source_knowledge_bridge",
+  })).json();
+  assert.equal(existingUpdate.candidate.status, "existing_dossier_update");
+
+  const updateEnrichment = await (await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "6 Bit",
+    targetCandidateId: existingUpdate.candidate.id,
+    reason: "BNL generated existing dossier update enrichment.",
+    evidenceSummary: "Existing Dossier Update enrichment only.",
+    sourceLanes: ["existing_dossier_update"],
+    sourceTypes: ["existing_dossier_update_note"],
+    ingestKey: "bnl:enrichment-existing-update:enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+  })).json();
+  assert.equal(updateEnrichment.autoAction, "attached_existing");
+  assert.equal(updateEnrichment.recommendation.status, "attached_to_existing_dossier_update");
+  state = await store.getDossierWorkflowState();
+  const updateCandidate = state.candidates.find((candidate) => candidate.id === existingUpdate.candidate.id);
+  assert.equal(updateCandidate.status, "existing_dossier_update");
+  assert.equal(updateCandidate.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit")), beforePublic);
+  assert.equal(state.drafts.length, 0);
+});
+
+test("BNL Source File enrichment without target remains in inbox and cannot convert to a new candidate", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const payload = await (await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "Untargeted Enrichment Subject",
+    reason: "BNL generated enrichment without a safe target.",
+    evidenceSummary: "Review-only enrichment should not create intake.",
+    sourceLanes: ["source_file_enrichment"],
+    sourceTypes: ["untargeted_enrichment"],
+    missingInfo: ["Resolve exact target."],
+    publicSafetyNotes: ["Owner/admin review required."],
+    doNotSay: ["Do not create public copy."],
+    ingestKey: "bnl:untargeted-enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+  })).json();
+
+  assert.equal(payload.autoAction, "left_for_review");
+  assert.equal(payload.candidate, undefined);
+  assert.equal(payload.recommendation.status, "new");
+  assert.equal(payload.recommendation.ingestSource, "bnl_source_file_enrichment");
+  assert.deepEqual(payload.recommendation.sourceLanes, ["admin_manual"]);
+  assert.deepEqual(payload.recommendation.sourceTypes, ["untargeted_enrichment"]);
+  assert.match(payload.recommendation.publicSafetyNotes.join(" "), /left in Recommendation Inbox/);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 0);
+  assert.equal(state.drafts.length, 0);
+  assert.equal(state.recommendations.length, 1);
+
+  const convertResponse = await authedPost({
+    action: "convertRecommendationToCandidate",
+    recommendationId: payload.recommendation.id,
+  });
+  assert.equal(convertResponse.status, 400);
+  assert.equal((await convertResponse.json()).code, "enrichment_cannot_create_candidate");
+});
+
+test("admin dossier UI labels BNL Source File enrichment separately from bridge and discovery", () => {
+  const dashboard = source("src/app/admin/dossiers/page.tsx");
+  const recommendationPage = source("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx");
+  const candidatePage = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+
+  assert.match(dashboard, /BNL Source File Enrichment/);
+  assert.match(dashboard, /Review-only internal case-file material; not public copy/);
+  assert.match(recommendationPage, /BNL Source File Enrichment/);
+  assert.match(recommendationPage, /not candidate discovery/);
+  assert.match(recommendationPage, /not raw bridge intake/);
+  assert.match(recommendationPage, /Owner\/admin review is required before any public use/);
+  assert.match(candidatePage, /BNL Source File Enrichment/);
+  assert.match(candidatePage, /Internal case-file material/);
+});

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -1050,3 +1050,69 @@ test("BNL source file read model keeps public endpoint separate and does not exp
   assert.deepEqual(findForbiddenKeys(internalPayload), []);
   assert.doesNotMatch(JSON.stringify(internalPayload), /test-source-file-read-token|stripeSessionId|customerId|accountId|paymentIntent|submitterToken|fileUrl|contactEmail/);
 });
+
+test("BNL source file read model includes Source File Enrichment notes only in protected source files", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState({
+    candidate: {
+      id: "candidate_enrichment_subject",
+      name: "Enrichment Read Subject",
+      status: "active_source_file",
+      sourceFileNotes: [
+        {
+          id: "note_enrichment_subject",
+          candidateId: "candidate_enrichment_subject",
+          type: "general_note",
+          text: "BNL Source File Enrichment origin. Review-only internal case-file material; not public copy. Owner/admin review required before public use.",
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          ingestSource: "bnl_source_file_enrichment",
+          ingestKey: "bnl:enrichment-read-subject",
+          createdAt: "2026-05-30T00:00:00.000Z",
+          updatedAt: "2026-05-30T00:00:00.000Z",
+        },
+      ],
+    },
+    recommendations: [
+      {
+        id: "rec_enrichment_subject",
+        type: "modify_existing_dossier",
+        subjectName: "Enrichment Read Subject",
+        targetCandidateId: "candidate_enrichment_subject",
+        status: "attached_to_source_file",
+        reason: "BNL generated review-only source-file enrichment.",
+        evidenceSummary: JSON.stringify({ observedFacts: ["Internal enrichment fact"], warnings: ["Do not publish raw note"] }),
+        confidence: "medium",
+        sourceLanes: ["admin_manual", "rd_context"],
+        sourceTypes: ["source_file_note", "warning"],
+        ingestKey: "bnl:enrichment-read-subject",
+        ingestSource: "bnl_source_file_enrichment",
+        publicSafetyNotes: ["Review-only internal case-file material."],
+        missingInfo: ["Confirm owner-approved public copy."],
+        doNotSay: ["Do not publish raw note."],
+        createdAt: "2026-05-30T00:00:00.000Z",
+        updatedAt: "2026-05-30T00:00:00.000Z",
+      },
+    ],
+    drafts: [],
+  });
+
+  const payload = await (await sourceFilesGet("?subject=Enrichment%20Read%20Subject")).json();
+  assert.equal(payload.found, true);
+  assert.equal(payload.sourceFile.candidateId, candidate.id);
+  assert.equal(payload.sourceFile.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(payload.sourceFile.sourceFileNotes[0].publicSafe, false);
+  assert.equal(payload.sourceFile.attachedRecommendations[0].ingestSource, "bnl_source_file_enrichment");
+  assert.deepEqual(payload.sourceFile.attachedRecommendations[0].sourceTypes, ["source_file_note", "warning"]);
+  assert.match(payload.sourceFile.attachedRecommendations[0].evidenceSummary, /observedFacts/);
+  assert.equal(payload.sourceFile.visibility.publicUse, false);
+  assert.equal(payload.sourceFile.visibility.publicUseReviewRequired, true);
+
+  const publicPayload = await modelJson();
+  assert.doesNotMatch(
+    JSON.stringify(publicPayload),
+    /Enrichment Read Subject|bnl_source_file_enrichment|Internal enrichment fact|source_file_note/,
+  );
+});


### PR DESCRIPTION
### Motivation
- Treat BNL-generated source-file enrichment as a distinct, review-only ingest source so enrichment packets are preserved and routed safely instead of collapsing into bridge/discovery material.
- Ensure admins can see provenance and structured enrichment metadata, attach enrichment to the correct workflow lane, and keep all enrichment internal/not-public by default.

### Description
- Introduced `bnl_source_file_enrichment` to ingest/source unions, added `sourceTypes` on recommendations, and new terminal statuses for enrichment attachment lanes (`attached_to_candidate_intake`, `attached_to_existing_dossier_update`).
- Updated the BNL ingest route to accept `bnl_source_file_enrichment`, normalize enrichment/bridge lane aliases, preserve structured `evidenceSummary` JSON, and accept `sourceTypes` from payloads.
- Implemented enrichment routing in the workflow store so targeted enrichment attaches as review-only notes to Active Source Files, Candidate Intake, or Existing Dossier Update lanes and untargeted enrichment stays in the Recommendation Inbox; enrichment cannot auto-create new candidates.
- Surface enrichment clearly in admin UI: dashboard provenance, recommendation detail, and candidate/source-file note views now label enrichment as “BNL Source File Enrichment” with review-only/internal/not-public badges; protected source-file read model preserves enrichment notes and `sourceTypes` while public read model remains unchanged.

### Testing
- Ran type-check and lint: `npx tsc --noEmit` and `npx eslint` on changed files, both succeeded.
- Ran unit/integration suites: `node --test tests/admin-dossiers.test.mjs`, `node --test tests/bnl-read-model.test.mjs`, and `npm run test:queue`, all tests passed (admin tests: 80 passed, read-model tests: 31 passed, combined queue tests: 117 passed).
- Verified targeted scenarios in tests: attachment to active source file, intake attachment, existing-dossier-update attachment, untargeted-inbox behavior, blocked auto-conversion, metadata preservation, and UI labeling all pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba0ae06c48321a73b6806307bc248)