### PR TITLE
Existing Dossier Update lookup + admin naming cleanup

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -416,7 +416,7 @@ export default function CandidateReviewPage() {
       void loadWorkflow()
         .catch((err) =>
           setError(
-            err instanceof Error ? err.message : "Failed to load candidate.",
+            err instanceof Error ? err.message : "Failed to load workflow record.",
           ),
         )
         .finally(() => setLoading(false));
@@ -559,11 +559,11 @@ export default function CandidateReviewPage() {
     try {
       const data = await postWorkflow({ action, candidateId });
       setNotice(
-        `${data.candidate?.name ?? "Candidate"} updated. Workflow records remain internal only.`,
+        `${data.candidate?.name ?? "Workflow record"} updated. Workflow records remain internal only.`,
       );
     } catch (err) {
       setNotice(
-        err instanceof Error ? err.message : "Failed to update candidate.",
+        err instanceof Error ? err.message : "Failed to update workflow record.",
       );
     }
   }
@@ -605,14 +605,14 @@ export default function CandidateReviewPage() {
         action === "archiveCandidate"
           ? "Source file archived. It is removed from active dashboard lanes without deleting public dossiers or published data."
           : action === "restoreCandidate"
-            ? "Source file restored to Candidate Intake so it can be reviewed and promoted again if needed."
+            ? "Workflow record restored to intake review so it can be reviewed and promoted again if needed."
             : action === "permanentlyDeleteCandidate"
               ? "Source file permanently deleted from unpublished workflow records. Public dossiers were not changed."
               : action === "attachCandidateToExistingDossier"
                 ? "Existing public dossier target attached. Public dossier content was not changed."
                 : action === "markCandidateAsExistingDossierUpdate"
-                  ? "Source file moved to Existing Dossier Updates / Enrichment. Public dossier content was not changed."
-                  : "Candidate promoted to an Active BNL Source File. Public dossiers were not changed.",
+                  ? "Workflow record moved to Existing Dossier Updates / Enrichment. Public dossier content was not changed."
+                  : "Intake item promoted to an active BNL Source File. Public dossiers were not changed.",
       );
     } catch (err) {
       setNotice(
@@ -744,7 +744,7 @@ export default function CandidateReviewPage() {
           </p>
           {isExistingDossierUpdate && (
             <p className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
-              This is not a new dossier candidate. This is review material for an existing public dossier.
+              This workflow record is an existing dossier update / enrichment target, not a new dossier proposal.
             </p>
           )}
           <div className="mt-4">

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -428,7 +428,7 @@ export default function DossierControlCenterPage() {
         state: target?.status === "active_source_file"
           ? "BNL Source File Enrichment / Active Source File"
           : target?.status === "candidate_intake"
-            ? "BNL Source File Enrichment / Candidate Intake"
+            ? "BNL Source File Enrichment / Intake Item"
             : target?.status === "existing_dossier_update"
               ? "BNL Source File Enrichment / Existing Dossier Update"
               : "BNL Source File Enrichment / Recommendation Inbox",
@@ -465,7 +465,7 @@ export default function DossierControlCenterPage() {
     }
     return {
       match,
-      state: "No BNL Source File match / Candidate Intake / Newly Discovered",
+      state: "No active source file match / Intake Item / Newly Discovered",
       nextAction: "Stage for intake, then promote if accepted",
     };
   }
@@ -508,11 +508,11 @@ export default function DossierControlCenterPage() {
     try {
       const data = await postWorkflow({ action, candidateId });
       setNotice(
-        `${data.candidate?.name ?? "Candidate"} updated. Workflow records remain internal only.`,
+        `${data.candidate?.name ?? "Workflow record"} updated. Workflow records remain internal only.`,
       );
     } catch (err) {
       setNotice(
-        err instanceof Error ? err.message : "Failed to update candidate.",
+        err instanceof Error ? err.message : "Failed to update workflow record.",
       );
     }
   }
@@ -581,7 +581,7 @@ export default function DossierControlCenterPage() {
         action === "archiveCandidate"
           ? `${candidate.name} archived. It moved out of active dashboard lanes and public dossiers were not changed.`
           : action === "restoreCandidate"
-            ? `${candidate.name} restored to Candidate Intake. Public dossiers were not changed.`
+            ? `${candidate.name} restored to intake review. Public dossiers were not changed.`
             : action === "permanentlyDeleteCandidate"
               ? `${candidate.name} permanently deleted from unpublished workflow records. Public dossiers were not changed.`
               : action === "attachCandidateToExistingDossier"
@@ -912,7 +912,7 @@ export default function DossierControlCenterPage() {
 
         <DashboardCard
           eyebrow="Candidate Intake"
-          title="Candidate Intake / Newly Discovered"
+          title="Intake Items / Newly Discovered"
           aside={<StatusPill>{candidateIntakeItems.length} staged items</StatusPill>}
         >
           <p className="text-sm text-muted mb-4">
@@ -923,7 +923,7 @@ export default function DossierControlCenterPage() {
           </p>
           {candidateIntakeItems.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No newly discovered Candidate Intake items are waiting.
+              No newly discovered intake items are waiting.
             </p>
           ) : (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
@@ -933,7 +933,7 @@ export default function DossierControlCenterPage() {
                     <div>
                       <p className="font-bold text-foreground">{candidate.name}</p>
                       <p>Source: {candidateProvenance(candidate)}</p>
-                      <p>Status/stage: Candidate Intake / {candidate.status}</p>
+                      <p>Status/stage: Intake item / {candidate.status}</p>
                       {(candidate.publicSafetyNotes ?? []).length > 0 && (
                         <p className="text-accent">Warning badges: source warnings present</p>
                       )}
@@ -962,8 +962,8 @@ export default function DossierControlCenterPage() {
 
         <DashboardCard
           eyebrow="Existing dossier updates"
-          title="Existing Dossier Updates / Enrichment Candidates"
-          aside={<StatusPill>{existingDossierUpdates.length} update candidates</StatusPill>}
+          title="Existing Dossier Updates / Enrichment Targets"
+          aside={<StatusPill>{existingDossierUpdates.length} update records</StatusPill>}
         >
           <p className="text-sm text-muted mb-4">
             Exact public dossier matches are staged as proposed updates/enrichment
@@ -972,7 +972,7 @@ export default function DossierControlCenterPage() {
           </p>
           {existingDossierUpdates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No existing public dossier update candidates are waiting.
+              No existing public dossier update records are waiting.
             </p>
           ) : (
             <div className="space-y-3">
@@ -1357,7 +1357,7 @@ export default function DossierControlCenterPage() {
           </p>
           {archivedCandidates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No archived Candidate Intake or Source File items.
+              No archived workflow records.
             </p>
           ) : (
             <div className="space-y-2 text-sm text-muted">
@@ -1444,7 +1444,7 @@ export default function DossierControlCenterPage() {
             </li>
           </ul>
           <p className="text-xs text-muted">
-            Dedicated pages keep operators in one lane: candidate review,
+            Dedicated pages keep operators in one lane: workflow record review,
             focused draft editor, owner review, or merge review. Dashboard
             buttons navigate; there is no hidden editor below unrelated sections
             and no dashboard auto-scroll workflow.

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -167,7 +167,7 @@ function terminalRecommendationMessage(recommendation: DossierRecommendation) {
     return "Attached to matched BNL Source File.";
   }
   if (recommendation.status === "attached_to_candidate_intake") {
-    return "Attached to Candidate Intake as review-only enrichment.";
+    return "Attached to intake item as review-only enrichment.";
   }
   if (recommendation.status === "attached_to_existing_dossier_update") {
     return "Attached to Existing Dossier Update as review-only enrichment.";
@@ -302,7 +302,7 @@ export default function DossierRecommendationPage() {
       ? targetCandidate?.status === "active_source_file"
         ? "Active Source File"
         : targetCandidate?.status === "candidate_intake"
-          ? "Candidate Intake"
+          ? "Intake Item"
           : targetCandidate?.status === "existing_dossier_update"
             ? "Existing Dossier Update"
             : "Recommendation Inbox"
@@ -476,14 +476,14 @@ export default function DossierRecommendationPage() {
                   href={`/admin/dossiers/candidates/${targetCandidate.id}`}
                   className="mt-2 inline-flex text-accent hover:underline"
                 >
-                  Open target BNL Source File: {targetCandidate.name}
+                  Open target workflow record: {targetCandidate.name}
                 </Link>
               ) : recommendation.targetCandidateId ? (
                 <Link
                   href={`/admin/dossiers/candidates/${recommendation.targetCandidateId}`}
                   className="mt-2 inline-flex text-accent hover:underline"
                 >
-                  Open target BNL Source File
+                  Open target workflow record
                 </Link>
               ) : null}
               <p className="mt-2 text-xs uppercase tracking-widest text-muted">
@@ -665,13 +665,13 @@ export default function DossierRecommendationPage() {
               </h2>
               <p className="text-sm text-muted mt-2">
                 Recommendation subject: {recommendation.subjectName}. This creates
-                a proposed alias on the selected BNL Source File only. It does not
+                a proposed alias on the selected workflow record only. It does not
                 confirm the alias, publish, merge source files, create a draft, or
                 create tags.
               </p>
               {preselectedCandidateId && (
                 <p className="mt-2 text-sm text-accent">
-                  Matched/pre-targeted BNL Source File: {targetCandidate?.name ?? exactCandidate?.name ?? possibleCandidates[0]?.name}
+                  Matched/pre-targeted enrichment target: {targetCandidate?.name ?? exactCandidate?.name ?? possibleCandidates[0]?.name}
                 </p>
               )}
             </div>

--- a/src/app/api/bnl/source-files/route.ts
+++ b/src/app/api/bnl/source-files/route.ts
@@ -52,7 +52,15 @@ type MatchKind =
   | "name"
   | "compact_name"
   | "normalized_name"
-  | "confirmed_alias";
+  | "confirmed_alias"
+  | "candidate_intake_name"
+  | "candidate_intake_compact_name"
+  | "candidate_intake_normalized_name"
+  | "candidate_intake_confirmed_alias"
+  | "existing_dossier_update_name"
+  | "existing_dossier_update_compact_name"
+  | "existing_dossier_update_normalized_name"
+  | "existing_dossier_update_confirmed_alias";
 
 type PossibleMatchKind =
   | "same_name"
@@ -60,14 +68,25 @@ type PossibleMatchKind =
   | "unconfirmed_alias"
   | "partial_name";
 
+type WorkflowLane =
+  | "candidate_intake"
+  | "active_source_file"
+  | "existing_dossier_update";
+
 type QueryMode = "candidateId" | "subject" | "alias" | "normalizedName";
 
+type AliasMatchKind = Extract<MatchKind, `${string}alias`>;
+type DirectMatchKind = Exclude<MatchKind, AliasMatchKind>;
+
 type ResolvedMatch =
-  | { candidate: DossierCandidate; matchKind: Exclude<MatchKind, "confirmed_alias"> }
+  | {
+      candidate: DossierCandidate;
+      matchKind: DirectMatchKind;
+    }
   | {
       candidate: DossierCandidate;
       alias: DossierIdentityLink;
-      matchKind: "confirmed_alias";
+      matchKind: AliasMatchKind;
     };
 
 type SourceFileSummary = {
@@ -77,7 +96,7 @@ type SourceFileSummary = {
   normalizedName: string;
   candidateType: DossierCandidate["candidateType"];
   status: DossierCandidate["status"];
-  workflowLane: "active_source_file" | "existing_dossier_update";
+  workflowLane: WorkflowLane;
   sourceFileActive: boolean;
   laneDescription: string;
   tier: DossierCandidate["tier"];
@@ -159,7 +178,11 @@ type SourceFileSummary = {
     createdAt: string;
   } | null;
   ownerReview: {
-    status: "waiting" | "changes_requested" | "approved" | "not_in_owner_review";
+    status:
+      | "waiting"
+      | "changes_requested"
+      | "approved"
+      | "not_in_owner_review";
     draftId: string | null;
   };
   duplicateWarnings: {
@@ -186,7 +209,9 @@ function tokenMatches(providedToken: string): boolean {
   if (!expectedToken || !providedToken) return false;
   const expected = Buffer.from(expectedToken);
   const provided = Buffer.from(providedToken);
-  return expected.length === provided.length && timingSafeEqual(expected, provided);
+  return (
+    expected.length === provided.length && timingSafeEqual(expected, provided)
+  );
 }
 
 function cleanQueryValue(value: string | null): string {
@@ -199,7 +224,9 @@ function queryFrom(req: Request): { mode: QueryMode; value: string } | null {
   if (candidateId) return { mode: "candidateId", value: candidateId };
   const alias = cleanQueryValue(url.searchParams.get("alias"));
   if (alias) return { mode: "alias", value: alias };
-  const normalizedName = cleanQueryValue(url.searchParams.get("normalizedName"));
+  const normalizedName = cleanQueryValue(
+    url.searchParams.get("normalizedName"),
+  );
   if (normalizedName) return { mode: "normalizedName", value: normalizedName };
   const subject = cleanQueryValue(url.searchParams.get("subject"));
   if (subject) return { mode: "subject", value: subject };
@@ -208,6 +235,57 @@ function queryFrom(req: Request): { mode: QueryMode; value: string } | null {
 
 function isActiveCandidate(candidate: DossierCandidate): boolean {
   return isActiveSourceFileCandidate(candidate);
+}
+
+function isLookupCandidate(candidate: DossierCandidate): boolean {
+  return (
+    isActiveCandidate(candidate) ||
+    candidate.status === "candidate_intake" ||
+    candidate.status === "existing_dossier_update"
+  );
+}
+
+function workflowLaneFor(candidate: DossierCandidate): WorkflowLane {
+  if (candidate.status === "candidate_intake") return "candidate_intake";
+  if (candidate.status === "existing_dossier_update") {
+    return "existing_dossier_update";
+  }
+  return "active_source_file";
+}
+
+function laneDescriptionFor(candidate: DossierCandidate): string {
+  const lane = workflowLaneFor(candidate);
+  if (lane === "candidate_intake") {
+    return "Candidate Intake / newly discovered subject; not active case-file fact.";
+  }
+  if (lane === "existing_dossier_update") {
+    return "Existing Dossier Update / Enrichment material; not an active Source File and not public copy.";
+  }
+  return "Active BNL Source File / internal working case file.";
+}
+
+function matchKindForLane(
+  candidate: DossierCandidate,
+  baseKind: "name" | "compact_name" | "normalized_name" | "confirmed_alias",
+): MatchKind {
+  const lane = workflowLaneFor(candidate);
+  if (lane === "candidate_intake") {
+    if (baseKind === "name") return "candidate_intake_name";
+    if (baseKind === "compact_name") return "candidate_intake_compact_name";
+    if (baseKind === "normalized_name")
+      return "candidate_intake_normalized_name";
+    return "candidate_intake_confirmed_alias";
+  }
+  if (lane === "existing_dossier_update") {
+    if (baseKind === "name") return "existing_dossier_update_name";
+    if (baseKind === "compact_name")
+      return "existing_dossier_update_compact_name";
+    if (baseKind === "normalized_name") {
+      return "existing_dossier_update_normalized_name";
+    }
+    return "existing_dossier_update_confirmed_alias";
+  }
+  return baseKind;
 }
 
 function noteSummary(note: DossierSourceFileNote): string {
@@ -222,7 +300,8 @@ function hasPartialNameOverlap(query: string, name: string): boolean {
   const compactQuery = compactDossierSubjectName(query);
   const compactName = compactDossierSubjectName(name);
   if (!normalizedQuery || !normalizedName) return false;
-  if (normalizedQuery === normalizedName || compactQuery === compactName) return false;
+  if (normalizedQuery === normalizedName || compactQuery === compactName)
+    return false;
   if (normalizedQuery.length < 4 || normalizedName.length < 4) return false;
   return (
     normalizedQuery.includes(normalizedName) ||
@@ -237,11 +316,15 @@ function possibleMatchSummary(
   matchKind: PossibleMatchKind,
   alias?: DossierIdentityLink,
 ) {
+  const workflowLane = workflowLaneFor(candidate);
   return {
     candidateId: candidate.id,
     name: candidate.name,
     normalizedName: normalizeDossierSubjectName(candidate.name),
     status: candidate.status,
+    workflowLane,
+    sourceFileActive: workflowLane === "active_source_file",
+    laneDescription: laneDescriptionFor(candidate),
     candidateType: candidate.candidateType,
     source: candidate.source,
     confidence: candidate.confidence ?? null,
@@ -266,7 +349,10 @@ function possibleMatchSummary(
   };
 }
 
-function findActiveDraft(drafts: DossierDraft[], candidateId: string): DossierDraft | null {
+function findActiveDraft(
+  drafts: DossierDraft[],
+  candidateId: string,
+): DossierDraft | null {
   return (
     drafts.find(
       (draft) =>
@@ -278,13 +364,17 @@ function findActiveDraft(drafts: DossierDraft[], candidateId: string): DossierDr
   );
 }
 
-function ownerReviewStatus(draft: DossierDraft | null): SourceFileSummary["ownerReview"] {
+function ownerReviewStatus(
+  draft: DossierDraft | null,
+): SourceFileSummary["ownerReview"] {
   if (!draft) return { status: "not_in_owner_review", draftId: null };
-  if (draft.status === "ready_for_owner_review") return { status: "waiting", draftId: draft.id };
+  if (draft.status === "ready_for_owner_review")
+    return { status: "waiting", draftId: draft.id };
   if (draft.status === "owner_changes_requested") {
     return { status: "changes_requested", draftId: draft.id };
   }
-  if (draft.status === "owner_approved") return { status: "approved", draftId: draft.id };
+  if (draft.status === "owner_approved")
+    return { status: "approved", draftId: draft.id };
   return { status: "not_in_owner_review", draftId: draft.id };
 }
 
@@ -295,7 +385,10 @@ function sourceFileReadModel(input: {
 }): SourceFileSummary {
   const activeDraft = findActiveDraft(input.drafts, input.candidate.id);
   const attachedRecommendations = input.recommendations
-    .filter((recommendation) => recommendation.targetCandidateId === input.candidate.id)
+    .filter(
+      (recommendation) =>
+        recommendation.targetCandidateId === input.candidate.id,
+    )
     .slice(0, MAX_RECOMMENDATIONS)
     .map((recommendation) => ({
       id: recommendation.id,
@@ -320,15 +413,9 @@ function sourceFileReadModel(input: {
     normalizedName: normalizeDossierSubjectName(input.candidate.name),
     candidateType: input.candidate.candidateType,
     status: input.candidate.status,
-    workflowLane:
-      input.candidate.status === "existing_dossier_update"
-        ? "existing_dossier_update"
-        : "active_source_file",
-    sourceFileActive: input.candidate.status !== "existing_dossier_update",
-    laneDescription:
-      input.candidate.status === "existing_dossier_update"
-        ? "Update/enrichment material for an existing public dossier; not a new public dossier candidate."
-        : "Active BNL Source File / internal working case file.",
+    workflowLane: workflowLaneFor(input.candidate),
+    sourceFileActive: workflowLaneFor(input.candidate) === "active_source_file",
+    laneDescription: laneDescriptionFor(input.candidate),
     tier: input.candidate.tier,
     score: input.candidate.score,
     confidence: input.candidate.confidence ?? null,
@@ -336,7 +423,8 @@ function sourceFileReadModel(input: {
     sourceLanes: input.candidate.sourceLanes ?? [],
     ingestSource: input.candidate.ingestSource ?? null,
     ingestKey: input.candidate.ingestKey ?? null,
-    createdFromRecommendationId: input.candidate.createdFromRecommendationId ?? null,
+    createdFromRecommendationId:
+      input.candidate.createdFromRecommendationId ?? null,
     reason: input.candidate.reason,
     whyNow: input.candidate.whyNow,
     evidenceSummary: input.candidate.evidenceSummary,
@@ -369,24 +457,27 @@ function sourceFileReadModel(input: {
       createdAt: note.createdAt,
       updatedAt: note.updatedAt,
     })),
-    identityLinks: (input.candidate.identityLinks ?? []).map((identityLink) => ({
-      id: identityLink.id,
-      label: identityLink.label,
-      normalizedLabel: identityLink.normalizedLabel,
-      type: identityLink.type,
-      visibility: identityLink.visibility,
-      status: identityLink.status,
-      source: identityLink.source,
-      confidence: identityLink.confidence ?? null,
-      useForMatching: identityLink.useForMatching,
-      useInPublicDossier: identityLink.useInPublicDossier,
-      note: identityLink.note ?? null,
-      createdFromRecommendationId: identityLink.createdFromRecommendationId ?? null,
-      createdFromRecommendationSubject:
-        identityLink.createdFromRecommendationSubject ?? null,
-      createdAt: identityLink.createdAt,
-      updatedAt: identityLink.updatedAt,
-    })),
+    identityLinks: (input.candidate.identityLinks ?? []).map(
+      (identityLink) => ({
+        id: identityLink.id,
+        label: identityLink.label,
+        normalizedLabel: identityLink.normalizedLabel,
+        type: identityLink.type,
+        visibility: identityLink.visibility,
+        status: identityLink.status,
+        source: identityLink.source,
+        confidence: identityLink.confidence ?? null,
+        useForMatching: identityLink.useForMatching,
+        useInPublicDossier: identityLink.useInPublicDossier,
+        note: identityLink.note ?? null,
+        createdFromRecommendationId:
+          identityLink.createdFromRecommendationId ?? null,
+        createdFromRecommendationSubject:
+          identityLink.createdFromRecommendationSubject ?? null,
+        createdAt: identityLink.createdAt,
+        updatedAt: identityLink.updatedAt,
+      }),
+    ),
     attachedRecommendations,
     activeDraft: activeDraft
       ? {
@@ -414,13 +505,15 @@ function resolveSourceFile(input: {
   value: string;
   candidates: DossierCandidate[];
 }) {
-  const activeCandidates = input.candidates.filter(isActiveCandidate);
+  const lookupCandidates = input.candidates.filter(isLookupCandidate);
   const normalizedValue = normalizeDossierSubjectName(input.value);
   const compactValue = compactDossierSubjectName(input.value);
 
   if (input.mode === "candidateId") {
-    const exact = input.candidates.find((candidate) => candidate.id === input.value);
-    if (exact && (isActiveCandidate(exact) || exact.status === "existing_dossier_update")) {
+    const exact = input.candidates.find(
+      (candidate) => candidate.id === input.value,
+    );
+    if (exact && isLookupCandidate(exact)) {
       return {
         matches: [{ candidate: exact, matchKind: "candidate_id" as const }],
         possibleMatches: [],
@@ -429,24 +522,42 @@ function resolveSourceFile(input: {
     return { matches: [], possibleMatches: [] };
   }
 
-  const directMatches: ResolvedMatch[] = activeCandidates
+  const directMatches: ResolvedMatch[] = lookupCandidates
     .map((candidate): ResolvedMatch | null => {
       const normalizedName = normalizeDossierSubjectName(candidate.name);
       const compactName = compactDossierSubjectName(candidate.name);
-      if (input.mode === "normalizedName" && normalizedValue === normalizedName) {
-        return { candidate, matchKind: "normalized_name" as const };
+      if (
+        input.mode === "normalizedName" &&
+        normalizedValue === normalizedName
+      ) {
+        return {
+          candidate,
+          matchKind: matchKindForLane(
+            candidate,
+            "normalized_name",
+          ) as DirectMatchKind,
+        };
       }
       if (input.mode === "subject" && normalizedValue === normalizedName) {
-        return { candidate, matchKind: "name" as const };
+        return {
+          candidate,
+          matchKind: matchKindForLane(candidate, "name") as DirectMatchKind,
+        };
       }
       if (input.mode === "subject" && compactValue === compactName) {
-        return { candidate, matchKind: "compact_name" as const };
+        return {
+          candidate,
+          matchKind: matchKindForLane(
+            candidate,
+            "compact_name",
+          ) as DirectMatchKind,
+        };
       }
       return null;
     })
     .filter((match): match is ResolvedMatch => Boolean(match));
 
-  const confirmedAliasMatches: ResolvedMatch[] = activeCandidates
+  const confirmedAliasMatches: ResolvedMatch[] = lookupCandidates
     .map((candidate): ResolvedMatch | null => {
       const alias = (candidate.identityLinks ?? []).find(
         (identityLink) =>
@@ -454,22 +565,39 @@ function resolveSourceFile(input: {
           identityLink.useForMatching === true &&
           identityLink.normalizedLabel === normalizedValue,
       );
-      return alias ? { candidate, alias, matchKind: "confirmed_alias" as const } : null;
+      return alias
+        ? {
+            candidate,
+            alias,
+            matchKind: matchKindForLane(
+              candidate,
+              "confirmed_alias",
+            ) as AliasMatchKind,
+          }
+        : null;
     })
     .filter((match): match is ResolvedMatch => Boolean(match));
 
-  const matches = input.mode === "alias" ? confirmedAliasMatches : directMatches;
+  const allMatches =
+    input.mode === "alias" ? confirmedAliasMatches : directMatches;
+  const activeMatches = allMatches.filter((match) =>
+    isActiveCandidate(match.candidate),
+  );
+  const matches = activeMatches.length > 0 ? activeMatches : allMatches;
   const matchedIds = new Set(matches.map((match) => match.candidate.id));
 
-  const possibleMatches = activeCandidates
+  const possibleMatches = lookupCandidates
     .filter((candidate) => !matchedIds.has(candidate.id))
     .flatMap((candidate) => {
       const alias = (candidate.identityLinks ?? []).find(
         (identityLink) =>
           identityLink.normalizedLabel === normalizedValue &&
-          (identityLink.status !== "confirmed" || identityLink.useForMatching !== true),
+          (identityLink.status !== "confirmed" ||
+            identityLink.useForMatching !== true),
       );
-      if (alias) return [possibleMatchSummary(candidate, "unconfirmed_alias", alias)];
+      if (alias) {
+        return [possibleMatchSummary(candidate, "unconfirmed_alias", alias)];
+      }
       const normalizedName = normalizeDossierSubjectName(candidate.name);
       const compactName = compactDossierSubjectName(candidate.name);
       if (normalizedValue === normalizedName) {
@@ -478,7 +606,10 @@ function resolveSourceFile(input: {
       if (compactValue === compactName) {
         return [possibleMatchSummary(candidate, "compact_name")];
       }
-      if (input.mode !== "alias" && hasPartialNameOverlap(input.value, candidate.name)) {
+      if (
+        input.mode !== "alias" &&
+        hasPartialNameOverlap(input.value, candidate.name)
+      ) {
         return [possibleMatchSummary(candidate, "partial_name")];
       }
       return [];
@@ -514,6 +645,11 @@ export async function GET(req: Request) {
 
   if (matches.length === 1) {
     const match = matches[0];
+    const sourceRecord = sourceFileReadModel({
+      candidate: match.candidate,
+      drafts: state.drafts,
+      recommendations: state.recommendations,
+    });
     return NextResponse.json(
       {
         ok: true,
@@ -536,11 +672,12 @@ export async function GET(req: Request) {
                 useInPublicDossier: match.alias.useInPublicDossier,
               }
             : null,
-        sourceFile: sourceFileReadModel({
-          candidate: match.candidate,
-          drafts: state.drafts,
-          recommendations: state.recommendations,
-        }),
+        workflowLane: workflowLaneFor(match.candidate),
+        sourceFileActive:
+          workflowLaneFor(match.candidate) === "active_source_file",
+        laneDescription: laneDescriptionFor(match.candidate),
+        sourceFile: sourceRecord,
+        sourceRecord,
         possibleMatches,
         readModelBoundary: VISIBILITY_BOUNDARY,
         generatedAt: new Date().toISOString(),
@@ -552,7 +689,7 @@ export async function GET(req: Request) {
   const multipleMatches = matches.map((match) =>
     possibleMatchSummary(
       match.candidate,
-      match.matchKind === "confirmed_alias" ? "unconfirmed_alias" : "same_name",
+      match.matchKind.includes("alias") ? "unconfirmed_alias" : "same_name",
       "alias" in match ? match.alias : undefined,
     ),
   );

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -284,7 +284,7 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
     "Delete Permanently",
     "Move to Existing Dossier Update",
     "Attach to Existing Public Dossier",
-    "Existing Dossier Updates / Enrichment Candidates",
+    "Existing Dossier Updates / Enrichment Targets",
     "owner approval required before public changes",
     "DELETE SOURCE FILE",
     "Safe cleanup: move this source file out of active dashboard lanes without deleting public dossiers or published data.",
@@ -514,7 +514,7 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Possible connection, not confirmed identity",
     "Existing Public Dossier Match",
     "No existing public dossier match currently attached.",
-    "This is not a new dossier candidate. This is review material for an existing public dossier.",
+    "This workflow record is an existing dossier update / enrichment target, not a new dossier proposal.",
     "Move Back to Active Source File",
   ]) {
     assertIncludesCopy(pageCopy, label);
@@ -2911,7 +2911,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Matched existing BNL Source File/);
   assert.match(dashboard, /Pre-targeted BNL Source File/);
   assert.match(dashboard, /Possible duplicate \/ identity warning/);
-  assert.match(dashboard, /No BNL Source File match/);
+  assert.match(dashboard, /No active source file match/);
   assert.match(dashboard, /Review Recommendation/);
   assert.match(dashboard, /archiveDossierRecommendation/);
   assert.doesNotMatch(dashboard, /Attach to Existing Source File/);
@@ -2926,7 +2926,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(sourceFilePage, /Save Info/);
   assert.match(sourceFilePage, /Identity \/ Alias Review/);
   assert.match(sourceFilePage, /Aliases help BNL route future recommendations/);
-  assert.match(sourceFilePage, /Internal aliases are not public dossier text/);
+  assert.match(sourceFilePage, /Internal aliases are not\s+public dossier text/);
   assert.match(sourceFilePage, /Add Identity Link/);
   assert.match(dashboard, /Aliases: /);
   assert.match(dashboard, /Identity warnings/);
@@ -3324,8 +3324,9 @@ test("BNL Source Knowledge Bridge new-subject recommendations create Candidate I
   assert.equal(adminPayload.drafts.length, 0);
 
   const intakeProtectedPayload = await (await sourceFilesGet("?subject=Bridge%20Memory%20Subject")).json();
-  assert.equal(intakeProtectedPayload.found, false);
-  assert.match(intakeProtectedPayload.reason, /No BNL Source File match found/);
+  assert.equal(intakeProtectedPayload.found, true);
+  assert.equal(intakeProtectedPayload.sourceFile.workflowLane, "candidate_intake");
+  assert.equal(intakeProtectedPayload.sourceFile.sourceFileActive, false);
 
   const promoted = await (await authedPost({
     action: "promoteCandidateToSourceFile",
@@ -3546,7 +3547,9 @@ test("Candidate Intake promotion, archive/restore, and protected delete keep sou
   assert.equal(intake.candidate.status, "candidate_intake");
   assert.equal((await sourceFilesGet("?subject=Cleanup%20Intake%20Subject")).status, 200);
   const intakeRead = await (await sourceFilesGet("?subject=Cleanup%20Intake%20Subject")).json();
-  assert.equal(intakeRead.found, false);
+  assert.equal(intakeRead.found, true);
+  assert.equal(intakeRead.sourceFile.workflowLane, "candidate_intake");
+  assert.equal(intakeRead.sourceFile.sourceFileActive, false);
 
   const promoted = await (await authedPost({
     action: "promoteCandidateToSourceFile",
@@ -3683,14 +3686,16 @@ test("active Source File with an existing public dossier match reclassifies to E
   assert.equal(updateLaneCandidate.existingDossierMatch.name, "Mac Modem");
 
   const subjectRead = await (await sourceFilesGet(`?subject=${encodeURIComponent("Mac Modem")}`)).json();
-  assert.equal(subjectRead.found, false);
-  assert.match(subjectRead.reason, /No BNL Source File match found/);
+  assert.equal(subjectRead.found, true);
+  assert.equal(subjectRead.matchKind, "existing_dossier_update_name");
+  assert.equal(subjectRead.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(subjectRead.sourceFile.sourceFileActive, false);
 
   const candidateRead = await (await sourceFilesGet(`?candidateId=${encodeURIComponent(created.candidate.id)}`)).json();
   assert.equal(candidateRead.found, true);
   assert.equal(candidateRead.sourceFile.workflowLane, "existing_dossier_update");
   assert.equal(candidateRead.sourceFile.sourceFileActive, false);
-  assert.match(candidateRead.sourceFile.laneDescription, /update\/enrichment material/i);
+  assert.match(candidateRead.sourceFile.laneDescription, /Existing Dossier Update \/ Enrichment material/);
   assert.equal(candidateRead.sourceFile.duplicateWarnings.existingDossierMatch.name, "Mac Modem");
 
   const publicReadModelPayload = await (await readModel.GET(

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -808,7 +808,7 @@ test("BNL source file read model requires the private read token", async () => {
   assert.equal((await sourceFilesGet("?subject=Signal%20Witch", "wrong-token")).status, 401);
 });
 
-test("BNL source file read model resolves subject and returns bounded provenance and safety metadata", async () => {
+test("BNL source file read model resolves active Source Files by subject and returns bounded provenance and safety metadata", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
   const candidate = await seedSourceFileReadModelState();
@@ -822,6 +822,11 @@ test("BNL source file read model resolves subject and returns bounded provenance
   assert.equal(payload.found, true);
   assert.equal(payload.mutation, false);
   assert.equal(payload.matchKind, "name");
+  assert.equal(payload.workflowLane, "active_source_file");
+  assert.equal(payload.sourceFileActive, true);
+  assert.equal(payload.sourceFile.workflowLane, "active_source_file");
+  assert.equal(payload.sourceFile.sourceFileActive, true);
+  assert.equal(payload.sourceRecord.candidateId, candidate.id);
   assert.equal(payload.sourceFile.candidateId, candidate.id);
   assert.equal(payload.sourceFile.name, "Signal Witch");
   assert.equal(payload.sourceFile.normalizedName, "signal witch");
@@ -938,6 +943,138 @@ test("BNL source file read model resolves candidateId and normalizedName lookups
   assert.equal(byNormalizedName.matchKind, "normalized_name");
 });
 
+test("BNL source file read model resolves Existing Dossier Updates by exact subject when no active Source File exists", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState({
+    candidate: {
+      id: "candidate_hellcatnz_update",
+      name: "HellcatNZ",
+      status: "existing_dossier_update",
+      existingDossierMatch: { id: "hellcatnz", name: "HellcatNZ", confidence: "high" },
+    },
+    drafts: [],
+  });
+
+  const payload = await (await sourceFilesGet("?subject=HellcatNZ")).json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.found, true);
+  assert.equal(payload.matchKind, "existing_dossier_update_name");
+  assert.equal(payload.workflowLane, "existing_dossier_update");
+  assert.equal(payload.sourceFileActive, false);
+  assert.equal(payload.laneDescription, "Existing Dossier Update / Enrichment material; not an active Source File and not public copy.");
+  assert.equal(payload.sourceFile.candidateId, candidate.id);
+  assert.equal(payload.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(payload.sourceFile.sourceFileActive, false);
+  assert.equal(payload.sourceRecord.workflowLane, "existing_dossier_update");
+  assert.match(payload.readModelBoundary.boundaryLabel, /internal working case file; not a public dossier/);
+});
+
+test("BNL source file read model resolves Existing Dossier Updates by candidateId, alias, and normalizedName with lane labels", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const candidate = await seedSourceFileReadModelState({
+    candidate: {
+      id: "candidate_update_alias_lookup",
+      name: "Existing Update Target",
+      status: "existing_dossier_update",
+      identityLinks: [
+        {
+          id: "alias_update_lookup",
+          candidateId: "candidate_update_alias_lookup",
+          label: "Update Alias",
+          normalizedLabel: workflow.normalizeDossierSubjectName("Update Alias"),
+          type: "alias",
+          visibility: "internal_only",
+          status: "confirmed",
+          source: "owner_confirmed",
+          confidence: "confirmed",
+          useForMatching: true,
+          useInPublicDossier: false,
+          createdAt: "2026-05-30T00:00:00.000Z",
+          updatedAt: "2026-05-30T00:00:00.000Z",
+        },
+      ],
+    },
+    drafts: [],
+  });
+
+  const byId = await (await sourceFilesGet(`?candidateId=${candidate.id}`)).json();
+  assert.equal(byId.found, true);
+  assert.equal(byId.matchKind, "candidate_id");
+  assert.equal(byId.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(byId.sourceFile.sourceFileActive, false);
+
+  const byNormalized = await (await sourceFilesGet("?normalizedName=existing%20update%20target")).json();
+  assert.equal(byNormalized.found, true);
+  assert.equal(byNormalized.matchKind, "existing_dossier_update_normalized_name");
+  assert.equal(byNormalized.sourceFile.workflowLane, "existing_dossier_update");
+
+  const byAlias = await (await sourceFilesGet("?alias=Update%20Alias")).json();
+  assert.equal(byAlias.found, true);
+  assert.equal(byAlias.matchKind, "existing_dossier_update_confirmed_alias");
+  assert.equal(byAlias.matchedAlias.label, "Update Alias");
+  assert.equal(byAlias.sourceFile.workflowLane, "existing_dossier_update");
+});
+
+test("BNL source file read model resolves Candidate Intake exact lookup with intake lane labels", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  await seedSourceFileReadModelState({
+    candidate: {
+      id: "candidate_intake_lookup",
+      name: "Fresh Intake Target",
+      status: "candidate_intake",
+    },
+    drafts: [],
+  });
+
+  const payload = await (await sourceFilesGet("?subject=Fresh%20Intake%20Target")).json();
+  assert.equal(payload.found, true);
+  assert.equal(payload.matchKind, "candidate_intake_name");
+  assert.equal(payload.workflowLane, "candidate_intake");
+  assert.equal(payload.sourceFile.workflowLane, "candidate_intake");
+  assert.equal(payload.sourceFile.sourceFileActive, false);
+  assert.equal(payload.sourceFile.laneDescription, "Candidate Intake / newly discovered subject; not active case-file fact.");
+});
+
+test("BNL source file read model keeps active Source File priority over same-name update records", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const active = sourceFileCandidate({
+    id: "candidate_shared_active",
+    name: "Shared Signal",
+    status: "active_source_file",
+  });
+  const update = sourceFileCandidate({
+    id: "candidate_shared_update",
+    name: "Shared Signal",
+    status: "existing_dossier_update",
+    sourceFileNotes: [],
+    identityLinks: [],
+  });
+  await workflowStore.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [update, active],
+    drafts: [],
+    recommendations: [],
+    updatedAt: "2026-05-30T00:00:00.000Z",
+  });
+
+  const payload = await (await sourceFilesGet("?subject=Shared%20Signal")).json();
+  assert.equal(payload.found, true);
+  assert.equal(payload.sourceFile.candidateId, active.id);
+  assert.equal(payload.matchKind, "name");
+  assert.equal(payload.sourceFile.workflowLane, "active_source_file");
+  assert.equal(payload.possibleMatches.some((match) => match.candidateId === update.id && match.workflowLane === "existing_dossier_update"), true);
+
+  const byUpdateId = await (await sourceFilesGet(`?candidateId=${update.id}`)).json();
+  assert.equal(byUpdateId.found, true);
+  assert.equal(byUpdateId.sourceFile.candidateId, update.id);
+  assert.equal(byUpdateId.sourceFile.workflowLane, "existing_dossier_update");
+});
+
 test("BNL source file read model resolves confirmed aliases only", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
@@ -1013,7 +1150,7 @@ test("BNL source file read model does not return archived or denied workflow rec
   assert.equal(deniedPayload.found, false);
 });
 
-test("BNL source file read model labels Existing Dossier Updates only on explicit candidateId lookup", async () => {
+test("BNL source file read model labels Existing Dossier Updates without making them active Source Files", async () => {
   await resetDossierWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
   const candidate = await seedSourceFileReadModelState({
@@ -1025,14 +1162,16 @@ test("BNL source file read model labels Existing Dossier Updates only on explici
   });
 
   const subjectPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();
-  assert.equal(subjectPayload.found, false);
-  assert.match(subjectPayload.reason, /No BNL Source File match found/);
+  assert.equal(subjectPayload.found, true);
+  assert.equal(subjectPayload.matchKind, "existing_dossier_update_name");
+  assert.equal(subjectPayload.sourceFile.workflowLane, "existing_dossier_update");
+  assert.equal(subjectPayload.sourceFile.sourceFileActive, false);
 
   const candidatePayload = await (await sourceFilesGet(`?candidateId=${candidate.id}`)).json();
   assert.equal(candidatePayload.found, true);
   assert.equal(candidatePayload.sourceFile.workflowLane, "existing_dossier_update");
   assert.equal(candidatePayload.sourceFile.sourceFileActive, false);
-  assert.match(candidatePayload.sourceFile.laneDescription, /update\/enrichment material/i);
+  assert.match(candidatePayload.sourceFile.laneDescription, /Existing Dossier Update \/ Enrichment material/);
   assert.equal(candidatePayload.sourceFile.duplicateWarnings.existingDossierMatch.name, "Mac Modem");
 });
 
@@ -1066,7 +1205,7 @@ test("BNL source file read model keeps public endpoint separate and does not exp
   const publicPayload = await modelJson();
   assert.doesNotMatch(
     JSON.stringify(publicPayload),
-    /Signal Witch|sourceFileNotes|identityLinks|bnl:signal-witch:read-model-test/,
+    /Signal Witch|sourceFileNotes|identityLinks|bnl:signal-witch:read-model-test|candidate_intake|existing_dossier_update/,
   );
 
   const internalPayload = await (await sourceFilesGet("?subject=Signal%20Witch")).json();


### PR DESCRIPTION
### Motivation
- Ensure BNL protected source-file lookup can resolve Existing Dossier Update / Enrichment and Candidate Intake records by name, alias, normalized name, or internal workflow record ID while keeping them clearly labeled and not treated as active Source Files.
- Preserve Active Source File priority for subject lookups and maintain public/private read-model boundaries.
- Clean up admin-facing wording to reduce legacy “candidate” language and use clearer terms like workflow record, intake item, and existing dossier update.

### Description
- Updated protected BNL lookup in `src/app/api/bnl/source-files/route.ts` to include non-active lanes: Candidate Intake and Existing Dossier Update records can now be resolved for internal/operator lookup while remaining clearly labeled.
- Added lane-aware response metadata including `workflowLane`, `sourceFileActive`, `laneDescription`, and source-record metadata so downstream BNL enrichment can identify the correct workflow lane without treating update/intake records as active Source Files.
- Preserved Active Source File priority for normal subject lookup, while allowing exact candidate/internal record ID targeting to resolve the intended workflow record.
- Updated admin UI copy in `/admin/dossiers`, candidate/detail workflow pages, and recommendation detail pages to reduce confusing legacy “candidate” wording where the record is actually an intake item, source file, or existing dossier update.
- Public read-model and publishing behavior remain unchanged.

### Testing
All checks are passing on the current PR branch:

- `node --test tests/admin-dossiers.test.mjs` — passed
- `npx tsc --noEmit` — passed
- Targeted `npx eslint` on PR #150 changed files — passed
- `node --test tests/bnl-read-model.test.mjs` — passed
- `npm run test:queue` — passed

The prior note about 4 failing admin tests / eslint not run was stale. Codex verified the current branch already contains the expectation fixes and no additional tracked code changes were needed.

### Manual verification after merge
1. Confirm an item such as HellcatNZ is in Existing Dossier Update / Enrichment.
2. Run `!bnl source enrich HellcatNZ | dry_run=true`.
3. Expected: BNL should resolve the target and label it as Existing Dossier Update / Enrichment, not say no target found.
4. Confirm public dossier pages do not change.
5. Confirm Active Source Files still resolve normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba796c9108321addf1c4effb5d73e)