### PR TITLE
Source File Notes UI Cleanup — Human-readable case-file view & collapsed audit details

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -16,6 +16,7 @@ import {
   type DossierRecommendation,
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
+import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -343,6 +344,85 @@ function IdentityLinkCard({
           )}
         </div>
       )}
+    </article>
+  );
+}
+
+function HumanReadableNoteView({
+  view,
+  createdAt,
+  workflowLane,
+  appliedDraftId,
+}: {
+  view: ReturnType<typeof createHumanReadableSourceFileNoteView>;
+  createdAt?: string;
+  workflowLane?: string;
+  appliedDraftId?: string;
+}) {
+  return (
+    <article className="border border-border/70 bg-background/20 p-4 space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <p className="text-foreground font-semibold">{view.sourceLabel}</p>
+          <p className="text-xs text-muted">{view.sourceCopy}</p>
+          {view.legacyRawFormatting && (
+            <p className="text-xs text-accent">
+              This note uses legacy/raw formatting; the readable case-file view below is derived for admin review only.
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusBadge>{view.reviewStatus ?? "review"}</StatusBadge>
+          <StatusBadge>Created {formatDate(createdAt)}</StatusBadge>
+          {workflowLane && <StatusBadge>Lane {workflowLane}</StatusBadge>}
+          <StatusBadge>{view.warningCount} warnings</StatusBadge>
+          <StatusBadge>{view.missingInfoCount} missing info</StatusBadge>
+        </div>
+      </div>
+      <p className="border border-border/60 bg-background/30 p-3 text-sm text-foreground">
+        {view.summary}
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {view.sections.map((section) => (
+          <section key={section.title} className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
+            <h3 className="font-bold text-foreground mb-2">{section.title}</h3>
+            {section.items.length === 1 ? (
+              <p className="whitespace-pre-wrap">{section.items[0]}</p>
+            ) : (
+              <ul className="list-disc pl-5 space-y-1">
+                {section.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+      </div>
+      {appliedDraftId && (
+        <p className="text-xs text-muted">
+          Applied draft: <Link className="text-accent hover:underline" href={`/admin/dossiers/drafts/${appliedDraftId}`}>{appliedDraftId}</Link>
+        </p>
+      )}
+      <details className="border border-border/60 bg-background/20 p-3 text-xs text-muted">
+        <summary className="cursor-pointer font-semibold text-foreground">
+          Raw metadata / audit details
+        </summary>
+        <div className="mt-3 space-y-3">
+          {view.rawMetadata.length > 0 && (
+            <dl className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {view.rawMetadata.map((item, index) => (
+                <div key={`${item.label}-${index}`} className="border border-border/50 bg-background/20 p-2">
+                  <dt className="uppercase tracking-widest text-accent">{item.label}</dt>
+                  <dd className="break-words whitespace-pre-wrap">{item.value || "—"}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words border border-border/50 bg-background/30 p-3">
+            {view.rawText || "No raw text stored."}
+          </pre>
+        </div>
+      </details>
     </article>
   );
 }
@@ -1359,47 +1439,15 @@ export default function CandidateReviewPage() {
             <p>No saved source notes yet.</p>
           ) : (
             <div className="space-y-3">
-              {sourceNotes.map((note) => {
-                const isEnrichmentNote =
-                  note.ingestSource === "bnl_source_file_enrichment";
-                return (
-                <article
+              {sourceNotes.map((note) => (
+                <HumanReadableNoteView
                   key={note.id}
-                  className="border border-border/70 bg-background/20 p-3"
-                >
-                  <p className="text-foreground font-semibold">
-                    {isEnrichmentNote ? "BNL Source File Enrichment" : note.type} / {note.status}
-                  </p>
-                  {isEnrichmentNote && (
-                    <div className="mb-2 flex flex-wrap gap-2">
-                      <StatusBadge>Review-only</StatusBadge>
-                      <StatusBadge>Internal case-file material</StatusBadge>
-                      <StatusBadge>Not public copy</StatusBadge>
-                      <StatusBadge>Owner/admin review required</StatusBadge>
-                    </div>
-                  )}
-                  <p className="whitespace-pre-wrap">{note.text}</p>
-                  <p>
-                    Source: {note.source} / Ingest source: {note.ingestSource ?? "—"} / Public safe:{" "}
-                    {String(note.publicSafe)} / Created:{" "}
-                    {formatDate(note.createdAt)}
-                  </p>
-                  <p>
-                    Applied draft:{" "}
-                    {note.appliesToDraftId ? (
-                      <Link
-                        className="text-accent hover:underline"
-                        href={`/admin/dossiers/drafts/${note.appliesToDraftId}`}
-                      >
-                        {note.appliesToDraftId}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </p>
-                </article>
-              );
-              })}
+                  view={createHumanReadableSourceFileNoteView(note)}
+                  createdAt={note.createdAt}
+                  workflowLane={candidate.status}
+                  appliedDraftId={note.appliesToDraftId}
+                />
+              ))}
             </div>
           )}
         </Section>
@@ -1429,13 +1477,13 @@ export default function CandidateReviewPage() {
               <p>—</p>
             )}
           </Section>
-          <Section title="Known / Claimed / Inferred">{list(candidate.knownFacts)}</Section>
+          <Section title="Review Context / Possible Supporting Evidence">{list(candidate.knownFacts)}</Section>
           <Section title="Corrections / extra notes">
             <p>Saved notes now live in BNL Source File Notes above.</p>
           </Section>
           <Section title="Missing Info">{list(candidate.missingInfo)}</Section>
           <Section title="Do Not Say">{list(candidate.doNotSay)}</Section>
-          <Section title="Public-Safe Facts">
+          <Section title="Public-Safe Facts Pending Owner/Admin Approval">
             {list(candidate.knownFacts?.filter(Boolean), "No public-safe facts marked yet.")}
           </Section>
           <Section title="Internal-Only Notes">
@@ -1444,7 +1492,7 @@ export default function CandidateReviewPage() {
                 {sourceNotes
                   .filter((note) => note.publicSafe !== true)
                   .map((note) => (
-                    <li key={note.id}>{note.text}</li>
+                    <li key={note.id}>{createHumanReadableSourceFileNoteView(note).summary}</li>
                   ))}
               </ul>
             ) : (

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -13,6 +13,7 @@ import {
   type DossierIdentityLinkVisibility,
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
+import { createHumanReadableRecommendationView } from "@/lib/dossier-note-display";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -143,6 +144,76 @@ function Field({
     <section className="border border-border/70 bg-background/20 p-4 text-sm text-muted">
       <h2 className="font-bold text-foreground mb-2">{title}</h2>
       {children}
+    </section>
+  );
+}
+
+function StatusBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex border border-border bg-background/40 px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted">
+      {children}
+    </span>
+  );
+}
+
+function HumanReadableRecommendationCaseFile({
+  recommendation,
+}: {
+  recommendation: DossierRecommendation;
+}) {
+  const view = createHumanReadableRecommendationView(recommendation);
+  return (
+    <section className="border border-border bg-surface p-5 space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.4em] text-accent">Human case-file view</p>
+          <h2 className="text-2xl font-bold text-foreground">{view.sourceLabel}</h2>
+          <p className="text-sm text-muted">{view.sourceCopy}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusBadge>{recommendation.status}</StatusBadge>
+          <StatusBadge>Created {formatDate(recommendation.createdAt)}</StatusBadge>
+          <StatusBadge>{view.warningCount} warnings</StatusBadge>
+          <StatusBadge>{view.missingInfoCount} missing info</StatusBadge>
+        </div>
+      </div>
+      <p className="border border-border/60 bg-background/30 p-3 text-sm text-foreground">
+        {view.summary}
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {view.sections.map((section) => (
+          <section key={section.title} className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
+            <h3 className="font-bold text-foreground mb-2">{section.title}</h3>
+            {section.items.length === 1 ? (
+              <p className="whitespace-pre-wrap">{section.items[0]}</p>
+            ) : (
+              <ul className="list-disc pl-5 space-y-1">
+                {section.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+      </div>
+      <details className="border border-border/60 bg-background/20 p-3 text-xs text-muted">
+        <summary className="cursor-pointer font-semibold text-foreground">
+          Raw metadata / audit details
+        </summary>
+        <div className="mt-3 space-y-3">
+          <dl className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {view.rawMetadata.map((item, index) => (
+              <div key={`${item.label}-${index}`} className="border border-border/50 bg-background/20 p-2">
+                <dt className="uppercase tracking-widest text-accent">{item.label}</dt>
+                <dd className="break-words whitespace-pre-wrap">{item.value || "—"}</dd>
+              </div>
+            ))}
+          </dl>
+          <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words border border-border/50 bg-background/30 p-3">
+            {view.rawText || "No raw text stored."}
+          </pre>
+        </div>
+      </details>
     </section>
   );
 }
@@ -817,6 +888,7 @@ export default function DossierRecommendationPage() {
             </form>
           </section>
         )}
+        <HumanReadableRecommendationCaseFile recommendation={recommendation} />
         <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Field title="Subject">
             <p>{recommendation.subjectName}</p>
@@ -826,7 +898,7 @@ export default function DossierRecommendationPage() {
               {recommendation.type} / {recommendation.status}
             </p>
           </Field>
-          <Field title="Ingest source">
+          <Field title="Admin audit summary">
             <p>{recommendationProvenance(recommendation)}</p>
             <p>Created by: {recommendation.createdBy ?? "—"}</p>
             <p>Ingest source: {recommendation.ingestSource ?? "—"}</p>

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -1,0 +1,221 @@
+import type {
+  DossierRecommendation,
+  DossierRecommendationIngestSource,
+  DossierSourceFileNote,
+} from "./dossier-workflow";
+
+export type DossierHumanReadableSection = {
+  title: string;
+  items: string[];
+};
+
+export type DossierHumanReadableNoteView = {
+  sourceLabel: string;
+  sourceCopy: string;
+  isLegacyBridge: boolean;
+  isEnrichment: boolean;
+  legacyRawFormatting: boolean;
+  summary: string;
+  sections: DossierHumanReadableSection[];
+  rawMetadata: Array<{ label: string; value: string }>;
+  rawText?: string;
+  warningCount: number;
+  missingInfoCount: number;
+  reviewStatus?: string;
+  workflowLane?: string;
+};
+
+type NoteLike = Pick<
+  DossierSourceFileNote,
+  | "type"
+  | "text"
+  | "source"
+  | "publicSafe"
+  | "createdAt"
+  | "ingestKey"
+  | "ingestedAt"
+  | "ingestSource"
+> & {
+  status?: string;
+  sourceLanes?: string[];
+  sourceTypes?: string[];
+  confidence?: string;
+  missingInfo?: string[];
+  publicSafetyNotes?: string[];
+  doNotSay?: string[];
+  suggestedAction?: string;
+  evidenceSummary?: string;
+  reason?: string;
+};
+
+const rawMetadataHeadingPattern =
+  /^(ingest\s*key|ingestkey|source\s*lane|source\s*lanes|source\s*types|source\s*counts|evidence\s*mapping|source\s*qualities|visibility|confidence|confidence\s*debug|debug|internal\s*id|internal\s*ids|taxonomy\s*metadata)\s*:/i;
+
+const evidenceHeadingPattern = /^(evidence|possible supporting evidence)\s*:/i;
+const publicSafetyHeadingPattern = /^(public safety|safety note|safety notes|source warnings?)\s*:/i;
+const missingInfoHeadingPattern = /^(missing info|missing information|needs owner review)\s*:/i;
+const doNotSayHeadingPattern = /^(do not say|do-not-say)\s*:/i;
+const actionHeadingPattern = /^(suggested next action|suggested action|next action)\s*:/i;
+const summaryHeadingPattern = /^(summary|review context|why it matters|review reason|reason)\s*:/i;
+
+function cleanLine(line: string) {
+  return line.replace(/^[-*•]\s*/, "").trim();
+}
+
+function withoutHeading(line: string) {
+  return cleanLine(line).replace(/^[^:]{1,80}:\s*/, "").trim();
+}
+
+function addItem(sections: Map<string, string[]>, title: string, value?: string) {
+  const item = value?.trim();
+  if (!item) return;
+  const items = sections.get(title) ?? [];
+  if (!items.includes(item)) items.push(item);
+  sections.set(title, items);
+}
+
+function sourceLabel(ingestSource?: DossierRecommendationIngestSource) {
+  if (ingestSource === "bnl_source_knowledge_bridge") {
+    return {
+      label: "Legacy BNL Source Knowledge Bridge Note",
+      copy:
+        "This is review-only source material imported from the older bridge path. Treat it as internal context, not public dossier copy.",
+    };
+  }
+  if (ingestSource === "bnl_source_file_enrichment") {
+    return {
+      label: "BNL Source File Enrichment",
+      copy:
+        "Review-only enrichment generated for this workflow record. Public copy still requires owner/admin approval.",
+    };
+  }
+  return {
+    label: "BNL Source File Note",
+    copy:
+      "Internal working case-file material. Review before using in any proposed or public dossier copy.",
+  };
+}
+
+function excerpt(text: string, maxLength = 220) {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, maxLength - 1).trim()}…`;
+}
+
+export function createHumanReadableSourceFileNoteView(
+  note: NoteLike,
+): DossierHumanReadableNoteView {
+  const source = sourceLabel(note.ingestSource);
+  const sections = new Map<string, string[]>();
+  const rawMetadata: Array<{ label: string; value: string }> = [];
+  const text = note.text ?? "";
+  const rawLines = text
+    .split(/\n+/)
+    .map(cleanLine)
+    .filter(Boolean);
+  let legacyRawFormatting = false;
+  let summary = "";
+
+  for (const line of rawLines) {
+    if (rawMetadataHeadingPattern.test(line)) {
+      legacyRawFormatting = true;
+      const [label, ...rest] = line.split(":");
+      rawMetadata.push({ label: label.trim(), value: rest.join(":").trim() });
+      continue;
+    }
+    if (/source lanes\/types summary|source lanes:|ingest key:|confidence:|taxonomy metadata:/i.test(line)) {
+      legacyRawFormatting = true;
+      const [label, ...rest] = line.split(":");
+      rawMetadata.push({ label: label.trim(), value: rest.join(":").trim() });
+      continue;
+    }
+    if (evidenceHeadingPattern.test(line)) {
+      addItem(sections, "Possible Supporting Evidence", withoutHeading(line));
+    } else if (publicSafetyHeadingPattern.test(line)) {
+      addItem(sections, "Public Safety", withoutHeading(line));
+    } else if (missingInfoHeadingPattern.test(line)) {
+      addItem(sections, "Missing Info", withoutHeading(line));
+    } else if (doNotSayHeadingPattern.test(line)) {
+      addItem(sections, "Do Not Say", withoutHeading(line));
+    } else if (actionHeadingPattern.test(line)) {
+      addItem(sections, "Suggested Next Action", withoutHeading(line));
+    } else if (summaryHeadingPattern.test(line)) {
+      addItem(sections, "Review Context", withoutHeading(line));
+    } else if (/public use requires review|internal\/private review|required|review-only|not public copy|owner\/admin review/i.test(line)) {
+      addItem(sections, "Needs Owner Review", line);
+    } else if (!summary) {
+      summary = line;
+    } else {
+      addItem(sections, "Source-Limited Notes", line);
+    }
+  }
+
+  if (!summary) summary = excerpt(text) || "Review-only internal source-file note.";
+
+  addItem(sections, "Summary", summary);
+  addItem(sections, "Why It Matters / Review Reason", note.reason);
+  addItem(sections, "Evidence", note.evidenceSummary);
+  for (const item of note.publicSafetyNotes ?? []) addItem(sections, "Source Warnings", item);
+  for (const item of note.missingInfo ?? []) addItem(sections, "Missing Info", item);
+  for (const item of note.doNotSay ?? []) addItem(sections, "Do Not Say", item);
+  addItem(sections, "Suggested Next Action", note.suggestedAction);
+  addItem(sections, "Admin Metadata", `Source: ${note.source ?? "—"}`);
+  addItem(sections, "Admin Metadata", `Status: ${note.status ?? "—"}`);
+  addItem(sections, "Admin Metadata", `Public safe: ${String(note.publicSafe)}`);
+
+  if (note.ingestKey) rawMetadata.push({ label: "ingestKey", value: note.ingestKey });
+  if (note.ingestedAt) rawMetadata.push({ label: "ingestedAt", value: note.ingestedAt });
+  if (note.ingestSource) rawMetadata.push({ label: "ingestSource", value: note.ingestSource });
+  if (note.sourceLanes?.length) rawMetadata.push({ label: "sourceLanes", value: note.sourceLanes.join(", ") });
+  if (note.sourceTypes?.length) rawMetadata.push({ label: "sourceTypes", value: note.sourceTypes.join(", ") });
+  if (note.confidence) rawMetadata.push({ label: "confidence", value: note.confidence });
+
+  const warningCount = (note.publicSafetyNotes ?? []).length +
+    Array.from(sections.entries())
+      .filter(([title]) => title === "Source Warnings" || title === "Public Safety")
+      .reduce((count, [, items]) => count + items.length, 0);
+  const missingInfoCount =
+    (note.missingInfo ?? []).length + (sections.get("Missing Info")?.length ?? 0);
+
+  return {
+    sourceLabel: source.label,
+    sourceCopy: source.copy,
+    isLegacyBridge: note.ingestSource === "bnl_source_knowledge_bridge",
+    isEnrichment: note.ingestSource === "bnl_source_file_enrichment",
+    legacyRawFormatting,
+    summary: excerpt(summary),
+    sections: Array.from(sections.entries()).map(([title, items]) => ({ title, items })),
+    rawMetadata,
+    rawText: text,
+    warningCount,
+    missingInfoCount,
+    reviewStatus: note.status,
+  };
+}
+
+export function createHumanReadableRecommendationView(
+  recommendation: DossierRecommendation,
+): DossierHumanReadableNoteView {
+  return createHumanReadableSourceFileNoteView({
+    type: "general_note",
+    text: [recommendation.reason, recommendation.evidenceSummary]
+      .filter(Boolean)
+      .join("\n\n"),
+    source: "bnl_recommendation",
+    status: recommendation.status,
+    publicSafe: false,
+    createdAt: recommendation.createdAt,
+    ingestKey: recommendation.ingestKey,
+    ingestedAt: recommendation.ingestedAt,
+    ingestSource: recommendation.ingestSource,
+    sourceLanes: recommendation.sourceLanes,
+    sourceTypes: recommendation.sourceTypes,
+    confidence: recommendation.confidence,
+    missingInfo: recommendation.missingInfo,
+    publicSafetyNotes: recommendation.publicSafetyNotes,
+    doNotSay: recommendation.doNotSay,
+    suggestedAction: recommendation.suggestedAction,
+    evidenceSummary: recommendation.evidenceSummary,
+    reason: recommendation.reason,
+  });
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -52,6 +52,7 @@ const store = require("../src/lib/dossier-workflow-store.ts");
 const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
+const noteDisplay = require("../src/lib/dossier-note-display.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -374,8 +375,8 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Do not treat this as public copy",
     "Case File Summary",
     "Evidence / Source Notes",
-    "Known / Claimed / Inferred",
-    "Public-Safe Facts",
+    "Review Context / Possible Supporting Evidence",
+    "Public-Safe Facts Pending Owner/Admin Approval",
     "Internal-Only Notes",
     "Source Warnings",
     "Conflicts / Needs Review",
@@ -499,8 +500,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Internal working case file",
     "Do not treat this as public copy",
     "Evidence / Source Notes",
-    "Known / Claimed / Inferred",
-    "Public-Safe Facts",
+    "Review Context / Possible Supporting Evidence",
+    "Public-Safe Facts Pending Owner/Admin Approval",
     "Internal-Only Notes",
     "Source Warnings",
     "Conflicts / Needs Review",
@@ -541,6 +542,88 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   assert.doesNotMatch(page, />Final Approve<|>Publish<|>Delete<|>Final Merge</);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
   assert.doesNotMatch(page, /publishDraft/);
+});
+
+
+test("admin source file note display derives a human case-file view and collapses raw metadata", () => {
+  const legacy = noteDisplay.createHumanReadableSourceFileNoteView({
+    type: "general_note",
+    text: [
+      "Bridge memory suggests recurring source context.",
+      "Source qualities: source-blind memory trace",
+      "Visibility: internal/debug",
+      "Evidence mapping: ingestKey -> bridge record",
+      "Missing info: confirm owner-approved public copy",
+      "Do not say: do not present bridge memory as a known fact",
+    ].join("\n"),
+    source: "bnl_recommendation",
+    status: "active",
+    publicSafe: false,
+    createdAt: "2026-05-30T00:00:00.000Z",
+    ingestSource: "bnl_source_knowledge_bridge",
+    ingestKey: "bnl:bridge-debug-key",
+  });
+
+  assert.equal(legacy.sourceLabel, "Legacy BNL Source Knowledge Bridge Note");
+  assert.match(legacy.sourceCopy, /older bridge path/);
+  assert.equal(legacy.legacyRawFormatting, true);
+  assert.match(legacy.summary, /Bridge memory suggests/);
+  assert.equal(legacy.sections.some((section) => section.title === "Known Facts"), false);
+  assert.equal(legacy.sections.some((section) => section.title === "Missing Info"), true);
+  assert.equal(legacy.sections.some((section) => section.title === "Do Not Say"), true);
+  assert.equal(legacy.rawMetadata.some((item) => item.label === "Source qualities"), true);
+  assert.equal(legacy.rawMetadata.some((item) => item.label === "ingestKey"), true);
+
+  const enrichment = noteDisplay.createHumanReadableSourceFileNoteView({
+    type: "general_note",
+    text: "Summary: Enrichment found review-only context.\nSafety note: keep internal.",
+    source: "bnl_recommendation",
+    status: "active",
+    publicSafe: false,
+    createdAt: "2026-05-30T00:00:00.000Z",
+    ingestSource: "bnl_source_file_enrichment",
+    ingestKey: "bnl:enrichment-key",
+  });
+
+  assert.equal(enrichment.sourceLabel, "BNL Source File Enrichment");
+  assert.match(enrichment.sourceCopy, /Public copy still requires owner\/admin approval/);
+  assert.equal(enrichment.rawMetadata.some((item) => item.label === "ingestKey"), true);
+});
+
+test("admin Source File and recommendation pages render readable sections with collapsed audit details", () => {
+  const displayHelper = normalizedSource("src/lib/dossier-note-display.ts");
+  const candidatePage = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${displayHelper}`;
+  const recommendationPage = `${normalizedSource("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx")} ${displayHelper}`;
+
+  for (const label of [
+    "HumanReadableNoteView",
+    "Legacy BNL Source Knowledge Bridge Note",
+    "BNL Source File Enrichment",
+    "This is review-only source material imported from the older bridge path. Treat it as internal context, not public dossier copy.",
+    "Review-only enrichment generated for this workflow record. Public copy still requires owner/admin approval.",
+    "Raw metadata / audit details",
+    "warnings",
+    "missing info",
+    "Review Context / Possible Supporting Evidence",
+    "Source-Limited Notes",
+    "Needs Owner Review",
+  ]) {
+    assertIncludesCopy(candidatePage, label);
+  }
+
+  for (const label of [
+    "Human case-file view",
+    "Raw metadata / audit details",
+    "Summary",
+    "Why It Matters / Review Reason",
+    "Evidence",
+    "Source Warnings",
+    "Missing Info",
+    "Suggested Next Action",
+    "Do Not Say",
+  ]) {
+    assertIncludesCopy(recommendationPage, label);
+  }
 });
 
 test("dedicated duplicate merge route contains focused manual merge workflow", () => {
@@ -4051,7 +4134,7 @@ test("BNL Source File enrichment without target remains in inbox and cannot conv
 test("admin dossier UI labels BNL Source File enrichment separately from bridge and discovery", () => {
   const dashboard = source("src/app/admin/dossiers/page.tsx");
   const recommendationPage = source("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx");
-  const candidatePage = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const candidatePage = `${source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${source("src/lib/dossier-note-display.ts")}`;
 
   assert.match(dashboard, /BNL Source File Enrichment/);
   assert.match(dashboard, /Review-only internal case-file material; not public copy/);
@@ -4060,5 +4143,5 @@ test("admin dossier UI labels BNL Source File enrichment separately from bridge 
   assert.match(recommendationPage, /not raw bridge intake/);
   assert.match(recommendationPage, /Owner\/admin review is required before any public use/);
   assert.match(candidatePage, /BNL Source File Enrichment/);
-  assert.match(candidatePage, /Internal case-file material/);
+  assert.match(candidatePage, /internal case-file material|Internal working case-file material/);
 });


### PR DESCRIPTION
### Motivation

- BNL ingest produces richer enrichment and bridge notes, but the admin UI still displayed raw backend metadata as noisy dumps; admins need readable, safety-aware case-file views. 

### Description

- Add a shared parser/display helper `src/lib/dossier-note-display.ts` that produces a human-readable note view (sections like Summary, Why It Matters, Evidence, Missing Info, Do Not Say) and collects raw audit metadata for a collapsed details panel. 
- Wire the human view into the admin Source File page by adding a `HumanReadableNoteView` component and replacing raw note cards with `createHumanReadableSourceFileNoteView(note)` renderings; rename/adjust headings (e.g. `Known / Claimed / Inferred` → `Review Context / Possible Supporting Evidence`, `Public-Safe Facts` → `Public-Safe Facts Pending Owner/Admin Approval`). 
- Add the same human case-file sectioning to the recommendation detail page via `HumanReadableRecommendationCaseFile` using `createHumanReadableRecommendationView(recommendation)`, and move raw ingest/audit fields into a collapsed “Raw metadata / audit details” block. 
- Label notes by ingest path: `bnl_source_knowledge_bridge` → “Legacy BNL Source Knowledge Bridge Note” and `bnl_source_file_enrichment` → “BNL Source File Enrichment”, with admin copy clarifying review-only status. 
- Preserve all stored data and public boundaries: only display/parsing/UI changes were made, no API/public-read-model/publishing/ingest behavior or stored-note mutation. 
- Files changed: `src/lib/dossier-note-display.ts` (new), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, and test updates in `tests/admin-dossiers.test.mjs`.

### Testing

- Ran TypeScript check: `npx tsc --noEmit --pretty false` (passed). 
- Ran lint on changed files: `npx eslint src/lib/dossier-note-display.ts 'src/app/admin/dossiers/candidates/[candidateId]/page.tsx' 'src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx' tests/admin-dossiers.test.mjs` (no errors). 
- Ran unit/integration suites: `node --test tests/admin-dossiers.test.mjs` and `node --test tests/bnl-read-model.test.mjs` and `npm run test:queue` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bbc4f9a108321a5fba083f8e6646c)