### PR TITLE
Website PR #152 — Source File Summary + Plain‑English Case‑File UX

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -17,6 +17,11 @@ import {
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
+import {
+  createDossierSourceFileSummary,
+  formatDossierSummaryBadge,
+  type DossierSourceFileSummary,
+} from "@/lib/dossier-source-file-summary";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -193,7 +198,7 @@ function sourceWarningLabels(input: {
     ...input.recommendations.flatMap((recommendation) => recommendation.sourceLanes),
   ]);
   return uniqueLabels([
-    lanes.has("broadcast_memory") ? "Source-blind memory trace" : "",
+    lanes.has("broadcast_memory") ? "Review-only memory context" : "",
     input.candidate.ingestSource === "bnl_dynamic_candidate_discovery" ||
     input.candidate.ingestSource === "bnl_source_knowledge_bridge" ||
     input.candidate.ingestSource === "bnl_source_file_enrichment" ||
@@ -348,6 +353,75 @@ function IdentityLinkCard({
   );
 }
 
+function SummaryList({ items }: { items: string[] }) {
+  return items.length === 1 ? (
+    <p>{items[0]}</p>
+  ) : (
+    <ul className="list-disc pl-5 space-y-1">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function SourceFileSummaryPanel({
+  summary,
+}: {
+  summary: DossierSourceFileSummary;
+}) {
+  return (
+    <section className="border border-accent/70 bg-surface p-5 space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.45em] text-accent mb-2">
+            Source File Summary
+          </p>
+          <h2 className="text-2xl font-bold text-foreground">Current Read</h2>
+          <p className="mt-2 text-sm text-muted max-w-4xl">{summary.currentRead}</p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+          <StatusBadge>
+            Substance: {formatDossierSummaryBadge(summary.substanceLevel)}
+          </StatusBadge>
+          <StatusBadge>
+            Public readiness: {formatDossierSummaryBadge(summary.publicReadiness)}
+          </StatusBadge>
+          <StatusBadge>
+            Existing public dossier: {formatDossierSummaryBadge(summary.existingPublicDossier)}
+          </StatusBadge>
+          <StatusBadge>
+            Next action: {formatDossierSummaryBadge(summary.nextAction)}
+          </StatusBadge>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm text-muted">
+        <Section title="What BNL Actually Knows">
+          <SummaryList items={summary.knownContext} />
+        </Section>
+        <Section title="Why This File Exists">
+          <p>{summary.whyTracked}</p>
+        </Section>
+        <Section title="Useful Evidence">
+          <SummaryList items={summary.usefulEvidence} />
+        </Section>
+        <Section title="Patterns / Themes">
+          <SummaryList items={summary.patterns} />
+        </Section>
+        <Section title="Open Questions">
+          <SummaryList items={[...summary.uncertainties, ...summary.missingInfo]} />
+        </Section>
+        <Section title="Recommended Next Step">
+          <p>{summary.recommendedNextAction}</p>
+        </Section>
+      </div>
+      <p className="text-xs text-muted">
+        Internal-only briefing. It helps operators decide what to review next and does not publish or change public dossier copy.
+      </p>
+    </section>
+  );
+}
+
 function HumanReadableNoteView({
   view,
   createdAt,
@@ -363,25 +437,22 @@ function HumanReadableNoteView({
     <article className="border border-border/70 bg-background/20 p-4 space-y-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
-          <p className="text-foreground font-semibold">{view.sourceLabel}</p>
+          <p className="text-foreground font-semibold">{view.summary}</p>
           <p className="text-xs text-muted">{view.sourceCopy}</p>
           {view.legacyRawFormatting && (
             <p className="text-xs text-accent">
-              This note uses legacy/raw formatting; the readable case-file view below is derived for admin review only.
+              This older note had technical formatting. The readable case-file view below is derived for admin review only.
             </p>
           )}
         </div>
         <div className="flex flex-wrap gap-2">
           <StatusBadge>{view.reviewStatus ?? "review"}</StatusBadge>
           <StatusBadge>Created {formatDate(createdAt)}</StatusBadge>
-          {workflowLane && <StatusBadge>Lane {workflowLane}</StatusBadge>}
+          {workflowLane && <StatusBadge>Review-only</StatusBadge>}
           <StatusBadge>{view.warningCount} warnings</StatusBadge>
           <StatusBadge>{view.missingInfoCount} missing info</StatusBadge>
         </div>
       </div>
-      <p className="border border-border/60 bg-background/30 p-3 text-sm text-foreground">
-        {view.summary}
-      </p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {view.sections.map((section) => (
           <section key={section.title} className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
@@ -405,7 +476,7 @@ function HumanReadableNoteView({
       )}
       <details className="border border-border/60 bg-background/20 p-3 text-xs text-muted">
         <summary className="cursor-pointer font-semibold text-foreground">
-          Raw metadata / audit details
+          Technical audit details
         </summary>
         <div className="mt-3 space-y-3">
           {view.rawMetadata.length > 0 && (
@@ -419,7 +490,7 @@ function HumanReadableNoteView({
             </dl>
           )}
           <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words border border-border/50 bg-background/30 p-3">
-            {view.rawText || "No raw text stored."}
+            {view.rawText || "No original text stored."}
           </pre>
         </div>
       </details>
@@ -496,7 +567,7 @@ export default function CandidateReviewPage() {
       void loadWorkflow()
         .catch((err) =>
           setError(
-            err instanceof Error ? err.message : "Failed to load workflow record.",
+            err instanceof Error ? err.message : "Failed to load internal record.",
           ),
         )
         .finally(() => setLoading(false));
@@ -554,6 +625,13 @@ export default function CandidateReviewPage() {
   const attachedRecommendations = (payload?.recommendations ?? []).filter(
     (recommendation) => recommendation.targetCandidateId === candidate?.id,
   );
+  const sourceFileSummary = candidate
+    ? createDossierSourceFileSummary({
+        candidate,
+        drafts: linkedDrafts,
+        recommendations: attachedRecommendations,
+      })
+    : null;
   const identityLinks = [...(candidate?.identityLinks ?? [])].sort(
     (a, b) =>
       (a.status === "proposed" ? -1 : 1) -
@@ -643,7 +721,7 @@ export default function CandidateReviewPage() {
       );
     } catch (err) {
       setNotice(
-        err instanceof Error ? err.message : "Failed to update workflow record.",
+        err instanceof Error ? err.message : "Failed to update internal record.",
       );
     }
   }
@@ -687,7 +765,7 @@ export default function CandidateReviewPage() {
           : action === "restoreCandidate"
             ? "Workflow record restored to intake review so it can be reviewed and promoted again if needed."
             : action === "permanentlyDeleteCandidate"
-              ? "Source file permanently deleted from unpublished workflow records. Public dossiers were not changed."
+              ? "Source file permanently deleted from unpublished internal records. Public dossiers were not changed."
               : action === "attachCandidateToExistingDossier"
                 ? "Existing public dossier target attached. Public dossier content was not changed."
                 : action === "markCandidateAsExistingDossierUpdate"
@@ -784,7 +862,7 @@ export default function CandidateReviewPage() {
     return (
       <MinimalState
         title="Loading BNL Source File"
-        message="Checking the candidate workflow record."
+        message="Checking the Source File."
       />
     );
   if (error || !payload)
@@ -824,7 +902,7 @@ export default function CandidateReviewPage() {
           </p>
           {isExistingDossierUpdate && (
             <p className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
-              This workflow record is an existing dossier update / enrichment target, not a new dossier proposal.
+              This internal record is an existing dossier update / enrichment target, not a new dossier proposal.
             </p>
           )}
           <div className="mt-4">
@@ -1000,20 +1078,17 @@ export default function CandidateReviewPage() {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
+        {sourceFileSummary && <SourceFileSummaryPanel summary={sourceFileSummary} />}
+
         <section className="border border-border bg-surface p-5 space-y-4">
           <h2 className="text-2xl font-bold text-foreground">
-            Case File Summary
+            Review Boundaries
           </h2>
           <p className="text-sm text-muted">
-            The BNL Source File is an internal working case file / evidence
-            folder. It can contain confirmed facts, claimed facts, inferred
-            facts, messy evidence, recommendation evidence clusters,
-            source-blind memory traces, private/internal notes, conflicting
-            information, missing info, warnings, do-not-say
-            notes, identity possibilities, duplicate/identity warnings,
-            taxonomy suggestions, public safety notes, and public-safe facts. It
-            is not an
-            almost-public dossier.
+            This is an internal working case file. It can hold confirmed facts,
+            claims that need review, possible connections, public-safety notes,
+            and private context. It is not public copy and should not be treated
+            as proof on its own.
           </p>
           <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
             {sourceWarningLabels({ candidate, recommendations: attachedRecommendations }).map((label) => (

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -122,16 +122,16 @@ function linkedActiveDraftFor(
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
   if (recommendation.ingestSource === "bnl_source_file_enrichment") {
-    return "BNL Source File Enrichment";
+    return "BNL review addendum";
   }
   if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
-    return "BNL dynamic discovery";
+    return "BNL records";
   }
   if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
-    return "BNL Source Knowledge Bridge";
+    return "Older BNL review note";
   }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
-    return "BNL-ingested";
+    return "Known from BNL records";
   }
   return recommendation.createdBy
     ? `Seeded by ${recommendation.createdBy}`
@@ -140,15 +140,16 @@ function recommendationProvenance(recommendation: DossierRecommendation) {
 
 function candidateProvenance(candidate: DossierCandidate) {
   if (candidate.source === "bnl_source_file_enrichment") {
-    return `BNL Source File Enrichment${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+    return "Known from BNL records / review addendum";
   }
   if (candidate.source === "bnl_dynamic_candidate_discovery") {
-    return `BNL dynamic discovery${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+    return "Known from BNL records";
   }
   if (candidate.source === "bnl_source_knowledge_bridge") {
-    return `BNL Source Knowledge Bridge${candidate.sourceLanes?.length ? ` / ${candidate.sourceLanes.join(", ")}` : ""}`;
+    return "Known from older BNL review notes";
   }
-  return candidate.source;
+  if (candidate.source === "manual") return "Added by an operator";
+  return "Internal note";
 }
 
 function StatusPill({ children }: { children: React.ReactNode }) {
@@ -426,12 +427,12 @@ export default function DossierControlCenterPage() {
       return {
         match,
         state: target?.status === "active_source_file"
-          ? "BNL Source File Enrichment / Active Source File"
+          ? "BNL review addendum / Active Source File"
           : target?.status === "candidate_intake"
-            ? "BNL Source File Enrichment / Intake Item"
+            ? "BNL review addendum / Intake Item"
             : target?.status === "existing_dossier_update"
-              ? "BNL Source File Enrichment / Existing Dossier Update"
-              : "BNL Source File Enrichment / Recommendation Inbox",
+              ? "BNL review addendum / Existing Dossier Update"
+              : "BNL review addendum / Recommendation Inbox",
         nextAction: "Review-only internal case-file material; not public copy",
       };
     }
@@ -512,7 +513,7 @@ export default function DossierControlCenterPage() {
       );
     } catch (err) {
       setNotice(
-        err instanceof Error ? err.message : "Failed to update workflow record.",
+        err instanceof Error ? err.message : "Failed to update internal record.",
       );
     }
   }
@@ -583,7 +584,7 @@ export default function DossierControlCenterPage() {
           : action === "restoreCandidate"
             ? `${candidate.name} restored to intake review. Public dossiers were not changed.`
             : action === "permanentlyDeleteCandidate"
-              ? `${candidate.name} permanently deleted from unpublished workflow records. Public dossiers were not changed.`
+              ? `${candidate.name} permanently deleted from unpublished internal records. Public dossiers were not changed.`
               : action === "attachCandidateToExistingDossier"
                 ? `${candidate.name} attached to an existing public dossier target. Public dossier content was not changed.`
                 : action === "markCandidateAsExistingDossierUpdate"
@@ -918,8 +919,8 @@ export default function DossierControlCenterPage() {
           <p className="text-sm text-muted mb-4">
             BNL-discovered subjects stay here until an admin explicitly promotes
             them to an Active BNL Source File / Working Case File. Evidence,
-            source warnings, ingest keys, safety notes, do-not-say notes, and
-            missing-info notes are preserved during promotion.
+            review warnings, safety notes, do-not-say notes, and open questions
+            are preserved during promotion.
           </p>
           {candidateIntakeItems.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
@@ -985,8 +986,8 @@ export default function DossierControlCenterPage() {
                       <p>Matched public dossier: {candidate.existingDossierMatch?.name ?? "—"}</p>
                       <p>Public dossier target id: {candidate.existingDossierMatch?.id ?? "—"}</p>
                       <p>Match confidence: {candidate.existingDossierMatch?.confidence ?? "—"}</p>
-                      <p>Evidence/source notes: {(candidate.sourceFileNotes ?? []).length} notes preserved</p>
-                      <p>Source warnings: {(candidate.publicSafetyNotes ?? []).length} public-safety notes / {(candidate.doNotSay ?? []).length} do-not-say notes / {(candidate.missingInfo ?? []).length} missing-info notes</p>
+                      <p>Evidence and notes: {(candidate.sourceFileNotes ?? []).length} notes preserved</p>
+                      <p>Review warnings: {(candidate.publicSafetyNotes ?? []).length} public-safety notes / {(candidate.doNotSay ?? []).length} do-not-say notes / {(candidate.missingInfo ?? []).length} open questions</p>
                       <p>Proposed action: review update/enrichment; owner approval required before public changes.</p>
                     </div>
                     <div className="flex flex-wrap gap-2">
@@ -1357,7 +1358,7 @@ export default function DossierControlCenterPage() {
           </p>
           {archivedCandidates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No archived workflow records.
+              No archived internal records.
             </p>
           ) : (
             <div className="space-y-2 text-sm text-muted">
@@ -1444,7 +1445,7 @@ export default function DossierControlCenterPage() {
             </li>
           </ul>
           <p className="text-xs text-muted">
-            Dedicated pages keep operators in one lane: workflow record review,
+            Dedicated pages keep operators in one lane: internal record review,
             focused draft editor, owner review, or merge review. Dashboard
             buttons navigate; there is no hidden editor below unrelated sections
             and no dashboard auto-scroll workflow.

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -117,16 +117,16 @@ function formatDate(value?: string) {
 
 function recommendationProvenance(recommendation: DossierRecommendation) {
   if (recommendation.ingestSource === "bnl_source_file_enrichment") {
-    return "BNL Source File Enrichment";
+    return "BNL review addendum";
   }
   if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") {
-    return "BNL dynamic discovery";
+    return "Known from BNL records";
   }
   if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
-    return "BNL Source Knowledge Bridge";
+    return "Older BNL review note";
   }
   if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
-    return "BNL-ingested";
+    return "Known from BNL records";
   }
   return recommendation.createdBy
     ? `Seeded by ${recommendation.createdBy}`
@@ -156,30 +156,50 @@ function StatusBadge({ children }: { children: React.ReactNode }) {
   );
 }
 
+function recommendationAddsUsefulInformation(recommendation: DossierRecommendation) {
+  return Boolean(
+    recommendation.evidenceSummary ||
+      recommendation.reason ||
+      (recommendation.missingInfo ?? []).length ||
+      (recommendation.publicSafetyNotes ?? []).length ||
+      (recommendation.doNotSay ?? []).length,
+  );
+}
+
 function HumanReadableRecommendationCaseFile({
   recommendation,
 }: {
   recommendation: DossierRecommendation;
 }) {
   const view = createHumanReadableRecommendationView(recommendation);
+  const addsUsefulInformation = recommendationAddsUsefulInformation(recommendation);
   return (
     <section className="border border-border bg-surface p-5 space-y-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
-          <p className="text-xs uppercase tracking-[0.4em] text-accent">Human case-file view</p>
-          <h2 className="text-2xl font-bold text-foreground">{view.sourceLabel}</h2>
+          <p className="text-xs uppercase tracking-[0.4em] text-accent">Plain-English review view</p>
+          <h2 className="text-2xl font-bold text-foreground">Recommendation Takeaway</h2>
           <p className="text-sm text-muted">{view.sourceCopy}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <StatusBadge>{recommendation.status}</StatusBadge>
           <StatusBadge>Created {formatDate(recommendation.createdAt)}</StatusBadge>
           <StatusBadge>{view.warningCount} warnings</StatusBadge>
-          <StatusBadge>{view.missingInfoCount} missing info</StatusBadge>
+          <StatusBadge>{view.missingInfoCount} open questions</StatusBadge>
+          <StatusBadge>{addsUsefulInformation ? "Adds review context" : "Thin: routing only"}</StatusBadge>
         </div>
       </div>
-      <p className="border border-border/60 bg-background/30 p-3 text-sm text-foreground">
-        {view.summary}
-      </p>
+      <div className="border border-border/60 bg-background/30 p-3 text-sm text-foreground space-y-2">
+        <p className="font-semibold">{view.summary}</p>
+        <p className="text-muted">
+          {addsUsefulInformation
+            ? "This recommendation may add useful internal context. Review the claims and safety notes before attaching it to a source file or drafting from it."
+            : "This recommendation is currently thin. It mainly says where the item belongs and does not add enough useful context to draft from."}
+        </p>
+        <p className="text-muted">
+          Next step: attach it to the right BNL Source File, create a proposed identity link, dismiss it, or convert it only after confirming it is a separate subject.
+        </p>
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {view.sections.map((section) => (
           <section key={section.title} className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
@@ -198,7 +218,7 @@ function HumanReadableRecommendationCaseFile({
       </div>
       <details className="border border-border/60 bg-background/20 p-3 text-xs text-muted">
         <summary className="cursor-pointer font-semibold text-foreground">
-          Raw metadata / audit details
+          Technical audit details
         </summary>
         <div className="mt-3 space-y-3">
           <dl className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -210,7 +230,7 @@ function HumanReadableRecommendationCaseFile({
             ))}
           </dl>
           <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words border border-border/50 bg-background/30 p-3">
-            {view.rawText || "No raw text stored."}
+            {view.rawText || "No original text stored."}
           </pre>
         </div>
       </details>
@@ -547,14 +567,14 @@ export default function DossierRecommendationPage() {
                   href={`/admin/dossiers/candidates/${targetCandidate.id}`}
                   className="mt-2 inline-flex text-accent hover:underline"
                 >
-                  Open target workflow record: {targetCandidate.name}
+                  Open target internal record: {targetCandidate.name}
                 </Link>
               ) : recommendation.targetCandidateId ? (
                 <Link
                   href={`/admin/dossiers/candidates/${recommendation.targetCandidateId}`}
                   className="mt-2 inline-flex text-accent hover:underline"
                 >
-                  Open target workflow record
+                  Open target internal record
                 </Link>
               ) : null}
               <p className="mt-2 text-xs uppercase tracking-widest text-muted">
@@ -600,14 +620,14 @@ export default function DossierRecommendationPage() {
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
         {isEnrichmentRecommendation && (
           <section className="border border-accent/60 bg-accent/10 p-5 text-sm text-accent space-y-3">
-            <p className="text-xs uppercase tracking-[0.45em]">BNL Source File Enrichment</p>
+            <p className="text-xs uppercase tracking-[0.45em]">BNL Review Addendum</p>
             <h2 className="text-2xl font-bold">Review-only internal case-file material</h2>
             <p>
-              This packet is BNL-generated enrichment, not candidate discovery,
-              not raw bridge intake, not public copy, and not publication approval.
-              Owner/admin review is required before any public use.
+              This packet is BNL-generated review context, not candidate discovery,
+              not public copy, and not publication approval. Owner/admin review
+              is required before any public use.
             </p>
-            <p>Enrichment target lane: {enrichmentLane}</p>
+            <p>Review target: {enrichmentLane}</p>
             {targetCandidate ? (
               <p>Target record: {targetCandidate.name} ({targetCandidate.status})</p>
             ) : (
@@ -736,7 +756,7 @@ export default function DossierRecommendationPage() {
               </h2>
               <p className="text-sm text-muted mt-2">
                 Recommendation subject: {recommendation.subjectName}. This creates
-                a proposed alias on the selected workflow record only. It does not
+                a proposed alias on the selected internal record only. It does not
                 confirm the alias, publish, merge source files, create a draft, or
                 create tags.
               </p>

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -77,22 +77,22 @@ function addItem(sections: Map<string, string[]>, title: string, value?: string)
 function sourceLabel(ingestSource?: DossierRecommendationIngestSource) {
   if (ingestSource === "bnl_source_knowledge_bridge") {
     return {
-      label: "Legacy BNL Source Knowledge Bridge Note",
+      label: "Older BNL Review Note",
       copy:
-        "This is review-only source material imported from the older bridge path. Treat it as internal context, not public dossier copy.",
+        "Review-only context connected to this subject. Treat it as internal background, not public dossier copy.",
     };
   }
   if (ingestSource === "bnl_source_file_enrichment") {
     return {
-      label: "BNL Source File Enrichment",
+      label: "BNL Review Addendum",
       copy:
-        "Review-only enrichment generated for this workflow record. Public copy still requires owner/admin approval.",
+        "Review-only enrichment for this subject. Public copy still requires owner/admin approval.",
     };
   }
   return {
-    label: "BNL Source File Note",
+    label: "Internal Case-File Note",
     copy:
-      "Internal working case-file material. Review before using in any proposed or public dossier copy.",
+      "Internal working material. Review before using in any proposed or public dossier copy.",
   };
 }
 
@@ -100,6 +100,36 @@ function excerpt(text: string, maxLength = 220) {
   const compact = text.replace(/\s+/g, " ").trim();
   if (compact.length <= maxLength) return compact;
   return `${compact.slice(0, maxLength - 1).trim()}…`;
+}
+
+function hasSubstance(note: NoteLike, sections: Map<string, string[]>) {
+  return Boolean(
+    note.evidenceSummary ||
+      note.reason ||
+      sections.get("Confirmed / Strong")?.length ||
+      sections.get("Claimed / Needs Review")?.length ||
+      sections.get("Pattern BNL Noticed")?.length ||
+      sections.get("Not Public Yet")?.length ||
+      (note.publicSafetyNotes ?? []).length ||
+      (note.missingInfo ?? []).length,
+  );
+}
+
+function plainTakeaway(note: NoteLike, sections: Map<string, string[]>, fallback: string) {
+  if (note.ingestSource === "bnl_source_knowledge_bridge") {
+    return hasSubstance(note, sections)
+      ? "BNL found older review-only context connected to this subject. Review the evidence before using it publicly."
+      : "BNL found review-only context connected to this subject, but the note does not yet contain enough public-safe detail to draft from.";
+  }
+  if (note.ingestSource === "bnl_source_file_enrichment") {
+    return hasSubstance(note, sections)
+      ? "BNL found review-only enrichment for this subject. Check what is useful, claimed, or not public before drafting from it."
+      : "BNL added a review-only enrichment note, but it mostly confirms the file needs more useful context before drafting.";
+  }
+  if (hasSubstance(note, sections)) {
+    return "This internal note may add useful context. Review what is confirmed, claimed, or not public before drafting from it.";
+  }
+  return fallback || "This internal note is review-only and does not yet add enough public-safe detail to draft from.";
 }
 
 export function createHumanReadableSourceFileNoteView(
@@ -130,39 +160,38 @@ export function createHumanReadableSourceFileNoteView(
       continue;
     }
     if (evidenceHeadingPattern.test(line)) {
-      addItem(sections, "Possible Supporting Evidence", withoutHeading(line));
+      addItem(sections, "Claimed / Needs Review", withoutHeading(line));
     } else if (publicSafetyHeadingPattern.test(line)) {
-      addItem(sections, "Public Safety", withoutHeading(line));
+      addItem(sections, "Not Public Yet", withoutHeading(line));
     } else if (missingInfoHeadingPattern.test(line)) {
-      addItem(sections, "Missing Info", withoutHeading(line));
+      addItem(sections, "Open Questions", withoutHeading(line));
     } else if (doNotSayHeadingPattern.test(line)) {
-      addItem(sections, "Do Not Say", withoutHeading(line));
+      addItem(sections, "Not Public Yet", withoutHeading(line));
     } else if (actionHeadingPattern.test(line)) {
-      addItem(sections, "Suggested Next Action", withoutHeading(line));
+      addItem(sections, "Recommended Next Step", withoutHeading(line));
     } else if (summaryHeadingPattern.test(line)) {
-      addItem(sections, "Review Context", withoutHeading(line));
+      addItem(sections, "Pattern BNL Noticed", withoutHeading(line));
     } else if (/public use requires review|internal\/private review|required|review-only|not public copy|owner\/admin review/i.test(line)) {
-      addItem(sections, "Needs Owner Review", line);
+      addItem(sections, "Not Public Yet", line);
     } else if (!summary) {
       summary = line;
     } else {
-      addItem(sections, "Source-Limited Notes", line);
+      addItem(sections, "Claimed / Needs Review", line);
     }
   }
 
   if (!summary) summary = excerpt(text) || "Review-only internal source-file note.";
 
-  addItem(sections, "Summary", summary);
-  addItem(sections, "Why It Matters / Review Reason", note.reason);
-  addItem(sections, "Evidence", note.evidenceSummary);
-  for (const item of note.publicSafetyNotes ?? []) addItem(sections, "Source Warnings", item);
-  for (const item of note.missingInfo ?? []) addItem(sections, "Missing Info", item);
-  for (const item of note.doNotSay ?? []) addItem(sections, "Do Not Say", item);
-  addItem(sections, "Suggested Next Action", note.suggestedAction);
-  addItem(sections, "Admin Metadata", `Source: ${note.source ?? "—"}`);
-  addItem(sections, "Admin Metadata", `Status: ${note.status ?? "—"}`);
-  addItem(sections, "Admin Metadata", `Public safe: ${String(note.publicSafe)}`);
+  addItem(sections, "Pattern BNL Noticed", note.reason || summary);
+  addItem(sections, "Claimed / Needs Review", note.evidenceSummary);
+  for (const item of note.publicSafetyNotes ?? []) addItem(sections, "Not Public Yet", item);
+  for (const item of note.missingInfo ?? []) addItem(sections, "Open Questions", item);
+  for (const item of note.doNotSay ?? []) addItem(sections, "Not Public Yet", item);
+  addItem(sections, "Recommended Next Step", note.suggestedAction);
 
+  rawMetadata.push({ label: "noteSource", value: note.source ?? "—" });
+  rawMetadata.push({ label: "noteStatus", value: note.status ?? "—" });
+  rawMetadata.push({ label: "publicSafe", value: String(note.publicSafe) });
   if (note.ingestKey) rawMetadata.push({ label: "ingestKey", value: note.ingestKey });
   if (note.ingestedAt) rawMetadata.push({ label: "ingestedAt", value: note.ingestedAt });
   if (note.ingestSource) rawMetadata.push({ label: "ingestSource", value: note.ingestSource });
@@ -172,10 +201,10 @@ export function createHumanReadableSourceFileNoteView(
 
   const warningCount = (note.publicSafetyNotes ?? []).length +
     Array.from(sections.entries())
-      .filter(([title]) => title === "Source Warnings" || title === "Public Safety")
+      .filter(([title]) => title === "Not Public Yet")
       .reduce((count, [, items]) => count + items.length, 0);
   const missingInfoCount =
-    (note.missingInfo ?? []).length + (sections.get("Missing Info")?.length ?? 0);
+    (note.missingInfo ?? []).length + (sections.get("Open Questions")?.length ?? 0);
 
   return {
     sourceLabel: source.label,
@@ -183,7 +212,7 @@ export function createHumanReadableSourceFileNoteView(
     isLegacyBridge: note.ingestSource === "bnl_source_knowledge_bridge",
     isEnrichment: note.ingestSource === "bnl_source_file_enrichment",
     legacyRawFormatting,
-    summary: excerpt(summary),
+    summary: plainTakeaway(note, sections, excerpt(summary)),
     sections: Array.from(sections.entries()).map(([title, items]) => ({ title, items })),
     rawMetadata,
     rawText: text,

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -1,0 +1,269 @@
+import type {
+  DossierCandidate,
+  DossierDraft,
+  DossierRecommendation,
+} from "./dossier-workflow";
+
+export type DossierSourceFileSubstanceLevel =
+  | "thin"
+  | "partial"
+  | "useful"
+  | "strong";
+
+export type DossierSourceFilePublicReadiness =
+  | "not_ready"
+  | "needs_review"
+  | "draftable"
+  | "owner_approved";
+
+export type DossierSourceFileNextAction =
+  | "archive"
+  | "enrich"
+  | "attach_to_existing_dossier"
+  | "draft_public_dossier"
+  | "owner_review";
+
+export type DossierSourceFileSummary = {
+  currentRead: string;
+  knownContext: string[];
+  whyTracked: string;
+  usefulEvidence: string[];
+  patterns: string[];
+  uncertainties: string[];
+  missingInfo: string[];
+  recommendedNextAction: string;
+  substanceLevel: DossierSourceFileSubstanceLevel;
+  publicReadiness: DossierSourceFilePublicReadiness;
+  existingPublicDossier: "yes" | "no" | "linked_update_target";
+  nextAction: DossierSourceFileNextAction;
+  lastUpdatedAt: string;
+};
+
+type SummaryInput = {
+  candidate: DossierCandidate;
+  drafts?: DossierDraft[];
+  recommendations?: DossierRecommendation[];
+};
+
+const activeDraftStatuses = new Set<DossierDraft["status"]>([
+  "draft",
+  "owner_changes_requested",
+  "ready_for_owner_review",
+]);
+
+function unique(items: Array<string | undefined | null>, limit = 4): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const item of items) {
+    const clean = item?.replace(/\s+/g, " ").trim();
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function hasMeaningfulText(value?: string) {
+  return Boolean(value && value.replace(/\s+/g, " ").trim().length >= 24);
+}
+
+function noteIsUseful(note: NonNullable<DossierCandidate["sourceFileNotes"]>[number]) {
+  return (
+    note.publicSafe === true ||
+    note.source === "admin_manual" ||
+    note.source === "owner_manual" ||
+    hasMeaningfulText(note.text)
+  );
+}
+
+function substanceScore({
+  candidate,
+  recommendations = [],
+}: SummaryInput): number {
+  let score = 0;
+  if (hasMeaningfulText(candidate.reason)) score += 1;
+  if (hasMeaningfulText(candidate.whyNow)) score += 1;
+  if (hasMeaningfulText(candidate.evidenceSummary)) score += 1;
+  score += Math.min(candidate.knownFacts?.length ?? 0, 3);
+  score += Math.min(candidate.evidenceItems?.length ?? 0, 3);
+  score += Math.min(
+    (candidate.sourceFileNotes ?? []).filter(noteIsUseful).length,
+    3,
+  );
+  score += Math.min(
+    recommendations.filter(
+      (recommendation) =>
+        hasMeaningfulText(recommendation.reason) ||
+        hasMeaningfulText(recommendation.evidenceSummary),
+    ).length,
+    3,
+  );
+  if (candidate.publicSafetyNotes?.length) score += 1;
+  if (candidate.doNotSay?.length) score += 1;
+  return score;
+}
+
+function substanceLevel(input: SummaryInput): DossierSourceFileSubstanceLevel {
+  const score = substanceScore(input);
+  if (score >= 10) return "strong";
+  if (score >= 6) return "useful";
+  if (score >= 3) return "partial";
+  return "thin";
+}
+
+function labelLevel(level: DossierSourceFileSubstanceLevel) {
+  return level[0].toUpperCase() + level.slice(1);
+}
+
+function publicReadiness(
+  level: DossierSourceFileSubstanceLevel,
+  drafts: DossierDraft[] = [],
+): DossierSourceFilePublicReadiness {
+  if (drafts.some((draft) => draft.status === "owner_approved")) {
+    return "owner_approved";
+  }
+  if (drafts.some((draft) => draft.status === "ready_for_owner_review")) {
+    return "draftable";
+  }
+  if (level === "useful" || level === "strong") return "needs_review";
+  return "not_ready";
+}
+
+function nextAction(input: {
+  candidate: DossierCandidate;
+  drafts?: DossierDraft[];
+  level: DossierSourceFileSubstanceLevel;
+  readiness: DossierSourceFilePublicReadiness;
+}): DossierSourceFileNextAction {
+  const { candidate, drafts = [], level, readiness } = input;
+  if (candidate.status === "archived" || candidate.status === "denied") {
+    return "archive";
+  }
+  if (candidate.existingDossierMatch || candidate.status === "existing_dossier_update") {
+    return "attach_to_existing_dossier";
+  }
+  if (readiness === "owner_approved" || drafts.some((draft) => draft.status === "ready_for_owner_review")) {
+    return "owner_review";
+  }
+  if (level === "useful" || level === "strong") return "draft_public_dossier";
+  return "enrich";
+}
+
+function nextActionCopy(action: DossierSourceFileNextAction) {
+  if (action === "archive") return "Archive or keep closed unless a lead asks for more review.";
+  if (action === "attach_to_existing_dossier") return "Review the new context and attach only useful, public-safe updates to the linked public dossier later.";
+  if (action === "draft_public_dossier") return "Review the evidence, separate claims from confirmed facts, then draft a public dossier only from approved material.";
+  if (action === "owner_review") return "Send the reviewed draft or update notes through owner review before anything public changes.";
+  return "Add real context: repeated appearances, channel notes, public-safe facts, missing history, and owner/admin review notes.";
+}
+
+export function createDossierSourceFileSummary(
+  input: SummaryInput,
+): DossierSourceFileSummary {
+  const { candidate, drafts = [], recommendations = [] } = input;
+  const level = substanceLevel(input);
+  const readiness = publicReadiness(level, drafts);
+  const action = nextAction({ candidate, drafts, level, readiness });
+  const activeDraft = drafts.find((draft) => activeDraftStatuses.has(draft.status));
+  const usefulEvidence = unique(
+    [
+      candidate.evidenceSummary,
+      ...(candidate.evidenceItems ?? []).map((item) => item.summary || item.label),
+      ...recommendations.map((recommendation) => recommendation.evidenceSummary),
+    ],
+    4,
+  );
+  const knownContext = unique(
+    [
+      ...((candidate.knownFacts ?? []).length
+        ? candidate.knownFacts ?? []
+        : [candidate.reason]),
+      ...(candidate.sourceFileNotes ?? [])
+        .filter((note) => note.publicSafe === true)
+        .map((note) => note.text),
+    ],
+    4,
+  );
+  const patterns = unique(
+    [
+      candidate.whyNow,
+      ...recommendations.map((recommendation) => recommendation.reason),
+    ],
+    3,
+  );
+  const uncertainties = unique(
+    [
+      ...(candidate.publicSafetyNotes ?? []),
+      ...(candidate.doNotSay ?? []),
+      ...recommendations.flatMap((recommendation) => [
+        ...(recommendation.publicSafetyNotes ?? []),
+        ...(recommendation.doNotSay ?? []),
+      ]),
+    ],
+    4,
+  );
+  const missingInfo = unique(
+    [
+      ...(candidate.missingInfo ?? []),
+      ...recommendations.flatMap((recommendation) => recommendation.missingInfo ?? []),
+    ],
+    4,
+  );
+  const thinCopy =
+    "This file is currently thin. It confirms the subject exists in BNL records, but it does not yet contain enough history, repeated behavior, channel context, or public-safe facts to support a useful dossier.";
+
+  return {
+    currentRead:
+      level === "thin"
+        ? thinCopy
+        : `${candidate.name} has a ${labelLevel(level).toLowerCase()} internal case file. Review what is confirmed, what is only claimed, and what still needs owner/admin review before drafting from it.`,
+    knownContext:
+      knownContext.length > 0
+        ? knownContext
+        : ["BNL has this subject in the internal review workspace, but no substantial public-safe context has been captured yet."],
+    whyTracked:
+      candidate.reason ||
+      candidate.whyNow ||
+      "This subject is being tracked because it appeared in BNL records and needs human review before any public use.",
+    usefulEvidence:
+      usefulEvidence.length > 0
+        ? usefulEvidence
+        : ["No useful evidence has been captured yet beyond the fact that this internal file exists."],
+    patterns:
+      patterns.length > 0
+        ? patterns
+        : ["No repeated pattern has been established yet."],
+    uncertainties:
+      uncertainties.length > 0
+        ? uncertainties
+        : ["Treat names, mentions, and possible connections as unconfirmed until reviewed."],
+    missingInfo:
+      missingInfo.length > 0
+        ? missingInfo
+        : ["Needs more history, repeated appearances, public-safe facts, and owner/admin context."],
+    recommendedNextAction: nextActionCopy(action),
+    substanceLevel: level,
+    publicReadiness: readiness,
+    existingPublicDossier: candidate.existingDossierMatch
+      ? candidate.status === "existing_dossier_update"
+        ? "linked_update_target"
+        : "yes"
+      : "no",
+    nextAction: action,
+    lastUpdatedAt:
+      [candidate.updatedAt, activeDraft?.updatedAt, recommendations[0]?.updatedAt]
+        .filter(Boolean)
+        .sort()
+        .at(-1) ?? candidate.updatedAt,
+  };
+}
+
+export function formatDossierSummaryBadge(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -53,6 +53,7 @@ const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
+const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -344,7 +345,7 @@ test("dossier admin pages expose the control-center/source-hub/draft-workspace m
   const sourceFileCopy = normalizedSource(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
   );
-  assertIncludesCopy(sourceFileCopy, "Case File Summary");
+  assertIncludesCopy(sourceFileCopy, "Source File Summary");
   assertIncludesCopy(sourceFileCopy, "Archive");
   assertIncludesCopy(sourceFileCopy, "Delete Permanently");
   assertIncludesCopy(sourceFileCopy, "Restore");
@@ -373,7 +374,7 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
   for (const label of [
     "Internal working case file",
     "Do not treat this as public copy",
-    "Case File Summary",
+    "Source File Summary",
     "Evidence / Source Notes",
     "Review Context / Possible Supporting Evidence",
     "Public-Safe Facts Pending Owner/Admin Approval",
@@ -384,7 +385,7 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Do Not Say",
     "Missing Info",
     "Ready for Proposed Dossier",
-    "Source-blind memory trace",
+    "Review-only memory context",
     "Internal/private review required",
     "Public use not allowed until review",
   ]) {
@@ -480,13 +481,10 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Source notes",
     "Unapplied notes",
     "Next action",
-    "Case File Summary",
-    "recommendation evidence clusters",
-    "missing info",
-    "public safety notes",
-    "do-not-say notes",
-    "taxonomy suggestions",
-    "duplicate/identity warnings",
+    "Source File Summary",
+    "Review Boundaries",
+    "claims that need review",
+    "public-safety notes",
     "Add to BNL Source File",
     "This adds information to this subject&apos;s BNL Source File. It does not directly edit the proposed dossier.",
     "Recommendation/evidence clusters",
@@ -508,14 +506,14 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Identity / Alias Review",
     "Do Not Say",
     "Missing Info",
-    "Source-blind memory trace",
+    "Review-only memory context",
     "Internal/private review required",
     "Public use not allowed until review",
     "Owner review required",
     "Possible connection, not confirmed identity",
     "Existing Public Dossier Match",
     "No existing public dossier match currently attached.",
-    "This workflow record is an existing dossier update / enrichment target, not a new dossier proposal.",
+    "This internal record is an existing dossier update / enrichment target, not a new dossier proposal.",
     "Move Back to Active Source File",
   ]) {
     assertIncludesCopy(pageCopy, label);
@@ -564,13 +562,13 @@ test("admin source file note display derives a human case-file view and collapse
     ingestKey: "bnl:bridge-debug-key",
   });
 
-  assert.equal(legacy.sourceLabel, "Legacy BNL Source Knowledge Bridge Note");
-  assert.match(legacy.sourceCopy, /older bridge path/);
+  assert.equal(legacy.sourceLabel, "Older BNL Review Note");
+  assert.match(legacy.sourceCopy, /Review-only context connected/);
   assert.equal(legacy.legacyRawFormatting, true);
-  assert.match(legacy.summary, /Bridge memory suggests/);
+  assert.match(legacy.summary, /review-only context connected/);
   assert.equal(legacy.sections.some((section) => section.title === "Known Facts"), false);
-  assert.equal(legacy.sections.some((section) => section.title === "Missing Info"), true);
-  assert.equal(legacy.sections.some((section) => section.title === "Do Not Say"), true);
+  assert.equal(legacy.sections.some((section) => section.title === "Open Questions"), true);
+  assert.equal(legacy.sections.some((section) => section.title === "Not Public Yet"), true);
   assert.equal(legacy.rawMetadata.some((item) => item.label === "Source qualities"), true);
   assert.equal(legacy.rawMetadata.some((item) => item.label === "ingestKey"), true);
 
@@ -585,42 +583,56 @@ test("admin source file note display derives a human case-file view and collapse
     ingestKey: "bnl:enrichment-key",
   });
 
-  assert.equal(enrichment.sourceLabel, "BNL Source File Enrichment");
+  assert.equal(enrichment.sourceLabel, "BNL Review Addendum");
   assert.match(enrichment.sourceCopy, /Public copy still requires owner\/admin approval/);
   assert.equal(enrichment.rawMetadata.some((item) => item.label === "ingestKey"), true);
 });
 
 test("admin Source File and recommendation pages render readable sections with collapsed audit details", () => {
   const displayHelper = normalizedSource("src/lib/dossier-note-display.ts");
-  const candidatePage = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${displayHelper}`;
+  const summaryHelper = normalizedSource("src/lib/dossier-source-file-summary.ts");
+  const candidatePage = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${displayHelper} ${summaryHelper}`;
   const recommendationPage = `${normalizedSource("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx")} ${displayHelper}`;
 
   for (const label of [
     "HumanReadableNoteView",
-    "Legacy BNL Source Knowledge Bridge Note",
-    "BNL Source File Enrichment",
-    "This is review-only source material imported from the older bridge path. Treat it as internal context, not public dossier copy.",
-    "Review-only enrichment generated for this workflow record. Public copy still requires owner/admin approval.",
-    "Raw metadata / audit details",
+    "Source File Summary",
+    "Current Read",
+    "What BNL Actually Knows",
+    "Why This File Exists",
+    "Useful Evidence",
+    "Patterns / Themes",
+    "Open Questions",
+    "Recommended Next Step",
+    "Substance:",
+    "Public readiness:",
+    "Existing public dossier:",
+    "Next action:",
+    "This file is currently thin",
+    "Older BNL Review Note",
+    "BNL Review Addendum",
+    "Review-only context connected to this subject",
+    "Technical audit details",
     "warnings",
-    "missing info",
-    "Review Context / Possible Supporting Evidence",
-    "Source-Limited Notes",
-    "Needs Owner Review",
+    "Open Questions",
+    "Claimed / Needs Review",
+    "Pattern BNL Noticed",
+    "Not Public Yet",
   ]) {
     assertIncludesCopy(candidatePage, label);
   }
 
   for (const label of [
-    "Human case-file view",
-    "Raw metadata / audit details",
-    "Summary",
-    "Why It Matters / Review Reason",
-    "Evidence",
-    "Source Warnings",
-    "Missing Info",
-    "Suggested Next Action",
-    "Do Not Say",
+    "Plain-English review view",
+    "Recommendation Takeaway",
+    "Technical audit details",
+    "Adds review context",
+    "Thin: routing only",
+    "Claimed / Needs Review",
+    "Pattern BNL Noticed",
+    "Not Public Yet",
+    "Open Questions",
+    "Recommended Next Step",
   ]) {
     assertIncludesCopy(recommendationPage, label);
   }
@@ -3061,6 +3073,90 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   );
 });
 
+
+
+test("derived Source File summary labels thin files without fake substance", () => {
+  const thinCandidate = {
+    id: "candidate_thin",
+    name: "Thin Subject",
+    candidateType: "unknown",
+    source: "bnl_dynamic_candidate_discovery",
+    tier: "weak_candidate",
+    score: 1,
+    whyNow: "",
+    reason: "",
+    evidenceSummary: "",
+    sourceFileNotes: [],
+    status: "active_source_file",
+    createdAt: "2026-05-31T00:00:00.000Z",
+    updatedAt: "2026-05-31T00:00:00.000Z",
+  };
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: thinCandidate,
+    drafts: [],
+    recommendations: [],
+  });
+  assert.equal(summary.substanceLevel, "thin");
+  assert.equal(summary.publicReadiness, "not_ready");
+  assert.match(summary.currentRead, /currently thin/);
+  assert.match(summary.usefulEvidence[0], /No useful evidence/);
+  assert.doesNotMatch(
+    JSON.stringify(summary),
+    /ingest|source lane|evidence mapping|workflow record|bridge|metadata|payload|normalized|targetCandidateId|internal id|raw source|source qualities/i,
+  );
+
+  const usefulSummary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: {
+      ...thinCandidate,
+      reason: "Repeated approved-channel mentions and admin notes suggest this subject needs review.",
+      whyNow: "The subject has appeared repeatedly around BARCODE Radio planning notes.",
+      evidenceSummary: "Approved notes mention repeated appearances and a public-safe role summary.",
+      knownFacts: ["Confirmed / Strong public-safe context exists in approved notes."],
+      evidenceItems: [
+        {
+          id: "evidence_1",
+          type: "operator_note",
+          label: "Approved note",
+          summary: "Public-safe approved note with repeated appearances.",
+          publicSafe: true,
+        },
+      ],
+      sourceFileNotes: [
+        {
+          id: "note_1",
+          candidateId: "candidate_thin",
+          type: "fact",
+          text: "Public-safe admin note with concrete context for review.",
+          source: "admin_manual",
+          status: "active",
+          publicSafe: true,
+          createdAt: "2026-05-31T00:00:00.000Z",
+          updatedAt: "2026-05-31T00:00:00.000Z",
+        },
+      ],
+    },
+    drafts: [],
+    recommendations: [
+      {
+        id: "rec_1",
+        type: "new_subject",
+        subjectName: "Thin Subject",
+        reason: "Repeated approved-channel references need admin review.",
+        evidenceSummary: "Multiple approved notes mention the subject in the same context.",
+        confidence: "medium",
+        status: "new",
+        createdBy: "bnl",
+        sourceLanes: ["rd_context"],
+        sourceTypes: [],
+        targetCandidateId: "candidate_thin",
+        createdAt: "2026-05-31T00:00:00.000Z",
+        updatedAt: "2026-05-31T00:00:00.000Z",
+      },
+    ],
+  });
+  assert.match(usefulSummary.substanceLevel, /useful|strong/);
+});
+
 test("source note and recommendation actions enforce auth and validation", async () => {
   await resetWorkflowStore();
   const unauthNote = await route.POST(
@@ -4136,12 +4232,11 @@ test("admin dossier UI labels BNL Source File enrichment separately from bridge 
   const recommendationPage = source("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx");
   const candidatePage = `${source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${source("src/lib/dossier-note-display.ts")}`;
 
-  assert.match(dashboard, /BNL Source File Enrichment/);
-  assert.match(dashboard, /Review-only internal case-file material; not public copy/);
-  assert.match(recommendationPage, /BNL Source File Enrichment/);
+  assert.match(dashboard, /BNL review addendum|Known from BNL records \/ review addendum/);
+  assert.match(recommendationPage, /BNL Review Addendum|BNL review addendum/);
   assert.match(recommendationPage, /not candidate discovery/);
-  assert.match(recommendationPage, /not raw bridge intake/);
-  assert.match(recommendationPage, /Owner\/admin review is required before any public use/);
-  assert.match(candidatePage, /BNL Source File Enrichment/);
-  assert.match(candidatePage, /internal case-file material|Internal working case-file material/);
+  assert.doesNotMatch(recommendationPage, /raw bridge intake/);
+  assert.match(recommendationPage, /Owner\/admin review[\s\S]*required before any public use/);
+  assert.match(candidatePage, /BNL Review Addendum/);
+  assert.match(candidatePage, /Internal working material|Review-only enrichment/);
 });


### PR DESCRIPTION
### Motivation
- Make BNL Source File admin pages read like short internal case files that immediately answer what is known, what is missing, and what to do next. 
- Remove implementation-heavy backend language from the main admin reading experience while preserving full technical/audit details in a collapsed view. 
- Provide a stable, structured summary shape so derived summaries can later be persisted or edited by operators. 

### Description
- Added a derived Source File summary helper `createDossierSourceFileSummary` and badge formatter (`src/lib/dossier-source-file-summary.ts`) that produces `currentRead`, `knownContext`, `whyTracked`, `usefulEvidence`, `patterns`, `uncertainties`, `missingInfo`, `recommendedNextAction`, `substanceLevel`, `publicReadiness`, `existingPublicDossier`, `nextAction`, and `lastUpdatedAt` fields. 
- Rendered a top-level Source File Summary panel on the admin candidate page with status badges and short sections (`src/app/admin/dossiers/candidates/[candidateId]/page.tsx`). 
- Rewrote note rendering to lead with a plain‑English takeaway, separate claimed vs stronger evidence into readable sections, and move raw/technical metadata into a collapsed "Technical audit details" block (`src/lib/dossier-note-display.ts`). 
- Updated the recommendation detail page UX to show a plain‑English recommendation takeaway and a thin/vs/useful indicator with next-step guidance (`src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`). 
- Reduced backend wording in admin dashboard/candidate provenance copy and replaced technical labels with operator-facing phrases while preserving internal behavior (`src/app/admin/dossiers/page.tsx`). 
- Added/updated unit tests and expectations to assert the new summary panel, thin-file behavior, plain-language note cards, collapsed technical details, and wording changes (`tests/admin-dossiers.test.mjs`). 

### Testing
- Ran type check with `npx tsc --noEmit` and linting on touched files via `npx eslint` with no blocking errors. 
- Ran the full admin dossier unit suite `node --test tests/admin-dossiers.test.mjs` and the BNL read-model suite `node --test tests/bnl-read-model.test.mjs`; both suites passed in this environment. 
- Ran queue-related integration checks via `npm run test:queue` which executed `tests/queue-playback.test.mjs` and `tests/bnl-read-model.test.mjs` and completed successfully. 
- Note: attempting `npx playwright --version` to capture a browser screenshot failed due to a registry access `403` in this environment, which does not affect the repository tests or runtime changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcfeeec448321bbd2692dfa9fc76b)