### PR TITLE
Website PR #154 — Public dossier fallback for protected source-file lookup

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -971,6 +971,21 @@ export default function DossierControlCenterPage() {
             work, not as brand-new public dossiers. Owner approval is required
             before public changes.
           </p>
+          <div className="mb-4 grid grid-cols-1 md:grid-cols-3 gap-3 text-sm text-muted">
+            <p className="border border-border/70 bg-background/20 p-3">
+              Existing public dossier found: protected source lookup can now
+              recognize a published dossier target even when no internal update
+              file exists yet.
+            </p>
+            <p className="border border-border/70 bg-background/20 p-3">
+              No internal update file exists yet: use the protected Create
+              Existing Dossier Update action before enrichment attaches notes.
+            </p>
+            <p className="border border-border/70 bg-background/20 p-3">
+              Review-only; no public changes. The update lane does not approve
+              public copy, aliases, identity merges, or publication.
+            </p>
+          </div>
           {existingDossierUpdates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
               No existing public dossier update records are waiting.

--- a/src/app/api/bnl/source-files/route.ts
+++ b/src/app/api/bnl/source-files/route.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
+import { databasePage, type DatabaseEntry } from "@/content";
 import {
   compactDossierSubjectName,
   isActiveSourceFileCandidate,
@@ -10,7 +11,10 @@ import {
   type DossierRecommendation,
   type DossierSourceFileNote,
 } from "@/lib/dossier-workflow";
-import { getDossierWorkflowState } from "@/lib/dossier-workflow-store";
+import {
+  createExistingDossierUpdateTarget,
+  getDossierWorkflowState,
+} from "@/lib/dossier-workflow-store";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -60,7 +64,8 @@ type MatchKind =
   | "existing_dossier_update_name"
   | "existing_dossier_update_compact_name"
   | "existing_dossier_update_normalized_name"
-  | "existing_dossier_update_confirmed_alias";
+  | "existing_dossier_update_confirmed_alias"
+  | "public_dossier_only";
 
 type PossibleMatchKind =
   | "same_name"
@@ -71,12 +76,153 @@ type PossibleMatchKind =
 type WorkflowLane =
   | "candidate_intake"
   | "active_source_file"
-  | "existing_dossier_update";
+  | "existing_dossier_update"
+  | "public_dossier_update_target";
 
 type QueryMode = "candidateId" | "subject" | "alias" | "normalizedName";
 
 type AliasMatchKind = Extract<MatchKind, `${string}alias`>;
 type DirectMatchKind = Exclude<MatchKind, AliasMatchKind>;
+
+type PublicDossierMatchKind =
+  | "public_dossier_name"
+  | "public_dossier_normalized_name"
+  | "public_dossier_compact_name"
+  | "public_dossier_slug"
+  | "public_dossier_tag";
+
+type PublicDossierMatch = {
+  entry: DatabaseEntry;
+  slug: string;
+  matchKind: PublicDossierMatchKind;
+};
+
+const PUBLIC_DOSSIER_ONLY_WARNING =
+  "Public dossier exists, but no internal Existing Dossier Update record exists yet. Create an internal update target before enrichment can attach notes.";
+
+function slugifyPublicDossierName(name: string) {
+  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+}
+
+function publicDossierMatchSummary(match: PublicDossierMatch) {
+  return {
+    targetDossierId: match.entry.id,
+    publicDossierName: match.entry.name,
+    publicDossierSlug: match.slug,
+    publicDossierPath: `/database/${match.slug}`,
+    publicDossierCategory: match.entry.category,
+    publicDossierKind: match.entry.kind,
+    publicDossierStatus: match.entry.status,
+    publicDossierClearance: match.entry.clearance,
+    matchKind: match.matchKind,
+    confidence:
+      match.matchKind === "public_dossier_name" ||
+      match.matchKind === "public_dossier_normalized_name" ||
+      match.matchKind === "public_dossier_slug"
+        ? "high"
+        : "medium",
+  };
+}
+
+function resolvePublicDossierOnlyMatch(input: {
+  mode: QueryMode;
+  value: string;
+}): PublicDossierMatch[] {
+  if (input.mode === "candidateId") return [];
+  const normalizedValue = normalizeDossierSubjectName(input.value);
+  const compactValue = compactDossierSubjectName(input.value);
+  const slugValue = slugifyPublicDossierName(input.value);
+  if (!normalizedValue && !slugValue) return [];
+
+  return databasePage.entries
+    .map((entry): PublicDossierMatch | null => {
+      const slug = slugifyPublicDossierName(entry.name);
+      const normalizedName = normalizeDossierSubjectName(entry.name);
+      const compactName = compactDossierSubjectName(entry.name);
+      const tagMatch = (entry.tags ?? []).some(
+        (tag) => normalizeDossierSubjectName(tag) === normalizedValue,
+      );
+
+      if (input.mode === "alias" && tagMatch) {
+        return { entry, slug, matchKind: "public_dossier_tag" };
+      }
+      if (input.mode === "normalizedName" && normalizedValue === normalizedName) {
+        return { entry, slug, matchKind: "public_dossier_normalized_name" };
+      }
+      if (input.mode === "subject" && input.value.trim() === entry.name) {
+        return { entry, slug, matchKind: "public_dossier_name" };
+      }
+      if (input.mode === "subject" && normalizedValue === normalizedName) {
+        return { entry, slug, matchKind: "public_dossier_normalized_name" };
+      }
+      if (input.mode === "subject" && compactValue === compactName) {
+        return { entry, slug, matchKind: "public_dossier_compact_name" };
+      }
+      if (input.mode !== "alias" && slugValue === slug) {
+        return { entry, slug, matchKind: "public_dossier_slug" };
+      }
+      return null;
+    })
+    .filter((match): match is PublicDossierMatch => Boolean(match));
+}
+
+function publicDossierOnlyResponse(input: {
+  query: { mode: QueryMode; value: string };
+  match: PublicDossierMatch;
+  possibleMatches: ReturnType<typeof possibleMatchSummary>[];
+}) {
+  const publicMatch = publicDossierMatchSummary(input.match);
+  return {
+    ok: true,
+    found: true,
+    scope: "bnl_internal_source_file_read_model",
+    auth: "BNL_SOURCE_FILE_READ_TOKEN",
+    mutation: false,
+    query: input.query,
+    matchKind: "public_dossier_only" as const,
+    workflowLane: "public_dossier_update_target" as const,
+    sourceFileActive: false,
+    laneDescription:
+      "Existing public dossier found; no internal update file exists yet. Protected/internal suggestion only.",
+    publicDossierMatchFound: true,
+    existingDossierUpdateLane: false,
+    candidateIntake: false,
+    publicCopyApproval: false,
+    reviewRequired: true,
+    recommendedAction: "create_existing_dossier_update" as const,
+    warning: PUBLIC_DOSSIER_ONLY_WARNING,
+    targetDossierId: input.match.entry.id,
+    publicDossierName: input.match.entry.name,
+    publicDossierSlug: input.match.slug,
+    publicDossierPath: `/database/${input.match.slug}`,
+    publicDossierMatch: publicMatch,
+    sourceFile: null,
+    sourceRecord: null,
+    possibleMatches: input.possibleMatches,
+    createExistingDossierUpdateAction: {
+      method: "POST",
+      endpoint: "/api/bnl/source-files",
+      action: "create_existing_dossier_update",
+      targetDossierId: input.match.entry.id,
+      publicDossierSlug: input.match.slug,
+      requestedSubject: input.query.value,
+      mutation: "internal_workflow_only",
+      publishesPublicDossier: false,
+    },
+    readModelBoundary: {
+      ...VISIBILITY_BOUNDARY,
+      boundaryLabel:
+        "internal protected lookup fallback; existing public dossier target suggestion only",
+      publishWarning:
+        "Public dossier-only fallback is not an active Source File, Candidate Intake item, public copy approval, alias confirmation, identity merge, or publication action",
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function stringFromBody(value: unknown): string {
+  return typeof value === "string" ? value.trim().slice(0, 200) : "";
+}
 
 type ResolvedMatch =
   | {
@@ -643,6 +789,20 @@ export async function GET(req: Request) {
     candidates: state.candidates,
   });
 
+  if (matches.length === 0) {
+    const publicDossierMatches = resolvePublicDossierOnlyMatch(query);
+    if (publicDossierMatches.length === 1) {
+      return NextResponse.json(
+        publicDossierOnlyResponse({
+          query,
+          match: publicDossierMatches[0],
+          possibleMatches,
+        }),
+        { headers: { "Cache-Control": CACHE_CONTROL } },
+      );
+    }
+  }
+
   if (matches.length === 1) {
     const match = matches[0];
     const sourceRecord = sourceFileReadModel({
@@ -713,6 +873,88 @@ export async function GET(req: Request) {
           : possibleMatches.length > 0
             ? "Only possible BNL Source File matches found; no confirmed match was resolved."
             : "No BNL Source File match found.",
+      readModelBoundary: VISIBILITY_BOUNDARY,
+      generatedAt: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}
+
+export async function POST(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Valid JSON body is required" },
+      { status: 400, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const action = stringFromBody(body.action);
+  if (action !== "create_existing_dossier_update") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Unsupported action",
+        supportedActions: ["create_existing_dossier_update"],
+      },
+      { status: 400, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const targetDossierId = stringFromBody(body.targetDossierId);
+  const requestedSubject = stringFromBody(body.requestedSubject);
+  const publicDossierSlug = stringFromBody(body.publicDossierSlug);
+  const publicDossierName = stringFromBody(body.publicDossierName);
+  const entry = targetDossierId
+    ? databasePage.entries.find((item) => item.id === targetDossierId)
+    : databasePage.entries.find((item) => {
+        const slug = slugifyPublicDossierName(item.name);
+        return (
+          (publicDossierSlug && slug === publicDossierSlug) ||
+          (publicDossierName &&
+            normalizeDossierSubjectName(item.name) ===
+              normalizeDossierSubjectName(publicDossierName))
+        );
+      });
+
+  if (!entry) {
+    return NextResponse.json(
+      { ok: false, error: "Existing public dossier target was not found" },
+      { status: 404, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const beforePublicDossier = JSON.stringify(entry);
+  const candidate = await createExistingDossierUpdateTarget({
+    dossierId: entry.id,
+    requestedSubject: requestedSubject || publicDossierName || entry.name,
+    createdBy: "bnl_source_files_protected_lookup",
+  });
+  const afterEntry = databasePage.entries.find((item) => item.id === entry.id);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      action,
+      mutation: "internal_workflow_only",
+      publishesPublicDossier: false,
+      publicDossierMutated: JSON.stringify(afterEntry) !== beforePublicDossier,
+      workflowLane: "existing_dossier_update",
+      sourceFileActive: false,
+      existingDossierUpdateLane: true,
+      publicDossierMatchFound: true,
+      targetDossierId: entry.id,
+      publicDossierName: entry.name,
+      publicDossierSlug: slugifyPublicDossierName(entry.name),
+      candidate,
+      warning:
+        "Internal Existing Dossier Update lane created for review-only enrichment. No public dossier content was published or changed.",
       readModelBoundary: VISIBILITY_BOUNDARY,
       generatedAt: new Date().toISOString(),
     },

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6,6 +6,7 @@ import {
   type CreateDossierSourceFileNoteInput,
   type UpdateDossierSourceFileSummaryInput,
   type CreateManualDossierCandidateInput,
+  type CreateExistingDossierUpdateTargetInput,
   type DossierCandidate,
   type DossierCandidateStatus,
   type DossierIdentityLink,
@@ -2186,6 +2187,125 @@ export function archiveDossierRecommendation(
   recommendationId: string,
 ): Promise<DossierRecommendation> {
   return setRecommendationStatus(recommendationId, "archived");
+}
+
+function candidateTypeFromPublicDossierEntry(
+  entry: DatabaseEntry,
+): DossierCandidate["candidateType"] {
+  if (entry.kind === "artist") return "artist";
+  if (entry.kind === "community_member" || entry.category === "Personnel") {
+    return "community_member";
+  }
+  if (entry.category === "Production") return "production";
+  if (entry.category === "Interface") return "interface";
+  if (entry.category === "Sponsor") return "sponsor";
+  if (entry.category === "Entity") return "entity";
+  return "unknown";
+}
+
+export async function createExistingDossierUpdateTarget(
+  input: CreateExistingDossierUpdateTargetInput,
+): Promise<DossierCandidate> {
+  const now = new Date().toISOString();
+  const entry = databasePage.entries.find((item) => item.id === input.dossierId);
+  if (!entry) {
+    throw new DossierWorkflowInputError(
+      "Existing public dossier target was not found",
+      400,
+      "existing_dossier_not_found",
+    );
+  }
+
+  const existingDossierMatch = {
+    id: entry.id,
+    name: entry.name,
+    confidence: "high" as const,
+  };
+  const requestedSubject = input.requestedSubject?.trim();
+  const requestedSubjectNote =
+    requestedSubject && requestedSubject !== entry.name
+      ? ` Requested lookup subject: ${requestedSubject}.`
+      : "";
+
+  const candidate: DossierCandidate = {
+    id: createCandidateId(),
+    name: entry.name,
+    candidateType: candidateTypeFromPublicDossierEntry(entry),
+    source: "website_read_model",
+    tier: "review_candidate",
+    score: 58,
+    whyNow:
+      "BNL/operator requested source enrichment for an existing public dossier subject.",
+    reason:
+      "Existing public dossier found; internal update lane created for review-only enrichment.",
+    firstSeenAt: now,
+    lastSeenAt: now,
+    evidenceSummary: `Existing public dossier ${entry.id} / ${entry.name} matched protected source-file lookup.${requestedSubjectNote}`,
+    evidenceItems: [
+      {
+        id: createEvidenceId(),
+        type: "website_context",
+        label: "Existing public dossier match",
+        summary: `Existing public dossier ${entry.id} / ${entry.name} is the review-only update target.`,
+        count: 1,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        publicSafe: true,
+      },
+    ],
+    evidenceCount: 1,
+    knownFacts: [`Existing public dossier target: ${entry.id} / ${entry.name}.`],
+    confidence: "medium",
+    duplicateRisk: "high",
+    existingDossierMatch,
+    recommendedCategory: entry.category,
+    recommendedKind: entry.kind,
+    recommendedEcosystemLane: entry.ecosystemLane,
+    recommendedIdentityAuthority: entry.identityAuthority,
+    recommendedStatus: entry.status,
+    recommendedClearance: entry.clearance,
+    recommendedOrigin: entry.origin,
+    recommendedTags: entry.tags,
+    proposedTags: [],
+    missingInfo: [
+      "Review enrichment notes before applying anything to a proposed dossier or public content.",
+    ],
+    doNotSay: [
+      "Do not treat update notes as owner-approved public copy.",
+    ],
+    publicSafetyNotes: [
+      "Review-only update material; do not publish automatically.",
+      "This internal update lane does not approve public copy, aliases, identity merges, or publication.",
+    ],
+    sourceFileNotes: [],
+    identityLinks: [],
+    sourceLanes: ["website_dossier"],
+    status: "existing_dossier_update",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  let createdOrExistingCandidate = candidate;
+
+  await updateDossierWorkflowState((currentState) => {
+    const existing = currentState.candidates.find(
+      (item) =>
+        item.status === "existing_dossier_update" &&
+        item.existingDossierMatch?.id === entry.id,
+    );
+    if (existing) {
+      createdOrExistingCandidate = existing;
+      return currentState;
+    }
+
+    return {
+      ...currentState,
+      candidates: [candidate, ...currentState.candidates],
+      updatedAt: now,
+    };
+  });
+
+  return createdOrExistingCandidate;
 }
 
 export async function createManualDossierCandidate(

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -313,6 +313,12 @@ export type CreateManualDossierCandidateInput = {
   primaryLink?: DossierDraft["fields"]["primaryLink"];
 };
 
+export type CreateExistingDossierUpdateTargetInput = {
+  dossierId: string;
+  requestedSubject?: string;
+  createdBy?: string;
+};
+
 export type DossierDuplicateGroup = {
   id: string;
   normalizedName: string;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -4391,3 +4391,11 @@ test("recommendation detail case-file view uses the same sanitizer", () => {
   assert.match(mainText, /BNL has a local profile match for this subject/);
   assert.match(JSON.stringify(view.rawMetadata), /relationship_journal|rd_context|bnl:rec_filter/);
 });
+
+test("admin dashboard explains public dossier-only source lookup fallback", () => {
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+  assertIncludesCopy(pageCopy, "Existing public dossier found");
+  assertIncludesCopy(pageCopy, "No internal update file exists yet");
+  assertIncludesCopy(pageCopy, "Create Existing Dossier Update");
+  assertIncludesCopy(pageCopy, "Review-only; no public changes");
+});

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -82,6 +82,22 @@ async function resetDossierWorkflowStore() {
   });
 }
 
+
+async function sourceFilesPost(body, token = "test-source-file-read-token") {
+  return sourceFilesReadModel.POST(
+    new Request("https://example.test/api/bnl/source-files", {
+      method: "POST",
+      headers: token
+        ? {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          }
+        : { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
 async function sourceFilesGet(query, token = "test-source-file-read-token") {
   return sourceFilesReadModel.GET(
     new Request(`https://example.test/api/bnl/source-files${query}`, {
@@ -860,6 +876,97 @@ test("BNL source file read model resolves active Source Files by subject and ret
 });
 
 
+
+
+test("BNL source file read model falls back to a public dossier-only target without exposing internal notes", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const before = await workflowStore.getDossierWorkflowState();
+
+  const response = await sourceFilesGet(`?subject=${encodeURIComponent("DJ Floppydisc")}`);
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+
+  assert.equal(payload.ok, true);
+  assert.equal(payload.found, true);
+  assert.equal(payload.matchKind, "public_dossier_only");
+  assert.equal(payload.workflowLane, "public_dossier_update_target");
+  assert.equal(payload.sourceFileActive, false);
+  assert.equal(payload.publicDossierMatchFound, true);
+  assert.equal(payload.existingDossierUpdateLane, false);
+  assert.equal(payload.candidateIntake, false);
+  assert.equal(payload.publicCopyApproval, false);
+  assert.equal(payload.targetDossierId, "EN-004");
+  assert.equal(payload.publicDossierName, "DJ Floppydisc");
+  assert.equal(payload.publicDossierSlug, "dj-floppydisc");
+  assert.equal(payload.recommendedAction, "create_existing_dossier_update");
+  assert.equal(payload.createExistingDossierUpdateAction.action, "create_existing_dossier_update");
+  assert.equal(payload.createExistingDossierUpdateAction.publishesPublicDossier, false);
+  assert.match(payload.warning, /Public dossier exists/);
+  assert.equal(payload.sourceFile, null);
+  assert.equal(payload.sourceRecord, null);
+  assert.doesNotMatch(JSON.stringify(payload), /sourceFileNotes|identityLinks|internal notes|private aliases/i);
+
+  const after = await workflowStore.getDossierWorkflowState();
+  assert.deepEqual(after, before);
+});
+
+test("BNL source file read model public dossier fallback resolves normalized and compact public names", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+
+  const normalized = await (await sourceFilesGet("?normalizedName=dj%20floppydisc")).json();
+  assert.equal(normalized.matchKind, "public_dossier_only");
+  assert.equal(normalized.publicDossierName, "DJ Floppydisc");
+  assert.equal(normalized.publicDossierMatch.matchKind, "public_dossier_normalized_name");
+
+  const compact = await (await sourceFilesGet("?subject=DJFloppydisc")).json();
+  assert.equal(compact.matchKind, "public_dossier_only");
+  assert.equal(compact.publicDossierName, "DJ Floppydisc");
+  assert.equal(compact.publicDossierMatch.matchKind, "public_dossier_compact_name");
+});
+
+test("BNL source file read model creates an internal Existing Dossier Update target from public dossier fallback only", async () => {
+  await resetDossierWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const publicBefore = JSON.stringify(databasePage.entries.find((entry) => entry.id === "EN-004"));
+
+  const createResponse = await sourceFilesPost({
+    action: "create_existing_dossier_update",
+    targetDossierId: "EN-004",
+    requestedSubject: "DJ Floppydisc",
+  });
+  assert.equal(createResponse.status, 200);
+  const created = await createResponse.json();
+
+  assert.equal(created.ok, true);
+  assert.equal(created.mutation, "internal_workflow_only");
+  assert.equal(created.publishesPublicDossier, false);
+  assert.equal(created.publicDossierMutated, false);
+  assert.equal(created.workflowLane, "existing_dossier_update");
+  assert.equal(created.sourceFileActive, false);
+  assert.equal(created.candidate.status, "existing_dossier_update");
+  assert.equal(created.candidate.source, "website_read_model");
+  assert.equal(created.candidate.candidateType, "entity");
+  assert.equal(created.candidate.existingDossierMatch.id, "EN-004");
+  assert.equal(created.candidate.existingDossierMatch.name, "DJ Floppydisc");
+  assert.match(created.candidate.reason, /Existing public dossier found/);
+  assert.match(created.candidate.whyNow, /BNL\/operator requested/);
+  assert.match(created.candidate.publicSafetyNotes.join(" "), /Review-only update material; do not publish automatically/);
+  assert.match(created.candidate.doNotSay.join(" "), /Do not treat update notes as owner-approved public copy/);
+  assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.id === "EN-004")), publicBefore);
+
+  const lookup = await (await sourceFilesGet(`?subject=${encodeURIComponent("DJ Floppydisc")}`)).json();
+  assert.equal(lookup.matchKind, "existing_dossier_update_name");
+  assert.equal(lookup.workflowLane, "existing_dossier_update");
+  assert.equal(lookup.sourceFileActive, false);
+  assert.equal(lookup.sourceFile.duplicateWarnings.existingDossierMatch.id, "EN-004");
+
+  const publicReadModelPayload = await (await readModel.GET(
+    new Request("https://example.test/api/bnl/read-model"),
+  )).json();
+  assert.doesNotMatch(JSON.stringify(publicReadModelPayload), /internal update lane|review-only enrichment|owner-approved public copy/i);
+});
 
 test("BNL source file read model includes Source Knowledge Bridge candidates with boundary warnings", async () => {
   await resetDossierWorkflowStore();


### PR DESCRIPTION
### Motivation
- The protected BNL source-file lookup currently returns “no confirmed target” for subjects that already have a public dossier, forcing unnecessary Candidate Intake creation. This change enables safe protected fallback to existing public dossiers so enrichment can target an Appropriate Existing Dossier Update lane. 
- The fallback must remain internal-only and must not mutate or publish public dossier content or expose internal notes publicly. 

### Description
- Extend the protected `/api/bnl/source-files` GET lookup to search `databasePage.entries` when no workflow candidate matches and return a clear `public_dossier_only` / `public_dossier_update_target` response with target dossier id, slug, matchKind, recommended action, review warnings, and a stable create-action contract (`create_existing_dossier_update`). (modified: `src/app/api/bnl/source-files/route.ts`) 
- Add a protected POST action `create_existing_dossier_update` on `/api/bnl/source-files` that calls a new internal workflow function to create or reuse an internal `existing_dossier_update` candidate linked to the public dossier without changing or publishing the public dossier. (modified: `src/app/api/bnl/source-files/route.ts`, `src/lib/dossier-workflow-store.ts`) 
- Implement `createExistingDossierUpdateTarget` and conservative type inference from public dossier entries in the workflow store, reusing an existing update lane when present and populating review-only safety/do-not-say notes and provenance. (added: `src/lib/dossier-workflow-store.ts`; added type: `CreateExistingDossierUpdateTargetInput` in `src/lib/dossier-workflow.ts`) 
- Surface a short explanatory copy in the admin Dossier Control Center clarifying the protected public-dossier fallback and the safe “Create Existing Dossier Update” flow. (modified: `src/app/admin/dossiers/page.tsx`) 
- Add/update unit tests that assert the protected fallback behavior, normalized/compact name resolution, safe POST creation behavior, absence of public mutation/exposed internal notes, and admin copy presence. (modified/added: `tests/bnl-read-model.test.mjs`, `tests/admin-dossiers.test.mjs`) 

### Testing
- Type-check: `npx tsc --noEmit` succeeded. 
- Lint: targeted `eslint` runs on changed files completed with no blocking errors. 
- Unit tests: `node --test tests/bnl-read-model.test.mjs` passed (all tests green). 
- Admin tests: `node --test tests/admin-dossiers.test.mjs` passed (all tests green). 
- Full queue/test run: `npm run test:queue` (which runs queue and read-model suites) passed; overall test suites passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c90e1b10483218ee6607519c2fe54)