### PR TITLE
Fix duplicate imports in admin dossier draft page

### DIFF
--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { DossierPageView } from "@/components/DossierPageView";
+import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { draftToDossierPreviewViewModel } from "@/lib/dossier-page-view-model";
 import Link from "next/link";
-import { DossierPageView } from "@/components/DossierPageView";
-import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { useParams } from "next/navigation";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -18,7 +17,6 @@ import {
   validateDossierPublicDraftFields,
   type DossierDraftFieldWarning,
 } from "@/lib/dossier-public-copy-guard";
-import { draftToDossierPreviewViewModel } from "@/lib/dossier-page-view-model";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
 import {
   DOSSIER_ECOSYSTEM_LANE_OPTIONS,


### PR DESCRIPTION
### Motivation
- Fix a production build error caused by duplicate imports of `DossierPageView` and `draftToDossierPreviewViewModel` in `src/app/admin/dossiers/drafts/[draftId]/page.tsx` introduced after PR #156.

### Description
- Cleaned the top import block in `src/app/admin/dossiers/drafts/[draftId]/page.tsx` so each symbol (including `DossierPageView` and `draftToDossierPreviewViewModel`) is imported exactly once; only this file was modified and no behavior was changed.

### Testing
- Ran `npx tsc --noEmit` which passed.  
- Ran `node --test tests/admin-dossiers.test.mjs` which exercised the test suite but 3 tests failed with an unrelated `ReferenceError: dossierPageViewModel is not defined`.  
- Ran `npm run build` which failed due to a Next.js font fetch error for `Geist Mono` from Google Fonts, a network/font issue unrelated to the import fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc62b85188321b0dc3eeb03d76c56)