### PR TITLE
Stop starter notes leaking into public Proposed Dossier fields

### DIFF
--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -13,6 +13,9 @@ import {
   type DossierDuplicateGroup,
 } from "@/lib/dossier-workflow";
 import {
+  DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+  DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+  isDossierPublicCopyPlaceholder,
   sanitizeDossierPublicCopy,
   validateDossierPublicDraftFields,
   type DossierDraftFieldWarning,
@@ -183,6 +186,21 @@ function draftFieldsForPublicGuard(form: DraftForm): DossierDraft["fields"] {
   };
 }
 
+function ThinSourcePublicCopyWarning({
+  show,
+}: {
+  show: boolean;
+}) {
+  if (!show) return null;
+  return (
+    <section className="border border-accent/70 bg-accent/10 p-5 text-sm text-accent">
+      Source material is not strong enough for public dossier copy yet. Add
+      public-safe facts or use BNL Edit Chat after more source context is
+      available.
+    </section>
+  );
+}
+
 function PublicCopyGuardWarning({
   warnings,
 }: {
@@ -237,8 +255,8 @@ function ProposedDossierPreview({
       status: form.status || "PENDING",
       clearance: form.clearance || "PUBLIC",
       origin: form.origin || "UNVERIFIED",
-      role: role || "Clean role needed before owner review.",
-      summary: summary || "Clean summary needed before owner review.",
+      role: role || DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+      summary: summary || DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
       notes,
       tags,
       proposedTags,
@@ -359,7 +377,16 @@ export default function DossierDraftEditorPage() {
   const publicCopyWarnings = form
     ? validateDossierPublicDraftFields(draftFieldsForPublicGuard(form))
     : [];
-  const publicCopyIsDirty = publicCopyWarnings.length > 0;
+  const sourceMaterialNeedsPublicCopy = Boolean(
+    form &&
+      (!form.summary.trim() ||
+        !form.role.trim() ||
+        isDossierPublicCopyPlaceholder(form.summary) ||
+        isDossierPublicCopyPlaceholder(form.role) ||
+        sourceFileSummary?.substanceLevel === "thin"),
+  );
+  const publicCopyIsDirty =
+    publicCopyWarnings.length > 0 || sourceMaterialNeedsPublicCopy;
 
   function draftFieldsFromForm() {
     if (!form) return {};
@@ -891,6 +918,7 @@ export default function DossierDraftEditorPage() {
             />
           </section>
           <PublicCopyGuardWarning warnings={publicCopyWarnings} />
+          <ThinSourcePublicCopyWarning show={sourceMaterialNeedsPublicCopy} />
           <ProposedDossierPreview
             form={form}
             candidate={candidate ?? undefined}

--- a/src/lib/dossier-public-copy-guard.ts
+++ b/src/lib/dossier-public-copy-guard.ts
@@ -33,7 +33,35 @@ const SOURCE_LABELS = [
   "local_relationship_trace",
 ];
 
+export const DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER =
+  "Clean public summary needed before owner review.";
+export const DOSSIER_PUBLIC_NOTES_PLACEHOLDER =
+  "Clean public notes needed before owner review.";
+export const DOSSIER_PUBLIC_ROLE_PLACEHOLDER =
+  "Clean role needed before owner review.";
+
+const PUBLIC_COPY_PLACEHOLDERS = new Set([
+  DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER.toLowerCase(),
+  DOSSIER_PUBLIC_NOTES_PLACEHOLDER.toLowerCase(),
+  DOSSIER_PUBLIC_ROLE_PLACEHOLDER.toLowerCase(),
+]);
+
 const JUNK_PATTERNS = [
+  /\bstarter note only\s*:/i,
+  /\bstarter evidence note\s*:/i,
+  /\bpublic safety\s*:/i,
+  /\bmissing info\s*:/i,
+  /\bbroadcast_memory\s*:/i,
+  /\bdo not expose private discord identity\b/i,
+  /\bverify public-safe wording\b/i,
+  /\binternal discovery classification\b/i,
+  /\bbnl discovery is review-only\b/i,
+  /\breview before converting\b/i,
+  /\bmedium-confidence bnl discovery\b/i,
+  /\bsource-file\b/i,
+  /\bsource file\b/i,
+  /\bdossier seed\b/i,
+  /\badd a dossier entry\b/i,
   /\buser_profiles\//i,
   /\bconversations\//i,
   /\brelationship_journal\b/i,
@@ -113,6 +141,11 @@ function isMostlyBackendTerms(value: string): boolean {
   if (!words || words.length < 5) return false;
   const backendCount = words.filter((word) => BACKEND_TERMS.includes(word)).length;
   return backendCount >= 3 && backendCount / words.length >= 0.35;
+}
+
+export function isDossierPublicCopyPlaceholder(value: string | undefined): boolean {
+  const trimmed = value?.trim().toLowerCase();
+  return Boolean(trimmed && PUBLIC_COPY_PLACEHOLDERS.has(trimmed));
 }
 
 export function containsDossierPublicCopyJunk(value: string): boolean {

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -132,8 +132,6 @@ function substanceScore({
     ).length,
     3,
   );
-  if (candidate.publicSafetyNotes?.length) score += 1;
-  if (candidate.doNotSay?.length) score += 1;
   return score;
 }
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1,6 +1,12 @@
 import { Redis } from "@upstash/redis";
 import { databasePage, type DatabaseEntry } from "@/content";
-import { validateDossierPublicDraftFields } from "@/lib/dossier-public-copy-guard";
+import {
+  DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+  DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+  isDossierPublicCopyPlaceholder,
+  sanitizeDossierPublicCopy,
+  validateDossierPublicDraftFields,
+} from "@/lib/dossier-public-copy-guard";
 import {
   scoreManualDossierCandidate,
   type CreateDossierRecommendationInput,
@@ -162,8 +168,12 @@ export function validateDossierDraftFieldsForOwnerReview(
   if (!normalized.status) missing.push("status");
   if (!normalized.clearance) missing.push("clearance");
   if (!normalized.origin) missing.push("origin");
-  if (!normalized.role) missing.push("role");
-  if (!normalized.summary) missing.push("summary");
+  if (!normalized.role || isDossierPublicCopyPlaceholder(normalized.role)) {
+    missing.push("role");
+  }
+  if (!normalized.summary || isDossierPublicCopyPlaceholder(normalized.summary)) {
+    missing.push("summary");
+  }
   if (!normalized.tags || normalized.tags.length === 0) missing.push("tags");
 
   const publicCopyWarnings = validateDossierPublicDraftFields(fields);
@@ -2649,6 +2659,29 @@ export async function updateDossierCandidateStatus(
   return updatedCandidate;
 }
 
+function cleanDraftSeedText(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const clean = sanitizeDossierPublicCopy(value);
+  return clean || undefined;
+}
+
+function cleanDraftSeedTags(values: string[] | undefined): string[] {
+  return (values ?? [])
+    .map((value) => sanitizeDossierPublicCopy(value))
+    .filter(Boolean);
+}
+
+function cleanDraftSeedPrimaryLink(
+  link: DossierWorkflowLink | undefined,
+): DossierWorkflowLink | undefined {
+  if (!link?.url) return undefined;
+  const label = sanitizeDossierPublicCopy(link.label);
+  return {
+    ...link,
+    label: label || "Featured link",
+  };
+}
+
 export async function createDraftFromCandidate(
   candidateId: string,
 ): Promise<DossierDraft | null> {
@@ -2672,17 +2705,10 @@ export async function createDraftFromCandidate(
       return currentState;
     }
 
-    const starterNotes = [
-      candidate.evidenceSummary
-        ? `Starter evidence note: ${candidate.evidenceSummary}`
-        : "",
-      ...(candidate.publicSafetyNotes ?? []).map(
-        (note) => `Public safety: ${note}`,
-      ),
-      ...(candidate.missingInfo ?? []).map((note) => `Missing info: ${note}`),
-    ]
-      .filter(Boolean)
-      .join("\n");
+    const publicSummary = cleanDraftSeedText(candidate.evidenceSummary);
+    const publicTags = cleanDraftSeedTags(candidate.recommendedTags);
+    const publicProposedTags = cleanDraftSeedTags(candidate.proposedTags);
+    const publicPrimaryLink = cleanDraftSeedPrimaryLink(candidate.primaryLink);
 
     draft = {
       id: createDraftId(),
@@ -2697,13 +2723,12 @@ export async function createDraftFromCandidate(
         status: candidate.recommendedStatus ?? "PENDING",
         clearance: candidate.recommendedClearance ?? "PUBLIC",
         origin: candidate.recommendedOrigin ?? "UNVERIFIED",
-        summary: candidate.evidenceSummary
-          ? `Starter note only: ${candidate.evidenceSummary}`
-          : "",
-        notes: starterNotes,
-        tags: candidate.recommendedTags ?? [],
-        proposedTags: candidate.proposedTags ?? [],
-        primaryLink: candidate.primaryLink,
+        role: DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+        summary: publicSummary ?? DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+        notes: "",
+        tags: publicTags,
+        proposedTags: publicProposedTags,
+        primaryLink: publicPrimaryLink,
         files: [],
       }),
       createdAt: now,

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -55,6 +55,7 @@ const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts")
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
+const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -138,6 +139,37 @@ test("draft proposed dossier preview maps draft fields into shared public layout
 });
 
 
+test("proposed dossier preview sanitizes internal starter phrases before DossierPageView", () => {
+  const adminPageSource = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
+  assert.match(adminPageSource, /sanitizeDossierPublicCopy\(form\.summary\)/);
+  assert.match(adminPageSource, /sanitizeDossierPublicCopy\(form\.notes\)/);
+  assert.match(adminPageSource, /<DossierPageView dossier=\{dossier\} \/>/);
+
+  const draft = {
+    id: "draft-sanitized-preview",
+    fields: {
+      name: "Starter Subject",
+      role: publicCopyGuard.sanitizeDossierPublicCopy(
+        "Starter note only: add a dossier entry",
+      ) || publicCopyGuard.DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+      summary: publicCopyGuard.sanitizeDossierPublicCopy(
+        "Starter note only: add a dossier entry",
+      ) || publicCopyGuard.DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+      notes: publicCopyGuard.sanitizeDossierPublicCopy(
+        "Starter evidence note: Missing info: confirm copy",
+      ),
+      tags: [],
+      proposedTags: [],
+      files: [],
+    },
+  };
+  const viewModel = dossierPageViewModel.draftToDossierPreviewViewModel(draft);
+  assert.doesNotMatch(
+    JSON.stringify(viewModel),
+    /Starter note only|Starter evidence note|Missing info|add a dossier entry/i,
+  );
+});
+
 test("phase 2 draft editor stacks source summary, BNL edit panel, and dossier preview full-width", () => {
   const adminPageSource = normalizedSource("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   const sourceSummaryIndex = adminPageSource.indexOf("BNL Source File Summary");
@@ -175,8 +207,8 @@ test("admin source-file caveats stay outside the public-style dossier preview mo
   };
   const viewModel = dossierPageViewModel.draftToDossierPreviewViewModel(draft);
 
-  assertIncludesCopy(adminPageSource, "Admin-only warnings / missing info / caveats:");
-  assertIncludesCopy(adminPageSource, "Source-file notes remain internal. Only the proposed fields below are being previewed.");
+  assertIncludesCopy(adminPageSource, "Developer / Raw Source Audit — internal debugging only");
+  assertIncludesCopy(adminPageSource, "Public safety notes:");
   assert.match(componentSource, /UNPUBLISHED PREVIEW/);
   assert.doesNotMatch(componentSource, /missingInfo|publicSafetyNotes|sourceFileNotes|evidenceSummary|doNotSay/);
   assert.doesNotMatch(JSON.stringify(viewModel), /missingInfo|publicSafetyNotes|sourceFileNotes|evidenceSummary|doNotSay|raw-metadata/);
@@ -619,6 +651,7 @@ test("admin dirty-copy warning stays outside shared public DossierPageView", () 
     : "";
   assert.match(draftPage, /PublicCopyGuardWarning/);
   assert.match(draftPage, /Clean draft public copy/);
+  assert.match(draftPage, /Source material is not strong enough for public dossier copy yet/);
   assert.doesNotMatch(sharedView, /Clean draft public copy/);
   assert.doesNotMatch(sharedView, /PublicCopyGuardWarning/);
 });
@@ -700,6 +733,32 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
 
 
 
+test("dossier public-copy guard flags internal starter and source phrases", () => {
+  for (const phrase of [
+    "Starter note only: internal scaffold",
+    "Starter evidence note: internal scaffold",
+    "Public safety: private_review_required",
+    "Missing info: confirm owner-approved public copy",
+    "broadcast_memory: internal lane",
+    "Do not expose private Discord identity",
+    "Verify public-safe wording before publishing.",
+    "Internal discovery classification: review-only",
+    "BNL discovery is review-only until admin review.",
+    "Medium-confidence BNL discovery.",
+    "Review before converting, merging, aliasing, drafting, or publishing.",
+    "source-file note copied into public copy",
+    "source file note copied into public copy",
+    "dossier seed for internal workflow",
+    "add a dossier entry",
+  ]) {
+    assert.equal(
+      publicCopyGuard.containsDossierPublicCopyJunk(phrase),
+      true,
+      `${phrase} should be blocked from public draft fields`,
+    );
+  }
+});
+
 test("dossier public-copy guard flags backend source junk but allows human copy", () => {
   assert.equal(
     publicCopyGuard.containsDossierPublicCopyJunk(
@@ -745,8 +804,9 @@ test("draft public-copy validation warns on dirty proposed fields", () => {
     name: "Debug Subject",
     role: "candidateId: dossier_candidate_debug_12345",
     summary: "conversations/public_discord_observed conversations/public_discord_observed",
-    notes: "Bridge source lane mapping: conversations -> unknown, user_profiles -> unknown",
+    notes: "Starter evidence note: Public safety: review before publishing",
     tags: ["artist", "user_profiles/local_profile_observed"],
+    proposedTags: ["source file", "manual-review"],
     primaryLink: {
       label: "ingestKey bnl:debug-source",
       url: "https://example.test",
@@ -756,7 +816,7 @@ test("draft public-copy validation warns on dirty proposed fields", () => {
 
   assert.deepEqual(
     warnings.map((warning) => warning.label),
-    ["Role", "Summary", "Notes", "Tags", "Primary Link label"],
+    ["Role", "Summary", "Notes", "Tags", "Proposed tags", "Primary Link label"],
   );
 });
 
@@ -1329,6 +1389,75 @@ test("createDraftFromCandidate creates one workflow draft from candidate recomme
   assert.equal(payload.drafts.length, 1);
 });
 
+test("createDraftFromCandidate keeps internal starter notes out of public draft fields", async () => {
+  await resetWorkflowStore();
+  const input = {
+    ...manualCandidateInput,
+    name: "Thin Starter Note Candidate",
+    reason: "add a dossier entry",
+    whyNow: "broadcast_memory: internal review lane",
+    evidenceSummary: "add a dossier entry",
+    knownFacts: [],
+    missingInfo: ["confirm owner-approved public copy"],
+    doNotSay: ["Do not expose private Discord identity"],
+    publicSafetyNotes: ["Verify public-safe wording before publishing."],
+    recommendedTags: ["source file", "artist"],
+    proposedTags: ["dossier seed", "manual-review"],
+    primaryLink: {
+      ...manualCandidateInput.primaryLink,
+      label: "source-file dossier seed",
+    },
+  };
+  const created = await (
+    await authedPost({
+      action: "createManualCandidate",
+      input,
+    })
+  ).json();
+  const payload = await (
+    await authedPost({
+      action: "createDraftFromCandidate",
+      candidateId: created.candidate.id,
+    })
+  ).json();
+
+  const fields = payload.draft.fields;
+  const publicText = JSON.stringify({
+    summary: fields.summary,
+    notes: fields.notes,
+    role: fields.role,
+    tags: fields.tags,
+    proposedTags: fields.proposedTags,
+    primaryLinkLabel: fields.primaryLink?.label,
+  });
+  for (const phrase of [
+    "Starter note only",
+    "Starter evidence note",
+    "Public safety:",
+    "Missing info:",
+    "broadcast_memory:",
+    "add a dossier entry",
+    "dossier seed",
+    "source-file",
+  ]) {
+    assert.doesNotMatch(publicText, new RegExp(phrase, "i"));
+  }
+  assert.equal(fields.summary, publicCopyGuard.DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER);
+  assert.equal(fields.role, publicCopyGuard.DOSSIER_PUBLIC_ROLE_PLACEHOLDER);
+  assert.equal(fields.notes, undefined);
+  assert.deepEqual(fields.tags, ["artist"]);
+  assert.deepEqual(fields.proposedTags, ["manual-review"]);
+  assert.equal(fields.primaryLink.label, "Featured link");
+
+  const sourceSummary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: created.candidate,
+    drafts: [payload.draft],
+  });
+  assert.equal(sourceSummary.substanceLevel, "thin");
+  assert.match(JSON.stringify(sourceSummary), /confirm owner-approved public copy|Verify public-safe wording/);
+  assert.doesNotMatch(JSON.stringify(fields), /confirm owner-approved public copy|Verify public-safe wording/);
+});
+
 test("createDraftFromCandidate returns existing active draft without duplicating", async () => {
   await resetWorkflowStore();
   const createCandidatePayload = await (
@@ -1505,7 +1634,7 @@ test("submitDraftForOwnerReview validates required fields and updates owner queu
 });
 
 
-test("owner review submission blocks dirty Summary, Role, and Tags", async () => {
+test("owner review submission blocks dirty Summary, Notes, Role, and Tags", async () => {
   await resetWorkflowStore();
   const createCandidatePayload = await (
     await authedPost({
@@ -1529,7 +1658,8 @@ test("owner review submission blocks dirty Summary, Role, and Tags", async () =>
       ecosystemLane: manualCandidateInput.recommendedEcosystemLane,
       identityAuthority: manualCandidateInput.recommendedIdentityAuthority,
       role: "candidateId: dossier_candidate_debug_12345",
-      summary: "conversations/public_discord_observed conversations/public_discord_observed",
+      summary: "Starter note only: add a dossier entry",
+      notes: "Starter evidence note: Public safety: verify public-safe wording",
       tags: ["artist", "user_profiles/local_profile_observed"],
     },
   });
@@ -1543,6 +1673,7 @@ test("owner review submission blocks dirty Summary, Role, and Tags", async () =>
   assert.equal(dirtyPayload.code, "invalid_draft_fields");
   assert.ok(dirtyPayload.missingFields.includes("role"));
   assert.ok(dirtyPayload.missingFields.includes("summary"));
+  assert.ok(dirtyPayload.missingFields.includes("notes"));
   assert.ok(dirtyPayload.missingFields.includes("tags"));
 });
 


### PR DESCRIPTION
### Motivation
- Prevent internal/source scaffolding and admin-only phrases from being copied into public-facing Proposed Dossier fields so owner review and public previews are never seeded with backend/debug text.
- Ensure thin or technical source files do not produce invented public summaries and that admins see clear signals when source material is insufficient.

### Description
- Extend the public-copy guard with new placeholder constants and additional junk patterns to catch internal phrases like `Starter note only`, `Starter evidence note`, `Public safety:`, `Missing info:`, `broadcast_memory`, `source file`, `dossier seed`, and `add a dossier entry`, and expose `isDossierPublicCopyPlaceholder` and placeholders for role/summary/notes. (`src/lib/dossier-public-copy-guard.ts`)
- Stop seeding internal starter notes into drafts by sanitizing candidate-derived values before seeding: implement `cleanDraftSeedText`, `cleanDraftSeedTags`, and `cleanDraftSeedPrimaryLink` and change `createDraftFromCandidate` to use sanitized `summary`, `tags`, `proposedTags`, and `primaryLink` while leaving `notes` empty and setting safe role/summary placeholders for thin sources. (`src/lib/dossier-workflow-store.ts`)
- Treat placeholder summary/role (and thin source files) as missing for owner-review validation so placeholder values block submission until replaced with curated public-safe copy. (`src/lib/dossier-workflow-store.ts`)
- Add an admin-only thin-source warning component above the Proposed Dossier preview and make the draft preview use the sanitized placeholders so the shared `DossierPageView` never receives raw internal lines. (`src/app/admin/dossiers/drafts/[draftId]/page.tsx`)
- Preserve full internal/source visibility in admin-only Source Summary / Raw Audit areas and adjust source-file substance scoring so public-safety/do-not-say warnings do not inflate substance. (`src/lib/dossier-source-file-summary.ts`, `src/app/admin/dossiers/drafts/[draftId]/page.tsx`)
- Add and update regression tests covering sanitization, guard detection for new phrases, thin-source placeholder behavior, owner-review blocking, admin-only visibility, and that `DossierPageView` preview does not render internal starter phrases. (`tests/admin-dossiers.test.mjs`)

### Testing
- Ran `npx tsc --noEmit` and type-checking completed successfully. 
- Ran `node --test tests/admin-dossiers.test.mjs` and the full admin-dossiers test suite passed locally. 
- Ran targeted linting with `npx eslint` on changed files and it completed without errors. 
- Attempted `npm run build` but the Next/Turbopack build failed due to a network fetch error fetching the `Geist Mono` Google font (Turbopack/next/font network issue), unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc9c4b7008321a802b49629ff3d57)