### PR TITLE
Meaning-first Source/Mem renderer + collapse raw provenance for admin Source File

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -19,6 +19,12 @@ import {
 import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
+import {
+  sanitizeMeaningFirstItems,
+  sourceFileEvidenceClusterItems,
+  sourceFileReasonMeaning,
+  sourceFileWhyNowMeaning,
+} from "@/lib/dossier-source-memory-meaning";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -160,6 +166,41 @@ function list(items: string[] | undefined, empty = "—") {
   );
 }
 
+function meaningFirstList(
+  items: Array<string | undefined> | undefined,
+  empty = "—",
+  subjectName?: string,
+) {
+  return list(
+    sanitizeMeaningFirstItems(items ?? [], {
+      subjectName,
+      fallback: empty,
+      includePublicDiscord: true,
+    }),
+    empty,
+  );
+}
+
+function recommendationEvidenceItems(recommendation: DossierRecommendation) {
+  const clusterItems = sourceFileEvidenceClusterItems(
+    [
+      recommendation.evidenceSummary,
+      recommendation.reason,
+      ...(recommendation.sourceTypes ?? []),
+      ...(recommendation.sourceLanes ?? []),
+    ],
+    { subjectName: recommendation.subjectName },
+  );
+  const humanItems = sanitizeMeaningFirstItems(
+    [recommendation.evidenceSummary, recommendation.reason],
+    {
+      subjectName: recommendation.subjectName,
+      includePublicDiscord: true,
+    },
+  );
+  return clusterItems.length ? clusterItems : humanItems;
+}
+
 function Section({
   title,
   children,
@@ -286,8 +327,8 @@ function IdentityLinkCard({
         </div>
       </div>
       <p>
-        Type: {identityLink.type} / Visibility: {identityLink.visibility} /
-        Source: {identityLink.source}
+        Identity-link review metadata is admin-only and does not publish, merge,
+        or prove a public identity.
       </p>
       <p>Confidence: {identityLink.confidence ?? "—"}</p>
       {identityLink.createdFromRecommendationId && (
@@ -301,11 +342,15 @@ function IdentityLinkCard({
               recommendation?.subjectName ??
               "—"}
           </p>
-          <p>Source lanes: {recommendation?.sourceLanes.join(", ") ?? "—"}</p>
-          <p>
-            Ingest source:{" "}
-            {recommendation?.ingestSource ?? recommendation?.createdBy ?? "—"}
-          </p>
+          {recommendation ? (
+            <ul className="list-disc pl-5 space-y-1">
+              {recommendationEvidenceItems(recommendation).map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Review-only recommendation context is attached.</p>
+          )}
           <Link
             href={`/admin/dossiers/recommendations/${identityLink.createdFromRecommendationId}`}
             className="inline-flex text-accent hover:underline"
@@ -1369,10 +1414,17 @@ export default function CandidateReviewPage() {
                   <p className="text-foreground font-semibold">
                     {recommendation.subjectName}
                   </p>
-                  <p>
-                    {recommendation.evidenceSummary || recommendation.reason}
-                  </p>
-                  <p>Source lanes: {recommendation.sourceLanes.join(", ")}</p>
+                  {recommendationEvidenceItems(recommendation).length ? (
+                    <ul className="list-disc pl-5 space-y-1">
+                      {recommendationEvidenceItems(recommendation).map(
+                        (item) => (
+                          <li key={item}>{item}</li>
+                        ),
+                      )}
+                    </ul>
+                  ) : (
+                    <p>More public-safe context needed before drafting.</p>
+                  )}
                 </article>
               ))}
             </div>
@@ -1660,22 +1712,48 @@ export default function CandidateReviewPage() {
 
         <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Section title="Reason">
-            <p>{candidate.reason || "—"}</p>
+            <p>{sourceFileReasonMeaning(candidate.reason, candidate.name)}</p>
           </Section>
           <Section title="Why now">
-            <p>{candidate.whyNow || "—"}</p>
+            <p>{sourceFileWhyNowMeaning(candidate.whyNow)}</p>
           </Section>
           <Section title="Evidence summary">
-            <p>{candidate.evidenceSummary || "—"}</p>
+            <p>
+              {
+                sanitizeMeaningFirstItems([candidate.evidenceSummary], {
+                  subjectName: candidate.name,
+                  fallback: "—",
+                  includePublicDiscord: true,
+                })[0]
+              }
+            </p>
           </Section>
           <Section title="Evidence items">
             {candidate.evidenceItems?.length ? (
               candidate.evidenceItems.map((item) => (
                 <article key={item.id} className="mb-2">
-                  <p className="text-foreground">{item.label}</p>
-                  <p>{item.summary}</p>
+                  <p className="text-foreground">
+                    {
+                      sanitizeMeaningFirstItems([item.label], {
+                        subjectName: candidate.name,
+                        fallback: "Internal evidence item.",
+                      })[0]
+                    }
+                  </p>
                   <p>
-                    Type: {item.type} / Public safe: {String(item.publicSafe)}
+                    {
+                      sanitizeMeaningFirstItems([item.summary], {
+                        subjectName: candidate.name,
+                        fallback: "Owner review required before public use.",
+                        includePublicDiscord: true,
+                      })[0]
+                    }
+                  </p>
+                  <p>
+                    Visibility:{" "}
+                    {item.publicSafe
+                      ? "public-safe after review"
+                      : "internal review only"}
                   </p>
                 </article>
               ))
@@ -1684,16 +1762,23 @@ export default function CandidateReviewPage() {
             )}
           </Section>
           <Section title="Review Context / Possible Supporting Evidence">
-            {list(candidate.knownFacts)}
+            {meaningFirstList(candidate.knownFacts, "—", candidate.name)}
           </Section>
           <Section title="Corrections / extra notes">
             <p>Saved notes now live in BNL Source File Notes above.</p>
           </Section>
-          <Section title="Missing Info">{list(candidate.missingInfo)}</Section>
-          <Section title="Do Not Say">{list(candidate.doNotSay)}</Section>
+          <Section title="Missing Info">
+            {meaningFirstList(candidate.missingInfo, "—", candidate.name)}
+          </Section>
+          <Section title="Do Not Say">
+            {meaningFirstList(candidate.doNotSay, "—", candidate.name)}
+          </Section>
           <Section title="Public-Safe Facts Pending Owner/Admin Approval">
             {list(
-              candidate.knownFacts?.filter(Boolean),
+              sanitizeMeaningFirstItems(
+                candidate.knownFacts?.filter(Boolean) ?? [],
+                { subjectName: candidate.name },
+              ),
               "No public-safe facts marked yet.",
             )}
           </Section>
@@ -1727,7 +1812,7 @@ export default function CandidateReviewPage() {
             <p>Pending identity aliases: {proposedIdentityLinks.length}</p>
           </Section>
           <Section title="Public safety notes">
-            {list(candidate.publicSafetyNotes)}
+            {meaningFirstList(candidate.publicSafetyNotes, "—", candidate.name)}
           </Section>
           <Section title="Recommended taxonomy">
             <p>

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -3,6 +3,7 @@ import type {
   DossierRecommendationIngestSource,
   DossierSourceFileNote,
 } from "./dossier-workflow";
+import { sourceMemoryMeaningItems } from "./dossier-source-memory-meaning";
 
 export type DossierHumanReadableSection = {
   title: string;
@@ -150,11 +151,12 @@ function uniqueItems(items: string[], limit = 6) {
 }
 
 function translatedTechnicalSignals(value: string) {
-  return uniqueItems(
-    technicalTranslations
+  return uniqueItems([
+    ...sourceMemoryMeaningItems(value, { includePublicDiscord: true }),
+    ...technicalTranslations
       .filter(([pattern]) => pattern.test(value))
       .map(([, copy]) => copy),
-  );
+  ]);
 }
 
 export function containsDossierBackendJunk(value?: string | null) {

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -8,6 +8,13 @@ import {
   hasDossierMeaningfulPattern,
   sanitizeDossierMeaningItems,
 } from "./dossier-note-display";
+import {
+  isRawSourceMemoryDebugText,
+  sanitizeMeaningFirstItems,
+  sourceFileEvidenceClusterItems,
+  sourceFileReasonMeaning,
+  sourceFileWhyNowMeaning,
+} from "./dossier-source-memory-meaning";
 
 export type DossierSourceFileSubstanceLevel =
   | "thin"
@@ -67,7 +74,8 @@ function unique(items: Array<string | undefined | null>, limit = 4): string[] {
 function cleanOperatorSummaryValue(value?: string | null): string | undefined {
   const clean = value?.replace(/\s+/g, " ").trim();
   if (!clean) return undefined;
-  if (containsDossierBackendJunk(clean)) return undefined;
+  if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean))
+    return undefined;
   return clean;
 }
 
@@ -226,12 +234,44 @@ export function createDossierSourceFileSummary(
     [operatorSummary?.summaryText],
     1,
   )[0];
+  const rawEvidenceValues = [
+    candidate.evidenceSummary,
+    candidate.reason,
+    candidate.whyNow,
+    ...(candidate.evidenceItems ?? []).flatMap((item) => [
+      item.label,
+      item.summary,
+    ]),
+    ...(candidate.sourceFileNotes ?? []).map((note) => note.text),
+    ...recommendations.flatMap((recommendation) => [
+      recommendation.reason,
+      recommendation.evidenceSummary,
+      ...(recommendation.sourceTypes ?? []),
+      ...(recommendation.sourceLanes ?? []),
+    ]),
+  ];
+  const sourceMemoryEvidence = sourceFileEvidenceClusterItems(
+    rawEvidenceValues,
+    {
+      subjectName: candidate.name,
+    },
+  );
+  const nonPublicSourceNoteMeanings = sanitizeMeaningFirstItems(
+    (candidate.sourceFileNotes ?? [])
+      .filter((note) => note.publicSafe !== true)
+      .map((note) => note.text),
+    {
+      subjectName: candidate.name,
+      includePublicDiscord: true,
+    },
+  );
   const structuredSummary = unique(
     [candidate.evidenceSummary, candidate.reason],
     1,
   )[0];
   const usefulEvidence = unique(
     [
+      ...sourceMemoryEvidence,
       candidate.evidenceSummary,
       ...(candidate.evidenceItems ?? []).map(
         (item) => item.summary || item.label,
@@ -240,12 +280,12 @@ export function createDossierSourceFileSummary(
         (recommendation) => recommendation.evidenceSummary,
       ),
     ],
-    4,
+    5,
   );
   const knownContext = unique(
     [
       ...(candidate.knownFacts ?? []),
-      candidate.reason,
+      sourceFileReasonMeaning(candidate.reason, candidate.name),
       ...(candidate.sourceFileNotes ?? [])
         .filter((note) => note.publicSafe === true)
         .map((note) => note.text),
@@ -254,7 +294,7 @@ export function createDossierSourceFileSummary(
   );
   const patterns = unique(
     [
-      candidate.whyNow,
+      sourceFileWhyNowMeaning(candidate.whyNow),
       ...recommendations.map((recommendation) => recommendation.reason),
       ...(candidate.sourceFileNotes ?? []).map((note) => note.text),
     ].filter((item) => hasDossierMeaningfulPattern(item)),
@@ -283,12 +323,10 @@ export function createDossierSourceFileSummary(
   );
   const claimedNeedsReview = unique(
     [
-      candidate.reason,
-      candidate.whyNow,
+      sourceFileReasonMeaning(candidate.reason, candidate.name),
+      sourceFileWhyNowMeaning(candidate.whyNow),
       ...recommendations.map((recommendation) => recommendation.reason),
-      ...(candidate.sourceFileNotes ?? [])
-        .filter((note) => note.publicSafe !== true)
-        .map((note) => note.text),
+      ...nonPublicSourceNoteMeanings,
     ],
     4,
   );
@@ -337,7 +375,10 @@ export function createDossierSourceFileSummary(
               "BNL has this subject in the internal review workspace, but no substantial public-safe context has been captured yet.",
             ],
     whyTracked:
-      unique([candidate.reason, candidate.whyNow], 1)[0] ||
+      sanitizeMeaningFirstItems([candidate.reason, candidate.whyNow], {
+        subjectName: candidate.name,
+        limit: 1,
+      })[0] ||
       "This subject is being tracked because it appeared in BNL records and needs human review before any public use.",
     usefulEvidence:
       usefulEvidence.length > 0

--- a/src/lib/dossier-source-memory-meaning.ts
+++ b/src/lib/dossier-source-memory-meaning.ts
@@ -1,0 +1,196 @@
+const rawSourcePathPattern =
+  /\b(?:user_profiles|relationship_journal|conversations|memory_tiers|rd_context|broadcast_memory|source_blind_memory_trace|local_knowledge_store)\s*\/\s*[a-z0-9_/-]+\b/i;
+
+const rawBackendLabelPattern =
+  /\b(?:local_profile_observed|local_relationship_trace|public_discord_observed|source lane mapping|bridge source lane mapping|source lanes?:\s*unknown|unknown\s*->\s*unknown|help_signal\s*:|EDGE_SESSION|ingestKey|candidateId|recommendationId|targetId|sourceTypes|sourceCounts|memory_tiers|private_review_required|owner_review_required|public_use_not_allowed_until_review)\b/i;
+
+const rawIdPattern =
+  /\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl|edge_session|ingest)[_:][a-z0-9][a-z0-9_-]{8,}\b/i;
+
+const rawMappingOnlyPattern =
+  /\b(?:source lane mapping|bridge source lane mapping|source lanes?:\s*unknown|unknown\s*->\s*unknown)\b/i;
+
+const localProfilePattern =
+  /\buser_profiles\s*\/\s*local_profile_observed\b|\blocal_profile_observed\b/i;
+const relationshipTracePattern =
+  /\brelationship_journal\s*\/\s*local_relationship_trace\b|\blocal_relationship_trace\b|\brelationship_journal\b/i;
+const publicDiscordPattern =
+  /\bconversations\s*\/\s*public_discord_observed\b|\bpublic_discord_observed\b/i;
+const localKnowledgePattern =
+  /\bBNL local knowledge stores?\b|\blocal_knowledge_store\b/i;
+
+function compact(value?: string | null) {
+  return value?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function subjectCopy(subjectName?: string) {
+  const clean = compact(subjectName);
+  return clean ? ` for ${clean}` : " for this subject";
+}
+
+function unique(items: string[], limit = 5) {
+  const output: string[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const clean = compact(item);
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+export function isRawSourceMemoryDebugText(value?: string | null) {
+  const clean = compact(value);
+  if (!clean) return false;
+  return (
+    rawSourcePathPattern.test(clean) ||
+    rawBackendLabelPattern.test(clean) ||
+    rawIdPattern.test(clean)
+  );
+}
+
+export function isRawSourceMappingOnly(value?: string | null) {
+  return rawMappingOnlyPattern.test(compact(value));
+}
+
+export function sourceMemoryMeaningItems(
+  value?: string | null,
+  options: { subjectName?: string; includePublicDiscord?: boolean } = {},
+) {
+  const clean = compact(value);
+  if (!clean) return [];
+
+  if (/^\s*(?:bridge\s+)?source lane mapping\s*:/i.test(clean)) return [];
+
+  const items: string[] = [];
+  const subject = subjectCopy(options.subjectName);
+
+  if (localProfilePattern.test(clean)) {
+    items.push(`BNL found an internal local profile match${subject}.`);
+  }
+
+  if (relationshipTracePattern.test(clean)) {
+    items.push(
+      options.subjectName
+        ? `BNL found prior relationship/context notes connected to ${options.subjectName}.`
+        : "BNL found prior relationship/context notes connected to this subject.",
+    );
+  }
+
+  if (options.includePublicDiscord && publicDiscordPattern.test(clean)) {
+    items.push(
+      "BNL found approved public-side context connected to this subject, but owner review is still needed before public use.",
+    );
+  }
+
+  if (localKnowledgePattern.test(clean)) {
+    items.push(
+      "Internal BNL memory references exist, but they need owner review before public use.",
+    );
+  }
+
+  if (
+    /\b(?:private_review_required|owner_review_required|public_use_not_allowed_until_review|internal_only)\b/i.test(
+      clean,
+    )
+  ) {
+    items.push("This needs internal review before public use.");
+  }
+
+  if (
+    /\b(?:missing public-safe|public-safe display name|public link|role)\b/i.test(
+      clean,
+    )
+  ) {
+    items.push("Missing public-safe display name, role, and public link.");
+  }
+
+  if (items.length) return unique(items);
+  if (isRawSourceMappingOnly(clean)) return [];
+  if (isRawSourceMemoryDebugText(clean)) {
+    return [
+      "Internal BNL memory references exist, but they need owner review before public use.",
+    ];
+  }
+  return [];
+}
+
+export function meaningFirstSourceText(
+  value?: string | null,
+  options: {
+    subjectName?: string;
+    fallback?: string;
+    includePublicDiscord?: boolean;
+  } = {},
+) {
+  const clean = compact(value);
+  if (!clean) return options.fallback;
+  const meaning = sourceMemoryMeaningItems(clean, options);
+  if (meaning.length) return meaning.join(" ");
+  if (isRawSourceMemoryDebugText(clean)) return options.fallback;
+  return clean;
+}
+
+export function sourceFileReasonMeaning(
+  value: string | undefined | null,
+  subjectName: string,
+) {
+  const clean = compact(value);
+  if (!clean || isRawSourceMemoryDebugText(clean)) {
+    return `BNL found existing internal context for ${subjectName} and created this source file so an owner can decide whether it should become a usable dossier record.`;
+  }
+  return clean;
+}
+
+export function sourceFileWhyNowMeaning(value?: string | null) {
+  const clean = compact(value);
+  if (!clean || isRawSourceMemoryDebugText(clean)) {
+    return "Needs owner review before any public dossier copy is drafted, published, merged, or linked to an identity.";
+  }
+  return clean;
+}
+
+export function sourceFileEvidenceClusterItems(
+  values: Array<string | undefined | null>,
+  options: { subjectName?: string } = {},
+) {
+  const joined = values.map(compact).filter(Boolean).join("\n");
+  const items = sourceMemoryMeaningItems(joined, {
+    subjectName: options.subjectName,
+    includePublicDiscord: true,
+  });
+  if (isRawSourceMemoryDebugText(joined)) {
+    items.push(
+      "Public-safe identity is not confirmed.",
+      "Owner review required before public use.",
+      "More public-safe context needed before drafting.",
+    );
+  }
+  return unique(items, 5);
+}
+
+export function sanitizeMeaningFirstItems(
+  values: Array<string | undefined | null>,
+  options: {
+    subjectName?: string;
+    fallback?: string;
+    limit?: number;
+    includePublicDiscord?: boolean;
+  } = {},
+) {
+  const output: string[] = [];
+  for (const value of values) {
+    const clean = compact(value);
+    if (!clean) continue;
+    const meaning = sourceMemoryMeaningItems(clean, options);
+    if (meaning.length) output.push(...meaning);
+    else if (!isRawSourceMemoryDebugText(clean)) output.push(clean);
+  }
+  const result = unique(output, options.limit ?? 5);
+  if (result.length) return result;
+  return options.fallback ? [options.fallback] : [];
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -54,6 +54,7 @@ const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
+const sourceMemoryMeaning = require("../src/lib/dossier-source-memory-meaning.ts");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
 
@@ -4643,6 +4644,111 @@ test("admin dossier UI labels BNL Source File enrichment separately from bridge 
   assert.match(recommendationPage, /Owner\/admin review[\s\S]*required before any public use/);
   assert.match(candidatePage, /BNL Review Addendum/);
   assert.match(candidatePage, /Internal working material|Review-only enrichment/);
+});
+
+
+test("source memory meaning formatter interprets raw labels and keeps mappings debug-only", () => {
+  assert.deepEqual(
+    sourceMemoryMeaning.sourceMemoryMeaningItems(
+      "user_profiles/local_profile_observed: Local profile observed for Crow.",
+      { subjectName: "Crow" },
+    ),
+    ["BNL found an internal local profile match for Crow."],
+  );
+  assert.deepEqual(
+    sourceMemoryMeaning.sourceMemoryMeaningItems(
+      "relationship_journal/local_relationship_trace: help_signal: User asked for help...",
+    ),
+    ["BNL found prior relationship/context notes connected to this subject."],
+  );
+  assert.deepEqual(
+    sourceMemoryMeaning.sourceMemoryMeaningItems(
+      "source lane mapping: relationship_journal -> unknown, user_profiles -> unknown",
+    ),
+    [],
+  );
+  assert.equal(
+    sourceMemoryMeaning.isRawSourceMappingOnly(
+      "source lane mapping: relationship_journal -> unknown, user_profiles -> unknown",
+    ),
+    true,
+  );
+  assert.deepEqual(
+    sourceMemoryMeaning.sourceMemoryMeaningItems("BNL local knowledge stores."),
+    ["Internal BNL memory references exist, but they need owner review before public use."],
+  );
+});
+
+test("candidate Source File visible panels render interpreted memory evidence", () => {
+  const candidatePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  assert.doesNotMatch(candidatePage, /<p>Source lanes:/);
+  assert.match(candidatePage, /recommendationEvidenceItems/);
+  assert.match(candidatePage, /sourceFileReasonMeaning\(candidate\.reason, candidate\.name\)/);
+  assert.match(candidatePage, /sourceFileWhyNowMeaning\(candidate\.whyNow\)/);
+
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: {
+      id: "candidate_crow_memory",
+      name: "Crow",
+      candidateType: "unknown",
+      source: "bnl_source_knowledge_bridge",
+      tier: "review_candidate",
+      score: 4,
+      whyNow: "Source lanes: unknown",
+      reason:
+        "Knowledge bridge found Crow in existing BNL local knowledge stores (relationship_journal, user_profiles). Source qualities: local_profile_observed, local_relationship_trace.",
+      evidenceSummary:
+        "user_profiles/local_profile_observed relationship_journal/local_relationship_trace source lane mapping: relationship_journal -> unknown, user_profiles -> unknown",
+      status: "active_source_file",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      sourceFileNotes: [
+        {
+          id: "note_crow_memory",
+          candidateId: "candidate_crow_memory",
+          type: "general_note",
+          text: "relationship_journal/local_relationship_trace: help_signal: User asked for help... EDGE_SESSION abc",
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          createdAt: "2026-06-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  const visibleSummary = JSON.stringify({
+    currentRead: summary.currentRead,
+    knownContext: summary.knownContext,
+    usefulEvidence: summary.usefulEvidence,
+    patterns: summary.patterns,
+    confirmedStrong: summary.confirmedStrong,
+    claimedNeedsReview: summary.claimedNeedsReview,
+    missingInfo: summary.missingInfo,
+    notPublicYet: summary.notPublicYet,
+    recommendedNextAction: summary.recommendedNextAction,
+  });
+  assert.doesNotMatch(visibleSummary, /user_profiles\/local_profile_observed/i);
+  assert.doesNotMatch(visibleSummary, /relationship_journal\/local_relationship_trace/i);
+  assert.doesNotMatch(visibleSummary, /source lane mapping|Source lanes: unknown|unknown -> unknown|help_signal|EDGE_SESSION/i);
+  assert.match(visibleSummary, /BNL found an internal local profile match for Crow/);
+  assert.match(visibleSummary, /BNL found prior relationship\/context notes connected to Crow/);
+  assert.match(visibleSummary, /Public-safe identity is not confirmed/);
+
+  assert.equal(
+    sourceMemoryMeaning.sourceFileReasonMeaning(
+      "user_profiles/local_profile_observed conversations/public_discord_observed",
+      "Crow",
+    ),
+    "BNL found existing internal context for Crow and created this source file so an owner can decide whether it should become a usable dossier record.",
+  );
+  assert.equal(
+    sourceMemoryMeaning.sourceFileWhyNowMeaning(
+      "source lane mapping relationship_journal -> unknown",
+    ),
+    "Needs owner review before any public dossier copy is drafted, published, merged, or linked to an identity.",
+  );
 });
 
 test("source file meaning filter hides backend terms from main views while preserving audit details", () => {


### PR DESCRIPTION
### Motivation
- Admin Source File views were leaking raw backend/source-memory labels and fragments (e.g. `user_profiles/local_profile_observed`, `relationship_journal`, `source lane mapping`) into normal visible panels instead of human-readable interpretations.
- The goal is to present admin reviewers with interpreted, privacy-safe, human-friendly observations while keeping raw provenance available only in a collapsed developer audit area.
- This change prevents backend labels from becoming mistaken for public facts and reduces repeated/truncated raw evidence noise in the visible Source File summary and note panels.

### Description
- Added a new meaning-first formatter at `src/lib/dossier-source-memory-meaning.ts` that recognizes raw source/memory patterns and emits admin-friendly lines (e.g. "BNL found an internal local profile match for Crow."), suppresses mapping-only lines, and marks raw debug strings for audit-only display.
- Plumbed the formatter into note and summary pipelines by updating `src/lib/dossier-note-display.ts` and `src/lib/dossier-source-file-summary.ts` so `Useful Evidence`, `Claimed / Needs Review`, `Pattern BNL Noticed`, `Reason`, `Why now`, evidence clusters, and other visible buckets use interpreted text instead of raw labels.
- Updated the candidate Source File UI at `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` to render recommendation/evidence clusters and identity-recommendation snippets via meaning-first helpers (`sanitizeMeaningFirstItems`, `sourceFileEvidenceClusterItems`, `sourceFileReasonMeaning`, `sourceFileWhyNowMeaning`) and replaced visible `Source lanes`/`ingest` lines with interpreted bullets; raw metadata and `rawText` remain inside the existing collapsed `Developer / Raw Source Audit — internal debugging only` drawer.
- Extended technical translations in `dossier-note-display.ts` to include source-memory meanings so legacy/raw note fragments are translated into readable takeaways in normal panels while preserving raw details in `rawMetadata`/`rawText`.
- Added/updated focused tests in `tests/admin-dossiers.test.mjs` to assert that raw labels do not appear in visible summaries, that mappings are suppressed, that Reason/Why Now are human-readable, and that raw provenance remains accessible only via the audit area.
- Files changed: added `src/lib/dossier-source-memory-meaning.ts`; modified `src/lib/dossier-note-display.ts`, `src/lib/dossier-source-file-summary.ts`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`; updated tests in `tests/admin-dossiers.test.mjs`.

### Testing
- Ran `npx tsc --noEmit` and the type-check passed successfully.
- Ran `node --test tests/admin-dossiers.test.mjs` and the full test suite passed (all tests green after additions and fixes).
- Ran targeted `eslint` against modified files and it completed without new lint errors.
- Attempted `npm run build`; the build failed due to an environment font fetch issue (Turbopack/Next.js failed to fetch the Google-hosted `Geist Mono` font), which is an external network/font fetch problem and not a code/type/lint regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcdb8c0b8832187cd7595d28a94f5)