### PR TITLE
Consume BNL Source Packet v2

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -184,6 +184,8 @@ function meaningFirstList(
 function recommendationEvidenceItems(recommendation: DossierRecommendation) {
   const clusterItems = sourceFileEvidenceClusterItems(
     [
+      ...(recommendation.usefulEvidence ?? []),
+      ...(recommendation.knownContext ?? []),
       recommendation.evidenceSummary,
       recommendation.reason,
       ...(recommendation.sourceTypes ?? []),
@@ -192,7 +194,12 @@ function recommendationEvidenceItems(recommendation: DossierRecommendation) {
     { subjectName: recommendation.subjectName },
   );
   const humanItems = sanitizeMeaningFirstItems(
-    [recommendation.evidenceSummary, recommendation.reason],
+    [
+      ...(recommendation.usefulEvidence ?? []),
+      ...(recommendation.knownContext ?? []),
+      recommendation.evidenceSummary,
+      recommendation.reason,
+    ],
     {
       subjectName: recommendation.subjectName,
       includePublicDiscord: true,

--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1707,7 +1707,10 @@ export default function CandidateReviewPage() {
               {sourceNotes.map((note) => (
                 <HumanReadableNoteView
                   key={note.id}
-                  view={createHumanReadableSourceFileNoteView(note)}
+                  view={createHumanReadableSourceFileNoteView({
+                    ...note,
+                    subjectName: candidate.name,
+                  })}
                   createdAt={note.createdAt}
                   workflowLane={candidate.status}
                   appliedDraftId={note.appliesToDraftId}
@@ -1796,7 +1799,10 @@ export default function CandidateReviewPage() {
                   .filter((note) => note.publicSafe !== true)
                   .map((note) => (
                     <li key={note.id}>
-                      {createHumanReadableSourceFileNoteView(note).summary}
+                      {createHumanReadableSourceFileNoteView({
+                        ...note,
+                        subjectName: candidate.name,
+                      }).summary}
                     </li>
                   ))}
               </ul>

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -14,6 +14,7 @@ import {
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
 import { createHumanReadableRecommendationView } from "@/lib/dossier-note-display";
+import { sanitizeMeaningFirstItems } from "@/lib/dossier-source-memory-meaning";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -108,6 +109,22 @@ function list(items: string[] | undefined, empty = "—") {
   ) : (
     <p>{empty}</p>
   );
+}
+
+function sourceAuthorityItems(recommendation: DossierRecommendation): string[] {
+  const sanitized = sanitizeMeaningFirstItems(
+    recommendation.sourceAuthority ?? [],
+    { subjectName: recommendation.subjectName },
+  );
+  return [
+    ...sanitized,
+    recommendation.confidence
+      ? `Confidence: ${recommendation.confidence}`
+      : undefined,
+    (recommendation.sourceAuthority ?? []).length > 0 && sanitized.length === 0
+      ? "Source authority was supplied by BNL; review raw audit details before public use."
+      : undefined,
+  ].filter((item): item is string => Boolean(item));
 }
 
 function formatDate(value?: string) {
@@ -238,7 +255,7 @@ function HumanReadableRecommendationCaseFile({
       </div>
       <details className="border border-border/60 bg-background/20 p-3 text-xs text-muted">
         <summary className="cursor-pointer font-semibold text-foreground">
-          Technical audit details
+          Developer / Raw Source Audit
         </summary>
         <div className="mt-3 space-y-3">
           <dl className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -998,6 +1015,30 @@ export default function DossierRecommendationPage() {
               Recommendation detail is evidence for the internal working case
               file, not public dossier copy.
             </p>
+          </Field>
+          <Field title="Known Context / Current Read">
+            {list(recommendation.knownContext)}
+          </Field>
+          <Field title="Useful Evidence">
+            {list(recommendation.usefulEvidence)}
+          </Field>
+          <Field title="Private Relationship Context — Review Only">
+            {list(recommendation.relationshipSignals)}
+          </Field>
+          <Field title="Public-Safe Possibilities Pending Owner Review">
+            {list(recommendation.publicSafePossibilities)}
+          </Field>
+          <Field title="Private/Internal Notes">
+            {list(recommendation.privateOnlyNotes)}
+          </Field>
+          <Field title="Not Public Yet">
+            {list(recommendation.notPublicYet)}
+          </Field>
+          <Field title="Recommended Next Action">
+            <p>{recommendation.recommendedAction ?? recommendation.suggestedAction ?? "—"}</p>
+          </Field>
+          <Field title="Source Authority / Confidence">
+            {list(sourceAuthorityItems(recommendation))}
           </Field>
           <Field title="Evidence summary">
             <p>{recommendation.evidenceSummary ?? "—"}</p>

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -105,6 +105,33 @@ function stringList(value: unknown, maxItemLength = 500): string[] | undefined {
   return items.length ? (items as string[]) : [];
 }
 
+function packetStringList(
+  value: unknown,
+  maxItemLength = 1000,
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") {
+    const item = text(value, maxItemLength);
+    return item ? [item] : [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("Expected text or a list of strings");
+  }
+  if (value.length > 25) throw new Error("Packet field has too many items");
+  const items = value.map((item) => text(item, maxItemLength)).filter(Boolean);
+  return items.length ? (items as string[]) : [];
+}
+
+function rawJsonValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    throw new Error("rawProvenance must be JSON serializable");
+  }
+  if (json.length > 20000) throw new Error("rawProvenance is too large");
+  return JSON.parse(json);
+}
+
 function enumValue<T extends string>(
   value: unknown,
   allowed: readonly T[],
@@ -223,7 +250,22 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   }
 
   const subjectName = text(payload.subjectName, 200);
-  const reason = text(payload.reason, 2000);
+  const knownContext = packetStringList(payload.knownContext);
+  const usefulEvidence = packetStringList(payload.usefulEvidence);
+  const relationshipSignals = packetStringList(payload.relationshipSignals);
+  const publicSafePossibilities = packetStringList(
+    payload.publicSafePossibilities,
+  );
+  const privateOnlyNotes = packetStringList(payload.privateOnlyNotes);
+  const notPublicYet = packetStringList(payload.notPublicYet);
+  const recommendedAction = text(payload.recommendedAction, 1000);
+  const sourceAuthority = packetStringList(payload.sourceAuthority, 1000);
+  const rawProvenance = rawJsonValue(payload.rawProvenance);
+  const reason =
+    text(payload.reason, 2000) ??
+    knownContext?.[0] ??
+    usefulEvidence?.[0] ??
+    recommendedAction;
   const evidenceSummary =
     payload.evidenceSummary &&
     typeof payload.evidenceSummary === "object" &&
@@ -240,7 +282,9 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
         .slice(0, 2000)
     : evidenceSummary;
   if (!subjectName) throw new Error("subjectName is required");
-  if (!reason) throw new Error("reason is required");
+  if (!reason) {
+    throw new Error("reason or structured source context is required");
+  }
 
   return {
     type: enumValue(payload.type ?? "new_subject", RECOMMENDATION_TYPES, "type") ?? "new_subject",
@@ -254,6 +298,15 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     sourceLanes,
     sourceTypes: stringList(payload.sourceTypes, 120),
     suggestedAction: text(payload.suggestedAction, 500),
+    knownContext,
+    usefulEvidence,
+    relationshipSignals,
+    publicSafePossibilities,
+    privateOnlyNotes,
+    notPublicYet,
+    recommendedAction,
+    sourceAuthority,
+    rawProvenance,
     missingInfo: stringList(payload.missingInfo),
     publicSafetyNotes: stringList(payload.publicSafetyNotes),
     doNotSay: stringList(payload.doNotSay),

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -91,11 +91,23 @@ export function DossierSourceFileSummaryPanel({
         <Section title="Claimed / Needs Review">
           <SummaryList items={summary.claimedNeedsReview} />
         </Section>
+        <Section title="Private Relationship Context — Review Only">
+          <SummaryList items={summary.privateRelationshipContext} />
+        </Section>
+        <Section title="Public-Safe Possibilities Pending Owner Review">
+          <SummaryList items={summary.publicSafePossibilities} />
+        </Section>
+        <Section title="Private/Internal Notes">
+          <SummaryList items={summary.privateOnlyNotes} />
+        </Section>
         <Section title="Missing Info / Open Questions">
           <SummaryList items={summary.missingInfo} />
         </Section>
         <Section title="Not Public Yet">
           <SummaryList items={summary.notPublicYet} />
+        </Section>
+        <Section title="Source Authority / Confidence">
+          <SummaryList items={summary.sourceAuthority} />
         </Section>
         <Section title="Recommended Next Step">
           <p>{summary.recommendedNextAction}</p>

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -45,6 +45,15 @@ type NoteLike = Pick<
   publicSafetyNotes?: string[];
   doNotSay?: string[];
   suggestedAction?: string;
+  knownContext?: string[];
+  usefulEvidence?: string[];
+  relationshipSignals?: string[];
+  publicSafePossibilities?: string[];
+  privateOnlyNotes?: string[];
+  notPublicYet?: string[];
+  recommendedAction?: string;
+  sourceAuthority?: string[];
+  rawProvenance?: unknown;
   evidenceSummary?: string;
   reason?: string;
 };
@@ -444,8 +453,28 @@ export function createHumanReadableSourceFileNoteView(
   if (!summary)
     summary = excerpt(text) || "Review-only internal source-file note.";
 
+  for (const item of note.knownContext ?? [])
+    addItem(sections, "Known Context / Current Read", item);
+  for (const item of note.usefulEvidence ?? [])
+    addItem(sections, "Useful Evidence", item);
+  for (const item of note.relationshipSignals ?? [])
+    addItem(sections, "Private Relationship Context — Review Only", item);
+  for (const item of note.publicSafePossibilities ?? [])
+    addItem(
+      sections,
+      "Public-Safe Possibilities Pending Owner Review",
+      item,
+    );
+  for (const item of note.privateOnlyNotes ?? [])
+    addItem(sections, "Private/Internal Notes", item);
+  for (const item of note.notPublicYet ?? []) addShortWarning(sections, item);
+  addItem(sections, "Recommended Next Step", note.recommendedAction);
+  for (const item of note.sourceAuthority ?? [])
+    addItem(sections, "Source Authority / Confidence", item);
   addPattern(sections, note.reason);
-  addItem(sections, "Useful Evidence", note.evidenceSummary);
+  if ((note.usefulEvidence ?? []).length === 0) {
+    addItem(sections, "Useful Evidence", note.evidenceSummary);
+  }
   for (const item of note.publicSafetyNotes ?? [])
     addShortWarning(sections, item);
   for (const item of note.missingInfo ?? [])
@@ -481,6 +510,11 @@ export function createHumanReadableSourceFileNoteView(
     });
   if (note.confidence)
     rawMetadata.push({ label: "confidence", value: note.confidence });
+  if (note.rawProvenance !== undefined)
+    rawMetadata.push({
+      label: "rawProvenance",
+      value: JSON.stringify(note.rawProvenance, null, 2),
+    });
 
   const sectionEntries = Array.from(sections.entries())
     .map(([title, items]) => ({ title, items: uniqueItems(items) }))
@@ -514,7 +548,31 @@ export function createHumanReadableRecommendationView(
 ): DossierHumanReadableNoteView {
   return createHumanReadableSourceFileNoteView({
     type: "general_note",
-    text: [recommendation.reason, recommendation.evidenceSummary]
+    text: [
+      recommendation.reason,
+      (recommendation.knownContext ?? [])
+        .map((item) => `Known context: ${item}`)
+        .join("\n"),
+      (recommendation.usefulEvidence ?? [])
+        .map((item) => `Useful evidence: ${item}`)
+        .join("\n"),
+      (recommendation.relationshipSignals ?? [])
+        .map((item) => `Relationship signal — private review: ${item}`)
+        .join("\n"),
+      (recommendation.publicSafePossibilities ?? [])
+        .map((item) => `Public-safe possibility pending owner review: ${item}`)
+        .join("\n"),
+      (recommendation.privateOnlyNotes ?? [])
+        .map((item) => `Private/internal note: ${item}`)
+        .join("\n"),
+      (recommendation.notPublicYet ?? [])
+        .map((item) => `Not public yet: ${item}`)
+        .join("\n"),
+      recommendation.recommendedAction
+        ? `Recommended next action: ${recommendation.recommendedAction}`
+        : "",
+      recommendation.evidenceSummary,
+    ]
       .filter(Boolean)
       .join("\n\n"),
     source: "bnl_recommendation",
@@ -531,6 +589,15 @@ export function createHumanReadableRecommendationView(
     publicSafetyNotes: recommendation.publicSafetyNotes,
     doNotSay: recommendation.doNotSay,
     suggestedAction: recommendation.suggestedAction,
+    knownContext: recommendation.knownContext,
+    usefulEvidence: recommendation.usefulEvidence,
+    relationshipSignals: recommendation.relationshipSignals,
+    publicSafePossibilities: recommendation.publicSafePossibilities,
+    privateOnlyNotes: recommendation.privateOnlyNotes,
+    notPublicYet: recommendation.notPublicYet,
+    recommendedAction: recommendation.recommendedAction,
+    sourceAuthority: recommendation.sourceAuthority,
+    rawProvenance: recommendation.rawProvenance,
     evidenceSummary: recommendation.evidenceSummary,
     reason: recommendation.reason,
   });

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -3,7 +3,10 @@ import type {
   DossierRecommendationIngestSource,
   DossierSourceFileNote,
 } from "./dossier-workflow";
-import { sourceMemoryMeaningItems } from "./dossier-source-memory-meaning";
+import {
+  isRawSourceMemoryDebugText,
+  sourceMemoryMeaningItems,
+} from "./dossier-source-memory-meaning";
 
 export type DossierHumanReadableSection = {
   title: string;
@@ -56,6 +59,7 @@ type NoteLike = Pick<
   rawProvenance?: unknown;
   evidenceSummary?: string;
   reason?: string;
+  subjectName?: string;
 };
 
 const thinFileWarning =
@@ -79,7 +83,7 @@ const summaryHeadingPattern =
   /^(summary|review context|why it matters|review reason|reason)\s*:/i;
 
 const technicalTermPattern =
-  /\b(source lane|source_lanes|sourceTypes|sourceCounts|ingest|ingestKey|bridge source lane mapping|workflow record|payload|metadata|local_profile_observed|public_discord_observed|local_relationship_trace|relationship_journal|user_profiles|conversations|rd_context|broadcast_memory|public_safe_candidate|private_review_required|owner_review_required|public_use_not_allowed_until_review|internal_only|target id|targetId|candidate id|candidateId|recommendation id|recommendationId|source type mapping|source type mappings|source types|source_lanes|public_home|admin\/dossiers|api\/admin|api\/bnl)\b|unknown\s*->\s*unknown/i;
+  /\b(source lane|source_lanes|sourceTypes|sourceCounts|ingest|ingestKey|bridge source lane mapping|workflow record|payload|metadata|local_profile_observed|public_discord_observed|local_relationship_trace|relationship_journal|user_profiles|conversations|rd_context|broadcast_memory|help_signal|EDGE_SESSI(?:ON)?|BNL local knowledge stores?|public_safe_candidate|private_review_required|owner_review_required|public_use_not_allowed_until_review|internal_only|target id|targetId|candidate id|candidateId|recommendation id|recommendationId|source type mapping|source type mappings|source types|source_lanes|public_home|admin\/dossiers|api\/admin|api\/bnl)\b|unknown\s*->\s*unknown/i;
 
 const rawIdPattern =
   /\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl)_[a-z0-9][a-z0-9_-]{8,}\b/i;
@@ -159,18 +163,26 @@ function uniqueItems(items: string[], limit = 6) {
   return output;
 }
 
-function translatedTechnicalSignals(value: string) {
-  return uniqueItems([
-    ...sourceMemoryMeaningItems(value, { includePublicDiscord: true }),
-    ...technicalTranslations
+function translatedTechnicalSignals(
+  value: string,
+  options: { subjectName?: string } = {},
+) {
+  const sourceMemoryMeanings = sourceMemoryMeaningItems(value, {
+    subjectName: options.subjectName,
+    includePublicDiscord: true,
+  });
+  if (sourceMemoryMeanings.length) return uniqueItems(sourceMemoryMeanings);
+  return uniqueItems(
+    technicalTranslations
       .filter(([pattern]) => pattern.test(value))
       .map(([, copy]) => copy),
-  ]);
+  );
 }
 
 export function containsDossierBackendJunk(value?: string | null) {
   if (!value) return false;
   return (
+    isRawSourceMemoryDebugText(value) ||
     technicalTermPattern.test(value) ||
     routeLikePattern.test(value) ||
     rawIdPattern.test(value) ||
@@ -225,13 +237,23 @@ function stripBackendFragments(value: string) {
     .trim();
 }
 
-export function humanizeDossierMeaningLine(value?: string | null): string[] {
+export function humanizeDossierMeaningLine(
+  value?: string | null,
+  options: { subjectName?: string } = {},
+): string[] {
   const clean = cleanLine(value ?? "")
     .replace(/\s+/g, " ")
     .trim();
   if (!clean) return [];
 
-  const translations = translatedTechnicalSignals(clean);
+  const translations = translatedTechnicalSignals(clean, options);
+  if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
+    return translations.length
+      ? translations
+      : [
+          "Internal BNL memory references exist, but they need owner review before public use.",
+        ];
+  }
   const stripped = stripBackendFragments(clean);
   const includeStripped =
     sentenceHasHumanMeaning(stripped) &&
@@ -263,25 +285,44 @@ function addItem(
   sections: Map<string, string[]>,
   title: string,
   value?: string,
-  options?: { translateOnly?: boolean },
+  options?: { translateOnly?: boolean; subjectName?: string },
 ) {
   const candidates = options?.translateOnly
-    ? translatedTechnicalSignals(value ?? "")
-    : humanizeDossierMeaningLine(value);
+    ? translatedTechnicalSignals(value ?? "", {
+        subjectName: options.subjectName,
+      })
+    : humanizeDossierMeaningLine(value, { subjectName: options?.subjectName });
   if (!candidates.length) return;
   const items = uniqueItems([...(sections.get(title) ?? []), ...candidates]);
   sections.set(title, items);
 }
 
-function addPattern(sections: Map<string, string[]>, value?: string) {
+function addPattern(
+  sections: Map<string, string[]>,
+  value?: string,
+  options: { subjectName?: string } = {},
+) {
   if (!hasDossierMeaningfulPattern(value)) return;
-  addItem(sections, "Pattern BNL Noticed", value);
+  addItem(sections, "Pattern BNL Noticed", value, options);
 }
 
-function addShortWarning(sections: Map<string, string[]>, value?: string) {
-  const translations = translatedTechnicalSignals(value ?? "");
+function addShortWarning(
+  sections: Map<string, string[]>,
+  value?: string,
+  options: { subjectName?: string } = {},
+) {
+  if (containsDossierBackendJunk(value) || isRawSourceMemoryDebugText(value)) {
+    addItem(
+      sections,
+      "Not Public Yet",
+      "Do not use publicly until owner/admin review.",
+      options,
+    );
+    return;
+  }
+  const translations = translatedTechnicalSignals(value ?? "", options);
   if (translations.length) {
-    addItem(sections, "Not Public Yet", translations[0]);
+    addItem(sections, "Not Public Yet", translations[0], options);
     return;
   }
   if (
@@ -293,8 +334,26 @@ function addShortWarning(sections: Map<string, string[]>, value?: string) {
       sections,
       "Not Public Yet",
       "Do not use publicly until owner/admin review.",
+      options,
     );
   }
+}
+
+function addClaimedNeedsReview(
+  sections: Map<string, string[]>,
+  value?: string,
+  options: { subjectName?: string } = {},
+) {
+  if (containsDossierBackendJunk(value) || isRawSourceMemoryDebugText(value)) {
+    addItem(
+      sections,
+      "Claimed / Needs Review",
+      "Internal BNL memory references exist, but they need owner review before public use.",
+      options,
+    );
+    return;
+  }
+  addItem(sections, "Claimed / Needs Review", value, options);
 }
 
 function sourceLabel(ingestSource?: DossierRecommendationIngestSource) {
@@ -387,6 +446,7 @@ export function createHumanReadableSourceFileNoteView(
   const rawMetadata: Array<{ label: string; value: string }> = [];
   const text = note.text ?? "";
   const rawLines = text.split(/\n+/).map(cleanLine).filter(Boolean);
+  const subjectOptions = { subjectName: note.subjectName };
   let legacyRawFormatting = false;
   let summary = "";
 
@@ -396,9 +456,10 @@ export function createHumanReadableSourceFileNoteView(
       const [label, ...rest] = line.split(":");
       rawMetadata.push({ label: label.trim(), value: rest.join(":").trim() });
       addItem(sections, "Useful Evidence", rest.join(":"), {
+        ...subjectOptions,
         translateOnly: true,
       });
-      addShortWarning(sections, rest.join(":"));
+      addShortWarning(sections, rest.join(":"), subjectOptions);
       continue;
     }
     if (
@@ -410,31 +471,32 @@ export function createHumanReadableSourceFileNoteView(
       const [label, ...rest] = line.split(":");
       rawMetadata.push({ label: label.trim(), value: rest.join(":").trim() });
       addItem(sections, "Useful Evidence", rest.join(":"), {
+        ...subjectOptions,
         translateOnly: true,
       });
-      addShortWarning(sections, rest.join(":"));
+      addShortWarning(sections, rest.join(":"), subjectOptions);
       continue;
     }
     if (evidenceHeadingPattern.test(line)) {
-      addItem(sections, "Useful Evidence", withoutHeading(line));
+      addItem(sections, "Useful Evidence", withoutHeading(line), subjectOptions);
     } else if (publicSafetyHeadingPattern.test(line)) {
-      addShortWarning(sections, withoutHeading(line));
+      addShortWarning(sections, withoutHeading(line), subjectOptions);
     } else if (missingInfoHeadingPattern.test(line)) {
-      addItem(sections, "Open Questions", withoutHeading(line));
+      addItem(sections, "Open Questions", withoutHeading(line), subjectOptions);
     } else if (doNotSayHeadingPattern.test(line)) {
-      addShortWarning(sections, withoutHeading(line));
+      addShortWarning(sections, withoutHeading(line), subjectOptions);
     } else if (actionHeadingPattern.test(line)) {
-      addItem(sections, "Recommended Next Step", withoutHeading(line));
+      addItem(sections, "Recommended Next Step", withoutHeading(line), subjectOptions);
     } else if (summaryHeadingPattern.test(line)) {
       const body = withoutHeading(line);
-      if (hasDossierMeaningfulPattern(body)) addPattern(sections, body);
-      else addItem(sections, "Claimed / Needs Review", body);
+      if (hasDossierMeaningfulPattern(body)) addPattern(sections, body, subjectOptions);
+      else addClaimedNeedsReview(sections, body, subjectOptions);
     } else if (
       /public use requires review|internal\/private review|required|review-only|not public copy|owner\/admin review/i.test(
         line,
       )
     ) {
-      addShortWarning(sections, line);
+      addShortWarning(sections, line, subjectOptions);
     } else if (
       !summary &&
       sentenceHasHumanMeaning(line) &&
@@ -442,11 +504,14 @@ export function createHumanReadableSourceFileNoteView(
     ) {
       summary = line;
     } else if (hasDossierMeaningfulPattern(line)) {
-      addPattern(sections, line);
+      addPattern(sections, line, subjectOptions);
     } else {
-      addItem(sections, "Claimed / Needs Review", line);
-      addItem(sections, "Useful Evidence", line, { translateOnly: true });
-      addShortWarning(sections, line);
+      addClaimedNeedsReview(sections, line, subjectOptions);
+      addItem(sections, "Useful Evidence", line, {
+        ...subjectOptions,
+        translateOnly: true,
+      });
+      addShortWarning(sections, line, subjectOptions);
     }
   }
 
@@ -454,33 +519,36 @@ export function createHumanReadableSourceFileNoteView(
     summary = excerpt(text) || "Review-only internal source-file note.";
 
   for (const item of note.knownContext ?? [])
-    addItem(sections, "Known Context / Current Read", item);
+    addItem(sections, "Known Context / Current Read", item, subjectOptions);
   for (const item of note.usefulEvidence ?? [])
-    addItem(sections, "Useful Evidence", item);
+    addItem(sections, "Useful Evidence", item, subjectOptions);
   for (const item of note.relationshipSignals ?? [])
-    addItem(sections, "Private Relationship Context — Review Only", item);
+    addItem(sections, "Private Relationship Context — Review Only", item, subjectOptions);
   for (const item of note.publicSafePossibilities ?? [])
     addItem(
       sections,
       "Public-Safe Possibilities Pending Owner Review",
       item,
+      subjectOptions,
     );
   for (const item of note.privateOnlyNotes ?? [])
-    addItem(sections, "Private/Internal Notes", item);
-  for (const item of note.notPublicYet ?? []) addShortWarning(sections, item);
-  addItem(sections, "Recommended Next Step", note.recommendedAction);
+    addItem(sections, "Private/Internal Notes", item, subjectOptions);
+  for (const item of note.notPublicYet ?? [])
+    addShortWarning(sections, item, subjectOptions);
+  addItem(sections, "Recommended Next Step", note.recommendedAction, subjectOptions);
   for (const item of note.sourceAuthority ?? [])
-    addItem(sections, "Source Authority / Confidence", item);
-  addPattern(sections, note.reason);
+    addItem(sections, "Source Authority / Confidence", item, subjectOptions);
+  addPattern(sections, note.reason, subjectOptions);
   if ((note.usefulEvidence ?? []).length === 0) {
-    addItem(sections, "Useful Evidence", note.evidenceSummary);
+    addItem(sections, "Useful Evidence", note.evidenceSummary, subjectOptions);
   }
   for (const item of note.publicSafetyNotes ?? [])
-    addShortWarning(sections, item);
+    addShortWarning(sections, item, subjectOptions);
   for (const item of note.missingInfo ?? [])
-    addItem(sections, "Open Questions", item);
-  for (const item of note.doNotSay ?? []) addShortWarning(sections, item);
-  addItem(sections, "Recommended Next Step", note.suggestedAction);
+    addItem(sections, "Open Questions", item, subjectOptions);
+  for (const item of note.doNotSay ?? [])
+    addShortWarning(sections, item, subjectOptions);
+  addItem(sections, "Recommended Next Step", note.suggestedAction, subjectOptions);
 
   if (!sections.get("Pattern BNL Noticed")?.length) {
     sections.set("Pattern BNL Noticed", [noPatternCopy]);
@@ -515,6 +583,19 @@ export function createHumanReadableSourceFileNoteView(
       label: "rawProvenance",
       value: JSON.stringify(note.rawProvenance, null, 2),
     });
+
+  if (note.reason && containsDossierBackendJunk(note.reason)) {
+    rawMetadata.push({ label: "legacyReason", value: note.reason });
+  }
+  if (
+    note.evidenceSummary &&
+    containsDossierBackendJunk(note.evidenceSummary)
+  ) {
+    rawMetadata.push({
+      label: "legacyEvidenceSummary",
+      value: note.evidenceSummary,
+    });
+  }
 
   const sectionEntries = Array.from(sections.entries())
     .map(([title, items]) => ({ title, items: uniqueItems(items) }))
@@ -600,5 +681,6 @@ export function createHumanReadableRecommendationView(
     rawProvenance: recommendation.rawProvenance,
     evidenceSummary: recommendation.evidenceSummary,
     reason: recommendation.reason,
+    subjectName: recommendation.subjectName,
   });
 }

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -43,9 +43,13 @@ export type DossierSourceFileSummary = {
   patterns: string[];
   confirmedStrong: string[];
   claimedNeedsReview: string[];
+  privateRelationshipContext: string[];
+  publicSafePossibilities: string[];
+  privateOnlyNotes: string[];
   uncertainties: string[];
   missingInfo: string[];
   notPublicYet: string[];
+  sourceAuthority: string[];
   recommendedNextAction: string;
   substanceLevel: DossierSourceFileSubstanceLevel;
   publicReadiness: DossierSourceFilePublicReadiness;
@@ -250,6 +254,55 @@ export function createDossierSourceFileSummary(
       ...(recommendation.sourceLanes ?? []),
     ]),
   ];
+  const structuredKnownContext = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.knownContext ?? [],
+    ),
+    6,
+  );
+  const structuredUsefulEvidence = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.usefulEvidence ?? [],
+    ),
+    6,
+  );
+  const structuredRelationshipSignals = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.relationshipSignals ?? [],
+    ),
+    6,
+  );
+  const structuredPublicSafePossibilities = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.publicSafePossibilities ?? [],
+    ),
+    6,
+  );
+  const structuredPrivateOnlyNotes = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.privateOnlyNotes ?? [],
+    ),
+    6,
+  );
+  const structuredNotPublicYet = unique(
+    recommendations.flatMap((recommendation) =>
+      recommendation.notPublicYet ?? [],
+    ),
+    6,
+  );
+  const structuredRecommendedAction = unique(
+    recommendations.map((recommendation) => recommendation.recommendedAction),
+    1,
+  )[0];
+  const structuredSourceAuthority = unique(
+    recommendations.flatMap((recommendation) => [
+      ...(recommendation.sourceAuthority ?? []),
+      recommendation.confidence
+        ? `Confidence: ${recommendation.confidence}. Review source boundaries before public use.`
+        : undefined,
+    ]),
+    5,
+  );
   const sourceMemoryEvidence = sourceFileEvidenceClusterItems(
     rawEvidenceValues,
     {
@@ -271,6 +324,7 @@ export function createDossierSourceFileSummary(
   )[0];
   const usefulEvidence = unique(
     [
+      ...structuredUsefulEvidence,
       ...sourceMemoryEvidence,
       candidate.evidenceSummary,
       ...(candidate.evidenceItems ?? []).map(
@@ -284,6 +338,7 @@ export function createDossierSourceFileSummary(
   );
   const knownContext = unique(
     [
+      ...structuredKnownContext,
       ...(candidate.knownFacts ?? []),
       sourceFileReasonMeaning(candidate.reason, candidate.name),
       ...(candidate.sourceFileNotes ?? [])
@@ -302,6 +357,9 @@ export function createDossierSourceFileSummary(
   );
   const notPublicYet = unique(
     [
+      ...structuredNotPublicYet,
+      ...structuredPrivateOnlyNotes,
+      ...structuredRelationshipSignals,
       ...(candidate.publicSafetyNotes ?? []),
       ...(candidate.doNotSay ?? []),
       ...recommendations.flatMap((recommendation) => [
@@ -323,6 +381,8 @@ export function createDossierSourceFileSummary(
   );
   const claimedNeedsReview = unique(
     [
+      ...structuredRelationshipSignals,
+      ...structuredPublicSafePossibilities,
       sourceFileReasonMeaning(candidate.reason, candidate.name),
       sourceFileWhyNowMeaning(candidate.whyNow),
       ...recommendations.map((recommendation) => recommendation.reason),
@@ -395,6 +455,18 @@ export function createDossierSourceFileSummary(
       claimedNeedsReview.length > 0
         ? claimedNeedsReview
         : ["No human-readable claims have been extracted yet."],
+    privateRelationshipContext:
+      structuredRelationshipSignals.length > 0
+        ? structuredRelationshipSignals
+        : ["No private relationship/context signals are recorded in the structured packet."],
+    publicSafePossibilities:
+      structuredPublicSafePossibilities.length > 0
+        ? structuredPublicSafePossibilities
+        : ["No public-safe possibilities are pending owner review yet."],
+    privateOnlyNotes:
+      structuredPrivateOnlyNotes.length > 0
+        ? structuredPrivateOnlyNotes
+        : ["No private/internal notes are recorded in the structured packet."],
     uncertainties:
       uncertainties.length > 0
         ? uncertainties
@@ -413,7 +485,12 @@ export function createDossierSourceFileSummary(
       notPublicYet.length > 0
         ? notPublicYet
         : ["Do not say more publicly until owner/admin review confirms it."],
-    recommendedNextAction: operatorNextAction ?? nextActionCopy(action),
+    sourceAuthority:
+      structuredSourceAuthority.length > 0
+        ? structuredSourceAuthority
+        : ["Source authority has not been separated from confidence yet."],
+    recommendedNextAction:
+      operatorNextAction ?? structuredRecommendedAction ?? nextActionCopy(action),
     substanceLevel: level,
     publicReadiness: readiness,
     existingPublicDossier: candidate.existingDossierMatch

--- a/src/lib/dossier-source-memory-meaning.ts
+++ b/src/lib/dossier-source-memory-meaning.ts
@@ -2,7 +2,7 @@ const rawSourcePathPattern =
   /\b(?:user_profiles|relationship_journal|conversations|memory_tiers|rd_context|broadcast_memory|source_blind_memory_trace|local_knowledge_store)\s*\/\s*[a-z0-9_/-]+\b/i;
 
 const rawBackendLabelPattern =
-  /\b(?:local_profile_observed|local_relationship_trace|public_discord_observed|source lane mapping|bridge source lane mapping|source lanes?:\s*unknown|unknown\s*->\s*unknown|help_signal\s*:|EDGE_SESSION|ingestKey|candidateId|recommendationId|targetId|sourceTypes|sourceCounts|memory_tiers|private_review_required|owner_review_required|public_use_not_allowed_until_review)\b/i;
+  /\b(?:local_profile_observed|local_relationship_trace|public_discord_observed|source lane mapping|bridge source lane mapping|source lanes?:\s*unknown|unknown\s*->\s*unknown|help_signal\s*:|EDGE_SESSI(?:ON)?|ingestKey|candidateId|recommendationId|targetId|sourceTypes|sourceCounts|memory_tiers|private_review_required|owner_review_required|public_use_not_allowed_until_review)\b/i;
 
 const rawIdPattern =
   /\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl|edge_session|ingest)[_:][a-z0-9][a-z0-9_-]{8,}\b/i;
@@ -21,6 +21,12 @@ const localKnowledgePattern =
 
 function compact(value?: string | null) {
   return value?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function inferredSubject(value: string): string | undefined {
+  return value.match(/local profile observed for ([A-Z][A-Za-z0-9 ._-]{1,80})/i)?.[1]
+    ?.replace(/[.;:,].*$/, "")
+    .trim();
 }
 
 function subjectCopy(subjectName?: string) {
@@ -67,7 +73,8 @@ export function sourceMemoryMeaningItems(
   if (/^\s*(?:bridge\s+)?source lane mapping\s*:/i.test(clean)) return [];
 
   const items: string[] = [];
-  const subject = subjectCopy(options.subjectName);
+  const subjectName = options.subjectName ?? inferredSubject(clean);
+  const subject = subjectCopy(subjectName);
 
   if (localProfilePattern.test(clean)) {
     items.push(`BNL found an internal local profile match${subject}.`);
@@ -75,8 +82,8 @@ export function sourceMemoryMeaningItems(
 
   if (relationshipTracePattern.test(clean)) {
     items.push(
-      options.subjectName
-        ? `BNL found prior relationship/context notes connected to ${options.subjectName}.`
+      subjectName
+        ? `BNL found prior relationship/context notes connected to ${subjectName}.`
         : "BNL found prior relationship/context notes connected to this subject.",
     );
   }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -691,6 +691,28 @@ function normalizeSourceNoteInput(
   };
 }
 
+
+function normalizePacketStringArray(value: unknown): string[] | undefined {
+  const items = normalizeStringArray(value).slice(0, 25);
+  return items.length ? items : undefined;
+}
+
+function cloneJsonValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function firstStructuredRecommendationReason(
+  input: CreateDossierRecommendationInput,
+): string | undefined {
+  return (
+    normalizePacketStringArray(input.knownContext)?.[0] ??
+    normalizePacketStringArray(input.usefulEvidence)?.[0] ??
+    boundedText(input.recommendedAction, 1000) ??
+    normalizePacketStringArray(input.publicSafePossibilities)?.[0]
+  );
+}
+
 function normalizeRecommendationInput(
   input: CreateDossierRecommendationInput,
 ): Omit<
@@ -698,7 +720,8 @@ function normalizeRecommendationInput(
   "id" | "createdAt" | "updatedAt" | "status"
 > | null {
   const subjectName = boundedText(input.subjectName, 200);
-  const reason = boundedText(input.reason);
+  const reason =
+    boundedText(input.reason) ?? firstStructuredRecommendationReason(input);
   if (!subjectName || !reason) return null;
   const type = RECOMMENDATION_TYPES.includes(input.type)
     ? input.type
@@ -723,6 +746,17 @@ function normalizeRecommendationInput(
     sourceLanes: sourceLanes.length ? sourceLanes : ["admin_manual"],
     sourceTypes: normalizeStringArray(input.sourceTypes).slice(0, 25),
     suggestedAction: boundedText(input.suggestedAction, 500) || undefined,
+    knownContext: normalizePacketStringArray(input.knownContext),
+    usefulEvidence: normalizePacketStringArray(input.usefulEvidence),
+    relationshipSignals: normalizePacketStringArray(input.relationshipSignals),
+    publicSafePossibilities: normalizePacketStringArray(
+      input.publicSafePossibilities,
+    ),
+    privateOnlyNotes: normalizePacketStringArray(input.privateOnlyNotes),
+    notPublicYet: normalizePacketStringArray(input.notPublicYet),
+    recommendedAction: boundedText(input.recommendedAction, 1000) || undefined,
+    sourceAuthority: normalizePacketStringArray(input.sourceAuthority),
+    rawProvenance: cloneJsonValue(input.rawProvenance),
     missingInfo: normalizeStringArray(input.missingInfo),
     publicSafetyNotes: normalizeStringArray(input.publicSafetyNotes),
     doNotSay: normalizeStringArray(input.doNotSay),
@@ -875,7 +909,7 @@ function bnlAutoCandidateNoteText(
   ]
     .filter(Boolean)
     .join("\n\n")
-    .slice(0, 2000);
+    .slice(0, 4000);
 }
 
 function buildCandidateFromRecommendation(input: {
@@ -909,6 +943,7 @@ function buildCandidateFromRecommendation(input: {
     tier: "review_candidate",
     score: recommendationCandidateScore(recommendation),
     whyNow:
+      recommendation.recommendedAction ??
       recommendation.suggestedAction ??
       (source === "bnl_dynamic_candidate_discovery"
         ? "BNL dynamic candidate discovery."
@@ -918,8 +953,22 @@ function buildCandidateFromRecommendation(input: {
     reason: recommendation.reason,
     firstSeenAt: recommendation.ingestedAt ?? now,
     lastSeenAt: now,
-    evidenceSummary: recommendation.evidenceSummary ?? recommendation.reason,
-    evidenceItems: recommendation.evidenceSummary
+    evidenceSummary:
+      recommendation.usefulEvidence?.join("\n") ??
+      recommendation.evidenceSummary ??
+      recommendation.reason,
+    evidenceItems: (recommendation.usefulEvidence?.length ?? 0) > 0
+      ? recommendation.usefulEvidence!.map((summary) => ({
+          id: createEvidenceId(),
+          type: "operator_note" as const,
+          label: "BNL structured useful evidence",
+          summary,
+          count: 1,
+          firstSeenAt: recommendation.ingestedAt ?? now,
+          lastSeenAt: now,
+          publicSafe: false,
+        }))
+      : recommendation.evidenceSummary
       ? [
           {
             id: createEvidenceId(),
@@ -938,8 +987,10 @@ function buildCandidateFromRecommendation(input: {
           },
         ]
       : [],
-    evidenceCount: recommendation.evidenceSummary ? 1 : 0,
-    knownFacts: [],
+    evidenceCount:
+      recommendation.usefulEvidence?.length ??
+      (recommendation.evidenceSummary ? 1 : 0),
+    knownFacts: recommendation.knownContext ?? [],
     confidence: recommendation.confidence ?? "low",
     duplicateRisk: duplicate.risk,
     existingDossierMatch: duplicate.match,
@@ -953,9 +1004,15 @@ function buildCandidateFromRecommendation(input: {
     recommendedTags: recommendation.recommendedTags ?? [],
     proposedTags: [],
     missingInfo: recommendation.missingInfo ?? [],
-    doNotSay: recommendation.doNotSay ?? [],
+    doNotSay: uniqueStrings(
+      recommendation.doNotSay,
+      recommendation.notPublicYet,
+    ),
     publicSafetyNotes: uniqueStrings(
       recommendation.publicSafetyNotes,
+      recommendation.privateOnlyNotes,
+      recommendation.relationshipSignals,
+      recommendation.notPublicYet,
       bnlAutoCandidateSourceNotes(recommendation),
     ),
     sourceFileNotes: [{ ...note, candidateId: "" }],
@@ -1346,18 +1403,40 @@ export async function createDossierRecommendationIdempotent(
   };
 }
 
+function packetLines(label: string, items?: string[]): string[] {
+  return (items ?? []).map((item) => `${label}: ${item}`);
+}
+
 function recommendationSourceNoteText(
   recommendation: DossierRecommendation,
 ): string {
   return [
     `Recommendation reason: ${recommendation.reason}`,
+    ...packetLines("Known context", recommendation.knownContext),
+    ...packetLines("Useful evidence", recommendation.usefulEvidence),
+    ...packetLines(
+      "Relationship signal — private review",
+      recommendation.relationshipSignals,
+    ),
+    ...packetLines(
+      "Public-safe possibility pending owner review",
+      recommendation.publicSafePossibilities,
+    ),
+    ...packetLines("Private/internal note", recommendation.privateOnlyNotes),
+    ...packetLines("Not public yet", recommendation.notPublicYet),
+    recommendation.recommendedAction
+      ? `Recommended next action: ${recommendation.recommendedAction}`
+      : "",
+    ...(recommendation.sourceAuthority ?? []).map(
+      (item) => `Source authority / confidence boundary: ${item}`,
+    ),
     recommendation.evidenceSummary
       ? `Evidence summary: ${recommendation.evidenceSummary}`
       : "",
   ]
     .filter(Boolean)
     .join("\n\n")
-    .slice(0, 2000);
+    .slice(0, 4000);
 }
 
 export class DossierWorkflowInputError extends Error {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -372,6 +372,18 @@ export type DossierRecommendationIngestSource =
   | "system"
   | "unknown";
 
+export type DossierStructuredSourcePacket = {
+  knownContext?: string[];
+  usefulEvidence?: string[];
+  relationshipSignals?: string[];
+  publicSafePossibilities?: string[];
+  privateOnlyNotes?: string[];
+  notPublicYet?: string[];
+  recommendedAction?: string;
+  sourceAuthority?: string[];
+  rawProvenance?: unknown;
+};
+
 export type DossierRecommendation = {
   id: string;
   type: DossierRecommendationType;
@@ -386,6 +398,15 @@ export type DossierRecommendation = {
   sourceLanes: DossierRecommendationSourceLane[];
   sourceTypes?: string[];
   suggestedAction?: string;
+  knownContext?: string[];
+  usefulEvidence?: string[];
+  relationshipSignals?: string[];
+  publicSafePossibilities?: string[];
+  privateOnlyNotes?: string[];
+  notPublicYet?: string[];
+  recommendedAction?: string;
+  sourceAuthority?: string[];
+  rawProvenance?: unknown;
   missingInfo?: string[];
   publicSafetyNotes?: string[];
   doNotSay?: string[];
@@ -703,12 +724,21 @@ export type CreateDossierRecommendationInput = {
   subjectKey?: string;
   targetDossierId?: string;
   targetCandidateId?: string;
-  reason: string;
+  reason?: string;
   evidenceSummary?: string;
   confidence?: "low" | "medium" | "high";
   sourceLanes?: DossierRecommendationSourceLane[];
   sourceTypes?: string[];
   suggestedAction?: string;
+  knownContext?: string[];
+  usefulEvidence?: string[];
+  relationshipSignals?: string[];
+  publicSafePossibilities?: string[];
+  privateOnlyNotes?: string[];
+  notPublicYet?: string[];
+  recommendedAction?: string;
+  sourceAuthority?: string[];
+  rawProvenance?: unknown;
   missingInfo?: string[];
   publicSafetyNotes?: string[];
   doNotSay?: string[];

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -905,7 +905,7 @@ test("admin Source File and recommendation pages render readable sections with c
   for (const label of [
     "Plain-English review view",
     "Recommendation Takeaway",
-    "Technical audit details",
+    "Developer / Raw Source Audit",
     "Adds review context",
     "Thin: routing only",
     "Claimed / Needs Review",
@@ -5012,4 +5012,108 @@ test("raw provenance remains collapsed and outside normal preview surfaces", () 
   assert.match(draftPage, /Developer \/ Raw Source Audit — internal debugging only/);
   assert.match(candidatePage, /Developer \/ Raw Source Audit — internal debugging only/);
   assert.doesNotMatch(previewFunction, /candidate\?\.reason|candidate\?\.whyNow|candidate\?\.evidenceSummary|note\.text/);
+});
+
+test("BNL structured source packet v2 is ingested, summarized, and kept review-only", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const candidatePayload = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Structured Packet Subject",
+      reason: "Existing source file for structured packet review.",
+      evidenceSummary: "Reviewed starter context.",
+    },
+  })).json();
+  await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: candidatePayload.candidate.id,
+  });
+
+  const packet = {
+    type: "modify_existing_dossier",
+    subjectName: "Structured Packet Subject",
+    targetCandidateId: candidatePayload.candidate.id,
+    knownContext: ["BNL currently reads this subject as a recurring radio-side collaborator."],
+    usefulEvidence: ["Two reviewed source notes mention recurring set-support work."],
+    relationshipSignals: ["Private relationship context suggests an operator-adjacent connection."],
+    publicSafePossibilities: ["May be described as a collaborator after owner review."],
+    privateOnlyNotes: ["Private-only note about the internal contact path."],
+    notPublicYet: ["Do not publish the collaborator label until owner review."],
+    recommendedAction: "Ask an owner to separate public-safe collaborator language from internal relationship context.",
+    confidence: "high",
+    sourceAuthority: ["Mixed BNL memory plus admin review; not owner-confirmed."],
+    rawProvenance: {
+      backendTraceId: "raw-trace-structured-packet-v2",
+      lanes: ["relationship_journal", "operator_notes"],
+    },
+    sourceLanes: ["active_source_file", "operator_notes"],
+    sourceTypes: ["source_memory_packet_v2"],
+    ingestKey: "bnl:structured-source-packet-v2",
+    ingestSource: "bnl_source_file_enrichment",
+  };
+
+  const response = await bnlIngestPost(packet);
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.autoAction, "attached_existing");
+  assert.equal(payload.recommendation.reason, packet.knownContext[0]);
+  assert.deepEqual(payload.recommendation.knownContext, packet.knownContext);
+  assert.deepEqual(payload.recommendation.usefulEvidence, packet.usefulEvidence);
+  assert.deepEqual(payload.recommendation.relationshipSignals, packet.relationshipSignals);
+  assert.deepEqual(payload.recommendation.publicSafePossibilities, packet.publicSafePossibilities);
+  assert.deepEqual(payload.recommendation.privateOnlyNotes, packet.privateOnlyNotes);
+  assert.deepEqual(payload.recommendation.notPublicYet, packet.notPublicYet);
+  assert.equal(payload.recommendation.recommendedAction, packet.recommendedAction);
+  assert.deepEqual(payload.recommendation.sourceAuthority, packet.sourceAuthority);
+  assert.deepEqual(payload.recommendation.rawProvenance, packet.rawProvenance);
+
+  const state = await store.getDossierWorkflowState();
+  const savedRecommendation = state.recommendations.find(
+    (recommendation) => recommendation.ingestKey === packet.ingestKey,
+  );
+  assert.ok(savedRecommendation);
+  assert.deepEqual(savedRecommendation.usefulEvidence, packet.usefulEvidence);
+  assert.deepEqual(savedRecommendation.rawProvenance, packet.rawProvenance);
+  const sourceFile = state.candidates.find(
+    (candidate) => candidate.id === candidatePayload.candidate.id,
+  );
+  assert.ok(sourceFile);
+  assert.equal(sourceFile.sourceFileNotes.length, 1);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Useful evidence: Two reviewed source notes/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Relationship signal — private review/);
+  assert.doesNotMatch(sourceFile.sourceFileNotes[0].text, /raw-trace-structured-packet-v2/);
+
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: sourceFile,
+    recommendations: [savedRecommendation],
+  });
+  assert.match(JSON.stringify(summary.usefulEvidence), /Two reviewed source notes/);
+  assert.match(JSON.stringify(summary.privateRelationshipContext), /Private relationship context/);
+  assert.match(JSON.stringify(summary.claimedNeedsReview), /Private relationship context|collaborator after owner review/);
+  assert.match(JSON.stringify(summary.publicSafePossibilities), /collaborator after owner review/);
+  assert.match(JSON.stringify(summary.privateOnlyNotes), /internal contact path/);
+  assert.match(JSON.stringify(summary.notPublicYet), /Do not publish the collaborator label|Private relationship context|internal contact path/);
+  assert.match(JSON.stringify(summary.sourceAuthority), /Confidence: high|Mixed BNL memory/);
+  assert.doesNotMatch(JSON.stringify(summary), /raw-trace-structured-packet-v2/);
+
+  const view = noteDisplay.createHumanReadableRecommendationView(savedRecommendation);
+  assert.match(JSON.stringify(view.sections), /Two reviewed source notes/);
+  assert.match(JSON.stringify(view.sections), /Private Relationship Context/);
+  assert.match(JSON.stringify(view.rawMetadata), /raw-trace-structured-packet-v2/);
+  assert.doesNotMatch(JSON.stringify(view.sections), /raw-trace-structured-packet-v2/);
+
+  const draftPayload = await (await authedPost({
+    action: "createDraftFromCandidate",
+    candidateId: sourceFile.id,
+  })).json();
+  const draftText = JSON.stringify(draftPayload.draft.fields);
+  assert.doesNotMatch(draftText, /raw-trace-structured-packet-v2/);
+  assert.doesNotMatch(draftText, /Private-only note|internal contact path|relationship context/);
+
+  const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.doesNotMatch(JSON.stringify(publicPayload), /Structured Packet Subject|raw-trace-structured-packet-v2|internal contact path/);
+  assert.equal(state.drafts.length, 0, "No draft existed before the explicit createDraftFromCandidate call.");
 });

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -4772,14 +4772,101 @@ test("source file meaning filter hides backend terms from main views while prese
   const view = noteDisplay.createHumanReadableSourceFileNoteView(note);
   const mainText = JSON.stringify({ summary: view.summary, sections: view.sections });
   assert.doesNotMatch(mainText, /user_profiles|local_profile_observed|relationship_journal|unknown -> unknown|private_review_required|public_use_not_allowed_until_review|source lane/i);
-  assert.match(mainText, /BNL has a local profile match for this subject/);
+  assert.match(mainText, /BNL found an internal local profile match for this subject/);
   assert.match(mainText, /This needs internal review before public use|Do not use publicly until owner\/admin review/);
   assert.equal(
-    (mainText.match(/BNL has a local profile match for this subject/g) ?? []).length,
+    (mainText.match(/BNL found an internal local profile match for this subject/g) ?? []).length,
     1,
   );
   assert.match(JSON.stringify(view.rawMetadata), /source lane|relationship_journal|unknown/i);
   assert.match(view.rawText, /user_profiles\/local_profile_observed/);
+});
+
+
+
+test("legacy source-file note view translates raw source memory instead of leaking it", async () => {
+  await resetWorkflowStore();
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const rawLegacyText = [
+    "Evidence summary: user_profiles/local_profile_observed: Local profile observed for Crow. help_signal: EDGE_SESSION abc123456789",
+    "relationship_journal/local_relationship_trace: help_signal: User asked for help in EDGE_SESSION abc123456789",
+    "Source lanes: unknown",
+    "Source lane mapping: relationship_journal -> unknown, user_profiles -> unknown",
+    "Summary: BNL local knowledge stores.",
+  ].join("\n");
+  const note = {
+    type: "general_note",
+    text: rawLegacyText,
+    source: "bnl_recommendation",
+    status: "active",
+    publicSafe: false,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    ingestSource: "bnl_source_knowledge_bridge",
+    ingestKey: "bnl:legacy-crow-note",
+    evidenceSummary:
+      "user_profiles/local_profile_observed: Local profile observed for Crow. relationship_journal/local_relationship_trace help_signal: EDGE_SESSION abc123456789",
+    reason: "BNL local knowledge stores. relationship_journal/local_relationship_trace",
+    subjectName: "Crow",
+  };
+
+  const view = noteDisplay.createHumanReadableSourceFileNoteView(note);
+  const visibleSections = JSON.stringify(view.sections);
+  const usefulEvidence = JSON.stringify(
+    view.sections.find((section) => section.title === "Useful Evidence")?.items ?? [],
+  );
+  const claimedNeedsReview = JSON.stringify(
+    view.sections.find((section) => section.title === "Claimed / Needs Review")?.items ?? [],
+  );
+
+  for (const visibleText of [visibleSections, usefulEvidence, claimedNeedsReview]) {
+    assert.doesNotMatch(visibleText, /help_signal:?/i);
+    assert.doesNotMatch(visibleText, /EDGE_SESSI(?:ON)?/i);
+    assert.doesNotMatch(visibleText, /relationship_journal\/local_relationship_trace/i);
+    assert.doesNotMatch(visibleText, /user_profiles\/local_profile_observed/i);
+    assert.doesNotMatch(visibleText, /conversations\/public_discord_observed/i);
+    assert.doesNotMatch(visibleText, /source lane mapping|Source lanes: unknown|unknown -> unknown/i);
+    assert.doesNotMatch(visibleText, /: Local profile observed|: BNL local knowledge stores\./i);
+  }
+
+  assert.match(usefulEvidence, /BNL found an internal local profile match for Crow/);
+  assert.match(usefulEvidence, /BNL found prior relationship\/context notes connected to Crow/);
+  assert.match(visibleSections, /Internal BNL memory references exist, but they need owner review before public use/);
+  assert.equal(
+    (visibleSections.match(/local profile match/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (visibleSections.match(/relationship\/context notes/g) ?? []).length,
+    1,
+  );
+
+  assert.match(view.rawText ?? "", /user_profiles\/local_profile_observed/);
+  assert.match(view.rawText ?? "", /EDGE_SESSION/);
+  assert.match(JSON.stringify(view.rawMetadata), /legacyEvidenceSummary/);
+  assert.match(JSON.stringify(view.rawMetadata), /user_profiles\/local_profile_observed/);
+  assert.match(JSON.stringify(view.rawMetadata), /legacyReason/);
+  assert.match(JSON.stringify(view.rawMetadata), /relationship_journal\/local_relationship_trace/);
+
+  const candidatePayload = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      ...manualCandidateInput,
+      name: "Crow Legacy Note",
+      reason: "Manual review shell for legacy note leak test.",
+      evidenceSummary: note.evidenceSummary,
+    },
+  })).json();
+  const draftPayload = await (await authedPost({
+    action: "createDraftFromCandidate",
+    candidateId: candidatePayload.candidate.id,
+  })).json();
+  const draftText = JSON.stringify(draftPayload.draft.fields);
+  assert.doesNotMatch(draftText, /help_signal|EDGE_SESSION|user_profiles\/local_profile_observed|relationship_journal\/local_relationship_trace/i);
+
+  const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  assert.doesNotMatch(JSON.stringify(publicPayload), /Crow Legacy Note|help_signal|EDGE_SESSION|local_profile_observed/i);
 });
 
 test("source file summary suppresses fake patterns, shows thin warning, and prefers operator summary", () => {
@@ -4898,7 +4985,7 @@ test("recommendation detail case-file view uses the same sanitizer", () => {
   const view = noteDisplay.createHumanReadableRecommendationView(recommendation);
   const mainText = JSON.stringify({ summary: view.summary, sections: view.sections });
   assert.doesNotMatch(mainText, /relationship_journal|local_profile_observed|public_discord_observed|private_review_required|rd_context|target_id/);
-  assert.match(mainText, /BNL has a local profile match for this subject/);
+  assert.match(mainText, /BNL found an internal local profile match for Melanie Heart/);
   assert.match(JSON.stringify(view.rawMetadata), /relationship_journal|rd_context|bnl:rec_filter/);
 });
 


### PR DESCRIPTION
### Motivation
- Bring the website dossier/recommendation workflow up to date with the new meaning-first BNL source packet v2 so structured fields are stored and surfaced to admins instead of being lost in legacy freeform fields. 
- Keep raw audit data collapsed and internal only, and preserve existing fallback behavior for older records so no public publishing or new merge/publish side effects are introduced.

### Description
- Accept and persist the new packet fields (`knownContext`, `usefulEvidence`, `relationshipSignals`, `publicSafePossibilities`, `privateOnlyNotes`, `notPublicYet`, `recommendedAction`, `sourceAuthority`, `rawProvenance`) at ingest and in the workflow store, and prefer these structured fields over legacy `reason`/`evidenceSummary` when present.  
- Map structured fields into admin/source-file UI and summaries: `knownContext` → Known Context / Current Read, `usefulEvidence` → Useful Evidence, `relationshipSignals` → Private Relationship Context / Claimed Needs Review, `publicSafePossibilities` → Public-Safe Possibilities Pending Owner Review, `privateOnlyNotes` → Private/Internal Notes, `notPublicYet` → Not Public Yet warnings, `recommendedAction` → Recommended Next Action, and `sourceAuthority`/`confidence` → Source Authority / Confidence; `rawProvenance` is retained only in collapsed developer/raw audit metadata.  
- Files changed: `src/app/api/bnl/dossier-recommendations/route.ts`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-source-file-summary.ts`, `src/lib/dossier-note-display.ts`, `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, and `tests/admin-dossiers.test.mjs` to implement ingestion, storage, view mapping, and tests.  
- Preservation and privacy: `rawProvenance` is JSON-cloned and kept only in collapsed raw metadata/Audit (`Developer / Raw Source Audit`) and is not copied into Proposed Dossier fields or the public read model.

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it passed.  
- Ran the full admin dossier tests with `node --test tests/admin-dossiers.test.mjs` and all tests passed (108 tests).  
- Ran targeted `eslint` on changed files and it completed successfully.  
- Attempted `npm run build` but it failed only due to the environment blocking Turbopack/`next/font` from fetching the Google Font `Geist Mono` (`https://fonts.googleapis.com/...`); this is a known network fetch limitation and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd3d163548321831f2b10efee8887)