### PR TITLE
Add BNL Entity Readout admin panel to Source File & Recommendation pages

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -16,9 +16,11 @@ import {
   type DossierRecommendation,
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
+import { DossierEntityActivityReadoutPanel } from "@/components/DossierEntityActivityReadoutPanel";
 import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
+import { createDossierEntityActivityReadoutFromSourceFile } from "@/lib/dossier-entity-activity-readout";
 import {
   sanitizeMeaningFirstItems,
   sourceFileEvidenceClusterItems,
@@ -648,6 +650,13 @@ export default function CandidateReviewPage() {
         recommendations: attachedRecommendations,
       })
     : null;
+  const entityActivityReadout = candidate
+    ? createDossierEntityActivityReadoutFromSourceFile({
+        summary: sourceFileSummary,
+        recommendations: attachedRecommendations,
+        subjectName: candidate.name,
+      })
+    : null;
   const identityLinks = [...(candidate?.identityLinks ?? [])].sort(
     (a, b) =>
       (a.status === "proposed" ? -1 : 1) - (b.status === "proposed" ? -1 : 1) ||
@@ -1151,6 +1160,9 @@ export default function CandidateReviewPage() {
             <DossierSourceFileSummaryPanel summary={sourceFileSummary} />
             {/* Source File Summary */}
           </>
+        )}
+        {entityActivityReadout && (
+          <DossierEntityActivityReadoutPanel readout={entityActivityReadout} />
         )}
 
         <section className="border border-border bg-surface p-5 space-y-4">

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -13,7 +13,9 @@ import {
   type DossierIdentityLinkVisibility,
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
+import { DossierEntityActivityReadoutPanel } from "@/components/DossierEntityActivityReadoutPanel";
 import { createHumanReadableRecommendationView } from "@/lib/dossier-note-display";
+import { createDossierEntityActivityReadoutFromRecommendation } from "@/lib/dossier-entity-activity-readout";
 import { sanitizeMeaningFirstItems } from "@/lib/dossier-source-memory-meaning";
 
 type WorkflowPayload = {
@@ -387,6 +389,9 @@ export default function DossierRecommendationPage() {
       null,
     [payload?.recommendations, recommendationId],
   );
+  const entityActivityReadout = recommendation
+    ? createDossierEntityActivityReadoutFromRecommendation(recommendation)
+    : null;
   const targetCandidate = recommendation?.targetCandidateId
     ? (payload?.candidates.find(
         (candidate) => candidate.id === recommendation.targetCandidateId,
@@ -991,6 +996,12 @@ export default function DossierRecommendationPage() {
           </section>
         )}
         <HumanReadableRecommendationCaseFile recommendation={recommendation} />
+        {entityActivityReadout && (
+          <DossierEntityActivityReadoutPanel
+            readout={entityActivityReadout}
+            compact
+          />
+        )}
         <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Field title="Subject">
             <p>{recommendation.subjectName}</p>

--- a/src/components/DossierEntityActivityReadoutPanel.tsx
+++ b/src/components/DossierEntityActivityReadoutPanel.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import type React from "react";
+import type { DossierEntityActivityReadout } from "@/lib/dossier-entity-activity-readout";
+
+function ReadoutBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="border border-border bg-background/40 px-2 py-1 text-muted">
+      {children}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  children,
+  tone = "default",
+}: {
+  title: string;
+  children: React.ReactNode;
+  tone?: "default" | "review" | "caution";
+}) {
+  const toneClass =
+    tone === "caution"
+      ? "border-accent/70 bg-accent/10"
+      : tone === "review"
+        ? "border-border bg-background/30"
+        : "border-border/60 bg-background/20";
+  return (
+    <section className={`border p-3 text-sm text-muted ${toneClass}`}>
+      <h3 className="font-bold text-foreground mb-2">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function ReadoutList({ items, empty }: { items: string[]; empty: string }) {
+  return items.length ? (
+    items.length === 1 ? (
+      <p>{items[0]}</p>
+    ) : (
+      <ul className="list-disc pl-5 space-y-1">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    )
+  ) : (
+    <p className="text-muted">{empty}</p>
+  );
+}
+
+export function DossierEntityActivityReadoutPanel({
+  readout,
+  compact = false,
+}: {
+  readout: DossierEntityActivityReadout;
+  compact?: boolean;
+}) {
+  return (
+    <section className="border border-accent/70 bg-surface p-5 space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.45em] text-accent mb-2">
+            BNL Entity Readout / Entity Activity Summary
+          </p>
+          <h2 className="text-2xl font-bold text-foreground">
+            BNL Entity Readout
+          </h2>
+          <p className="mt-2 text-sm text-muted max-w-4xl">
+            The website is presenting BNL&apos;s structured readout for admin review
+            only. It is not public copy and does not autofill Proposed Dossier
+            fields.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+          <ReadoutBadge>
+            Source: {readout.readoutSource === "structured" ? "Structured packet" : "Safe fallback"}
+          </ReadoutBadge>
+          <ReadoutBadge>Review-only</ReadoutBadge>
+          <ReadoutBadge>No live BNL call</ReadoutBadge>
+          {readout.confidence && <ReadoutBadge>Confidence: {readout.confidence}</ReadoutBadge>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm text-muted">
+        <Section title="Current Read">
+          <p>{readout.currentRead}</p>
+        </Section>
+        <Section title="Known Context">
+          <ReadoutList
+            items={readout.knownContext}
+            empty="No public-safe facts confirmed yet."
+          />
+        </Section>
+        <Section title="Useful Evidence">
+          <ReadoutList
+            items={readout.usefulEvidence}
+            empty="No useful evidence has been attached to this entity readout yet."
+          />
+        </Section>
+        <Section title="Activity / Channel Signals">
+          <div className="space-y-2">
+            <p>No reviewed channel/activity summary has been attached yet.</p>
+            <p>Queue/submission history is not connected to BNL entity summaries yet.</p>
+          </div>
+        </Section>
+        <Section title="Relationship Context — Review Only" tone="review">
+          <ReadoutList
+            items={readout.relationshipSignals}
+            empty="No private relationship/context signals are recorded in the structured readout."
+          />
+        </Section>
+        <Section title="Public-Safe Possibilities Pending Owner Review" tone="review">
+          <ReadoutList
+            items={readout.publicSafePossibilities}
+            empty="Owner review needed before public wording."
+          />
+        </Section>
+        <Section title="Private/Internal Notes — Review Only" tone="review">
+          <ReadoutList
+            items={readout.privateOnlyNotes}
+            empty="No private/internal notes are recorded in the structured readout."
+          />
+        </Section>
+        <Section title="Not Public Yet" tone="caution">
+          <ReadoutList
+            items={readout.notPublicYet}
+            empty="Do not say more publicly until owner/admin review confirms it."
+          />
+        </Section>
+        {!compact && (
+          <Section title="Missing Info">
+            <ReadoutList
+              items={readout.missingInfo}
+              empty="Needs more public-safe history, owner review, and confirmed context."
+            />
+          </Section>
+        )}
+        <Section title="Source Authority / Confidence">
+          <ReadoutList
+            items={readout.sourceAuthority}
+            empty="Source authority has not been separated from confidence yet."
+          />
+          {readout.confidence && (
+            <p className="mt-2 text-xs uppercase tracking-widest text-accent">
+              Confidence: {readout.confidence}
+            </p>
+          )}
+        </Section>
+        <Section title="Recommended Next Action">
+          <p>{readout.recommendedAction}</p>
+        </Section>
+      </div>
+      <p className="text-xs text-muted">
+        Raw provenance stays in Developer / Raw Source Audit only. This readout
+        does not publish, merge entities, call BNL live, or create queue/payment
+        behavior.
+      </p>
+    </section>
+  );
+}

--- a/src/lib/dossier-entity-activity-readout.ts
+++ b/src/lib/dossier-entity-activity-readout.ts
@@ -1,0 +1,217 @@
+import type { DossierRecommendation } from "./dossier-workflow";
+import type { DossierSourceFileSummary } from "./dossier-source-file-summary";
+import { sanitizeDossierMeaningItems } from "./dossier-note-display";
+
+export type DossierEntityActivityReadout = {
+  currentRead: string;
+  knownContext: string[];
+  usefulEvidence: string[];
+  relationshipSignals: string[];
+  publicSafePossibilities: string[];
+  privateOnlyNotes: string[];
+  notPublicYet: string[];
+  missingInfo: string[];
+  sourceAuthority: string[];
+  recommendedAction: string;
+  confidence?: string;
+  readoutSource: "structured" | "fallback";
+};
+
+type ReadoutRecommendation = Pick<
+  DossierRecommendation,
+  | "subjectName"
+  | "knownContext"
+  | "usefulEvidence"
+  | "relationshipSignals"
+  | "publicSafePossibilities"
+  | "privateOnlyNotes"
+  | "notPublicYet"
+  | "missingInfo"
+  | "sourceAuthority"
+  | "recommendedAction"
+  | "suggestedAction"
+  | "confidence"
+>;
+
+const defaultCurrentRead =
+  "BNL has not attached a structured entity summary yet. Review the Source File Snapshot and add owner-reviewed context before public use.";
+
+function cleanItems(items: Array<string | undefined | null>, limit = 6) {
+  return sanitizeDossierMeaningItems(items, limit);
+}
+
+function cleanText(value?: string | null) {
+  return cleanItems([value], 1)[0];
+}
+
+function unique(items: string[], limit = 6) {
+  const output: string[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const clean = item.replace(/\s+/g, " ").trim();
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function recommendationHasStructuredReadout(
+  recommendation: ReadoutRecommendation,
+) {
+  return Boolean(
+    recommendation.knownContext?.length ||
+      recommendation.usefulEvidence?.length ||
+      recommendation.relationshipSignals?.length ||
+      recommendation.publicSafePossibilities?.length ||
+      recommendation.privateOnlyNotes?.length ||
+      recommendation.notPublicYet?.length ||
+      recommendation.missingInfo?.length ||
+      recommendation.sourceAuthority?.length ||
+      recommendation.recommendedAction ||
+      recommendation.confidence,
+  );
+}
+
+function structuredReadoutFromRecommendations(
+  recommendations: ReadoutRecommendation[],
+  subjectName?: string,
+): DossierEntityActivityReadout | null {
+  const structuredRecommendations = recommendations.filter(
+    recommendationHasStructuredReadout,
+  );
+  if (!structuredRecommendations.length) return null;
+
+  const knownContext = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.knownContext ?? [],
+    ),
+  );
+  const usefulEvidence = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.usefulEvidence ?? [],
+    ),
+  );
+  const relationshipSignals = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.relationshipSignals ?? [],
+    ),
+  );
+  const publicSafePossibilities = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.publicSafePossibilities ?? [],
+    ),
+  );
+  const privateOnlyNotes = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.privateOnlyNotes ?? [],
+    ),
+  );
+  const notPublicYet = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.notPublicYet ?? [],
+    ),
+  );
+  const missingInfo = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.missingInfo ?? [],
+    ),
+  );
+  const sourceAuthority = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.sourceAuthority ?? [],
+    ),
+    5,
+  );
+  const confidence = unique(
+    structuredRecommendations
+      .map((recommendation) => recommendation.confidence)
+      .filter(Boolean)
+      .map((item) => String(item)),
+    2,
+  ).join(", ");
+  const recommendedAction = cleanText(
+    structuredRecommendations.find((recommendation) => recommendation.recommendedAction)
+      ?.recommendedAction,
+  );
+  const subject = subjectName ?? structuredRecommendations[0]?.subjectName;
+
+  return {
+    currentRead:
+      knownContext[0] ??
+      recommendedAction ??
+      `BNL supplied a structured entity activity readout${subject ? ` for ${subject}` : ""}. Treat it as admin review context, not public copy.`,
+    knownContext,
+    usefulEvidence,
+    relationshipSignals,
+    publicSafePossibilities,
+    privateOnlyNotes,
+    notPublicYet,
+    missingInfo,
+    sourceAuthority,
+    recommendedAction:
+      recommendedAction ??
+      "Owner review needed before public wording, publishing, linking, or merging.",
+    confidence: confidence || undefined,
+    readoutSource: "structured",
+  };
+}
+
+export function createDossierEntityActivityReadoutFromSourceFile({
+  summary,
+  recommendations,
+  subjectName,
+}: {
+  summary?: DossierSourceFileSummary | null;
+  recommendations?: ReadoutRecommendation[];
+  subjectName?: string;
+}): DossierEntityActivityReadout {
+  const structuredReadout = structuredReadoutFromRecommendations(
+    recommendations ?? [],
+    subjectName,
+  );
+  if (structuredReadout) return structuredReadout;
+
+  return {
+    currentRead: cleanText(summary?.currentRead) ?? defaultCurrentRead,
+    knownContext: cleanItems(summary?.knownContext ?? []),
+    usefulEvidence: cleanItems(summary?.usefulEvidence ?? []),
+    relationshipSignals: cleanItems(summary?.privateRelationshipContext ?? []),
+    publicSafePossibilities: cleanItems(summary?.publicSafePossibilities ?? []),
+    privateOnlyNotes: cleanItems(summary?.privateOnlyNotes ?? []),
+    notPublicYet: cleanItems(summary?.notPublicYet ?? []),
+    missingInfo: cleanItems(summary?.missingInfo ?? []),
+    sourceAuthority: cleanItems(summary?.sourceAuthority ?? [], 5),
+    recommendedAction:
+      cleanText(summary?.recommendedNextAction) ??
+      "Owner review needed before public wording.",
+    readoutSource: "fallback",
+  };
+}
+
+export function createDossierEntityActivityReadoutFromRecommendation(
+  recommendation: ReadoutRecommendation,
+): DossierEntityActivityReadout {
+  return (
+    structuredReadoutFromRecommendations([recommendation], recommendation.subjectName) ??
+    {
+      currentRead: defaultCurrentRead,
+      knownContext: [],
+      usefulEvidence: [],
+      relationshipSignals: [],
+      publicSafePossibilities: [],
+      privateOnlyNotes: [],
+      notPublicYet: [],
+      missingInfo: [],
+      sourceAuthority: [],
+      recommendedAction:
+        cleanText(recommendation.suggestedAction) ??
+        "Owner review needed before public wording.",
+      confidence: recommendation.confidence,
+      readoutSource: "fallback",
+    }
+  );
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -54,6 +54,7 @@ const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
+const entityReadout = require("../src/lib/dossier-entity-activity-readout.ts");
 const sourceMemoryMeaning = require("../src/lib/dossier-source-memory-meaning.ts");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
@@ -5099,6 +5100,88 @@ test("raw provenance remains collapsed and outside normal preview surfaces", () 
   assert.match(draftPage, /Developer \/ Raw Source Audit — internal debugging only/);
   assert.match(candidatePage, /Developer \/ Raw Source Audit — internal debugging only/);
   assert.doesNotMatch(previewFunction, /candidate\?\.reason|candidate\?\.whyNow|candidate\?\.evidenceSummary|note\.text/);
+});
+
+test("BNL Entity Readout panel is mounted on admin Source File and recommendation pages", () => {
+  const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const recommendationPage = normalizedSource("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx");
+  const panel = normalizedSource("src/components/DossierEntityActivityReadoutPanel.tsx");
+
+  assert.match(sourceFilePage, /DossierEntityActivityReadoutPanel/);
+  assert.match(sourceFilePage, /createDossierEntityActivityReadoutFromSourceFile/);
+  assert.ok(
+    sourceFilePage.indexOf("DossierSourceFileSummaryPanel") <
+      sourceFilePage.indexOf("DossierEntityActivityReadoutPanel readout={entityActivityReadout}"),
+  );
+  assert.match(recommendationPage, /createDossierEntityActivityReadoutFromRecommendation/);
+  assert.match(recommendationPage, /DossierEntityActivityReadoutPanel/);
+  assertIncludesCopy(panel, "BNL Entity Readout / Entity Activity Summary");
+  assertIncludesCopy(panel, "Relationship Context — Review Only");
+  assertIncludesCopy(panel, "Public-Safe Possibilities Pending Owner Review");
+  assertIncludesCopy(panel, "Private/Internal Notes — Review Only");
+  assertIncludesCopy(panel, "Queue/submission history is not connected to BNL entity summaries yet.");
+  assertIncludesCopy(panel, "Source Authority / Confidence");
+  assertIncludesCopy(panel, "No live BNL call");
+  assertIncludesCopy(panel, "does not autofill Proposed Dossier fields");
+  assert.doesNotMatch(panel, /rawProvenance/);
+});
+
+test("BNL Entity Readout prefers structured packet fields and filters raw provenance labels", () => {
+  const recommendation = {
+    subjectName: "Structured Packet Subject",
+    knownContext: ["BNL currently reads this subject as a recurring radio-side collaborator."],
+    usefulEvidence: ["Two reviewed source notes mention recurring set-support work."],
+    relationshipSignals: ["Private relationship context suggests an operator-adjacent connection."],
+    publicSafePossibilities: ["May be described as a collaborator after owner review."],
+    privateOnlyNotes: ["Private-only note about the internal contact path."],
+    notPublicYet: ["Do not publish the collaborator label until owner review."],
+    missingInfo: ["Missing owner-confirmed public wording."],
+    recommendedAction: "Ask an owner to separate public-safe collaborator language from internal relationship context.",
+    confidence: "high",
+    sourceAuthority: [
+      "Mixed BNL memory plus admin review; not owner-confirmed.",
+      "relationship_journal/local_relationship_trace",
+    ],
+    suggestedAction: "Attach after review.",
+  };
+
+  const readout = entityReadout.createDossierEntityActivityReadoutFromRecommendation(recommendation);
+  assert.equal(readout.readoutSource, "structured");
+  assert.deepEqual(readout.knownContext, recommendation.knownContext);
+  assert.deepEqual(readout.usefulEvidence, recommendation.usefulEvidence);
+  assert.deepEqual(readout.relationshipSignals, recommendation.relationshipSignals);
+  assert.deepEqual(readout.publicSafePossibilities, recommendation.publicSafePossibilities);
+  assert.deepEqual(readout.privateOnlyNotes, recommendation.privateOnlyNotes);
+  assert.deepEqual(readout.notPublicYet, recommendation.notPublicYet);
+  assert.deepEqual(readout.missingInfo, recommendation.missingInfo);
+  assert.equal(readout.recommendedAction, recommendation.recommendedAction);
+  assert.equal(readout.confidence, "high");
+  assert.match(JSON.stringify(readout.sourceAuthority), /Mixed BNL memory/);
+  assert.doesNotMatch(
+    JSON.stringify(readout),
+    /relationship_journal|local_relationship_trace|user_profiles\/local_profile_observed|conversations\/public_discord_observed|source lane mapping|unknown -> unknown|help_signal|EDGE_SESSION|raw-trace|backendTraceId/,
+  );
+});
+
+test("BNL Entity Readout legacy fallback renders safe empty states without changing public previews", () => {
+  const readout = entityReadout.createDossierEntityActivityReadoutFromSourceFile({
+    summary: null,
+    recommendations: [],
+    subjectName: "Legacy Subject",
+  });
+  assert.equal(readout.readoutSource, "fallback");
+  assert.match(readout.currentRead, /not attached a structured entity summary/);
+  assert.deepEqual(readout.knownContext, []);
+  assert.deepEqual(readout.usefulEvidence, []);
+  assert.deepEqual(readout.privateOnlyNotes, []);
+
+  const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
+  assert.doesNotMatch(draftPage, /DossierEntityActivityReadoutPanel|createDossierEntityActivityReadout/);
+  assert.doesNotMatch(draftPage, /privateOnlyNotes|rawProvenance|relationshipSignals/);
+
+  const databaseSlugPage = source("src/app/database/[slug]/page.tsx");
+  assert.match(databaseSlugPage, /databasePage\.entries/);
+  assert.match(databaseSlugPage, /<DossierPageView dossier=\{databaseEntryToDossierPageViewModel\(entry\)\}/);
 });
 
 test("BNL structured source packet v2 is ingested, summarized, and kept review-only", async () => {


### PR DESCRIPTION
### Motivation
- Provide a clear, review-only admin surface that exposes BNL’s structured entity readout (Entity Activity Summary) on Source File pages so operators can see what BNL currently understands without exposing raw provenance. 
- Prefer structured packet fields (BNL Source Packet v2 / Entity Activity Summary) over legacy/derived text and keep privacy boundaries explicit (review-only, public-safe possibilities pending owner review, not-public-yet cautions).
- Keep raw provenance and backend labels out of normal admin readout and confined to Developer / Raw Source Audit only.

### Description
- Add a new readout adapter `createDossierEntityActivityReadoutFromSourceFile` / `createDossierEntityActivityReadoutFromRecommendation` that prefers structured packet fields (`knownContext`, `usefulEvidence`, `relationshipSignals`, `publicSafePossibilities`, `privateOnlyNotes`, `notPublicYet`, `missingInfo`, `sourceAuthority`, `recommendedAction`, `confidence`) and sanitizes items for human display. (new: `src/lib/dossier-entity-activity-readout.ts`)
- Add a dedicated admin UI component `DossierEntityActivityReadoutPanel` that renders BNL’s readout with sections and review-only labels and helpful empty states rather than dumping raw data. (new: `src/components/DossierEntityActivityReadoutPanel.tsx`)
- Mount the readout on admin Source File pages after the Source File Snapshot / Summary and before deeper operator summary/audit areas to prioritize visibility. (modified: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Mount a compact variant on recommendation detail pages so incoming structured packets can be sanity-checked before becoming Source Files. (modified: `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`)
- Add focused tests that assert panel presence, that structured fields are used when present, that privacy labels / empty states are correct, that raw provenance and backend labels do not appear in the readout, and that legacy fallback behavior leaves public preview surfaces unchanged. (modified: `tests/admin-dossiers.test.mjs`)
- Explicitly document and enforce that no publishing, owner-review auto-submit, live BNL calls, queue/payment, entity-merge, or public database mutation behavior was added.

Files changed: 
- Added: `src/components/DossierEntityActivityReadoutPanel.tsx` (UI panel)
- Added: `src/lib/dossier-entity-activity-readout.ts` (readout adapter + sanitization)
- Modified: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (mount readout)
- Modified: `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx` (mount compact readout)
- Modified: `tests/admin-dossiers.test.mjs` (unit tests for readout behavior)

### Testing
- Ran type check: `npx tsc --noEmit` — passed after small type sanitization fix.
- Ran unit tests: `node --test tests/admin-dossiers.test.mjs` — all tests passed (112 tests, 0 failures).
- Ran linter: `npx eslint src/components/DossierEntityActivityReadoutPanel.tsx src/lib/dossier-entity-activity-readout.ts src/app/admin/dossiers/candidates/[candidateId]/page.tsx src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx tests/admin-dossiers.test.mjs` — fixed a single react/no-unescaped-entities issue; lint succeeded afterward.
- Attempted full build: `npm run build` — build failed due to a known Next/Turbopack Google font fetch error for `Geist Mono` (network/font fetch issue), this is environment-related and unrelated to the change.

All automated checks passed except the environment-specific font fetch during `next build`, and tests confirm the panel renders, prefers structured packet fields, hides raw provenance from normal readout, displays review-only/privacy labels, and does not leak private data into public previews.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205202d5708321a09e3db2e9a558ef)