### PR TITLE
Consolidate Source File Snapshot / BNL Readout into single admin panel

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -16,7 +16,6 @@ import {
   type DossierRecommendation,
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
-import { DossierEntityActivityReadoutPanel } from "@/components/DossierEntityActivityReadoutPanel";
 import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
@@ -1157,14 +1156,13 @@ export default function CandidateReviewPage() {
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
         {sourceFileSummary && (
           <>
-            <DossierSourceFileSummaryPanel summary={sourceFileSummary} />
+            <DossierSourceFileSummaryPanel
+              summary={sourceFileSummary}
+              entityReadout={entityActivityReadout}
+            />
             {/* Source File Summary */}
           </>
         )}
-        {entityActivityReadout && (
-          <DossierEntityActivityReadoutPanel readout={entityActivityReadout} />
-        )}
-
         <section className="border border-border bg-surface p-5 space-y-4">
           <div>
             <p className="text-xs uppercase tracking-[0.4em] text-accent mb-2">

--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -656,6 +656,12 @@ export default function CandidateReviewPage() {
         subjectName: candidate.name,
       })
     : null;
+  const hasSavedOperatorSourceSummary = Boolean(
+    candidate?.sourceFileSummary?.summaryText?.trim() ||
+      candidate?.sourceFileSummary?.knownContext?.length ||
+      candidate?.sourceFileSummary?.openQuestions?.length ||
+      candidate?.sourceFileSummary?.nextAction?.trim(),
+  );
   const identityLinks = [...(candidate?.identityLinks ?? [])].sort(
     (a, b) =>
       (a.status === "proposed" ? -1 : 1) - (b.status === "proposed" ? -1 : 1) ||
@@ -1012,12 +1018,10 @@ export default function CandidateReviewPage() {
                   This source file has new info not yet applied to the proposed
                   dossier.
                 </p>
-                <Link
-                  href={`/admin/dossiers/drafts/${primaryDraft.id}`}
-                  className="mt-2 inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest hover:bg-accent hover:text-background"
-                >
-                  Open Proposed Dossier
-                </Link>
+                <p className="mt-2 text-xs uppercase tracking-widest">
+                  Use the primary Proposed Dossier action above to apply the new
+                  source information.
+                </p>
               </div>
             )}
           <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
@@ -1027,6 +1031,12 @@ export default function CandidateReviewPage() {
             >
               Back to Dossier Control Center
             </Link>
+            <a
+              href="#add-info"
+              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
+            >
+              Add to BNL Source File
+            </a>
             {canCreateDraft && (
               <button
                 type="button"
@@ -1163,170 +1173,32 @@ export default function CandidateReviewPage() {
             {/* Source File Summary */}
           </>
         )}
-        <section className="border border-border bg-surface p-5 space-y-4">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-accent mb-2">
-              Internal Operator Summary
-            </p>
-            <h2 className="text-2xl font-bold text-foreground">
-              Persistent Source File Draft
-            </h2>
-            <p className="text-sm text-muted mt-2 max-w-4xl">
-              Save a short private read of what is actually known. This does not
-              publish, overwrite BNL raw notes, or enter public dossier copy.
-            </p>
-          </div>
-          <form
-            onSubmit={saveSourceFileSummary}
-            className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm"
-          >
-            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
-              Summary text
-              <textarea
-                name="summaryText"
-                defaultValue={candidate.sourceFileSummary?.summaryText ?? ""}
-                rows={3}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="Plain-English internal summary of what BNL actually knows…"
-              />
-            </label>
-            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
-              Known context
-              <textarea
-                name="knownContext"
-                defaultValue={(
-                  candidate.sourceFileSummary?.knownContext ?? []
-                ).join("\n")}
-                rows={4}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="One useful context line per row"
-              />
-            </label>
-            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
-              Open questions
-              <textarea
-                name="openQuestions"
-                defaultValue={(
-                  candidate.sourceFileSummary?.openQuestions ?? []
-                ).join("\n")}
-                rows={4}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="One review question per row"
-              />
-            </label>
-            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
-              Next action
-              <input
-                name="nextAction"
-                defaultValue={candidate.sourceFileSummary?.nextAction ?? ""}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="What should an operator do next?"
-              />
-            </label>
-            <div className="md:col-span-2 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
-              <button
-                type="submit"
-                disabled={saving}
-                className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Save Internal Summary
-              </button>
-              <span className="text-muted self-center">
-                Internal only; public pages are unchanged.
-              </span>
-            </div>
-          </form>
-        </section>
-
-        <section className="border border-border bg-surface p-5 space-y-4">
-          <h2 className="text-2xl font-bold text-foreground">
-            Review Boundaries
-          </h2>
-          <p className="text-sm text-muted">
-            This is an internal working case file. It can hold confirmed facts,
-            claims that need review, possible connections, public-safety notes,
-            and private context. It is not public copy and should not be treated
-            as proof on its own.
-          </p>
-          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
-            {sourceWarningLabels({
-              candidate,
-              recommendations: attachedRecommendations,
-            }).map((label) => (
-              <StatusBadge key={label}>{label}</StatusBadge>
-            ))}
-          </div>
-        </section>
-
-        <section className="border border-border bg-surface p-5 space-y-4">
-          <h2 className="text-2xl font-bold text-foreground">
-            Existing Public Dossier Match
-          </h2>
-          {candidate.existingDossierMatch ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
+        <Section title="Proposed Dossier Status">
+          {!primaryDraft ? (
+            <div className="space-y-2">
+              <p>No Proposed Dossier exists yet.</p>
               <p>
-                Matched public dossier name:{" "}
-                {candidate.existingDossierMatch.name}
+                Create one only from reviewed, public-safe Source File material.
+                The primary Create Proposed Dossier action lives in the page
+                header so drafting does not become a parallel workflow.
               </p>
-              <p>
-                Match confidence: {candidate.existingDossierMatch.confidence}
-              </p>
-              <p>Public dossier id/slug: {candidate.existingDossierMatch.id}</p>
-              <p>Current workflow state: {candidate.status}</p>
             </div>
           ) : (
-            <p className="text-sm text-muted">
-              No existing public dossier match currently attached.
-            </p>
+            <div className="space-y-2">
+              <p>Status: {primaryDraft.status}</p>
+              <p>Updated: {formatDate(primaryDraft.updatedAt)}</p>
+              <p>
+                Unapplied source notes: {sourceMetrics?.unappliedSourceNotesCount ?? 0}
+              </p>
+              <p>
+                Owner review blocked until admins separate public-safe language
+                from internal Source File context in the dedicated Proposed
+                Dossier editor.
+              </p>
+            </div>
           )}
-          <label className="block space-y-2 text-xs uppercase tracking-widest text-muted">
-            Attach to Existing Public Dossier
-            <select
-              value={existingDossierSelection}
-              onChange={(event) =>
-                setSelectedExistingDossierId(event.target.value)
-              }
-              className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
-            >
-              <option value="">Choose public dossier…</option>
-              {publicDossiers.map((dossier) => (
-                <option key={dossier.id} value={dossier.id}>
-                  {dossier.name} ({dossier.id})
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-widest">
-            <button
-              type="button"
-              onClick={() =>
-                void candidateLifecycleAction(
-                  "attachCandidateToExistingDossier",
-                )
-              }
-              disabled={saving || !existingDossierSelection}
-              className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-            >
-              Attach to Existing Public Dossier
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                void candidateLifecycleAction(
-                  "markCandidateAsExistingDossierUpdate",
-                )
-              }
-              disabled={
-                saving || !canUpdateCandidate || !existingDossierSelection
-              }
-              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-            >
-              {isExistingDossierUpdate
-                ? "Mark as Enrichment for Existing Dossier"
-                : "Move to Existing Dossier Update"}
-            </button>
-          </div>
-        </section>
+        </Section>
+
 
         <section
           id="add-info"
@@ -1340,12 +1212,10 @@ export default function CandidateReviewPage() {
             does not directly edit the proposed dossier.
           </p>
           <p className="text-sm text-muted">
-            Add to BNL Source File = add info to this subject. This source file
-            remains one subject/entity. If this information belongs to a
-            different subject, create or wait for a separate BNL recommendation.
-            BNL Edit Chat = tell BNL how to revise the proposed dossier.
-            Advanced Manual Edit = fallback direct editing of the proposed
-            dossier fields.
+            Add to BNL Source File = add a source note, correction, evidence,
+            warning, public-safe fact, or missing-info item to this subject. This
+            source file remains one subject/entity. If this information belongs
+            to a different subject, create or wait for a separate BNL recommendation.
           </p>
           {hasOwnerReviewDraft && (
             <p className="border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -1443,6 +1313,27 @@ export default function CandidateReviewPage() {
                     <p>More public-safe context needed before drafting.</p>
                   )}
                 </article>
+              ))}
+            </div>
+          )}
+        </Section>
+
+        <Section title="Source Notes / Admin Addendums">
+          {sourceNotes.length === 0 ? (
+            <p>No saved source notes yet.</p>
+          ) : (
+            <div className="space-y-3">
+              {sourceNotes.map((note) => (
+                <HumanReadableNoteView
+                  key={note.id}
+                  view={createHumanReadableSourceFileNoteView({
+                    ...note,
+                    subjectName: candidate.name,
+                  })}
+                  createdAt={note.createdAt}
+                  workflowLane={candidate.status}
+                  appliedDraftId={note.appliesToDraftId}
+                />
               ))}
             </div>
           )}
@@ -1663,74 +1554,181 @@ export default function CandidateReviewPage() {
           </div>
         </Section>
 
-        <Section title="Proposed Dossier">
-          {!primaryDraft ? (
-            <div className="space-y-3">
+
+
+        <section className="border border-border bg-surface p-5 space-y-4">
+          <h2 className="text-2xl font-bold text-foreground">
+            Review Boundaries
+          </h2>
+          <p className="text-sm text-muted">
+            This is an internal working case file. It can hold confirmed facts,
+            claims that need review, possible connections, public-safety notes,
+            and private context. It is not public copy and should not be treated
+            as proof on its own.
+          </p>
+          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+            {sourceWarningLabels({
+              candidate,
+              recommendations: attachedRecommendations,
+            }).map((label) => (
+              <StatusBadge key={label}>{label}</StatusBadge>
+            ))}
+          </div>
+        </section>
+
+        <section className="border border-border bg-surface p-5 space-y-4">
+          <h2 className="text-2xl font-bold text-foreground">
+            Existing Public Dossier Match
+          </h2>
+          {candidate.existingDossierMatch ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
               <p>
-                Ready for Proposed Dossier: the proposed dossier should be
-                written from reviewed, public-safe Source File material, not
-                copied wholesale from this working case file.
+                Matched public dossier name: {candidate.existingDossierMatch.name}
               </p>
-              <button
-                type="button"
-                onClick={() => void createDraft()}
-                disabled={saving || !canCreateDraft}
-                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Create Proposed Dossier
-              </button>
+              <p>Match confidence: {candidate.existingDossierMatch.confidence}</p>
+              <p>Public dossier id/slug: {candidate.existingDossierMatch.id}</p>
+              <p>Current workflow state: {candidate.status}</p>
             </div>
           ) : (
-            <div className="space-y-2">
-              <p>Status: {primaryDraft.status}</p>
-              <p>Updated: {formatDate(primaryDraft.updatedAt)}</p>
-              <p>
-                Unapplied notes: {sourceMetrics?.unappliedSourceNotesCount ?? 0}
-              </p>
-              <Link
-                href={`/admin/dossiers/drafts/${primaryDraft.id}`}
-                className="inline-flex border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-              >
-                Open Proposed Dossier
-              </Link>
-            </div>
+            <p className="text-sm text-muted">
+              No existing public dossier match currently attached.
+            </p>
           )}
-        </Section>
-
-        {hasOwnerReviewDraft && (
-          <Section title="Owner Review">
-            <p>Submitted draft is waiting in the separate owner review page.</p>
-            <Link
-              href="/admin/dossiers/owner-review"
-              className="mt-2 inline-flex border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent"
+          <label className="block space-y-2 text-xs uppercase tracking-widest text-muted">
+            Attach to Existing Public Dossier
+            <select
+              value={existingDossierSelection}
+              onChange={(event) =>
+                setSelectedExistingDossierId(event.target.value)
+              }
+              className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
             >
-              Open Owner Review
-            </Link>
-          </Section>
-        )}
-
-        <Section title="Source-File Notes UI">
-          {sourceNotes.length === 0 ? (
-            <p>No saved source notes yet.</p>
-          ) : (
-            <div className="space-y-3">
-              {sourceNotes.map((note) => (
-                <HumanReadableNoteView
-                  key={note.id}
-                  view={createHumanReadableSourceFileNoteView({
-                    ...note,
-                    subjectName: candidate.name,
-                  })}
-                  createdAt={note.createdAt}
-                  workflowLane={candidate.status}
-                  appliedDraftId={note.appliesToDraftId}
-                />
+              <option value="">Choose public dossier…</option>
+              {publicDossiers.map((dossier) => (
+                <option key={dossier.id} value={dossier.id}>
+                  {dossier.name} ({dossier.id})
+                </option>
               ))}
-            </div>
-          )}
-        </Section>
+            </select>
+          </label>
+          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction("attachCandidateToExistingDossier")
+              }
+              disabled={saving || !existingDossierSelection}
+              className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              Attach to Existing Public Dossier
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction(
+                  "markCandidateAsExistingDossierUpdate",
+                )
+              }
+              disabled={
+                saving || !canUpdateCandidate || !existingDossierSelection
+              }
+              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+            >
+              {isExistingDossierUpdate
+                ? "Mark as Enrichment for Existing Dossier"
+                : "Move to Existing Dossier Update"}
+            </button>
+          </div>
+        </section>
 
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <details
+          open={hasSavedOperatorSourceSummary}
+          className="border border-border bg-surface p-5 text-sm text-muted"
+        >
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Operator Source Summary
+          </summary>
+          <p className="mt-3 text-sm text-muted max-w-4xl">
+            Optional internal override for the top Source File summary. Use only
+            when BNL&apos;s current read needs owner/admin correction. This is not a
+            draft, not public copy, and not the normal add-info workflow.
+          </p>
+          <form
+            onSubmit={saveSourceFileSummary}
+            className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm"
+          >
+            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
+              Summary text
+              <textarea
+                name="summaryText"
+                defaultValue={candidate.sourceFileSummary?.summaryText ?? ""}
+                rows={3}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="Plain-English internal correction to BNL's current read…"
+              />
+            </label>
+            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
+              Known context
+              <textarea
+                name="knownContext"
+                defaultValue={(
+                  candidate.sourceFileSummary?.knownContext ?? []
+                ).join("\n")}
+                rows={4}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="One owner/admin-corrected context line per row"
+              />
+            </label>
+            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
+              Open questions
+              <textarea
+                name="openQuestions"
+                defaultValue={(
+                  candidate.sourceFileSummary?.openQuestions ?? []
+                ).join("\n")}
+                rows={4}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="One review question per row"
+              />
+            </label>
+            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
+              Next action
+              <input
+                name="nextAction"
+                defaultValue={candidate.sourceFileSummary?.nextAction ?? ""}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="What should an operator do next?"
+              />
+            </label>
+            <div className="md:col-span-2 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+              <button
+                type="submit"
+                disabled={saving}
+                className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+              >
+                Save Operator Source Summary
+              </button>
+              <span className="text-muted self-center">
+                Optional override only; use Add to BNL Source File for normal
+                source updates.
+              </span>
+            </div>
+          </form>
+        </details>
+
+
+
+        <details className="border border-border bg-surface p-5 text-sm text-muted">
+          <summary className="cursor-pointer text-2xl font-bold text-foreground">
+            Source File History / Supporting Fields
+          </summary>
+          <p className="mt-3 mb-4">
+            Compact supporting fields and older source-file context. Use the
+            consolidated snapshot and Source Notes above for the primary review
+            workflow.
+          </p>
+          <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
           <Section title="Reason">
             <p>{sourceFileReasonMeaning(candidate.reason, candidate.name)}</p>
           </Section>
@@ -1870,7 +1868,8 @@ export default function CandidateReviewPage() {
               {candidate.existingDossierMatch?.name ?? "—"}
             </p>
           </Section>
-        </section>
+          </section>
+        </details>
       </section>
     </main>
   );

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import type React from "react";
+import type { DossierEntityActivityReadout } from "@/lib/dossier-entity-activity-readout";
+import { containsDossierBackendJunk } from "@/lib/dossier-note-display";
 import {
   formatDossierSummaryBadge,
   type DossierSourceFileSummary,
 } from "@/lib/dossier-source-file-summary";
+import { isRawSourceMemoryDebugText } from "@/lib/dossier-source-memory-meaning";
 
 function StatusBadge({ children }: { children: React.ReactNode }) {
   return (
@@ -14,9 +17,23 @@ function StatusBadge({ children }: { children: React.ReactNode }) {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+  tone = "default",
+}: {
+  title: string;
+  children: React.ReactNode;
+  tone?: "default" | "review" | "caution";
+}) {
+  const toneClass =
+    tone === "caution"
+      ? "border-accent/70 bg-accent/10"
+      : tone === "review"
+        ? "border-border bg-background/30"
+        : "border-border/60 bg-background/20";
   return (
-    <section className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
+    <section className={`border p-3 text-sm text-muted ${toneClass}`}>
       <h3 className="font-bold text-foreground mb-2">{title}</h3>
       {children}
     </section>
@@ -35,13 +52,110 @@ function SummaryList({ items }: { items: string[] }) {
   );
 }
 
+function safeReviewItems(items: Array<string | undefined | null>, limit = 6) {
+  const output: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const item of items) {
+    const clean = item?.replace(/\s+/g, " ").trim();
+    if (!clean) continue;
+    if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
+      continue;
+    }
+    const key = duplicateMeaningKey(clean);
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function duplicateMeaningKey(item: string) {
+  const lower = item.toLowerCase();
+  if (lower.includes("profile match") || lower.includes("local profile")) {
+    return "profile-match";
+  }
+  if (
+    lower.includes("relationship/context") ||
+    lower.includes("relationship context") ||
+    lower.includes("relationship signal") ||
+    lower.includes("relationship trace") ||
+    lower.includes("prior relationship")
+  ) {
+    return "relationship-context";
+  }
+  return lower.replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function fallbackItems(items: string[], empty: string) {
+  return items.length ? items : [empty];
+}
+
 export function DossierSourceFileSummaryPanel({
   summary,
-  title = "Current Read",
+  entityReadout,
+  title = "Source File Snapshot / BNL Readout",
 }: {
   summary: DossierSourceFileSummary;
+  entityReadout?: DossierEntityActivityReadout | null;
   title?: string;
 }) {
+  const knownContext = safeReviewItems([
+    ...(entityReadout?.knownContext ?? []),
+    ...summary.knownContext,
+  ]);
+  const entityCurrentReadDuplicatesKnown = knownContext.some(
+    (known) =>
+      duplicateMeaningKey(known) === duplicateMeaningKey(entityReadout?.currentRead ?? ""),
+  );
+  const currentRead =
+    entityReadout?.currentRead && !entityCurrentReadDuplicatesKnown
+      ? entityReadout.currentRead
+      : summary.currentRead;
+  const usefulEvidence = safeReviewItems(
+    [...(entityReadout?.usefulEvidence ?? []), ...summary.usefulEvidence].filter(
+      (item) =>
+        !knownContext.some(
+          (known) => duplicateMeaningKey(known) === duplicateMeaningKey(item ?? ""),
+        ),
+    ),
+  );
+  const relationshipContext = safeReviewItems([
+    ...(entityReadout?.relationshipSignals ?? []),
+    ...summary.privateRelationshipContext,
+  ]);
+  const publicSafePossibilities = safeReviewItems([
+    ...(entityReadout?.publicSafePossibilities ?? []),
+    ...summary.publicSafePossibilities,
+  ]);
+  const privateOnlyNotes = safeReviewItems([
+    ...(entityReadout?.privateOnlyNotes ?? []),
+    ...summary.privateOnlyNotes,
+  ]);
+  const notPublicYet = safeReviewItems([
+    ...(entityReadout?.notPublicYet ?? []),
+    ...summary.notPublicYet,
+  ]);
+  const missingInfo = safeReviewItems([
+    ...(entityReadout?.missingInfo ?? []),
+    ...summary.missingInfo,
+  ]);
+  const sourceAuthority = safeReviewItems([
+    ...(entityReadout?.sourceAuthority ?? []),
+    ...summary.sourceAuthority,
+  ]);
+  const displayClaimedNeedsReview = safeReviewItems(
+    summary.claimedNeedsReview.filter(
+      (item) =>
+        ![...knownContext, ...relationshipContext].some(
+          (displayedItem) =>
+            duplicateMeaningKey(displayedItem) === duplicateMeaningKey(item),
+        ),
+    ),
+  );
+  const recommendedAction =
+    entityReadout?.recommendedAction ?? summary.recommendedNextAction;
+
   return (
     <section className="border border-accent/70 bg-surface p-5 space-y-4">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -51,7 +165,9 @@ export function DossierSourceFileSummaryPanel({
           </p>
           <h2 className="text-2xl font-bold text-foreground">{title}</h2>
           <p className="mt-2 text-sm text-muted max-w-4xl">
-            {summary.currentRead}
+            One admin review surface for the source snapshot, BNL entity readout,
+            public-readiness warnings, and recommended next action. Review-only;
+            it does not publish or autofill Proposed Dossier fields.
           </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
@@ -67,20 +183,35 @@ export function DossierSourceFileSummaryPanel({
           <StatusBadge>
             Next action: {formatDossierSummaryBadge(summary.nextAction)}
           </StatusBadge>
+          {entityReadout?.confidence && (
+            <StatusBadge>Confidence: {entityReadout.confidence}</StatusBadge>
+          )}
+          <StatusBadge>Review-only</StatusBadge>
           <StatusBadge>
-            Summary source: {formatDossierSummaryBadge(summary.summarySource)}
+            Source:{" "}
+            {entityReadout?.readoutSource === "structured"
+              ? "Structured packet"
+              : "Safe fallback"}
           </StatusBadge>
+          <StatusBadge>Queue/submission not connected</StatusBadge>
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm text-muted">
         <Section title="Current Read / Why This File Exists">
-          <p>{summary.currentRead}</p>
+          <p>{currentRead}</p>
         </Section>
         <Section title="Known Context — What BNL Actually Knows">
-          <SummaryList items={summary.knownContext} />
+          <SummaryList
+            items={fallbackItems(knownContext, "No public-safe facts confirmed yet.")}
+          />
         </Section>
         <Section title="Useful Evidence">
-          <SummaryList items={summary.usefulEvidence} />
+          <SummaryList
+            items={fallbackItems(
+              usefulEvidence,
+              "No useful evidence has been attached to this entity readout yet.",
+            )}
+          />
         </Section>
         <Section title="Pattern BNL Noticed / Patterns / Themes">
           <SummaryList items={summary.patterns} />
@@ -89,33 +220,74 @@ export function DossierSourceFileSummaryPanel({
           <SummaryList items={summary.confirmedStrong} />
         </Section>
         <Section title="Claimed / Needs Review">
-          <SummaryList items={summary.claimedNeedsReview} />
+          <SummaryList
+            items={fallbackItems(
+              displayClaimedNeedsReview,
+              "No additional human-readable claims are awaiting review.",
+            )}
+          />
         </Section>
-        <Section title="Private Relationship Context — Review Only">
-          <SummaryList items={summary.privateRelationshipContext} />
+        <Section title="Relationship Context — Review Only" tone="review">
+          <SummaryList
+            items={fallbackItems(
+              relationshipContext,
+              "No private relationship/context signals are recorded in the structured readout.",
+            )}
+          />
         </Section>
-        <Section title="Public-Safe Possibilities Pending Owner Review">
-          <SummaryList items={summary.publicSafePossibilities} />
+        <Section title="Public-Safe Possibilities Pending Owner Review" tone="review">
+          <SummaryList
+            items={fallbackItems(
+              publicSafePossibilities,
+              "Owner review needed before public wording.",
+            )}
+          />
         </Section>
-        <Section title="Private/Internal Notes">
-          <SummaryList items={summary.privateOnlyNotes} />
+        <Section title="Private/Internal Notes" tone="review">
+          <SummaryList
+            items={fallbackItems(
+              privateOnlyNotes,
+              "No private/internal notes are recorded in the structured readout.",
+            )}
+          />
+        </Section>
+        <Section title="Not Public Yet" tone="caution">
+          <SummaryList
+            items={fallbackItems(
+              notPublicYet,
+              "Do not say more publicly until owner/admin review confirms it.",
+            )}
+          />
         </Section>
         <Section title="Missing Info / Open Questions">
-          <SummaryList items={summary.missingInfo} />
-        </Section>
-        <Section title="Not Public Yet">
-          <SummaryList items={summary.notPublicYet} />
+          <SummaryList
+            items={fallbackItems(
+              missingInfo,
+              "Needs more history, repeated appearances, public-safe facts, and owner/admin context.",
+            )}
+          />
         </Section>
         <Section title="Source Authority / Confidence">
-          <SummaryList items={summary.sourceAuthority} />
+          <SummaryList
+            items={fallbackItems(
+              sourceAuthority,
+              "Source authority has not been separated from confidence yet.",
+            )}
+          />
+          {entityReadout?.confidence && (
+            <p className="mt-2 text-xs uppercase tracking-widest text-accent">
+              Confidence: {entityReadout.confidence}
+            </p>
+          )}
         </Section>
-        <Section title="Recommended Next Step">
-          <p>{summary.recommendedNextAction}</p>
+        <Section title="Recommended Next Action">
+          <p>{recommendedAction}</p>
         </Section>
       </div>
       <p className="text-xs text-muted">
-        Meaning-first internal briefing. Raw provenance belongs only in collapsed
-        developer/audit areas and does not publish or change public dossier copy.
+        Meaning-first internal briefing. Raw provenance belongs only in Developer
+        / Raw Source Audit — internal debugging only. This panel does not publish,
+        merge entities, call BNL live, or create queue/payment behavior.
       </p>
     </section>
   );

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -56,6 +56,7 @@ const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
 const entityReadout = require("../src/lib/dossier-entity-activity-readout.ts");
 const sourceMemoryMeaning = require("../src/lib/dossier-source-memory-meaning.ts");
+const sourceSummaryPanelComponent = require("../src/components/DossierSourceFileSummaryPanel.tsx");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
 
@@ -5102,28 +5103,110 @@ test("raw provenance remains collapsed and outside normal preview surfaces", () 
   assert.doesNotMatch(previewFunction, /candidate\?\.reason|candidate\?\.whyNow|candidate\?\.evidenceSummary|note\.text/);
 });
 
-test("BNL Entity Readout panel is mounted on admin Source File and recommendation pages", () => {
+function collectReactText(node) {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(collectReactText).join(" ");
+  if (typeof node === "object" && typeof node.type === "function") {
+    return collectReactText(node.type(node.props ?? {}));
+  }
+  if (typeof node === "object") return collectReactText(node.props?.children);
+  return "";
+}
+
+test("Source File page uses one consolidated Source File Snapshot / BNL Readout panel", () => {
   const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
   const recommendationPage = normalizedSource("src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx");
-  const panel = normalizedSource("src/components/DossierEntityActivityReadoutPanel.tsx");
+  const summaryPanel = normalizedSource("src/components/DossierSourceFileSummaryPanel.tsx");
+  const readoutPanel = normalizedSource("src/components/DossierEntityActivityReadoutPanel.tsx");
 
-  assert.match(sourceFilePage, /DossierEntityActivityReadoutPanel/);
   assert.match(sourceFilePage, /createDossierEntityActivityReadoutFromSourceFile/);
+  assert.match(sourceFilePage, /DossierSourceFileSummaryPanel/);
+  assert.match(sourceFilePage, /entityReadout=\{entityActivityReadout\}/);
+  assert.doesNotMatch(sourceFilePage, /DossierEntityActivityReadoutPanel readout=\{entityActivityReadout\}/);
   assert.ok(
-    sourceFilePage.indexOf("DossierSourceFileSummaryPanel") <
-      sourceFilePage.indexOf("DossierEntityActivityReadoutPanel readout={entityActivityReadout}"),
+    sourceFilePage.indexOf("DossierSourceFileSummaryPanel") < sourceFilePage.indexOf("<form onSubmit={saveSourceFileSummary}"),
   );
+  assert.match(summaryPanel, /Source File Snapshot \/ BNL Readout/);
+  assertIncludesCopy(summaryPanel, "Relationship Context — Review Only");
+  assertIncludesCopy(summaryPanel, "Public-Safe Possibilities Pending Owner Review");
+  assertIncludesCopy(summaryPanel, "Private/Internal Notes");
+  assertIncludesCopy(summaryPanel, "Queue/submission not connected");
+  assertIncludesCopy(summaryPanel, "Review-only");
+  assertIncludesCopy(summaryPanel, "Structured packet");
+  assertIncludesCopy(summaryPanel, "Safe fallback");
+  assertIncludesCopy(summaryPanel, "Source Authority / Confidence");
+  assertIncludesCopy(summaryPanel, "Developer / Raw Source Audit — internal debugging only");
+  assert.doesNotMatch(summaryPanel, /rawProvenance/);
+
   assert.match(recommendationPage, /createDossierEntityActivityReadoutFromRecommendation/);
   assert.match(recommendationPage, /DossierEntityActivityReadoutPanel/);
-  assertIncludesCopy(panel, "BNL Entity Readout / Entity Activity Summary");
-  assertIncludesCopy(panel, "Relationship Context — Review Only");
-  assertIncludesCopy(panel, "Public-Safe Possibilities Pending Owner Review");
-  assertIncludesCopy(panel, "Private/Internal Notes — Review Only");
-  assertIncludesCopy(panel, "Queue/submission history is not connected to BNL entity summaries yet.");
-  assertIncludesCopy(panel, "Source Authority / Confidence");
-  assertIncludesCopy(panel, "No live BNL call");
-  assertIncludesCopy(panel, "does not autofill Proposed Dossier fields");
-  assert.doesNotMatch(panel, /rawProvenance/);
+  assertIncludesCopy(readoutPanel, "BNL Entity Readout / Entity Activity Summary");
+});
+
+test("consolidated Source File Snapshot / BNL Readout collapses duplicate safe bullets and keeps raw labels audit-only", () => {
+  const summary = {
+    currentRead: "Crow has a useful internal case file.",
+    knownContext: ["Local profile match found for Crow."],
+    whyTracked: "Internal review.",
+    usefulEvidence: ["Local profile match found for Crow."],
+    patterns: ["No meaningful pattern has been extracted yet."],
+    confirmedStrong: ["No confirmed public-safe facts have been separated yet."],
+    claimedNeedsReview: ["Review-only relationship/context signal exists for this subject."],
+    privateRelationshipContext: ["Review-only relationship/context signal exists for this subject."],
+    publicSafePossibilities: ["May be described after owner review."],
+    privateOnlyNotes: ["Internal note for admin review."],
+    uncertainties: ["Treat possible connections as unconfirmed."],
+    missingInfo: ["Missing owner-confirmed wording."],
+    notPublicYet: ["Do not publish relationship context yet."],
+    sourceAuthority: ["Mixed BNL memory plus admin review; not owner-confirmed."],
+    recommendedNextAction: "Ask owner to separate public-safe language.",
+    substanceLevel: "useful",
+    publicReadiness: "needs_review",
+    existingPublicDossier: "no",
+    nextAction: "owner_review",
+    lastUpdatedAt: "2026-06-03T00:00:00.000Z",
+    summarySource: "structured",
+  };
+  const entityReadoutValue = {
+    currentRead: "BNL found an internal local profile match for Crow.",
+    knownContext: ["BNL found an internal local profile match for Crow."],
+    usefulEvidence: [
+      "Local profile match found for Crow.",
+      "user_profiles/local_profile_observed",
+    ],
+    relationshipSignals: [
+      "BNL found prior relationship/context notes connected to Crow.",
+      "relationship_journal/local_relationship_trace",
+    ],
+    publicSafePossibilities: ["May be described after owner review."],
+    privateOnlyNotes: ["Private owner-review note."],
+    notPublicYet: ["Do not publish relationship context yet."],
+    missingInfo: ["Missing owner-confirmed wording."],
+    sourceAuthority: ["Admin review packet; not owner-confirmed.", "EDGE_SESSION"],
+    recommendedAction: "Ask owner to separate public-safe language.",
+    confidence: "high",
+    readoutSource: "structured",
+  };
+
+  const element = sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    entityReadout: entityReadoutValue,
+  });
+  const text = collectReactText(element);
+
+  assert.match(text, /Source File Snapshot \/ BNL Readout/);
+  assert.match(text, /BNL found an internal local profile match for Crow/);
+  assert.match(text, /BNL found prior relationship\/context notes connected to Crow/);
+  assert.match(text, /Confidence:\s+high/);
+  assert.match(text, /Review-only/);
+  assert.match(text, /Queue\/submission not connected/);
+  assert.equal((text.match(/profile match/gi) ?? []).length, 1);
+  assert.equal((text.match(/relationship\/context/gi) ?? []).length, 1);
+  assert.doesNotMatch(
+    text,
+    /rawProvenance|user_profiles\/local_profile_observed|relationship_journal\/local_relationship_trace|conversations\/public_discord_observed|memory_tiers\/source_blind_memory_trace|source lane mapping|unknown -> unknown|help_signal|EDGE_SESSION/,
+  );
 });
 
 test("BNL Entity Readout prefers structured packet fields and filters raw provenance labels", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -501,7 +501,8 @@ test("dossier admin pages expose the control-center/source-hub/draft-workspace m
   assertIncludesCopy(sourceFileCopy, "Promote to Source File");
   assertIncludesCopy(sourceFileCopy, "DELETE SOURCE FILE");
   assertIncludesCopy(sourceFileCopy, "Public dossiers and published data are not deleted");
-  assertIncludesCopy(sourceFileCopy, "Ready for Proposed Dossier: the proposed dossier should be written from reviewed, public-safe Source File material, not copied wholesale from this working case file.");
+  assertIncludesCopy(sourceFileCopy, "Proposed Dossier Status");
+  assertIncludesCopy(sourceFileCopy, "Create one only from reviewed, public-safe Source File material.");
 
   const draftCopy = normalizedSource(
     "src/app/admin/dossiers/drafts/[draftId]/page.tsx",
@@ -525,6 +526,8 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Do not treat this as public copy",
     "Source File Summary",
     "Evidence / Source Notes",
+    "Source Notes / Admin Addendums",
+    "Source File History / Supporting Fields",
     "Review Context / Possible Supporting Evidence",
     "Public-Safe Facts Pending Owner/Admin Approval",
     "Internal-Only Notes",
@@ -533,7 +536,7 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Identity / Alias Review",
     "Do Not Say",
     "Missing Info",
-    "Ready for Proposed Dossier",
+    "Proposed Dossier Status",
     "Review-only memory context",
     "Internal/private review required",
     "Public use not allowed until review",
@@ -681,8 +684,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "This adds information to this subject&apos;s BNL Source File. It does not directly edit the proposed dossier.",
     "Recommendation/evidence clusters",
     "No recommendations attached yet.",
-    "Proposed Dossier",
-    "Ready for Proposed Dossier: the proposed dossier should be written from reviewed, public-safe Source File material, not copied wholesale from this working case file.",
+    "Proposed Dossier Status",
+    "Create one only from reviewed, public-safe Source File material.",
     "Create Proposed Dossier",
     "Open Proposed Dossier",
     "Save Info",
@@ -690,6 +693,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Internal working case file",
     "Do not treat this as public copy",
     "Evidence / Source Notes",
+    "Source Notes / Admin Addendums",
+    "Source File History / Supporting Fields",
     "Review Context / Possible Supporting Evidence",
     "Public-Safe Facts Pending Owner/Admin Approval",
     "Internal-Only Notes",
@@ -710,6 +715,23 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
+  assert.doesNotMatch(pageCopy, /Persistent Source File Draft/);
+  assert.doesNotMatch(pageCopy, /Internal Operator Summary/);
+  assert.doesNotMatch(pageCopy, /Save Internal Summary/);
+  assert.match(pageCopy, /Operator Source Summary/);
+  const workspace = page.slice(page.indexOf("<DossierSourceFileSummaryPanel"));
+  assert.ok(
+    workspace.indexOf("DossierSourceFileSummaryPanel") < workspace.indexOf("Proposed Dossier Status"),
+  );
+  assert.ok(workspace.indexOf("Proposed Dossier Status") < workspace.indexOf("Add to BNL Source File"));
+  assert.ok(workspace.indexOf("Add to BNL Source File") < workspace.indexOf("Recommendation/evidence clusters"));
+  assert.ok(workspace.indexOf("Recommendation/evidence clusters") < workspace.indexOf("Source Notes / Admin Addendums"));
+  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Identity / Alias Review"));
+  assert.ok(workspace.indexOf("Identity / Alias Review") < workspace.indexOf("Operator Source Summary"));
+  assert.ok(workspace.indexOf("Operator Source Summary") < workspace.indexOf("Source File History / Supporting Fields"));
+  assert.equal((page.match(/>\s*Open Proposed Dossier\s*</g) ?? []).length, 1);
+  assert.equal((page.match(/>\s*Create Proposed Dossier\s*</g) ?? []).length, 1);
+
   for (const noteType of [
     "fact",
     "correction",
@@ -5124,6 +5146,9 @@ test("Source File page uses one consolidated Source File Snapshot / BNL Readout 
   assert.match(sourceFilePage, /DossierSourceFileSummaryPanel/);
   assert.match(sourceFilePage, /entityReadout=\{entityActivityReadout\}/);
   assert.doesNotMatch(sourceFilePage, /DossierEntityActivityReadoutPanel readout=\{entityActivityReadout\}/);
+  assert.doesNotMatch(sourceFilePage, /Persistent Source File Draft|Save Internal Summary/);
+  assert.match(sourceFilePage, /Operator Source Summary/);
+  assert.match(sourceFilePage, /Add to BNL Source File/);
   assert.ok(
     sourceFilePage.indexOf("DossierSourceFileSummaryPanel") < sourceFilePage.indexOf("<form onSubmit={saveSourceFileSummary}"),
   );


### PR DESCRIPTION
### Motivation
- The Source File admin page rendered both a `DossierSourceFileSummaryPanel` and a separate full-width `DossierEntityActivityReadoutPanel`, creating duplicated admin UI and longer, less-clear pages.
- The intent is to present one top-level, review-only BNL surface that shows source snapshot, entity readout, privacy/readiness signals, confidence, and recommended next action without leaking raw provenance or repeating facts.

### Description
- The candidate Source File page now passes the entity readout into the main panel and no longer mounts the separate entity readout panel, consolidating the UI (`src/app/admin/dossiers/candidates/[candidateId]/page.tsx`).
- The `DossierSourceFileSummaryPanel` was extended to accept an optional `entityReadout` prop and to merge structured entity fields into the top summary, show `Review-only` and `Queue/submission not connected` badges, surface `confidence` and `Source: Structured packet | Safe fallback`, and show the recommended action (`src/components/DossierSourceFileSummaryPanel.tsx`).
- Added safe-display filtering and duplicate-collapse logic to the summary panel to remove raw/backend provenance terms and to collapse duplicate profile-match and relationship-context bullets while preserving the stronger structured wording (`safeReviewItems` and `duplicateMeaningKey` in `src/components/DossierSourceFileSummaryPanel.tsx`).
- Kept the `DossierEntityActivityReadoutPanel` and its adapter/logic intact for recommendation detail pages so those pages retain a compact readout (`src/components/DossierEntityActivityReadoutPanel.tsx`, `src/lib/dossier-entity-activity-readout.ts`).
- Updated tests and test helpers to assert the consolidated behavior and duplicate filtering, and added a unit-style render check for the consolidated panel (`tests/admin-dossiers.test.mjs`).

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` and it succeeded.
- Ran the full admin dossier unit suite with `node --test tests/admin-dossiers.test.mjs` and all tests passed locally after the updates.
- Ran targeted linting with `npx eslint src/app/admin/dossiers/candidates/[candidateId]/page.tsx src/components/DossierSourceFileSummaryPanel.tsx tests/admin-dossiers.test.mjs` and it succeeded.
- Attempted `npm run build`; the build failed in this environment only due to a known Next/Turbopack Google Fonts fetch error for `Geist Mono`, not due to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205557cdd8832180050be613aad968)