### PR TITLE
Consume BNL entity evidence fields in Source File Snapshot readout

### DIFF
--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -123,7 +123,7 @@ function queueSubmissionItems(recommendation: DossierRecommendation): string[] {
     );
   }
   if (recommendation.queueSubmissionNote) items.push(recommendation.queueSubmissionNote);
-  return sanitizeMeaningFirstItems(items, 3);
+  return sanitizeMeaningFirstItems(items, { limit: 3 });
 }
 
 function sourceAuthorityItems(recommendation: DossierRecommendation): string[] {

--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -113,6 +113,19 @@ function list(items: string[] | undefined, empty = "—") {
   );
 }
 
+function queueSubmissionItems(recommendation: DossierRecommendation): string[] {
+  const items: string[] = [];
+  if (recommendation.queueSubmissionStatus === "not_connected") {
+    items.push("Queue/submission identity is not connected yet.");
+  } else if (recommendation.queueSubmissionStatus) {
+    items.push(
+      `Queue/submission status: ${recommendation.queueSubmissionStatus.replace(/_/g, " ")}.`,
+    );
+  }
+  if (recommendation.queueSubmissionNote) items.push(recommendation.queueSubmissionNote);
+  return sanitizeMeaningFirstItems(items, 3);
+}
+
 function sourceAuthorityItems(recommendation: DossierRecommendation): string[] {
   const sanitized = sanitizeMeaningFirstItems(
     recommendation.sourceAuthority ?? [],
@@ -1030,20 +1043,56 @@ export default function DossierRecommendationPage() {
           <Field title="Known Context / Current Read">
             {list(recommendation.knownContext)}
           </Field>
+          <Field title="Best Evidence to Review">
+            {list(recommendation.bestEvidenceToReview)}
+          </Field>
           <Field title="Useful Evidence">
             {list(recommendation.usefulEvidence)}
+          </Field>
+          <Field title="Observed Channels / Activity">
+            {list(recommendation.observedChannels)}
+          </Field>
+          <Field title="Conversation Highlights">
+            {list(recommendation.conversationHighlights)}
+          </Field>
+          <Field title="Music / Show Signals">
+            {list(recommendation.musicSignals)}
+          </Field>
+          <Field title="Community Signals">
+            {list(recommendation.communitySignals)}
+          </Field>
+          <Field title="BNL Interaction Signals">
+            {list(recommendation.bnlInteractionSignals)}
           </Field>
           <Field title="Private Relationship Context — Review Only">
             {list(recommendation.relationshipSignals)}
           </Field>
-          <Field title="Public-Safe Possibilities Pending Owner Review">
-            {list(recommendation.publicSafePossibilities)}
+          <Field title="Public-Safe / Public-Use Candidates Pending Owner Review">
+            {list([
+              ...(recommendation.publicSafePossibilities ?? []),
+              ...(recommendation.publicUseCandidates ?? []),
+            ])}
+          </Field>
+          <Field title="Review-Only Evidence">
+            {list(recommendation.reviewOnlyEvidence)}
           </Field>
           <Field title="Private/Internal Notes">
             {list(recommendation.privateOnlyNotes)}
           </Field>
           <Field title="Not Public Yet">
             {list(recommendation.notPublicYet)}
+          </Field>
+          <Field title="Source Coverage">
+            {list(recommendation.sourceCoverage)}
+          </Field>
+          <Field title="Topic Breakdown">
+            {list(recommendation.topicBreakdown)}
+          </Field>
+          <Field title="Evidence Details">
+            {list(recommendation.evidenceDetails)}
+          </Field>
+          <Field title="Queue / Submission Status">
+            {list(queueSubmissionItems(recommendation))}
           </Field>
           <Field title="Recommended Next Action">
             <p>{recommendation.recommendedAction ?? recommendation.suggestedAction ?? "—"}</p>

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -130,6 +130,82 @@ function packetStringList(
   return items.length ? (items as string[]) : [];
 }
 
+function coverageText(value: unknown, maxLength: number): string | undefined {
+  const clean = text(value, maxLength);
+  if (!clean) return undefined;
+  if (/[{}\[\]<>]/.test(clean) || /[\\/]/.test(clean)) {
+    throw new Error("sourceCoverage contains unsupported raw metadata");
+  }
+  if (/\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl)_[a-z0-9][a-z0-9_-]{8,}\b/i.test(clean)) {
+    throw new Error("sourceCoverage contains a raw identifier");
+  }
+  return clean;
+}
+
+function coverageLabel(value: string): string {
+  return value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function finiteCoverageNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Invalid sourceCoverage ${field}`);
+  }
+  if (Math.abs(value) > 1_000_000_000) {
+    throw new Error(`sourceCoverage ${field} is too large`);
+  }
+  return value;
+}
+
+function sourceCoverageItem(value: unknown): string | undefined {
+  if (typeof value === "string") return coverageText(value, 1000);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected sourceCoverage item to be text or an object");
+  }
+  const item = value as Record<string, unknown>;
+  const allowedKeys = new Set(["source", "count", "counts", "status"]);
+  for (const key of Object.keys(item)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error("sourceCoverage contains unsupported metadata");
+    }
+  }
+  const source = coverageText(item.source, 120);
+  const status = coverageText(item.status, 80);
+  const count = finiteCoverageNumber(item.count, "count");
+  const countParts: string[] = [];
+  if (item.counts !== undefined) {
+    if (!item.counts || typeof item.counts !== "object" || Array.isArray(item.counts)) {
+      throw new Error("sourceCoverage counts must be an object");
+    }
+    const counts = item.counts as Record<string, unknown>;
+    const entries = Object.entries(counts);
+    if (entries.length > 20) throw new Error("sourceCoverage counts has too many keys");
+    for (const [key, rawCount] of entries) {
+      const cleanKey = coverageText(key, 80);
+      const cleanCount = finiteCoverageNumber(rawCount, "counts value");
+      if (cleanKey && cleanCount !== undefined) {
+        countParts.push(`${coverageLabel(cleanKey)} ${cleanCount}`);
+      }
+    }
+  }
+  const label = source ? coverageLabel(source) : "Source coverage";
+  const pieces = countParts.length
+    ? [`${label}: ${countParts.join(", ")}`]
+    : count !== undefined
+      ? [`${label}: ${count} source row(s)`]
+      : [label];
+  if (status) pieces.push(coverageLabel(status));
+  return pieces.join(" ").trim();
+}
+
+function sourceCoverageList(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  const rawItems = Array.isArray(value) ? value : [value];
+  if (rawItems.length > 25) throw new Error("sourceCoverage has too many items");
+  const items = rawItems.map(sourceCoverageItem).filter(Boolean);
+  return items.length ? (items as string[]) : [];
+}
+
 function rawJsonValue(value: unknown): unknown {
   if (value === undefined) return undefined;
   const json = JSON.stringify(value);
@@ -273,7 +349,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   const bnlInteractionSignals = packetStringList(payload.bnlInteractionSignals);
   const musicSignals = packetStringList(payload.musicSignals);
   const communitySignals = packetStringList(payload.communitySignals);
-  const sourceCoverage = packetStringList(payload.sourceCoverage);
+  const sourceCoverage = sourceCoverageList(payload.sourceCoverage);
   const evidenceDetails = packetStringList(payload.evidenceDetails);
   const publicUseCandidates = packetStringList(payload.publicUseCandidates);
   const reviewOnlyEvidence = packetStringList(payload.reviewOnlyEvidence);

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -87,6 +87,14 @@ const IDENTITY_AUTHORITIES = [
   "mixed_or_unclear",
 ] as const satisfies readonly DossierIdentityAuthority[];
 const CONFIDENCES = ["low", "medium", "high"] as const;
+const QUEUE_SUBMISSION_STATUSES = [
+  "not_connected",
+  "connected",
+  "confirmed_submission",
+  "no_submission_found",
+  "review_needed",
+  "unknown",
+] as const;
 
 function text(value: unknown, maxLength: number): string | undefined {
   if (value === undefined || value === null) return undefined;
@@ -258,13 +266,32 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   );
   const privateOnlyNotes = packetStringList(payload.privateOnlyNotes);
   const notPublicYet = packetStringList(payload.notPublicYet);
+  const observedChannels = packetStringList(payload.observedChannels);
+  const conversationHighlights = packetStringList(payload.conversationHighlights);
+  const topicBreakdown = packetStringList(payload.topicBreakdown);
+  const bestEvidenceToReview = packetStringList(payload.bestEvidenceToReview);
+  const bnlInteractionSignals = packetStringList(payload.bnlInteractionSignals);
+  const musicSignals = packetStringList(payload.musicSignals);
+  const communitySignals = packetStringList(payload.communitySignals);
+  const sourceCoverage = packetStringList(payload.sourceCoverage);
+  const evidenceDetails = packetStringList(payload.evidenceDetails);
+  const publicUseCandidates = packetStringList(payload.publicUseCandidates);
+  const reviewOnlyEvidence = packetStringList(payload.reviewOnlyEvidence);
+  const queueSubmissionStatus = enumValue(
+    payload.queueSubmissionStatus,
+    QUEUE_SUBMISSION_STATUSES,
+    "queue submission status",
+  );
+  const queueSubmissionNote = text(payload.queueSubmissionNote, 1000);
   const recommendedAction = text(payload.recommendedAction, 1000);
   const sourceAuthority = packetStringList(payload.sourceAuthority, 1000);
   const rawProvenance = rawJsonValue(payload.rawProvenance);
   const reason =
     text(payload.reason, 2000) ??
     knownContext?.[0] ??
+    bestEvidenceToReview?.[0] ??
     usefulEvidence?.[0] ??
+    conversationHighlights?.[0] ??
     recommendedAction;
   const evidenceSummary =
     payload.evidenceSummary &&
@@ -304,6 +331,19 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     publicSafePossibilities,
     privateOnlyNotes,
     notPublicYet,
+    observedChannels,
+    conversationHighlights,
+    topicBreakdown,
+    bestEvidenceToReview,
+    bnlInteractionSignals,
+    musicSignals,
+    communitySignals,
+    sourceCoverage,
+    evidenceDetails,
+    publicUseCandidates,
+    reviewOnlyEvidence,
+    queueSubmissionStatus,
+    queueSubmissionNote,
     recommendedAction,
     sourceAuthority,
     rawProvenance,

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -91,6 +91,17 @@ function fallbackItems(items: string[], empty: string) {
   return items.length ? items : [empty];
 }
 
+function queueStatusItems(status?: string, note?: string) {
+  const items: string[] = [];
+  if (status === "not_connected") {
+    items.push("Queue/submission identity is not connected yet.");
+  } else if (status) {
+    items.push(`Queue/submission status: ${status.replace(/_/g, " ")}.`);
+  }
+  if (note) items.push(note);
+  return safeReviewItems(items, 3);
+}
+
 export function DossierSourceFileSummaryPanel({
   summary,
   entityReadout,
@@ -140,6 +151,54 @@ export function DossierSourceFileSummaryPanel({
     ...(entityReadout?.missingInfo ?? []),
     ...summary.missingInfo,
   ]);
+  const bestEvidenceToReview = safeReviewItems([
+    ...(entityReadout?.bestEvidenceToReview ?? []),
+    ...summary.bestEvidenceToReview,
+  ]);
+  const observedChannels = safeReviewItems([
+    ...(entityReadout?.observedChannels ?? []),
+    ...summary.observedChannels,
+  ]);
+  const conversationHighlights = safeReviewItems([
+    ...(entityReadout?.conversationHighlights ?? []),
+    ...summary.conversationHighlights,
+  ]);
+  const musicSignals = safeReviewItems([
+    ...(entityReadout?.musicSignals ?? []),
+    ...summary.musicSignals,
+  ]);
+  const communitySignals = safeReviewItems([
+    ...(entityReadout?.communitySignals ?? []),
+    ...summary.communitySignals,
+  ]);
+  const bnlInteractionSignals = safeReviewItems([
+    ...(entityReadout?.bnlInteractionSignals ?? []),
+    ...summary.bnlInteractionSignals,
+  ]);
+  const publicUseCandidates = safeReviewItems([
+    ...(entityReadout?.publicUseCandidates ?? []),
+    ...summary.publicUseCandidates,
+  ]);
+  const reviewOnlyEvidence = safeReviewItems([
+    ...(entityReadout?.reviewOnlyEvidence ?? []),
+    ...summary.reviewOnlyEvidence,
+  ]);
+  const sourceCoverage = safeReviewItems([
+    ...(entityReadout?.sourceCoverage ?? []),
+    ...summary.sourceCoverage,
+  ]);
+  const evidenceDetails = safeReviewItems([
+    ...(entityReadout?.evidenceDetails ?? []),
+    ...summary.evidenceDetails,
+  ]);
+  const topicBreakdown = safeReviewItems([
+    ...(entityReadout?.topicBreakdown ?? []),
+    ...summary.topicBreakdown,
+  ]);
+  const queueItems = queueStatusItems(
+    entityReadout?.queueSubmissionStatus ?? summary.queueSubmissionStatus,
+    entityReadout?.queueSubmissionNote ?? summary.queueSubmissionNote,
+  );
   const sourceAuthority = safeReviewItems([
     ...(entityReadout?.sourceAuthority ?? []),
     ...summary.sourceAuthority,
@@ -193,18 +252,20 @@ export function DossierSourceFileSummaryPanel({
               ? "Structured packet"
               : "Safe fallback"}
           </StatusBadge>
-          <StatusBadge>Queue/submission not connected</StatusBadge>
+          <StatusBadge>
+            {queueItems[0] ?? "Queue/submission not connected"}
+          </StatusBadge>
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm text-muted">
         <Section title="Current Read / Why This File Exists">
           <p>{currentRead}</p>
         </Section>
-        <Section title="Known Context — What BNL Actually Knows">
-          <SummaryList
-            items={fallbackItems(knownContext, "No public-safe facts confirmed yet.")}
-          />
-        </Section>
+        {bestEvidenceToReview.length > 0 && (
+          <Section title="Best Evidence to Review">
+            <SummaryList items={bestEvidenceToReview} />
+          </Section>
+        )}
         <Section title="Useful Evidence">
           <SummaryList
             items={fallbackItems(
@@ -213,6 +274,41 @@ export function DossierSourceFileSummaryPanel({
             )}
           />
         </Section>
+        {observedChannels.length > 0 && (
+          <Section title="Observed Channels / Activity">
+            <SummaryList items={observedChannels} />
+          </Section>
+        )}
+        {conversationHighlights.length > 0 && (
+          <Section title="Conversation Highlights">
+            <SummaryList items={conversationHighlights} />
+          </Section>
+        )}
+        {musicSignals.length > 0 && (
+          <Section title="Music / Show Signals">
+            <SummaryList items={musicSignals} />
+          </Section>
+        )}
+        {communitySignals.length > 0 && (
+          <Section title="Community Signals">
+            <SummaryList items={communitySignals} />
+          </Section>
+        )}
+        {bnlInteractionSignals.length > 0 && (
+          <Section title="BNL Interaction Signals" tone="review">
+            <SummaryList items={bnlInteractionSignals} />
+          </Section>
+        )}
+        {topicBreakdown.length > 0 && (
+          <Section title="Topic Breakdown">
+            <SummaryList items={topicBreakdown} />
+          </Section>
+        )}
+        {evidenceDetails.length > 0 && (
+          <Section title="Evidence Details">
+            <SummaryList items={evidenceDetails} />
+          </Section>
+        )}
         <Section title="Pattern BNL Noticed / Patterns / Themes">
           <SummaryList items={summary.patterns} />
         </Section>
@@ -235,14 +331,19 @@ export function DossierSourceFileSummaryPanel({
             )}
           />
         </Section>
-        <Section title="Public-Safe Possibilities Pending Owner Review" tone="review">
+        <Section title="Public-Safe / Public-Use Candidates Pending Owner Review" tone="review">
           <SummaryList
             items={fallbackItems(
-              publicSafePossibilities,
+              safeReviewItems([...publicSafePossibilities, ...publicUseCandidates]),
               "Owner review needed before public wording.",
             )}
           />
         </Section>
+        {reviewOnlyEvidence.length > 0 && (
+          <Section title="Review-Only Evidence" tone="review">
+            <SummaryList items={reviewOnlyEvidence} />
+          </Section>
+        )}
         <Section title="Private/Internal Notes" tone="review">
           <SummaryList
             items={fallbackItems(
@@ -259,6 +360,11 @@ export function DossierSourceFileSummaryPanel({
             )}
           />
         </Section>
+        {sourceCoverage.length > 0 && (
+          <Section title="Source Coverage">
+            <SummaryList items={sourceCoverage} />
+          </Section>
+        )}
         <Section title="Missing Info / Open Questions">
           <SummaryList
             items={fallbackItems(
@@ -267,6 +373,11 @@ export function DossierSourceFileSummaryPanel({
             )}
           />
         </Section>
+        {queueItems.length > 0 && (
+          <Section title="Queue / Submission Status" tone="review">
+            <SummaryList items={queueItems} />
+          </Section>
+        )}
         <Section title="Source Authority / Confidence">
           <SummaryList
             items={fallbackItems(

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -261,6 +261,11 @@ export function DossierSourceFileSummaryPanel({
         <Section title="Current Read / Why This File Exists">
           <p>{currentRead}</p>
         </Section>
+        <Section title="Known Context — What BNL Actually Knows">
+          <SummaryList
+            items={fallbackItems(knownContext, "No public-safe facts confirmed yet.")}
+          />
+        </Section>
         {bestEvidenceToReview.length > 0 && (
           <Section title="Best Evidence to Review">
             <SummaryList items={bestEvidenceToReview} />

--- a/src/lib/dossier-entity-activity-readout.ts
+++ b/src/lib/dossier-entity-activity-readout.ts
@@ -10,6 +10,19 @@ export type DossierEntityActivityReadout = {
   publicSafePossibilities: string[];
   privateOnlyNotes: string[];
   notPublicYet: string[];
+  observedChannels: string[];
+  conversationHighlights: string[];
+  topicBreakdown: string[];
+  bestEvidenceToReview: string[];
+  bnlInteractionSignals: string[];
+  musicSignals: string[];
+  communitySignals: string[];
+  sourceCoverage: string[];
+  evidenceDetails: string[];
+  publicUseCandidates: string[];
+  reviewOnlyEvidence: string[];
+  queueSubmissionStatus?: string;
+  queueSubmissionNote?: string;
   missingInfo: string[];
   sourceAuthority: string[];
   recommendedAction: string;
@@ -26,6 +39,19 @@ type ReadoutRecommendation = Pick<
   | "publicSafePossibilities"
   | "privateOnlyNotes"
   | "notPublicYet"
+  | "observedChannels"
+  | "conversationHighlights"
+  | "topicBreakdown"
+  | "bestEvidenceToReview"
+  | "bnlInteractionSignals"
+  | "musicSignals"
+  | "communitySignals"
+  | "sourceCoverage"
+  | "evidenceDetails"
+  | "publicUseCandidates"
+  | "reviewOnlyEvidence"
+  | "queueSubmissionStatus"
+  | "queueSubmissionNote"
   | "missingInfo"
   | "sourceAuthority"
   | "recommendedAction"
@@ -69,6 +95,19 @@ function recommendationHasStructuredReadout(
       recommendation.publicSafePossibilities?.length ||
       recommendation.privateOnlyNotes?.length ||
       recommendation.notPublicYet?.length ||
+      recommendation.observedChannels?.length ||
+      recommendation.conversationHighlights?.length ||
+      recommendation.topicBreakdown?.length ||
+      recommendation.bestEvidenceToReview?.length ||
+      recommendation.bnlInteractionSignals?.length ||
+      recommendation.musicSignals?.length ||
+      recommendation.communitySignals?.length ||
+      recommendation.sourceCoverage?.length ||
+      recommendation.evidenceDetails?.length ||
+      recommendation.publicUseCandidates?.length ||
+      recommendation.reviewOnlyEvidence?.length ||
+      recommendation.queueSubmissionStatus ||
+      recommendation.queueSubmissionNote ||
       recommendation.missingInfo?.length ||
       recommendation.sourceAuthority?.length ||
       recommendation.recommendedAction ||
@@ -115,6 +154,66 @@ function structuredReadoutFromRecommendations(
       (recommendation) => recommendation.notPublicYet ?? [],
     ),
   );
+
+  const observedChannels = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.observedChannels ?? [],
+    ),
+  );
+  const conversationHighlights = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.conversationHighlights ?? [],
+    ),
+  );
+  const topicBreakdown = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.topicBreakdown ?? [],
+    ),
+  );
+  const bestEvidenceToReview = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.bestEvidenceToReview ?? [],
+    ),
+  );
+  const bnlInteractionSignals = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.bnlInteractionSignals ?? [],
+    ),
+  );
+  const musicSignals = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.musicSignals ?? [],
+    ),
+  );
+  const communitySignals = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.communitySignals ?? [],
+    ),
+  );
+  const sourceCoverage = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.sourceCoverage ?? [],
+    ),
+  );
+  const evidenceDetails = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.evidenceDetails ?? [],
+    ),
+  );
+  const publicUseCandidates = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.publicUseCandidates ?? [],
+    ),
+  );
+  const reviewOnlyEvidence = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.reviewOnlyEvidence ?? [],
+    ),
+  );
+  const queueRecommendation = structuredRecommendations.find(
+    (recommendation) =>
+      recommendation.queueSubmissionStatus || recommendation.queueSubmissionNote,
+  );
   const missingInfo = cleanItems(
     structuredRecommendations.flatMap(
       (recommendation) => recommendation.missingInfo ?? [],
@@ -150,6 +249,19 @@ function structuredReadoutFromRecommendations(
     publicSafePossibilities,
     privateOnlyNotes,
     notPublicYet,
+    observedChannels,
+    conversationHighlights,
+    topicBreakdown,
+    bestEvidenceToReview,
+    bnlInteractionSignals,
+    musicSignals,
+    communitySignals,
+    sourceCoverage,
+    evidenceDetails,
+    publicUseCandidates,
+    reviewOnlyEvidence,
+    queueSubmissionStatus: queueRecommendation?.queueSubmissionStatus,
+    queueSubmissionNote: cleanText(queueRecommendation?.queueSubmissionNote),
     missingInfo,
     sourceAuthority,
     recommendedAction:
@@ -183,6 +295,19 @@ export function createDossierEntityActivityReadoutFromSourceFile({
     publicSafePossibilities: cleanItems(summary?.publicSafePossibilities ?? []),
     privateOnlyNotes: cleanItems(summary?.privateOnlyNotes ?? []),
     notPublicYet: cleanItems(summary?.notPublicYet ?? []),
+    observedChannels: cleanItems(summary?.observedChannels ?? []),
+    conversationHighlights: cleanItems(summary?.conversationHighlights ?? []),
+    topicBreakdown: cleanItems(summary?.topicBreakdown ?? []),
+    bestEvidenceToReview: cleanItems(summary?.bestEvidenceToReview ?? []),
+    bnlInteractionSignals: cleanItems(summary?.bnlInteractionSignals ?? []),
+    musicSignals: cleanItems(summary?.musicSignals ?? []),
+    communitySignals: cleanItems(summary?.communitySignals ?? []),
+    sourceCoverage: cleanItems(summary?.sourceCoverage ?? []),
+    evidenceDetails: cleanItems(summary?.evidenceDetails ?? []),
+    publicUseCandidates: cleanItems(summary?.publicUseCandidates ?? []),
+    reviewOnlyEvidence: cleanItems(summary?.reviewOnlyEvidence ?? []),
+    queueSubmissionStatus: summary?.queueSubmissionStatus,
+    queueSubmissionNote: cleanText(summary?.queueSubmissionNote),
     missingInfo: cleanItems(summary?.missingInfo ?? []),
     sourceAuthority: cleanItems(summary?.sourceAuthority ?? [], 5),
     recommendedAction:
@@ -205,6 +330,17 @@ export function createDossierEntityActivityReadoutFromRecommendation(
       publicSafePossibilities: [],
       privateOnlyNotes: [],
       notPublicYet: [],
+      observedChannels: [],
+      conversationHighlights: [],
+      topicBreakdown: [],
+      bestEvidenceToReview: [],
+      bnlInteractionSignals: [],
+      musicSignals: [],
+      communitySignals: [],
+      sourceCoverage: [],
+      evidenceDetails: [],
+      publicUseCandidates: [],
+      reviewOnlyEvidence: [],
       missingInfo: [],
       sourceAuthority: [],
       recommendedAction:

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -54,6 +54,19 @@ type NoteLike = Pick<
   publicSafePossibilities?: string[];
   privateOnlyNotes?: string[];
   notPublicYet?: string[];
+  observedChannels?: string[];
+  conversationHighlights?: string[];
+  topicBreakdown?: string[];
+  bestEvidenceToReview?: string[];
+  bnlInteractionSignals?: string[];
+  musicSignals?: string[];
+  communitySignals?: string[];
+  sourceCoverage?: string[];
+  evidenceDetails?: string[];
+  publicUseCandidates?: string[];
+  reviewOnlyEvidence?: string[];
+  queueSubmissionStatus?: string;
+  queueSubmissionNote?: string;
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;
@@ -535,6 +548,49 @@ export function createHumanReadableSourceFileNoteView(
     addItem(sections, "Private/Internal Notes", item, subjectOptions);
   for (const item of note.notPublicYet ?? [])
     addShortWarning(sections, item, subjectOptions);
+  for (const item of note.bestEvidenceToReview ?? [])
+    addItem(sections, "Best Evidence to Review", item, subjectOptions);
+  for (const item of note.observedChannels ?? [])
+    addItem(sections, "Observed Channels / Activity", item, subjectOptions);
+  for (const item of note.conversationHighlights ?? [])
+    addItem(sections, "Conversation Highlights", item, subjectOptions);
+  for (const item of note.musicSignals ?? [])
+    addItem(sections, "Music / Show Signals", item, subjectOptions);
+  for (const item of note.communitySignals ?? [])
+    addItem(sections, "Community Signals", item, subjectOptions);
+  for (const item of note.bnlInteractionSignals ?? [])
+    addItem(sections, "BNL Interaction Signals", item, subjectOptions);
+  for (const item of note.topicBreakdown ?? [])
+    addItem(sections, "Topic Breakdown", item, subjectOptions);
+  for (const item of note.evidenceDetails ?? [])
+    addItem(sections, "Evidence Details", item, subjectOptions);
+  for (const item of note.publicUseCandidates ?? [])
+    addItem(
+      sections,
+      "Public-Use Candidates Pending Owner Review",
+      item,
+      subjectOptions,
+    );
+  for (const item of note.reviewOnlyEvidence ?? [])
+    addItem(sections, "Review-Only Evidence", item, subjectOptions);
+  for (const item of note.sourceCoverage ?? [])
+    addItem(sections, "Source Coverage", item, subjectOptions);
+  if (note.queueSubmissionStatus === "not_connected") {
+    addItem(
+      sections,
+      "Queue / Submission Status",
+      "Queue/submission identity is not connected yet.",
+      subjectOptions,
+    );
+  } else if (note.queueSubmissionStatus) {
+    addItem(
+      sections,
+      "Queue / Submission Status",
+      `Queue/submission status: ${note.queueSubmissionStatus.replace(/_/g, " ")}.`,
+      subjectOptions,
+    );
+  }
+  addItem(sections, "Queue / Submission Status", note.queueSubmissionNote, subjectOptions);
   addItem(sections, "Recommended Next Step", note.recommendedAction, subjectOptions);
   for (const item of note.sourceAuthority ?? [])
     addItem(sections, "Source Authority / Confidence", item, subjectOptions);
@@ -649,6 +705,38 @@ export function createHumanReadableRecommendationView(
       (recommendation.notPublicYet ?? [])
         .map((item) => `Not public yet: ${item}`)
         .join("\n"),
+      (recommendation.bestEvidenceToReview ?? [])
+        .map((item) => `Best evidence to review: ${item}`)
+        .join("\n"),
+      (recommendation.observedChannels ?? [])
+        .map((item) => `Observed channel/activity: ${item}`)
+        .join("\n"),
+      (recommendation.conversationHighlights ?? [])
+        .map((item) => `Conversation highlight: ${item}`)
+        .join("\n"),
+      (recommendation.musicSignals ?? [])
+        .map((item) => `Music/show signal: ${item}`)
+        .join("\n"),
+      (recommendation.communitySignals ?? [])
+        .map((item) => `Community signal: ${item}`)
+        .join("\n"),
+      (recommendation.bnlInteractionSignals ?? [])
+        .map((item) => `BNL interaction signal: ${item}`)
+        .join("\n"),
+      (recommendation.publicUseCandidates ?? [])
+        .map((item) => `Public-use candidate pending owner review: ${item}`)
+        .join("\n"),
+      (recommendation.reviewOnlyEvidence ?? [])
+        .map((item) => `Review-only evidence: ${item}`)
+        .join("\n"),
+      recommendation.queueSubmissionStatus === "not_connected"
+        ? "Queue/submission status: Queue/submission identity is not connected yet."
+        : recommendation.queueSubmissionStatus
+          ? `Queue/submission status: ${recommendation.queueSubmissionStatus}`
+          : "",
+      recommendation.queueSubmissionNote
+        ? `Queue/submission note: ${recommendation.queueSubmissionNote}`
+        : "",
       recommendation.recommendedAction
         ? `Recommended next action: ${recommendation.recommendedAction}`
         : "",
@@ -676,6 +764,19 @@ export function createHumanReadableRecommendationView(
     publicSafePossibilities: recommendation.publicSafePossibilities,
     privateOnlyNotes: recommendation.privateOnlyNotes,
     notPublicYet: recommendation.notPublicYet,
+    observedChannels: recommendation.observedChannels,
+    conversationHighlights: recommendation.conversationHighlights,
+    topicBreakdown: recommendation.topicBreakdown,
+    bestEvidenceToReview: recommendation.bestEvidenceToReview,
+    bnlInteractionSignals: recommendation.bnlInteractionSignals,
+    musicSignals: recommendation.musicSignals,
+    communitySignals: recommendation.communitySignals,
+    sourceCoverage: recommendation.sourceCoverage,
+    evidenceDetails: recommendation.evidenceDetails,
+    publicUseCandidates: recommendation.publicUseCandidates,
+    reviewOnlyEvidence: recommendation.reviewOnlyEvidence,
+    queueSubmissionStatus: recommendation.queueSubmissionStatus,
+    queueSubmissionNote: recommendation.queueSubmissionNote,
     recommendedAction: recommendation.recommendedAction,
     sourceAuthority: recommendation.sourceAuthority,
     rawProvenance: recommendation.rawProvenance,

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -49,6 +49,19 @@ export type DossierSourceFileSummary = {
   uncertainties: string[];
   missingInfo: string[];
   notPublicYet: string[];
+  observedChannels: string[];
+  conversationHighlights: string[];
+  topicBreakdown: string[];
+  bestEvidenceToReview: string[];
+  bnlInteractionSignals: string[];
+  musicSignals: string[];
+  communitySignals: string[];
+  sourceCoverage: string[];
+  evidenceDetails: string[];
+  publicUseCandidates: string[];
+  reviewOnlyEvidence: string[];
+  queueSubmissionStatus?: string;
+  queueSubmissionNote?: string;
   sourceAuthority: string[];
   recommendedNextAction: string;
   substanceLevel: DossierSourceFileSubstanceLevel;
@@ -290,6 +303,67 @@ export function createDossierSourceFileSummary(
     ),
     6,
   );
+
+  const structuredObservedChannels = unique(
+    recommendations.flatMap((recommendation) => recommendation.observedChannels ?? []),
+    6,
+  );
+  const structuredConversationHighlights = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.conversationHighlights ?? [],
+    ),
+    6,
+  );
+  const structuredTopicBreakdown = unique(
+    recommendations.flatMap((recommendation) => recommendation.topicBreakdown ?? []),
+    6,
+  );
+  const structuredBestEvidenceToReview = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.bestEvidenceToReview ?? [],
+    ),
+    6,
+  );
+  const structuredBnlInteractionSignals = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.bnlInteractionSignals ?? [],
+    ),
+    6,
+  );
+  const structuredMusicSignals = unique(
+    recommendations.flatMap((recommendation) => recommendation.musicSignals ?? []),
+    6,
+  );
+  const structuredCommunitySignals = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.communitySignals ?? [],
+    ),
+    6,
+  );
+  const structuredSourceCoverage = unique(
+    recommendations.flatMap((recommendation) => recommendation.sourceCoverage ?? []),
+    6,
+  );
+  const structuredEvidenceDetails = unique(
+    recommendations.flatMap((recommendation) => recommendation.evidenceDetails ?? []),
+    6,
+  );
+  const structuredPublicUseCandidates = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.publicUseCandidates ?? [],
+    ),
+    6,
+  );
+  const structuredReviewOnlyEvidence = unique(
+    recommendations.flatMap(
+      (recommendation) => recommendation.reviewOnlyEvidence ?? [],
+    ),
+    6,
+  );
+  const queueRecommendation = recommendations.find(
+    (recommendation) =>
+      recommendation.queueSubmissionStatus || recommendation.queueSubmissionNote,
+  );
   const structuredRecommendedAction = unique(
     recommendations.map((recommendation) => recommendation.recommendedAction),
     1,
@@ -485,6 +559,19 @@ export function createDossierSourceFileSummary(
       notPublicYet.length > 0
         ? notPublicYet
         : ["Do not say more publicly until owner/admin review confirms it."],
+    observedChannels: structuredObservedChannels,
+    conversationHighlights: structuredConversationHighlights,
+    topicBreakdown: structuredTopicBreakdown,
+    bestEvidenceToReview: structuredBestEvidenceToReview,
+    bnlInteractionSignals: structuredBnlInteractionSignals,
+    musicSignals: structuredMusicSignals,
+    communitySignals: structuredCommunitySignals,
+    sourceCoverage: structuredSourceCoverage,
+    evidenceDetails: structuredEvidenceDetails,
+    publicUseCandidates: structuredPublicUseCandidates,
+    reviewOnlyEvidence: structuredReviewOnlyEvidence,
+    queueSubmissionStatus: queueRecommendation?.queueSubmissionStatus,
+    queueSubmissionNote: queueRecommendation?.queueSubmissionNote,
     sourceAuthority:
       structuredSourceAuthority.length > 0
         ? structuredSourceAuthority

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -707,7 +707,9 @@ function firstStructuredRecommendationReason(
 ): string | undefined {
   return (
     normalizePacketStringArray(input.knownContext)?.[0] ??
+    normalizePacketStringArray(input.bestEvidenceToReview)?.[0] ??
     normalizePacketStringArray(input.usefulEvidence)?.[0] ??
+    normalizePacketStringArray(input.conversationHighlights)?.[0] ??
     boundedText(input.recommendedAction, 1000) ??
     normalizePacketStringArray(input.publicSafePossibilities)?.[0]
   );
@@ -754,6 +756,19 @@ function normalizeRecommendationInput(
     ),
     privateOnlyNotes: normalizePacketStringArray(input.privateOnlyNotes),
     notPublicYet: normalizePacketStringArray(input.notPublicYet),
+    observedChannels: normalizePacketStringArray(input.observedChannels),
+    conversationHighlights: normalizePacketStringArray(input.conversationHighlights),
+    topicBreakdown: normalizePacketStringArray(input.topicBreakdown),
+    bestEvidenceToReview: normalizePacketStringArray(input.bestEvidenceToReview),
+    bnlInteractionSignals: normalizePacketStringArray(input.bnlInteractionSignals),
+    musicSignals: normalizePacketStringArray(input.musicSignals),
+    communitySignals: normalizePacketStringArray(input.communitySignals),
+    sourceCoverage: normalizePacketStringArray(input.sourceCoverage),
+    evidenceDetails: normalizePacketStringArray(input.evidenceDetails),
+    publicUseCandidates: normalizePacketStringArray(input.publicUseCandidates),
+    reviewOnlyEvidence: normalizePacketStringArray(input.reviewOnlyEvidence),
+    queueSubmissionStatus: input.queueSubmissionStatus,
+    queueSubmissionNote: boundedText(input.queueSubmissionNote, 1000) || undefined,
     recommendedAction: boundedText(input.recommendedAction, 1000) || undefined,
     sourceAuthority: normalizePacketStringArray(input.sourceAuthority),
     rawProvenance: cloneJsonValue(input.rawProvenance),
@@ -989,6 +1004,7 @@ function buildCandidateFromRecommendation(input: {
       : [],
     evidenceCount:
       recommendation.usefulEvidence?.length ??
+      recommendation.bestEvidenceToReview?.length ??
       (recommendation.evidenceSummary ? 1 : 0),
     knownFacts: recommendation.knownContext ?? [],
     confidence: recommendation.confidence ?? "low",
@@ -1424,6 +1440,27 @@ function recommendationSourceNoteText(
     ),
     ...packetLines("Private/internal note", recommendation.privateOnlyNotes),
     ...packetLines("Not public yet", recommendation.notPublicYet),
+    ...packetLines("Best evidence to review", recommendation.bestEvidenceToReview),
+    ...packetLines("Observed channel/activity", recommendation.observedChannels),
+    ...packetLines("Conversation highlight", recommendation.conversationHighlights),
+    ...packetLines("Topic breakdown", recommendation.topicBreakdown),
+    ...packetLines("BNL interaction signal", recommendation.bnlInteractionSignals),
+    ...packetLines("Music/show signal", recommendation.musicSignals),
+    ...packetLines("Community signal", recommendation.communitySignals),
+    ...packetLines("Source coverage", recommendation.sourceCoverage),
+    ...packetLines("Evidence detail", recommendation.evidenceDetails),
+    ...packetLines("Public-use candidate pending owner review", recommendation.publicUseCandidates),
+    ...packetLines("Review-only evidence", recommendation.reviewOnlyEvidence),
+    recommendation.queueSubmissionStatus
+      ? `Queue/submission status: ${
+          recommendation.queueSubmissionStatus === "not_connected"
+            ? "Queue/submission identity is not connected yet."
+            : recommendation.queueSubmissionStatus
+        }`
+      : "",
+    recommendation.queueSubmissionNote
+      ? `Queue/submission note: ${recommendation.queueSubmissionNote}`
+      : "",
     recommendation.recommendedAction
       ? `Recommended next action: ${recommendation.recommendedAction}`
       : "",

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -697,6 +697,65 @@ function normalizePacketStringArray(value: unknown): string[] | undefined {
   return items.length ? items : undefined;
 }
 
+function normalizeCoverageLabel(value: string): string {
+  return value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeCoverageText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const clean = boundedText(value, maxLength);
+  if (!clean) return undefined;
+  if (/[{}\[\]<>]/.test(clean) || /[\\/]/.test(clean)) return undefined;
+  if (/\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl)_[a-z0-9][a-z0-9_-]{8,}\b/i.test(clean)) {
+    return undefined;
+  }
+  return clean;
+}
+
+function normalizeCoverageNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (Math.abs(value) > 1_000_000_000) return undefined;
+  return value;
+}
+
+function normalizeSourceCoverageItem(value: unknown): string | undefined {
+  const textItem = normalizeCoverageText(value, 1000);
+  if (textItem) return textItem;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const item = value as Record<string, unknown>;
+  const source = normalizeCoverageText(item.source, 120);
+  const status = normalizeCoverageText(item.status, 80);
+  const count = normalizeCoverageNumber(item.count);
+  const countParts: string[] = [];
+  if (item.counts && typeof item.counts === "object" && !Array.isArray(item.counts)) {
+    for (const [key, rawCount] of Object.entries(item.counts).slice(0, 20)) {
+      const cleanKey = normalizeCoverageText(key, 80);
+      const cleanCount = normalizeCoverageNumber(rawCount);
+      if (cleanKey && cleanCount !== undefined) {
+        countParts.push(`${normalizeCoverageLabel(cleanKey)} ${cleanCount}`);
+      }
+    }
+  }
+  const label = source ? normalizeCoverageLabel(source) : "Source coverage";
+  const pieces = countParts.length
+    ? [`${label}: ${countParts.join(", ")}`]
+    : count !== undefined
+      ? [`${label}: ${count} source row(s)`]
+      : [label];
+  if (status) pieces.push(normalizeCoverageLabel(status));
+  const normalized = pieces.join(" ").trim();
+  return normalized && normalized !== "Source coverage" ? normalized : undefined;
+}
+
+function normalizeSourceCoverageInput(value: unknown): string[] | undefined {
+  const rawItems = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const items = rawItems
+    .slice(0, 25)
+    .map(normalizeSourceCoverageItem)
+    .filter((item): item is string => Boolean(item));
+  return items.length ? items : undefined;
+}
+
 function cloneJsonValue(value: unknown): unknown {
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value));
@@ -763,7 +822,7 @@ function normalizeRecommendationInput(
     bnlInteractionSignals: normalizePacketStringArray(input.bnlInteractionSignals),
     musicSignals: normalizePacketStringArray(input.musicSignals),
     communitySignals: normalizePacketStringArray(input.communitySignals),
-    sourceCoverage: normalizePacketStringArray(input.sourceCoverage),
+    sourceCoverage: normalizeSourceCoverageInput(input.sourceCoverage),
     evidenceDetails: normalizePacketStringArray(input.evidenceDetails),
     publicUseCandidates: normalizePacketStringArray(input.publicUseCandidates),
     reviewOnlyEvidence: normalizePacketStringArray(input.reviewOnlyEvidence),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -380,6 +380,17 @@ export type DossierQueueSubmissionStatus =
   | "review_needed"
   | "unknown";
 
+export type DossierSourceCoverageItem = {
+  source?: string;
+  count?: number;
+  counts?: Record<string, number>;
+  status?: string;
+};
+
+export type DossierSourceCoverageInput = Array<
+  string | DossierSourceCoverageItem
+>;
+
 export type DossierStructuredSourcePacket = {
   knownContext?: string[];
   usefulEvidence?: string[];
@@ -394,7 +405,7 @@ export type DossierStructuredSourcePacket = {
   bnlInteractionSignals?: string[];
   musicSignals?: string[];
   communitySignals?: string[];
-  sourceCoverage?: string[];
+  sourceCoverage?: DossierSourceCoverageInput;
   evidenceDetails?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];
@@ -777,7 +788,7 @@ export type CreateDossierRecommendationInput = {
   bnlInteractionSignals?: string[];
   musicSignals?: string[];
   communitySignals?: string[];
-  sourceCoverage?: string[];
+  sourceCoverage?: DossierSourceCoverageInput;
   evidenceDetails?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -372,6 +372,14 @@ export type DossierRecommendationIngestSource =
   | "system"
   | "unknown";
 
+export type DossierQueueSubmissionStatus =
+  | "not_connected"
+  | "connected"
+  | "confirmed_submission"
+  | "no_submission_found"
+  | "review_needed"
+  | "unknown";
+
 export type DossierStructuredSourcePacket = {
   knownContext?: string[];
   usefulEvidence?: string[];
@@ -379,6 +387,19 @@ export type DossierStructuredSourcePacket = {
   publicSafePossibilities?: string[];
   privateOnlyNotes?: string[];
   notPublicYet?: string[];
+  observedChannels?: string[];
+  conversationHighlights?: string[];
+  topicBreakdown?: string[];
+  bestEvidenceToReview?: string[];
+  bnlInteractionSignals?: string[];
+  musicSignals?: string[];
+  communitySignals?: string[];
+  sourceCoverage?: string[];
+  evidenceDetails?: string[];
+  publicUseCandidates?: string[];
+  reviewOnlyEvidence?: string[];
+  queueSubmissionStatus?: DossierQueueSubmissionStatus;
+  queueSubmissionNote?: string;
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;
@@ -404,6 +425,19 @@ export type DossierRecommendation = {
   publicSafePossibilities?: string[];
   privateOnlyNotes?: string[];
   notPublicYet?: string[];
+  observedChannels?: string[];
+  conversationHighlights?: string[];
+  topicBreakdown?: string[];
+  bestEvidenceToReview?: string[];
+  bnlInteractionSignals?: string[];
+  musicSignals?: string[];
+  communitySignals?: string[];
+  sourceCoverage?: string[];
+  evidenceDetails?: string[];
+  publicUseCandidates?: string[];
+  reviewOnlyEvidence?: string[];
+  queueSubmissionStatus?: DossierQueueSubmissionStatus;
+  queueSubmissionNote?: string;
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;
@@ -736,6 +770,19 @@ export type CreateDossierRecommendationInput = {
   publicSafePossibilities?: string[];
   privateOnlyNotes?: string[];
   notPublicYet?: string[];
+  observedChannels?: string[];
+  conversationHighlights?: string[];
+  topicBreakdown?: string[];
+  bestEvidenceToReview?: string[];
+  bnlInteractionSignals?: string[];
+  musicSignals?: string[];
+  communitySignals?: string[];
+  sourceCoverage?: string[];
+  evidenceDetails?: string[];
+  publicUseCandidates?: string[];
+  reviewOnlyEvidence?: string[];
+  queueSubmissionStatus?: DossierQueueSubmissionStatus;
+  queueSubmissionNote?: string;
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -5154,7 +5154,7 @@ test("Source File page uses one consolidated Source File Snapshot / BNL Readout 
   );
   assert.match(summaryPanel, /Source File Snapshot \/ BNL Readout/);
   assertIncludesCopy(summaryPanel, "Relationship Context — Review Only");
-  assertIncludesCopy(summaryPanel, "Public-Safe Possibilities Pending Owner Review");
+  assertIncludesCopy(summaryPanel, "Public-Safe / Public-Use Candidates Pending Owner Review");
   assertIncludesCopy(summaryPanel, "Private/Internal Notes");
   assertIncludesCopy(summaryPanel, "Queue/submission not connected");
   assertIncludesCopy(summaryPanel, "Review-only");
@@ -5184,6 +5184,17 @@ test("consolidated Source File Snapshot / BNL Readout collapses duplicate safe b
     uncertainties: ["Treat possible connections as unconfirmed."],
     missingInfo: ["Missing owner-confirmed wording."],
     notPublicYet: ["Do not publish relationship context yet."],
+    observedChannels: [],
+    conversationHighlights: [],
+    topicBreakdown: [],
+    bestEvidenceToReview: [],
+    bnlInteractionSignals: [],
+    musicSignals: [],
+    communitySignals: [],
+    sourceCoverage: [],
+    evidenceDetails: [],
+    publicUseCandidates: [],
+    reviewOnlyEvidence: [],
     sourceAuthority: ["Mixed BNL memory plus admin review; not owner-confirmed."],
     recommendedNextAction: "Ask owner to separate public-safe language.",
     substanceLevel: "useful",
@@ -5207,6 +5218,17 @@ test("consolidated Source File Snapshot / BNL Readout collapses duplicate safe b
     publicSafePossibilities: ["May be described after owner review."],
     privateOnlyNotes: ["Private owner-review note."],
     notPublicYet: ["Do not publish relationship context yet."],
+    observedChannels: ["Raw activity in EDGE_SESSION should be filtered"],
+    conversationHighlights: [],
+    topicBreakdown: [],
+    bestEvidenceToReview: [],
+    bnlInteractionSignals: [],
+    musicSignals: [],
+    communitySignals: [],
+    sourceCoverage: [],
+    evidenceDetails: [],
+    publicUseCandidates: [],
+    reviewOnlyEvidence: [],
     missingInfo: ["Missing owner-confirmed wording."],
     sourceAuthority: ["Admin review packet; not owner-confirmed.", "EDGE_SESSION"],
     recommendedAction: "Ask owner to separate public-safe language.",
@@ -5323,6 +5345,19 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
     recommendedAction: "Ask an owner to separate public-safe collaborator language from internal relationship context.",
     confidence: "high",
     sourceAuthority: ["Mixed BNL memory plus admin review; not owner-confirmed."],
+    observedChannels: ["Activity observed in owner-reviewable BARCODE Radio planning context."],
+    conversationHighlights: ["Conversation highlight notes recurring support around show planning."],
+    topicBreakdown: ["Topic breakdown emphasizes radio support and community coordination."],
+    bestEvidenceToReview: ["Owner should review the recurring set-support source note first."],
+    bnlInteractionSignals: ["BNL interaction signal: recurring admin-side mention pattern."],
+    musicSignals: ["Music/show signal: set-support work appears around radio planning."],
+    communitySignals: ["Community signal: repeated collaborator mentions in review context."],
+    sourceCoverage: ["Source coverage spans reviewed notes and BNL memory; no queue bridge."],
+    evidenceDetails: ["Evidence detail stays internal until owner-approved wording exists."],
+    publicUseCandidates: ["Possible collaborator wording pending owner review."],
+    reviewOnlyEvidence: ["Review-only evidence: internal relationship context needs owner review."],
+    queueSubmissionStatus: "not_connected",
+    queueSubmissionNote: "No confirmed queue/submission identity is linked to this source file.",
     rawProvenance: {
       backendTraceId: "raw-trace-structured-packet-v2",
       lanes: ["relationship_journal", "operator_notes"],
@@ -5346,6 +5381,16 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.deepEqual(payload.recommendation.notPublicYet, packet.notPublicYet);
   assert.equal(payload.recommendation.recommendedAction, packet.recommendedAction);
   assert.deepEqual(payload.recommendation.sourceAuthority, packet.sourceAuthority);
+  assert.deepEqual(payload.recommendation.observedChannels, packet.observedChannels);
+  assert.deepEqual(payload.recommendation.conversationHighlights, packet.conversationHighlights);
+  assert.deepEqual(payload.recommendation.bestEvidenceToReview, packet.bestEvidenceToReview);
+  assert.deepEqual(payload.recommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
+  assert.deepEqual(payload.recommendation.musicSignals, packet.musicSignals);
+  assert.deepEqual(payload.recommendation.communitySignals, packet.communitySignals);
+  assert.deepEqual(payload.recommendation.publicUseCandidates, packet.publicUseCandidates);
+  assert.deepEqual(payload.recommendation.reviewOnlyEvidence, packet.reviewOnlyEvidence);
+  assert.equal(payload.recommendation.queueSubmissionStatus, "not_connected");
+  assert.equal(payload.recommendation.queueSubmissionNote, packet.queueSubmissionNote);
   assert.deepEqual(payload.recommendation.rawProvenance, packet.rawProvenance);
 
   const state = await store.getDossierWorkflowState();
@@ -5354,6 +5399,13 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   );
   assert.ok(savedRecommendation);
   assert.deepEqual(savedRecommendation.usefulEvidence, packet.usefulEvidence);
+  assert.deepEqual(savedRecommendation.bestEvidenceToReview, packet.bestEvidenceToReview);
+  assert.deepEqual(savedRecommendation.observedChannels, packet.observedChannels);
+  assert.deepEqual(savedRecommendation.conversationHighlights, packet.conversationHighlights);
+  assert.deepEqual(savedRecommendation.musicSignals, packet.musicSignals);
+  assert.deepEqual(savedRecommendation.communitySignals, packet.communitySignals);
+  assert.deepEqual(savedRecommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
+  assert.equal(savedRecommendation.queueSubmissionStatus, "not_connected");
   assert.deepEqual(savedRecommendation.rawProvenance, packet.rawProvenance);
   const sourceFile = state.candidates.find(
     (candidate) => candidate.id === candidatePayload.candidate.id,
@@ -5362,12 +5414,25 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.equal(sourceFile.sourceFileNotes.length, 1);
   assert.match(sourceFile.sourceFileNotes[0].text, /Useful evidence: Two reviewed source notes/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Relationship signal — private review/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Best evidence to review: Owner should review/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Observed channel\/activity: Activity observed/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Queue\/submission identity is not connected yet/);
   assert.doesNotMatch(sourceFile.sourceFileNotes[0].text, /raw-trace-structured-packet-v2/);
 
   const summary = sourceFileSummary.createDossierSourceFileSummary({
     candidate: sourceFile,
     recommendations: [savedRecommendation],
   });
+  assert.match(JSON.stringify(summary.bestEvidenceToReview), /Owner should review/);
+  assert.match(JSON.stringify(summary.observedChannels), /Activity observed/);
+  assert.match(JSON.stringify(summary.conversationHighlights), /Conversation highlight/);
+  assert.match(JSON.stringify(summary.musicSignals), /Music\/show signal/);
+  assert.match(JSON.stringify(summary.communitySignals), /Community signal/);
+  assert.match(JSON.stringify(summary.bnlInteractionSignals), /BNL interaction signal/);
+  assert.match(JSON.stringify(summary.publicUseCandidates), /pending owner review/);
+  assert.match(JSON.stringify(summary.reviewOnlyEvidence), /Review-only evidence/);
+  assert.equal(summary.queueSubmissionStatus, "not_connected");
+  assert.match(summary.queueSubmissionNote, /No confirmed queue/);
   assert.match(JSON.stringify(summary.usefulEvidence), /Two reviewed source notes/);
   assert.match(JSON.stringify(summary.privateRelationshipContext), /Private relationship context/);
   assert.match(JSON.stringify(summary.claimedNeedsReview), /Private relationship context|collaborator after owner review/);
@@ -5379,6 +5444,14 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
 
   const view = noteDisplay.createHumanReadableRecommendationView(savedRecommendation);
   assert.match(JSON.stringify(view.sections), /Two reviewed source notes/);
+  assert.match(JSON.stringify(view.sections), /Best Evidence to Review/);
+  assert.match(JSON.stringify(view.sections), /Observed Channels \/ Activity/);
+  assert.match(JSON.stringify(view.sections), /Music \/ Show Signals/);
+  assert.match(JSON.stringify(view.sections), /Community Signals/);
+  assert.match(JSON.stringify(view.sections), /BNL Interaction Signals/);
+  assert.match(JSON.stringify(view.sections), /Public-Use Candidates Pending Owner Review/);
+  assert.match(JSON.stringify(view.sections), /Review-Only Evidence/);
+  assert.match(JSON.stringify(view.sections), /Queue\/submission identity is not connected yet/);
   assert.match(JSON.stringify(view.sections), /Private Relationship Context/);
   assert.match(JSON.stringify(view.rawMetadata), /raw-trace-structured-packet-v2/);
   assert.doesNotMatch(JSON.stringify(view.sections), /raw-trace-structured-packet-v2/);
@@ -5389,7 +5462,7 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   })).json();
   const draftText = JSON.stringify(draftPayload.draft.fields);
   assert.doesNotMatch(draftText, /raw-trace-structured-packet-v2/);
-  assert.doesNotMatch(draftText, /Private-only note|internal contact path|relationship context/);
+  assert.doesNotMatch(draftText, /Private-only note|internal contact path|relationship context|Owner should review|Conversation highlight|Review-only evidence/);
 
   const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
   assert.doesNotMatch(JSON.stringify(publicPayload), /Structured Packet Subject|raw-trace-structured-packet-v2|internal contact path/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -5352,7 +5352,15 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
     bnlInteractionSignals: ["BNL interaction signal: recurring admin-side mention pattern."],
     musicSignals: ["Music/show signal: set-support work appears around radio planning."],
     communitySignals: ["Community signal: repeated collaborator mentions in review context."],
-    sourceCoverage: ["Source coverage spans reviewed notes and BNL memory; no queue bridge."],
+    sourceCoverage: [
+      { source: "conversation", count: 14, status: "found" },
+      {
+        source: "channel_policy",
+        counts: { public_home: 12, public_context: 4 },
+        status: "found",
+      },
+      "Legacy source coverage text remains accepted.",
+    ],
     evidenceDetails: ["Evidence detail stays internal until owner-approved wording exists."],
     publicUseCandidates: ["Possible collaborator wording pending owner review."],
     reviewOnlyEvidence: ["Review-only evidence: internal relationship context needs owner review."],
@@ -5387,6 +5395,10 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.deepEqual(payload.recommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
   assert.deepEqual(payload.recommendation.musicSignals, packet.musicSignals);
   assert.deepEqual(payload.recommendation.communitySignals, packet.communitySignals);
+  assert.match(JSON.stringify(payload.recommendation.sourceCoverage), /conversation: 14 source row\(s\) found/);
+  assert.match(JSON.stringify(payload.recommendation.sourceCoverage), /channel policy: public home 12, public context 4 found/);
+  assert.match(JSON.stringify(payload.recommendation.sourceCoverage), /Legacy source coverage text remains accepted/);
+  assert.doesNotMatch(JSON.stringify(payload.recommendation.sourceCoverage), /\[object Object\]/);
   assert.deepEqual(payload.recommendation.publicUseCandidates, packet.publicUseCandidates);
   assert.deepEqual(payload.recommendation.reviewOnlyEvidence, packet.reviewOnlyEvidence);
   assert.equal(payload.recommendation.queueSubmissionStatus, "not_connected");
@@ -5405,6 +5417,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.deepEqual(savedRecommendation.musicSignals, packet.musicSignals);
   assert.deepEqual(savedRecommendation.communitySignals, packet.communitySignals);
   assert.deepEqual(savedRecommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
+  assert.match(JSON.stringify(savedRecommendation.sourceCoverage), /channel policy: public home 12, public context 4 found/);
+  assert.doesNotMatch(JSON.stringify(savedRecommendation.sourceCoverage), /\[object Object\]/);
   assert.equal(savedRecommendation.queueSubmissionStatus, "not_connected");
   assert.deepEqual(savedRecommendation.rawProvenance, packet.rawProvenance);
   const sourceFile = state.candidates.find(
@@ -5417,6 +5431,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(sourceFile.sourceFileNotes[0].text, /Best evidence to review: Owner should review/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Observed channel\/activity: Activity observed/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Queue\/submission identity is not connected yet/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Source coverage: channel policy: public home 12, public context 4 found/);
+  assert.doesNotMatch(sourceFile.sourceFileNotes[0].text, /\[object Object\]/);
   assert.doesNotMatch(sourceFile.sourceFileNotes[0].text, /raw-trace-structured-packet-v2/);
 
   const summary = sourceFileSummary.createDossierSourceFileSummary({
@@ -5429,6 +5445,9 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(summary.musicSignals), /Music\/show signal/);
   assert.match(JSON.stringify(summary.communitySignals), /Community signal/);
   assert.match(JSON.stringify(summary.bnlInteractionSignals), /BNL interaction signal/);
+  assert.match(JSON.stringify(summary.sourceCoverage), /conversation: 14 source row\(s\) found/);
+  assert.match(JSON.stringify(summary.sourceCoverage), /channel policy: public home 12, public context 4 found/);
+  assert.doesNotMatch(JSON.stringify(summary.sourceCoverage), /\[object Object\]/);
   assert.match(JSON.stringify(summary.publicUseCandidates), /pending owner review/);
   assert.match(JSON.stringify(summary.reviewOnlyEvidence), /Review-only evidence/);
   assert.equal(summary.queueSubmissionStatus, "not_connected");
@@ -5452,6 +5471,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(view.sections), /Public-Use Candidates Pending Owner Review/);
   assert.match(JSON.stringify(view.sections), /Review-Only Evidence/);
   assert.match(JSON.stringify(view.sections), /Queue\/submission identity is not connected yet/);
+  assert.match(JSON.stringify(view.sections), /channel policy: public home 12, public context 4 found/);
+  assert.doesNotMatch(JSON.stringify(view.sections), /\[object Object\]/);
   assert.match(JSON.stringify(view.sections), /Private Relationship Context/);
   assert.match(JSON.stringify(view.rawMetadata), /raw-trace-structured-packet-v2/);
   assert.doesNotMatch(JSON.stringify(view.sections), /raw-trace-structured-packet-v2/);
@@ -5462,7 +5483,7 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   })).json();
   const draftText = JSON.stringify(draftPayload.draft.fields);
   assert.doesNotMatch(draftText, /raw-trace-structured-packet-v2/);
-  assert.doesNotMatch(draftText, /Private-only note|internal contact path|relationship context|Owner should review|Conversation highlight|Review-only evidence/);
+  assert.doesNotMatch(draftText, /Private-only note|internal contact path|relationship context|Owner should review|Conversation highlight|Review-only evidence|channel policy|\[object Object\]/);
 
   const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
   assert.doesNotMatch(JSON.stringify(publicPayload), /Structured Packet Subject|raw-trace-structured-packet-v2|internal contact path/);


### PR DESCRIPTION
### Motivation
- BNL now emits richer structured entity evidence (observedChannels, conversationHighlights, bestEvidenceToReview, various signal lists, sourceCoverage, evidenceDetails, publicUseCandidates, reviewOnlyEvidence, queueSubmissionStatus/Note) and the site must accept, store, and surface those fields inside the existing Source File / BNL Readout workflow for admin review. 
- Keep all new fields internal/admin-only (no public dossier population or publishing), preserve raw provenance size/serialization limits, and avoid exposing backend labels or IDs in normal panels. 
- Show honest queue/submission status (display a specific message when not connected) and avoid creating new stores, panels, or public DB changes. 

### Description
- Ingest: extended the BNL dossier recommendation ingest route to validate and accept the new structured evidence fields and a bounded `queueSubmissionStatus` enum, using existing packet/list validation and raw provenance safeguards (`src/app/api/bnl/dossier-recommendations/route.ts`).
- Model/store: added the new fields to `DossierRecommendation` / structured packet types and `CreateDossierRecommendationInput`, normalized/persisted them in the existing workflow store, and included them when converting/attaching recommendations into source-file notes (no new store/table or public columns) (`src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`).
- Summary/readout mapping: mapped the new evidence fields into the existing Source File Summary and Entity Activity Readout helpers so the summary model exposes compact arrays for: Best Evidence to Review, Observed Channels / Activity, Conversation Highlights, Topic Breakdown, BNL interaction/music/community signals, Evidence Details, Source Coverage, Public-Use Candidates, Review-Only Evidence, and Queue/submission status/note (`src/lib/dossier-source-file-summary.ts`, `src/lib/dossier-entity-activity-readout.ts`).
- UI: updated the existing Source File Snapshot / BNL Readout panel to display compact, collapsed sections (keeps same panel; no new panel) and added matching compact fields on the recommendation detail page; empty sections are omitted or gracefully collapsed (`src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`).
- Human-readable conversion & privacy: the human-readable note view was extended to include the new fields in review sections while keeping `rawProvenance` in the Developer / Raw Source Audit area only and filtering backend technical labels from normal text (`src/lib/dossier-note-display.ts`).
- Queue status behavior: `queueSubmissionStatus === "not_connected"` is rendered as: “Queue/submission identity is not connected yet.” in both note text and UI summary sections.
- Tests: expanded `tests/admin-dossiers.test.mjs` to assert ingest acceptance, persistence, source-file note text, Source File Summary display of the new fields, queue-not-connected behavior, review-only/public-use labeling, raw provenance remains audit-only, and that no public/publishing behavior was added.  

Files changed (high level):
- API ingestion: `src/app/api/bnl/dossier-recommendations/route.ts`
- Types & workflow: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`
- Summaries/readout: `src/lib/dossier-source-file-summary.ts`, `src/lib/dossier-entity-activity-readout.ts`
- Note rendering: `src/lib/dossier-note-display.ts`
- UI panel: `src/components/DossierSourceFileSummaryPanel.tsx`
- Recommendation detail page: `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`
- Tests: `tests/admin-dossiers.test.mjs`

### Testing
- `git diff --check` passed locally for the modified files. 
- `npm install` could not complete in this environment due to a registry 403 fetching `@tailwindcss/postcss`, so local dependencies were not available and full toolchain checks could not run. 
- `npx tsc --noEmit` could not complete because TypeScript/Next/React type packages were not installed in the environment; type-check errors shown were dependency-related, not from the code changes themselves. 
- `node --test tests/admin-dossiers.test.mjs` could not run because the local `typescript` package was missing in the environment; the test file was updated with assertions for the new fields but was not executed successfully here. 
- `npx eslint ...` and `npm run build` could not be executed here because local `eslint`/`next` were not available (dependency-install blockage). 

Notes and risks
- All changes were implemented within the existing dossier workflow and UI panels; no new public routes, stores, or publishing behaviors were added. 
- Raw provenance remains only in the Developer / Raw Source Audit views; the implementation deliberately filters and translates backend labels for normal review surfaces. 
- The updated tests are included but could not be executed end-to-end in this environment due to dependency installation failures; please run the test suite and `npx tsc --noEmit`, `npx eslint`, and `npm run build` in CI or a developer environment with network access to npm to verify integration and type checks there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206bd0cbdc83219d4c5d761efc1dd6)