### PR TITLE
Allow BNL Source File Enrichment to attach across open review lanes

### DIFF
--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -33,6 +33,7 @@ import {
   type DossierDuplicateRisk,
   type DossierWorkflowLink,
   isActiveSourceFileCandidate,
+  isSourceFileEnrichmentAttachableCandidate,
   matchDossierRecommendationSubject,
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
@@ -1218,25 +1219,33 @@ export async function createDossierRecommendationIdempotent(
             "target_candidate_not_found",
           );
         }
-        if (
-          targetCandidate.status !== "active_source_file" &&
-          targetCandidate.status !== "candidate_intake" &&
-          targetCandidate.status !== "existing_dossier_update"
-        ) {
-          throw new DossierWorkflowInputError(
-            "BNL Source File Enrichment target is not an attachable workflow lane",
-            400,
-            "enrichment_target_not_attachable",
-          );
+        if (!isSourceFileEnrichmentAttachableCandidate(targetCandidate)) {
+          savedRecommendation = {
+            ...recommendation,
+            publicSafetyNotes: [
+              ...(recommendation.publicSafetyNotes ?? []),
+              "Target exists but is not open for enrichment attachment. No Source File, Proposed Dossier, public page, alias, merge, or owner-review state was changed.",
+            ],
+            updatedAt: now,
+          };
+          autoAction = "left_for_review";
+          return {
+            ...currentState,
+            recommendations: [
+              savedRecommendation,
+              ...currentState.recommendations,
+            ],
+            updatedAt: now,
+          };
         }
         const targetStatusNote =
-          targetCandidate.status === "active_source_file"
-            ? "attached to an Active BNL Source File for review only; no public dossier was changed."
-            : targetCandidate.status === "candidate_intake"
-              ? "attached to Candidate Intake as enrichment, not active case-file fact; no promotion occurred."
-              : targetCandidate.status === "existing_dossier_update"
-                ? "attached as Existing Dossier Update enrichment; public dossier content was not edited."
-                : "attached to the targeted workflow record for review only; no public content changed.";
+          targetCandidate.status === "candidate_intake"
+            ? "attached as review-only BNL Source File Enrichment to Candidate Intake; no public dossier content was changed; owner/admin review is still required."
+            : targetCandidate.status === "existing_dossier_update"
+              ? "attached as review-only BNL Source File Enrichment to Existing Dossier Update; no public dossier content was changed; owner/admin review is still required."
+              : targetCandidate.status === "active_source_file"
+                ? "attached as review-only BNL Source File Enrichment to an Active BNL Source File; no public dossier content was changed; owner/admin review is still required."
+                : "attached as review-only BNL Source File Enrichment to an open Source File review lane; no public dossier content was changed; owner/admin review is still required.";
         const updatedStatus: DossierRecommendationStatus =
           targetCandidate.status === "candidate_intake"
             ? "attached_to_candidate_intake"

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -607,6 +607,25 @@ export function isActiveSourceFileCandidate(
   );
 }
 
+const SOURCE_FILE_ENRICHMENT_ATTACHABLE_STATUSES = new Set<DossierCandidateStatus>([
+  "candidate_intake",
+  "active_source_file",
+  "existing_dossier_update",
+  "suggested",
+  "needs_review",
+  "selected",
+  "draft_requested",
+  "draft_ready",
+  "needs_revision",
+  "needs_more_evidence",
+]);
+
+export function isSourceFileEnrichmentAttachableCandidate(
+  candidate: Pick<DossierCandidate, "status">,
+): boolean {
+  return SOURCE_FILE_ENRICHMENT_ATTACHABLE_STATUSES.has(candidate.status);
+}
+
 function isActiveSubjectCandidate(candidate: DossierCandidate): boolean {
   return isActiveSourceFileCandidate(candidate);
 }

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -4585,6 +4585,7 @@ test("BNL Source File enrichment attaches to Candidate Intake and Existing Dossi
   let intakeCandidate = state.candidates.find((candidate) => candidate.id === intake.candidate.id);
   assert.equal(intakeCandidate.status, "candidate_intake");
   assert.equal(intakeCandidate.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(intakeCandidate.sourceFileNotes[0].publicSafe, false);
 
   const existingUpdate = await (await bnlIngestPost({
     type: "new_subject",
@@ -4613,8 +4614,175 @@ test("BNL Source File enrichment attaches to Candidate Intake and Existing Dossi
   const updateCandidate = state.candidates.find((candidate) => candidate.id === existingUpdate.candidate.id);
   assert.equal(updateCandidate.status, "existing_dossier_update");
   assert.equal(updateCandidate.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+  assert.equal(updateCandidate.sourceFileNotes[0].publicSafe, false);
   assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit")), beforePublic);
   assert.equal(state.drafts.length, 0);
+});
+
+test("BNL Source File enrichment attaches across open review lanes without public draft mutation", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const openStatuses = [
+    "suggested",
+    "needs_review",
+    "selected",
+    "draft_requested",
+    "draft_ready",
+    "needs_revision",
+    "needs_more_evidence",
+  ];
+
+  for (const status of openStatuses) {
+    const candidate = await store.createManualDossierCandidate({
+      ...manualCandidateInput,
+      name: `Open Enrichment ${status}`,
+      evidenceSummary: `Public-safe seed for ${status}.`,
+    });
+    await store.updateDossierCandidateStatus(candidate.id, status);
+    let draftBefore;
+    if (status === "draft_ready") {
+      draftBefore = await store.createDraftFromCandidate(candidate.id);
+      await store.updateDossierCandidateStatus(candidate.id, status);
+    }
+
+    const response = await bnlIngestPost({
+      type: "modify_existing_dossier",
+      subjectName: `Open Enrichment ${status}`,
+      targetCandidateId: candidate.id,
+      reason: `BNL generated ${status} source-file enrichment for review.`,
+      evidenceSummary: `Review-only enrichment for ${status}.`,
+      sourceLanes: ["active_source_file"],
+      sourceTypes: ["source_file_note"],
+      publicSafetyNotes: ["Review-only source enrichment."],
+      ingestKey: `bnl:open-enrichment:${status}`,
+      ingestSource: "bnl_source_file_enrichment",
+      rawProvenance: {
+        sourcePath: `internal/source/${status}`,
+        backendId: `backend-${status}`,
+      },
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.autoAction, "attached_existing");
+    assert.equal(payload.candidate, undefined);
+    assert.equal(payload.recommendation.status, "attached_to_source_file");
+    assert.equal(payload.recommendation.targetCandidateId, candidate.id);
+    assert.match(payload.recommendation.publicSafetyNotes.join(" "), /review-only BNL Source File Enrichment/);
+    assert.match(payload.recommendation.publicSafetyNotes.join(" "), /no public dossier content was changed/);
+    assert.match(payload.recommendation.publicSafetyNotes.join(" "), /owner\/admin review is still required/);
+    assert.deepEqual(payload.recommendation.rawProvenance, {
+      sourcePath: `internal/source/${status}`,
+      backendId: `backend-${status}`,
+    });
+
+    const state = await store.getDossierWorkflowState();
+    const savedCandidate = state.candidates.find((item) => item.id === candidate.id);
+    assert.equal(savedCandidate.status, status);
+    assert.equal(savedCandidate.sourceFileNotes.length, 1);
+    assert.equal(savedCandidate.sourceFileNotes[0].ingestSource, "bnl_source_file_enrichment");
+    assert.equal(savedCandidate.sourceFileNotes[0].publicSafe, false);
+    assert.match(savedCandidate.sourceFileNotes[0].text, /BNL Source File Enrichment/);
+
+    if (draftBefore) {
+      const draftAfter = state.drafts.find((draft) => draft.id === draftBefore.id);
+      assert.deepEqual(draftAfter.fields, draftBefore.fields);
+      assert.doesNotMatch(JSON.stringify(draftAfter.fields), /Review-only enrichment|source_file_note|backend-/);
+    }
+  }
+
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.doesNotMatch(JSON.stringify(publicPayload), /Open Enrichment|bnl_source_file_enrichment|backend-/);
+});
+
+test("BNL Source File enrichment terminal targets are left for review without attaching", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const terminalStatuses = ["archived", "approved", "denied", "merged"];
+
+  for (const status of terminalStatuses) {
+    const candidate = await store.createManualDossierCandidate({
+      ...manualCandidateInput,
+      name: `Terminal Enrichment ${status}`,
+    });
+    await store.updateDossierCandidateStatus(candidate.id, status);
+
+    const response = await bnlIngestPost({
+      type: "modify_existing_dossier",
+      subjectName: `Terminal Enrichment ${status}`,
+      targetCandidateId: candidate.id,
+      reason: `BNL generated terminal ${status} enrichment for review.`,
+      evidenceSummary: `Terminal enrichment for ${status}.`,
+      sourceLanes: ["active_source_file"],
+      sourceTypes: ["source_file_note"],
+      ingestKey: `bnl:terminal-enrichment:${status}`,
+      ingestSource: "bnl_source_file_enrichment",
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.autoAction, "left_for_review");
+    assert.equal(payload.candidate, undefined);
+    assert.equal(payload.recommendation.status, "new");
+    assert.equal(payload.recommendation.targetCandidateId, candidate.id);
+    assert.match(
+      payload.recommendation.publicSafetyNotes.join(" "),
+      /Target exists but is not open for enrichment attachment/,
+    );
+    assert.match(
+      payload.recommendation.publicSafetyNotes.join(" "),
+      /No Source File, Proposed Dossier, public page, alias, merge, or owner-review state was changed/,
+    );
+
+    const state = await store.getDossierWorkflowState();
+    const savedCandidate = state.candidates.find((item) => item.id === candidate.id);
+    assert.equal(savedCandidate.status, status);
+    assert.equal(savedCandidate.sourceFileNotes.length, 0);
+  }
+
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+});
+
+test("BNL Source File enrichment keeps missing targets strict and does not loosen other target rules", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const missingResponse = await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "Missing Target Enrichment",
+    targetCandidateId: "missing-candidate-id",
+    reason: "BNL generated enrichment for a bad target.",
+    evidenceSummary: "Should fail strictly.",
+    ingestKey: "bnl:missing-target-enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+  });
+  assert.equal(missingResponse.status, 404);
+  assert.equal((await missingResponse.json()).code, "target_candidate_not_found");
+
+  const intake = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Non Enrichment Intake Target",
+    reason: "BNL dynamic discovery created candidate intake.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:non-enrichment-intake-target:discovery",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  assert.equal(intake.candidate.status, "candidate_intake");
+
+  const bridgeResponse = await bnlIngestPost({
+    type: "modify_existing_dossier",
+    subjectName: "Non Enrichment Intake Target",
+    targetCandidateId: intake.candidate.id,
+    reason: "Bridge should not attach to candidate intake through enrichment rules.",
+    evidenceSummary: "Non-enrichment target rule should stay strict.",
+    ingestKey: "bnl:non-enrichment-intake-target:bridge",
+    ingestSource: "bnl_source_knowledge_bridge",
+  });
+  assert.equal(bridgeResponse.status, 400);
+  assert.equal((await bridgeResponse.json()).code, "target_candidate_not_active");
 });
 
 test("BNL Source File enrichment without target remains in inbox and cannot convert to a new candidate", async () => {


### PR DESCRIPTION
### Motivation
- The previous attachable-lane check rejected valid `bnl_source_file_enrichment` packets when a target candidate existed but was in an open review status outside the narrow hardcoded list, causing HTTP 400 failures.  
- Enrichment is review-only internal evidence and should be attachable to open review/source-file lanes without mutating public dossier copy or publishing.

### Description
- Add a helper `isSourceFileEnrichmentAttachableCandidate(...)` and status set in `src/lib/dossier-workflow.ts` to clearly enumerate attachable open-review statuses (`candidate_intake`, `active_source_file`, `existing_dossier_update`, `suggested`, `needs_review`, `selected`, `draft_requested`, `draft_ready`, `needs_revision`, `needs_more_evidence`).
- Update `createDossierRecommendationIdempotent(...)` in `src/lib/dossier-workflow-store.ts` to use the new helper, attach review-only `DossierSourceFileNote` entries with `publicSafe: false` for open review targets, and map recommendation statuses to `attached_to_candidate_intake`, `attached_to_existing_dossier_update`, or `attached_to_source_file` as appropriate.
- For terminal/non-attachable targets (`archived`, `approved`, `denied`, `merged`) do not hard-fail; instead save the recommendation to the inbox with `autoAction: "left_for_review"` and add a `publicSafetyNotes` message stating that no public/merge/alias/draft state was changed.
- Preserve strict 404 behavior when a provided `targetCandidateId` is missing and do not loosen rules for other recommendation types (e.g. bridge/discovery/manual/identity recommendations).
- Tests updated in `tests/admin-dossiers.test.mjs` to cover the new attachable statuses, confirm `publicSafe: false` on attached notes, assert no public draft/database/read-model mutation, verify terminal targets are left for review, and keep missing-target behavior strict.
- Files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `tests/admin-dossiers.test.mjs`.

### Testing
- Ran `npx tsc --noEmit` and it succeeded.
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed (`116` tests passed, `0` failed).
- Ran `npx eslint` against the changed files and it completed without blocking issues.
- Ran `npm run build` which failed due to an environment font fetch error (Next/Turbopack failed to fetch the Google font `Geist Mono`), this is a known CI/local environment limitation and unrelated to the workflow-store logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a207f1a8fc08321bc9c77e894fae417)