### PR TITLE
Turn BNL Source File Snapshot into human-readable admin case-file brief and ingest new evidence fields

### DIFF
--- a/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
+++ b/src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx
@@ -134,7 +134,7 @@ function sourceAuthorityItems(recommendation: DossierRecommendation): string[] {
   return [
     ...sanitized,
     recommendation.confidence
-      ? `Confidence: ${recommendation.confidence}`
+      ? `Source confidence: ${recommendation.confidence}`
       : undefined,
     (recommendation.sourceAuthority ?? []).length > 0 && sanitized.length === 0
       ? "Source authority was supplied by BNL; review raw audit details before public use."
@@ -1034,7 +1034,7 @@ export default function DossierRecommendationPage() {
           <Field title="Reason">
             <p>{recommendation.reason}</p>
           </Field>
-          <Field title="Evidence / Source Notes">
+          <Field title="Evidence Log">
             <p>
               Recommendation detail is evidence for the internal working case
               file, not public dossier copy.
@@ -1043,7 +1043,7 @@ export default function DossierRecommendationPage() {
           <Field title="Known Context / Current Read">
             {list(recommendation.knownContext)}
           </Field>
-          <Field title="Best Evidence to Review">
+          <Field title="What BNL Found">
             {list(recommendation.bestEvidenceToReview)}
           </Field>
           <Field title="Useful Evidence">
@@ -1052,7 +1052,7 @@ export default function DossierRecommendationPage() {
           <Field title="Observed Channels / Activity">
             {list(recommendation.observedChannels)}
           </Field>
-          <Field title="Conversation Highlights">
+          <Field title="Public Activity Notes">
             {list(recommendation.conversationHighlights)}
           </Field>
           <Field title="Music / Show Signals">
@@ -1073,10 +1073,10 @@ export default function DossierRecommendationPage() {
               ...(recommendation.publicUseCandidates ?? []),
             ])}
           </Field>
-          <Field title="Review-Only Evidence">
+          <Field title="Review-Only Cautions">
             {list(recommendation.reviewOnlyEvidence)}
           </Field>
-          <Field title="Private/Internal Notes">
+          <Field title="Review-Only Cautions / Internal Notes">
             {list(recommendation.privateOnlyNotes)}
           </Field>
           <Field title="Not Public Yet">
@@ -1085,10 +1085,22 @@ export default function DossierRecommendationPage() {
           <Field title="Source Coverage">
             {list(recommendation.sourceCoverage)}
           </Field>
-          <Field title="Topic Breakdown">
-            {list(recommendation.topicBreakdown)}
+          <Field title="Main Discussion Areas">
+            {list([
+              ...(recommendation.topTopicDetails ?? []),
+              ...(recommendation.topicBreakdown ?? []),
+            ])}
           </Field>
-          <Field title="Evidence Details">
+          <Field title="Activity Details">
+            {list([
+              ...(recommendation.topChannels ?? []),
+              ...(recommendation.activityFrequencySummary ?? []),
+              ...(recommendation.recentActivitySummary ?? []),
+              ...(recommendation.authoredVsMentionedSummary ?? []),
+              ...(recommendation.representativeEvidence ?? []),
+            ])}
+          </Field>
+          <Field title="Evidence Log Details">
             {list(recommendation.evidenceDetails)}
           </Field>
           <Field title="Queue / Submission Status">
@@ -1097,7 +1109,7 @@ export default function DossierRecommendationPage() {
           <Field title="Recommended Next Action">
             <p>{recommendation.recommendedAction ?? recommendation.suggestedAction ?? "—"}</p>
           </Field>
-          <Field title="Source Authority / Confidence">
+          <Field title="Evidence Status">
             {list(sourceAuthorityItems(recommendation))}
           </Field>
           <Field title="Evidence summary">

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -191,7 +191,12 @@ function reviewEvidenceText(value: unknown, field: string, maxLength = 1000): st
   if (clean === "[object Object]" || /\[object Object\]/i.test(clean)) {
     throw new Error(`${field} contains object text`);
   }
-  if (/[{}<>]/.test(clean) || /(?:^|\s)(?:[A-Za-z]:)?[\\/][\w./-]+/.test(clean) || /\b[\w.-]+(?:[\\/][\w.-]+){2,}\b/.test(clean)) {
+  const classificationLike = /\b(?:BNL\/source-file|source-file\/dossier(?:-related)?|music\/track|help\/support)\b/i.test(clean);
+  if (
+    /[{}<>]/.test(clean) ||
+    /(?:^|\s)(?:[A-Za-z]:)?[\\/][\w./-]+/.test(clean) ||
+    (!classificationLike && /\b[\w.-]+(?:[\\/][\w.-]+){2,}\b/.test(clean))
+  ) {
     throw new Error(`${field} contains unsupported raw metadata`);
   }
   if (/\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl|user|message|channel)_[a-z0-9][a-z0-9_-]{8,}\b/i.test(clean)) {
@@ -209,6 +214,26 @@ function reviewEvidenceNumber(value: unknown, field: string): number | undefined
   return value;
 }
 
+
+function evidenceLooksLikeClassification(value?: string) {
+  return /\b(?:automated topic|topic label|classified|classification|evidence categor(?:y|ies)|topic breakdown|topic detail|source-file|dossier|BNL\/source-file|BNL source-file|BNL\/source file|source file\/dossier)\b/i.test(value ?? "");
+}
+
+function evidenceClassificationCopy(value?: string) {
+  const clean = reviewEvidenceText(value, "classification", 240)
+    ?.replace(/\bauthored\b/gi, "")
+    .replace(/\bposted\b/gi, "")
+    .replace(/\bCrow\s+(?:discussed|posted about|talked about|authored)\b/gi, "")
+    .replace(/\bdiscussed\b/gi, "related to")
+    .replace(/\bhandling\b/gi, "context")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[-:;,\s]+|[-:;,\s]+$/g, "");
+  if (!clean) return undefined;
+  if (/\bclassified\b/i.test(clean) || /\bautomated topic/i.test(clean)) return clean;
+  return `Automated topic label: ${clean}. Needs human review before this becomes a subject claim.`;
+}
+
 function reviewEvidenceObjectItem(value: Record<string, unknown>, field: string, maxLength = 1000): string | undefined {
   const parts: string[] = [];
   for (const key of Object.keys(value)) {
@@ -216,13 +241,17 @@ function reviewEvidenceObjectItem(value: Record<string, unknown>, field: string,
       throw new Error(`${field} contains unsupported metadata`);
     }
   }
-  const summary = reviewEvidenceText(value.summary ?? value.detail ?? value.label, field, 500);
-  if (summary) parts.push(summary);
+  const rawSummary = reviewEvidenceText(value.summary ?? value.detail ?? value.label, field, 500);
   const topic = reviewEvidenceText(value.topic, field, 120);
+  const classificationCopy = evidenceLooksLikeClassification(topic) || evidenceLooksLikeClassification(rawSummary)
+    ? evidenceClassificationCopy(rawSummary) ?? evidenceClassificationCopy(topic)
+    : undefined;
+  if (classificationCopy) parts.push(classificationCopy);
+  else if (rawSummary) parts.push(rawSummary);
   const channel = reviewEvidenceText(value.channel, field, 120);
   const context = reviewEvidenceText(value.context, field, 180);
   let activityType = reviewEvidenceText(value.activityType ?? value.type ?? value.kind, field, 80);
-  if (/^authored$/i.test(activityType ?? "")) activityType = "posted";
+  if (/^authored$/i.test(activityType ?? "")) activityType = classificationCopy ? undefined : "posted";
   const status = reviewEvidenceText(value.status ?? value.visibility, field, 80);
   const relationship = reviewEvidenceText(value.relationship, field, 80);
   const window = reviewEvidenceText(value.window ?? value.recency ?? value.frequency, field, 160);
@@ -260,7 +289,7 @@ function reviewEvidenceObjectItem(value: Record<string, unknown>, field: string,
   }
   const detailParts = [
     activityType && coverageLabel(activityType),
-    topic && `about ${coverageLabel(topic)}`,
+    topic && (classificationCopy ? `automated topic label ${coverageLabel(topic)}` : `about ${coverageLabel(topic)}`),
     channel && `in ${channel.startsWith("#") ? channel : `#${coverageLabel(channel)}`}`,
     channels.length ? `in ${channels.map((item) => item.startsWith("#") ? item : `#${coverageLabel(item)}`).join(", ")}` : undefined,
     context && coverageLabel(context),

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -157,6 +157,140 @@ function finiteCoverageNumber(value: unknown, field: string): number | undefined
   return value;
 }
 
+
+const REVIEW_EVIDENCE_ALLOWED_KEYS = new Set([
+  "summary",
+  "label",
+  "detail",
+  "topic",
+  "channel",
+  "channels",
+  "context",
+  "status",
+  "kind",
+  "type",
+  "activityType",
+  "relationship",
+  "visibility",
+  "window",
+  "recency",
+  "frequency",
+  "count",
+  "counts",
+  "postedCount",
+  "mentionedCount",
+  "publicCount",
+  "recentCount",
+  "firstSeen",
+  "lastSeen",
+]);
+
+function reviewEvidenceText(value: unknown, field: string, maxLength = 1000): string | undefined {
+  const clean = text(value, maxLength);
+  if (!clean) return undefined;
+  if (clean === "[object Object]" || /\[object Object\]/i.test(clean)) {
+    throw new Error(`${field} contains object text`);
+  }
+  if (/[{}<>]/.test(clean) || /(?:^|\s)(?:[A-Za-z]:)?[\\/][\w./-]+/.test(clean) || /\b[\w.-]+(?:[\\/][\w.-]+){2,}\b/.test(clean)) {
+    throw new Error(`${field} contains unsupported raw metadata`);
+  }
+  if (/\b(?:candidate|target|dossier|source_file|recommendation|rec|bnl|user|message|channel)_[a-z0-9][a-z0-9_-]{8,}\b/i.test(clean)) {
+    throw new Error(`${field} contains a raw identifier`);
+  }
+  return clean;
+}
+
+function reviewEvidenceNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} count must be a number`);
+  }
+  if (Math.abs(value) > 1_000_000) throw new Error(`${field} count is too large`);
+  return value;
+}
+
+function reviewEvidenceObjectItem(value: Record<string, unknown>, field: string, maxLength = 1000): string | undefined {
+  const parts: string[] = [];
+  for (const key of Object.keys(value)) {
+    if (!REVIEW_EVIDENCE_ALLOWED_KEYS.has(key)) {
+      throw new Error(`${field} contains unsupported metadata`);
+    }
+  }
+  const summary = reviewEvidenceText(value.summary ?? value.detail ?? value.label, field, 500);
+  if (summary) parts.push(summary);
+  const topic = reviewEvidenceText(value.topic, field, 120);
+  const channel = reviewEvidenceText(value.channel, field, 120);
+  const context = reviewEvidenceText(value.context, field, 180);
+  let activityType = reviewEvidenceText(value.activityType ?? value.type ?? value.kind, field, 80);
+  if (/^authored$/i.test(activityType ?? "")) activityType = "posted";
+  const status = reviewEvidenceText(value.status ?? value.visibility, field, 80);
+  const relationship = reviewEvidenceText(value.relationship, field, 80);
+  const window = reviewEvidenceText(value.window ?? value.recency ?? value.frequency, field, 160);
+  const firstSeen = reviewEvidenceText(value.firstSeen, field, 80);
+  const lastSeen = reviewEvidenceText(value.lastSeen, field, 80);
+  const count = reviewEvidenceNumber(value.count, field);
+  const postedCount = reviewEvidenceNumber(value.postedCount, field);
+  const mentionedCount = reviewEvidenceNumber(value.mentionedCount, field);
+  const publicCount = reviewEvidenceNumber(value.publicCount, field);
+  const recentCount = reviewEvidenceNumber(value.recentCount, field);
+  const channels = Array.isArray(value.channels)
+    ? value.channels.slice(0, 6).map((item) => reviewEvidenceText(item, field, 80)).filter((item): item is string => Boolean(item))
+    : value.channels === undefined
+      ? []
+      : (() => { throw new Error(`${field} channels must be a list`); })();
+  const countParts: string[] = [];
+  if (count !== undefined) countParts.push(`${count} item${count === 1 ? "" : "s"}`);
+  if (postedCount !== undefined) countParts.push(`${postedCount} posted item${postedCount === 1 ? "" : "s"}`);
+  if (mentionedCount !== undefined) countParts.push(`${mentionedCount} mention${mentionedCount === 1 ? "" : "s"}`);
+  if (publicCount !== undefined) countParts.push(`${publicCount} approved public item${publicCount === 1 ? "" : "s"}`);
+  if (recentCount !== undefined) countParts.push(`${recentCount} recent item${recentCount === 1 ? "" : "s"}`);
+  if (value.counts !== undefined) {
+    if (!value.counts || typeof value.counts !== "object" || Array.isArray(value.counts)) {
+      throw new Error(`${field} counts must be an object`);
+    }
+    const entries = Object.entries(value.counts as Record<string, unknown>);
+    if (entries.length > 12) throw new Error(`${field} counts has too many keys`);
+    for (const [key, rawCount] of entries) {
+      const cleanKey = reviewEvidenceText(key, field, 80);
+      const cleanCount = reviewEvidenceNumber(rawCount, field);
+      if (cleanKey && cleanCount !== undefined) {
+        countParts.push(`${coverageLabel(cleanKey)} ${cleanCount}`);
+      }
+    }
+  }
+  const detailParts = [
+    activityType && coverageLabel(activityType),
+    topic && `about ${coverageLabel(topic)}`,
+    channel && `in ${channel.startsWith("#") ? channel : `#${coverageLabel(channel)}`}`,
+    channels.length ? `in ${channels.map((item) => item.startsWith("#") ? item : `#${coverageLabel(item)}`).join(", ")}` : undefined,
+    context && coverageLabel(context),
+    relationship && coverageLabel(relationship),
+    countParts.length ? countParts.join(", ") : undefined,
+    window && coverageLabel(window),
+    firstSeen && `first seen ${firstSeen}`,
+    lastSeen && `last seen ${lastSeen}`,
+    status && coverageLabel(status),
+  ].filter(Boolean);
+  if (detailParts.length) parts.push(detailParts.join("; "));
+  return reviewEvidenceText(parts.join(" — "), field, maxLength);
+}
+
+function reviewEvidenceItem(value: unknown, field: string): string | undefined {
+  if (typeof value === "string") return reviewEvidenceText(value, field);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} item must be text or a supported object`);
+  }
+  return reviewEvidenceObjectItem(value as Record<string, unknown>, field);
+}
+
+function reviewEvidenceList(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  const rawItems = Array.isArray(value) ? value : [value];
+  if (rawItems.length > 25) throw new Error(`${field} has too many items`);
+  const items = rawItems.map((item) => reviewEvidenceItem(item, field)).filter(Boolean);
+  return items.length ? (items as string[]) : [];
+}
+
 function sourceCoverageItem(value: unknown): string | undefined {
   if (typeof value === "string") return coverageText(value, 1000);
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -351,6 +485,12 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   const communitySignals = packetStringList(payload.communitySignals);
   const sourceCoverage = sourceCoverageList(payload.sourceCoverage);
   const evidenceDetails = packetStringList(payload.evidenceDetails);
+  const representativeEvidence = reviewEvidenceList(payload.representativeEvidence, "representativeEvidence");
+  const activityFrequencySummary = reviewEvidenceList(payload.activityFrequencySummary, "activityFrequencySummary");
+  const topChannels = reviewEvidenceList(payload.topChannels, "topChannels");
+  const topTopicDetails = reviewEvidenceList(payload.topTopicDetails, "topTopicDetails");
+  const recentActivitySummary = reviewEvidenceList(payload.recentActivitySummary, "recentActivitySummary");
+  const authoredVsMentionedSummary = reviewEvidenceList(payload.authoredVsMentionedSummary, "authoredVsMentionedSummary");
   const publicUseCandidates = packetStringList(payload.publicUseCandidates);
   const reviewOnlyEvidence = packetStringList(payload.reviewOnlyEvidence);
   const queueSubmissionStatus = enumValue(
@@ -416,6 +556,12 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     communitySignals,
     sourceCoverage,
     evidenceDetails,
+    representativeEvidence,
+    activityFrequencySummary,
+    topChannels,
+    topTopicDetails,
+    recentActivitySummary,
+    authoredVsMentionedSummary,
     publicUseCandidates,
     reviewOnlyEvidence,
     queueSubmissionStatus,

--- a/src/components/DossierEntityActivityReadoutPanel.tsx
+++ b/src/components/DossierEntityActivityReadoutPanel.tsx
@@ -34,6 +34,19 @@ function Section({
   );
 }
 
+function sourceConfidenceLabel(value?: string) {
+  const values = (value ?? "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+  const uniqueValues = Array.from(new Set(values));
+  if (uniqueValues.length !== 1) return "Mixed / review required";
+  if (uniqueValues[0] === "low") return "Low";
+  if (uniqueValues[0] === "medium") return "Medium";
+  if (uniqueValues[0] === "high") return "High";
+  return "Mixed / review required";
+}
+
 function ReadoutList({ items, empty }: { items: string[]; empty: string }) {
   return items.length ? (
     items.length === 1 ? (
@@ -79,7 +92,7 @@ export function DossierEntityActivityReadoutPanel({
           </ReadoutBadge>
           <ReadoutBadge>Review-only</ReadoutBadge>
           <ReadoutBadge>No live BNL call</ReadoutBadge>
-          {readout.confidence && <ReadoutBadge>Confidence: {readout.confidence}</ReadoutBadge>}
+          <ReadoutBadge>Source confidence: {sourceConfidenceLabel(readout.confidence)}</ReadoutBadge>
         </div>
       </div>
 
@@ -99,11 +112,18 @@ export function DossierEntityActivityReadoutPanel({
             empty="No useful evidence has been attached to this entity readout yet."
           />
         </Section>
-        <Section title="Activity / Channel Signals">
-          <div className="space-y-2">
-            <p>No reviewed channel/activity summary has been attached yet.</p>
-            <p>Queue/submission history is not connected to BNL entity summaries yet.</p>
-          </div>
+        <Section title="Activity Details">
+          <ReadoutList
+            items={[
+              ...readout.topChannels,
+              ...readout.topTopicDetails,
+              ...readout.activityFrequencySummary,
+              ...readout.recentActivitySummary,
+              ...readout.authoredVsMentionedSummary,
+              ...readout.representativeEvidence,
+            ]}
+            empty="No reviewed channel/activity summary has been attached yet. Queue/submission history is not connected to BNL entity summaries yet."
+          />
         </Section>
         <Section title="Relationship Context — Review Only" tone="review">
           <ReadoutList
@@ -117,7 +137,7 @@ export function DossierEntityActivityReadoutPanel({
             empty="Owner review needed before public wording."
           />
         </Section>
-        <Section title="Private/Internal Notes — Review Only" tone="review">
+        <Section title="Review-Only Cautions" tone="review">
           <ReadoutList
             items={readout.privateOnlyNotes}
             empty="No private/internal notes are recorded in the structured readout."
@@ -137,16 +157,14 @@ export function DossierEntityActivityReadoutPanel({
             />
           </Section>
         )}
-        <Section title="Source Authority / Confidence">
+        <Section title="Evidence Status">
           <ReadoutList
             items={readout.sourceAuthority}
-            empty="Source authority has not been separated from confidence yet."
+            empty="Source confidence: mixed / review required."
           />
-          {readout.confidence && (
-            <p className="mt-2 text-xs uppercase tracking-widest text-accent">
-              Confidence: {readout.confidence}
-            </p>
-          )}
+          <p className="mt-2 text-xs uppercase tracking-widest text-accent">
+            Source confidence: {sourceConfidenceLabel(readout.confidence)}
+          </p>
         </Section>
         <Section title="Recommended Next Action">
           <p>{readout.recommendedAction}</p>

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -55,25 +55,48 @@ function SummaryList({ items }: { items: string[] }) {
   );
 }
 
+function isClassificationText(value: string) {
+  return /\b(?:automated topic|topic label|classified|classification|evidence categor(?:y|ies)|topic breakdown|topic detail|source-file|dossier|BNL\/source-file|BNL source-file|BNL\/source file|source file\/dossier)\b/i.test(value);
+}
+
+function classificationLabel(value: string) {
+  const clean = value
+    .replace(/\bauthored\b/gi, "")
+    .replace(/\bposted\b/gi, "")
+    .replace(/\bCrow\s+(?:discussed|posted about|talked about|authored)\b/gi, "")
+    .replace(/\bdiscussed\b/gi, "related to")
+    .replace(/\bhandling\b/gi, "context")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[-:;,\s]+|[-:;,\s]+$/g, "");
+  if (/\bclassified\b/i.test(clean) || /\bautomated topic/i.test(clean)) {
+    return clean;
+  }
+  return `Automated topic label: ${clean}. Needs human review before this becomes a subject claim.`;
+}
+
 function displaySafeText(value?: string | null) {
   const clean = value?.replace(/\s+/g, " ").trim();
   if (!clean) return undefined;
-  if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
-    return undefined;
-  }
   if (/\[object Object\]/i.test(clean)) return undefined;
   if (/\b(?:authored_public_conversation|profile_match)\b/i.test(clean)) return undefined;
   if (/\b(?:user_profiles|conversations|relationship_journal|source_memory_packet|source table|table name)\b/i.test(clean)) {
     return undefined;
   }
+  if (isClassificationText(clean)) {
+    return classificationLabel(clean)
+      .replace(/\bpublic-side\b/gi, "approved public context")
+      .replace(/\brow\(s\)\b/gi, "items");
+  }
+  if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
+    return undefined;
+  }
   return clean
-    .replace(/\bauthored\b/gi, "posted")
-    .replace(/\bauthored public-side row\(s\)\b/gi, "posted in approved public context")
-    .replace(/\bpublic-side row\(s\)\b/gi, "approved public context")
+    .replace(/\bauthored public-side row\(s\)\b/gi, "approved public context item")
+    .replace(/\bpublic-side row\(s\)\b/gi, "approved public context item")
     .replace(/\brow\(s\)\b/gi, "items")
     .replace(/\bpublic-side\b/gi, "approved public context")
     .replace(/\bReview candidate\b/g, "Review item")
-    .replace(/\bcandidate\b/gi, "lead")
     .replace(/\bidentity matching context\b/gi, "identity review context")
     .replace(/\blocal context\b/gi, "BNL review context")
     .replace(/\bprofile_match\b/gi, "local profile match");
@@ -309,7 +332,9 @@ export function DossierSourceFileSummaryPanel({
   const adminCaseSummary = safeReviewItems([
     `Identity status: ${identityCertaintyLabel(summary)}; display name and role still need owner/admin confirmation before public use.`,
     observedChannels[0] || topChannels[0] || "Approved public/community activity may exist, but it still needs review.",
-    topicBreakdown[0] || topTopicDetails[0] || "Main discussion areas are based on approved evidence labels, not full conversation review.",
+    topicBreakdown.length || topTopicDetails.length
+      ? "Topic labels are BNL classifications, not public facts."
+      : "No main evidence category has been reviewed yet.",
     "Review-only cautions must stay internal unless owner/admin review approves them.",
     queueItems[0] ?? "Queue/submission history is not connected yet.",
   ], 5);
@@ -319,22 +344,22 @@ export function DossierSourceFileSummaryPanel({
       ? `Public activity: ${[...topChannels, ...observedChannels].slice(0, 2).join("; ")}.`
       : "Public activity: no approved public activity detail has been summarized yet.",
     topicBreakdown.length || topTopicDetails.length
-      ? `Main discussion areas: ${[...topTopicDetails, ...topicBreakdown].slice(0, 3).join("; ")}.`
-      : "Main discussion areas: topic detail is based on approved public-side evidence labels, not full conversation review.",
+      ? `Main evidence categories: BNL classified items under ${[...topTopicDetails, ...topicBreakdown].slice(0, 3).join("; ")}. Review item details before treating them as subject claims.`
+      : "Main evidence categories: topic detail is based on approved evidence labels, not full conversation review.",
     bestEvidenceToReview.length ? `Strong lead: ${bestEvidenceToReview[0]}` : undefined,
-    representativeEvidence.length ? `Representative activity: ${representativeEvidence[0]}` : undefined,
+    representativeEvidence.length ? `Representative public activity or review item: ${representativeEvidence[0]}` : undefined,
     reviewOnlyEvidence.length || relationshipContext.length
       ? "Review-only context exists, but it cannot become public copy without owner/admin review."
       : undefined,
   ], 6);
   const activityDetails = safeReviewItems([
     ...topChannels.map((item) => `Channel activity: ${item}`),
-    ...topTopicDetails.map((item) => `Topic detail: ${item}`),
+    ...topTopicDetails.map((item) => `BNL classification: ${item}`),
     ...activityFrequencySummary.map((item) => `Frequency: ${item}`),
     ...recentActivitySummary.map((item) => `Recency: ${item}`),
     ...authoredVsMentionedSummary.map((item) => `Posted/mentioned balance: ${item}`),
-    ...representativeEvidence.map((item) => `Example lead: ${item}`),
-    ...conversationHighlights.map((item) => `Public activity note: ${item}`),
+    ...representativeEvidence.map((item) => isClassificationText(item) ? `Review item: ${item}` : `Representative public activity: ${item}`),
+    ...conversationHighlights.map((item) => isClassificationText(item) ? `Review item: ${item}` : `Public activity note: ${item}`),
     ...musicSignals.map((item) => `Music/show note: ${item}`),
     ...communitySignals.map((item) => `Community note: ${item}`),
     ...bnlInteractionSignals.map((item) => `BNL handling note: ${item}`),

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -21,10 +21,12 @@ function Section({
   title,
   children,
   tone = "default",
+  helper,
 }: {
   title: string;
   children: React.ReactNode;
   tone?: "default" | "review" | "caution";
+  helper?: string;
 }) {
   const toneClass =
     tone === "caution"
@@ -34,7 +36,8 @@ function Section({
         : "border-border/60 bg-background/20";
   return (
     <section className={`border p-3 text-sm text-muted ${toneClass}`}>
-      <h3 className="font-bold text-foreground mb-2">{title}</h3>
+      <h3 className="font-bold text-foreground mb-1">{title}</h3>
+      {helper && <p className="mb-2 text-xs text-muted/80">{helper}</p>}
       {children}
     </section>
   );
@@ -52,15 +55,36 @@ function SummaryList({ items }: { items: string[] }) {
   );
 }
 
+function displaySafeText(value?: string | null) {
+  const clean = value?.replace(/\s+/g, " ").trim();
+  if (!clean) return undefined;
+  if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
+    return undefined;
+  }
+  if (/\[object Object\]/i.test(clean)) return undefined;
+  if (/\b(?:authored_public_conversation|profile_match)\b/i.test(clean)) return undefined;
+  if (/\b(?:user_profiles|conversations|relationship_journal|source_memory_packet|source table|table name)\b/i.test(clean)) {
+    return undefined;
+  }
+  return clean
+    .replace(/\bauthored\b/gi, "posted")
+    .replace(/\bauthored public-side row\(s\)\b/gi, "posted in approved public context")
+    .replace(/\bpublic-side row\(s\)\b/gi, "approved public context")
+    .replace(/\brow\(s\)\b/gi, "items")
+    .replace(/\bpublic-side\b/gi, "approved public context")
+    .replace(/\bReview candidate\b/g, "Review item")
+    .replace(/\bcandidate\b/gi, "lead")
+    .replace(/\bidentity matching context\b/gi, "identity review context")
+    .replace(/\blocal context\b/gi, "BNL review context")
+    .replace(/\bprofile_match\b/gi, "local profile match");
+}
+
 function safeReviewItems(items: Array<string | undefined | null>, limit = 6) {
   const output: string[] = [];
   const seenKeys = new Set<string>();
   for (const item of items) {
-    const clean = item?.replace(/\s+/g, " ").trim();
+    const clean = displaySafeText(item);
     if (!clean) continue;
-    if (containsDossierBackendJunk(clean) || isRawSourceMemoryDebugText(clean)) {
-      continue;
-    }
     const key = duplicateMeaningKey(clean);
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);
@@ -94,12 +118,59 @@ function fallbackItems(items: string[], empty: string) {
 function queueStatusItems(status?: string, note?: string) {
   const items: string[] = [];
   if (status === "not_connected") {
-    items.push("Queue/submission identity is not connected yet.");
+    items.push("Queue/submission history is not connected yet.");
   } else if (status) {
     items.push(`Queue/submission status: ${status.replace(/_/g, " ")}.`);
   }
   if (note) items.push(note);
   return safeReviewItems(items, 3);
+}
+
+function evidenceDepthLabel(level: DossierSourceFileSummary["substanceLevel"]) {
+  return { thin: "Thin", partial: "Partial", useful: "Useful", strong: "Strong" }[level];
+}
+
+function readinessLabel(readiness: DossierSourceFileSummary["publicReadiness"]) {
+  return {
+    not_ready: "Not Ready",
+    needs_review: "Needs Review",
+    draftable: "Draftable",
+    owner_approved: "Owner Approved",
+  }[readiness];
+}
+
+function identityCertaintyLabel(summary: DossierSourceFileSummary) {
+  if (summary.existingPublicDossier === "linked_update_target") return "Confirmed";
+  if (summary.existingPublicDossier === "yes") return "Needs Review";
+  return "Unconfirmed";
+}
+
+function sourceConfidenceLabel(value?: string) {
+  const values = (value ?? "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+  if (!values.length) return "Mixed / review required";
+  const uniqueValues = Array.from(new Set(values));
+  if (uniqueValues.length !== 1) return "Mixed / review required";
+  if (uniqueValues[0] === "low") return "Low";
+  if (uniqueValues[0] === "medium") return "Medium";
+  if (uniqueValues[0] === "high") return "High";
+  return "Mixed / review required";
+}
+
+function missingChecklist(items: string[]) {
+  return safeReviewItems(
+    [
+      ...items,
+      "Confirm public-safe display name.",
+      "Confirm public role/description.",
+      "Add public links.",
+      "Connect queue/submission identity when that bridge exists.",
+      "Confirm whether this subject should have a public dossier at all.",
+    ],
+    8,
+  );
 }
 
 export function DossierSourceFileSummaryPanel({
@@ -191,6 +262,30 @@ export function DossierSourceFileSummaryPanel({
     ...(entityReadout?.evidenceDetails ?? []),
     ...summary.evidenceDetails,
   ]);
+  const representativeEvidence = safeReviewItems([
+    ...(entityReadout?.representativeEvidence ?? []),
+    ...(summary.representativeEvidence ?? []),
+  ], 8);
+  const activityFrequencySummary = safeReviewItems([
+    ...(entityReadout?.activityFrequencySummary ?? []),
+    ...(summary.activityFrequencySummary ?? []),
+  ], 4);
+  const topChannels = safeReviewItems([
+    ...(entityReadout?.topChannels ?? []),
+    ...(summary.topChannels ?? []),
+  ]);
+  const topTopicDetails = safeReviewItems([
+    ...(entityReadout?.topTopicDetails ?? []),
+    ...(summary.topTopicDetails ?? []),
+  ]);
+  const recentActivitySummary = safeReviewItems([
+    ...(entityReadout?.recentActivitySummary ?? []),
+    ...(summary.recentActivitySummary ?? []),
+  ], 4);
+  const authoredVsMentionedSummary = safeReviewItems([
+    ...(entityReadout?.authoredVsMentionedSummary ?? []),
+    ...(summary.authoredVsMentionedSummary ?? []),
+  ], 4);
   const topicBreakdown = safeReviewItems([
     ...(entityReadout?.topicBreakdown ?? []),
     ...summary.topicBreakdown,
@@ -203,17 +298,61 @@ export function DossierSourceFileSummaryPanel({
     ...(entityReadout?.sourceAuthority ?? []),
     ...summary.sourceAuthority,
   ]);
-  const displayClaimedNeedsReview = safeReviewItems(
-    summary.claimedNeedsReview.filter(
-      (item) =>
-        ![...knownContext, ...relationshipContext].some(
-          (displayedItem) =>
-            duplicateMeaningKey(displayedItem) === duplicateMeaningKey(item),
-        ),
-    ),
-  );
   const recommendedAction =
     entityReadout?.recommendedAction ?? summary.recommendedNextAction;
+  const evidenceStatus = [
+    `Evidence depth: ${evidenceDepthLabel(summary.substanceLevel)}.`,
+    `Public readiness: ${readinessLabel(summary.publicReadiness)}.`,
+    `Identity certainty: ${identityCertaintyLabel(summary)}.`,
+    `Source confidence: ${sourceConfidenceLabel(entityReadout?.confidence)}.`,
+  ];
+  const adminCaseSummary = safeReviewItems([
+    `Identity status: ${identityCertaintyLabel(summary)}; display name and role still need owner/admin confirmation before public use.`,
+    observedChannels[0] || topChannels[0] || "Approved public/community activity may exist, but it still needs review.",
+    topicBreakdown[0] || topTopicDetails[0] || "Main discussion areas are based on approved evidence labels, not full conversation review.",
+    "Review-only cautions must stay internal unless owner/admin review approves them.",
+    queueItems[0] ?? "Queue/submission history is not connected yet.",
+  ], 5);
+  const whatBnlFound = safeReviewItems([
+    `Identity: ${knownContext[0] ?? "public display name and role still need owner/admin review."}`,
+    observedChannels.length || topChannels.length
+      ? `Public activity: ${[...topChannels, ...observedChannels].slice(0, 2).join("; ")}.`
+      : "Public activity: no approved public activity detail has been summarized yet.",
+    topicBreakdown.length || topTopicDetails.length
+      ? `Main discussion areas: ${[...topTopicDetails, ...topicBreakdown].slice(0, 3).join("; ")}.`
+      : "Main discussion areas: topic detail is based on approved public-side evidence labels, not full conversation review.",
+    bestEvidenceToReview.length ? `Strong lead: ${bestEvidenceToReview[0]}` : undefined,
+    representativeEvidence.length ? `Representative activity: ${representativeEvidence[0]}` : undefined,
+    reviewOnlyEvidence.length || relationshipContext.length
+      ? "Review-only context exists, but it cannot become public copy without owner/admin review."
+      : undefined,
+  ], 6);
+  const activityDetails = safeReviewItems([
+    ...topChannels.map((item) => `Channel activity: ${item}`),
+    ...topTopicDetails.map((item) => `Topic detail: ${item}`),
+    ...activityFrequencySummary.map((item) => `Frequency: ${item}`),
+    ...recentActivitySummary.map((item) => `Recency: ${item}`),
+    ...authoredVsMentionedSummary.map((item) => `Posted/mentioned balance: ${item}`),
+    ...representativeEvidence.map((item) => `Example lead: ${item}`),
+    ...conversationHighlights.map((item) => `Public activity note: ${item}`),
+    ...musicSignals.map((item) => `Music/show note: ${item}`),
+    ...communitySignals.map((item) => `Community note: ${item}`),
+    ...bnlInteractionSignals.map((item) => `BNL handling note: ${item}`),
+  ], 10);
+  const reviewCautions = safeReviewItems([
+    ...reviewOnlyEvidence,
+    ...relationshipContext,
+    ...privateOnlyNotes,
+    ...notPublicYet,
+    "Reception and co-participant analysis is not available yet.",
+  ], 8);
+  const evidenceLog = safeReviewItems([
+    ...sourceCoverage,
+    ...evidenceDetails,
+    ...usefulEvidence,
+    ...summary.patterns,
+    ...summary.confirmedStrong,
+  ], 10);
 
   return (
     <section className="border border-accent/70 bg-surface p-5 space-y-4">
@@ -242,9 +381,7 @@ export function DossierSourceFileSummaryPanel({
           <StatusBadge>
             Next action: {formatDossierSummaryBadge(summary.nextAction)}
           </StatusBadge>
-          {entityReadout?.confidence && (
-            <StatusBadge>Confidence: {entityReadout.confidence}</StatusBadge>
-          )}
+          <StatusBadge>Source confidence: {sourceConfidenceLabel(entityReadout?.confidence)}</StatusBadge>
           <StatusBadge>Review-only</StatusBadge>
           <StatusBadge>
             Source:{" "}
@@ -253,90 +390,51 @@ export function DossierSourceFileSummaryPanel({
               : "Safe fallback"}
           </StatusBadge>
           <StatusBadge>
-            {queueItems[0] ?? "Queue/submission not connected"}
+            {queueItems[0] ?? "Queue/submission history is not connected yet"}
           </StatusBadge>
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 text-sm text-muted">
-        <Section title="Current Read / Why This File Exists">
-          <p>{currentRead}</p>
-        </Section>
-        <Section title="Known Context — What BNL Actually Knows">
+        <Section
+          title="Current Read"
+          helper="Why this source file exists, what BNL sees now, and whether public use is safe yet."
+        >
           <SummaryList
-            items={fallbackItems(knownContext, "No public-safe facts confirmed yet.")}
+            items={[
+              summary.whyTracked,
+              currentRead,
+              `${readinessLabel(summary.publicReadiness)} for public use; owner/admin review is still required before public copy changes.`,
+            ]}
           />
         </Section>
-        {bestEvidenceToReview.length > 0 && (
-          <Section title="Best Evidence to Review">
-            <SummaryList items={bestEvidenceToReview} />
-          </Section>
-        )}
-        <Section title="Useful Evidence">
+        <Section
+          title="Admin Case Summary"
+          helper="Short grouped readout for admin triage. These are review notes, not public dossier text."
+        >
+          <SummaryList items={adminCaseSummary} />
+        </Section>
+        <Section
+          title="What BNL Found"
+          helper="Human-readable leads synthesized from structured evidence. Raw evidence rows stay out of this summary."
+        >
+          <SummaryList items={whatBnlFound} />
+        </Section>
+        <Section
+          title="Activity Details"
+          helper="Readable activity, channel, topic, frequency, and recency notes from the structured BNL evidence packet."
+        >
           <SummaryList
             items={fallbackItems(
-              usefulEvidence,
-              "No useful evidence has been attached to this entity readout yet.",
+              activityDetails,
+              "No structured activity details have been supplied yet.",
             )}
           />
         </Section>
-        {observedChannels.length > 0 && (
-          <Section title="Observed Channels / Activity">
-            <SummaryList items={observedChannels} />
-          </Section>
-        )}
-        {conversationHighlights.length > 0 && (
-          <Section title="Conversation Highlights">
-            <SummaryList items={conversationHighlights} />
-          </Section>
-        )}
-        {musicSignals.length > 0 && (
-          <Section title="Music / Show Signals">
-            <SummaryList items={musicSignals} />
-          </Section>
-        )}
-        {communitySignals.length > 0 && (
-          <Section title="Community Signals">
-            <SummaryList items={communitySignals} />
-          </Section>
-        )}
-        {bnlInteractionSignals.length > 0 && (
-          <Section title="BNL Interaction Signals" tone="review">
-            <SummaryList items={bnlInteractionSignals} />
-          </Section>
-        )}
-        {topicBreakdown.length > 0 && (
-          <Section title="Topic Breakdown">
-            <SummaryList items={topicBreakdown} />
-          </Section>
-        )}
-        {evidenceDetails.length > 0 && (
-          <Section title="Evidence Details">
-            <SummaryList items={evidenceDetails} />
-          </Section>
-        )}
-        <Section title="Pattern BNL Noticed / Patterns / Themes">
-          <SummaryList items={summary.patterns} />
-        </Section>
-        <Section title="Confirmed / Strong">
-          <SummaryList items={summary.confirmedStrong} />
-        </Section>
-        <Section title="Claimed / Needs Review">
-          <SummaryList
-            items={fallbackItems(
-              displayClaimedNeedsReview,
-              "No additional human-readable claims are awaiting review.",
-            )}
-          />
-        </Section>
-        <Section title="Relationship Context — Review Only" tone="review">
-          <SummaryList
-            items={fallbackItems(
-              relationshipContext,
-              "No private relationship/context signals are recorded in the structured readout.",
-            )}
-          />
-        </Section>
-        <Section title="Public-Safe / Public-Use Candidates Pending Owner Review" tone="review">
+        <Section
+          title="Dossier Use / Public-Safe Possibilities"
+          tone="review"
+          helper="What may become useful later. Public wording remains owner-review gated."
+        >
           <SummaryList
             items={fallbackItems(
               safeReviewItems([...publicSafePossibilities, ...publicUseCandidates]),
@@ -344,57 +442,31 @@ export function DossierSourceFileSummaryPanel({
             )}
           />
         </Section>
-        {reviewOnlyEvidence.length > 0 && (
-          <Section title="Review-Only Evidence" tone="review">
-            <SummaryList items={reviewOnlyEvidence} />
-          </Section>
-        )}
-        <Section title="Private/Internal Notes" tone="review">
-          <SummaryList
-            items={fallbackItems(
-              privateOnlyNotes,
-              "No private/internal notes are recorded in the structured readout.",
-            )}
-          />
+        <Section
+          title="Missing Before Public Dossier"
+          tone="caution"
+          helper="What still needs to be confirmed before this can become a clean public dossier."
+        >
+          <SummaryList items={missingChecklist(missingInfo)} />
         </Section>
-        <Section title="Not Public Yet" tone="caution">
-          <SummaryList
-            items={fallbackItems(
-              notPublicYet,
-              "Do not say more publicly until owner/admin review confirms it.",
-            )}
-          />
+        <Section
+          title="Review-Only Cautions"
+          tone="review"
+          helper="Internal, private, source-blind, or unconfirmed context. Do not use publicly unless owner/admin review approves it."
+        >
+          <SummaryList items={fallbackItems(reviewCautions, "No review-only cautions are recorded in the structured readout.")} />
         </Section>
-        {sourceCoverage.length > 0 && (
-          <Section title="Source Coverage">
-            <SummaryList items={sourceCoverage} />
-          </Section>
-        )}
-        <Section title="Missing Info / Open Questions">
-          <SummaryList
-            items={fallbackItems(
-              missingInfo,
-              "Needs more history, repeated appearances, public-safe facts, and owner/admin context.",
-            )}
-          />
+        <Section
+          title="Evidence Log"
+          helper="Historical notes and BNL enrichment records. These support review, but they are not public copy."
+        >
+          <SummaryList items={fallbackItems(evidenceLog, "No lower-priority evidence log entries have been attached yet.")} />
         </Section>
-        {queueItems.length > 0 && (
-          <Section title="Queue / Submission Status" tone="review">
-            <SummaryList items={queueItems} />
-          </Section>
-        )}
-        <Section title="Source Authority / Confidence">
-          <SummaryList
-            items={fallbackItems(
-              sourceAuthority,
-              "Source authority has not been separated from confidence yet.",
-            )}
-          />
-          {entityReadout?.confidence && (
-            <p className="mt-2 text-xs uppercase tracking-widest text-accent">
-              Confidence: {entityReadout.confidence}
-            </p>
-          )}
+        <Section
+          title="Evidence Status"
+          helper="Admin-friendly status labels derived from the available evidence and source confidence."
+        >
+          <SummaryList items={[...evidenceStatus, ...sourceAuthority]} />
         </Section>
         <Section title="Recommended Next Action">
           <p>{recommendedAction}</p>

--- a/src/lib/dossier-entity-activity-readout.ts
+++ b/src/lib/dossier-entity-activity-readout.ts
@@ -19,6 +19,12 @@ export type DossierEntityActivityReadout = {
   communitySignals: string[];
   sourceCoverage: string[];
   evidenceDetails: string[];
+  representativeEvidence: string[];
+  activityFrequencySummary: string[];
+  topChannels: string[];
+  topTopicDetails: string[];
+  recentActivitySummary: string[];
+  authoredVsMentionedSummary: string[];
   publicUseCandidates: string[];
   reviewOnlyEvidence: string[];
   queueSubmissionStatus?: string;
@@ -48,6 +54,12 @@ type ReadoutRecommendation = Pick<
   | "communitySignals"
   | "sourceCoverage"
   | "evidenceDetails"
+  | "representativeEvidence"
+  | "activityFrequencySummary"
+  | "topChannels"
+  | "topTopicDetails"
+  | "recentActivitySummary"
+  | "authoredVsMentionedSummary"
   | "publicUseCandidates"
   | "reviewOnlyEvidence"
   | "queueSubmissionStatus"
@@ -104,6 +116,12 @@ function recommendationHasStructuredReadout(
       recommendation.communitySignals?.length ||
       recommendation.sourceCoverage?.length ||
       recommendation.evidenceDetails?.length ||
+      recommendation.representativeEvidence?.length ||
+      recommendation.activityFrequencySummary?.length ||
+      recommendation.topChannels?.length ||
+      recommendation.topTopicDetails?.length ||
+      recommendation.recentActivitySummary?.length ||
+      recommendation.authoredVsMentionedSummary?.length ||
       recommendation.publicUseCandidates?.length ||
       recommendation.reviewOnlyEvidence?.length ||
       recommendation.queueSubmissionStatus ||
@@ -200,6 +218,40 @@ function structuredReadoutFromRecommendations(
       (recommendation) => recommendation.evidenceDetails ?? [],
     ),
   );
+  const representativeEvidence = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.representativeEvidence ?? [],
+    ),
+    8,
+  );
+  const activityFrequencySummary = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.activityFrequencySummary ?? [],
+    ),
+    4,
+  );
+  const topChannels = cleanItems(
+    structuredRecommendations.flatMap((recommendation) => recommendation.topChannels ?? []),
+    6,
+  );
+  const topTopicDetails = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.topTopicDetails ?? [],
+    ),
+    6,
+  );
+  const recentActivitySummary = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.recentActivitySummary ?? [],
+    ),
+    4,
+  );
+  const authoredVsMentionedSummary = cleanItems(
+    structuredRecommendations.flatMap(
+      (recommendation) => recommendation.authoredVsMentionedSummary ?? [],
+    ),
+    4,
+  );
   const publicUseCandidates = cleanItems(
     structuredRecommendations.flatMap(
       (recommendation) => recommendation.publicUseCandidates ?? [],
@@ -258,6 +310,12 @@ function structuredReadoutFromRecommendations(
     communitySignals,
     sourceCoverage,
     evidenceDetails,
+    representativeEvidence,
+    activityFrequencySummary,
+    topChannels,
+    topTopicDetails,
+    recentActivitySummary,
+    authoredVsMentionedSummary,
     publicUseCandidates,
     reviewOnlyEvidence,
     queueSubmissionStatus: queueRecommendation?.queueSubmissionStatus,
@@ -304,6 +362,12 @@ export function createDossierEntityActivityReadoutFromSourceFile({
     communitySignals: cleanItems(summary?.communitySignals ?? []),
     sourceCoverage: cleanItems(summary?.sourceCoverage ?? []),
     evidenceDetails: cleanItems(summary?.evidenceDetails ?? []),
+    representativeEvidence: cleanItems(summary?.representativeEvidence ?? [], 8),
+    activityFrequencySummary: cleanItems(summary?.activityFrequencySummary ?? [], 4),
+    topChannels: cleanItems(summary?.topChannels ?? [], 6),
+    topTopicDetails: cleanItems(summary?.topTopicDetails ?? [], 6),
+    recentActivitySummary: cleanItems(summary?.recentActivitySummary ?? [], 4),
+    authoredVsMentionedSummary: cleanItems(summary?.authoredVsMentionedSummary ?? [], 4),
     publicUseCandidates: cleanItems(summary?.publicUseCandidates ?? []),
     reviewOnlyEvidence: cleanItems(summary?.reviewOnlyEvidence ?? []),
     queueSubmissionStatus: summary?.queueSubmissionStatus,
@@ -339,6 +403,12 @@ export function createDossierEntityActivityReadoutFromRecommendation(
       communitySignals: [],
       sourceCoverage: [],
       evidenceDetails: [],
+      representativeEvidence: [],
+      activityFrequencySummary: [],
+      topChannels: [],
+      topTopicDetails: [],
+      recentActivitySummary: [],
+      authoredVsMentionedSummary: [],
       publicUseCandidates: [],
       reviewOnlyEvidence: [],
       missingInfo: [],

--- a/src/lib/dossier-note-display.ts
+++ b/src/lib/dossier-note-display.ts
@@ -63,6 +63,12 @@ type NoteLike = Pick<
   communitySignals?: string[];
   sourceCoverage?: string[];
   evidenceDetails?: string[];
+  representativeEvidence?: string[];
+  activityFrequencySummary?: string[];
+  topChannels?: string[];
+  topTopicDetails?: string[];
+  recentActivitySummary?: string[];
+  authoredVsMentionedSummary?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];
   queueSubmissionStatus?: string;
@@ -545,15 +551,15 @@ export function createHumanReadableSourceFileNoteView(
       subjectOptions,
     );
   for (const item of note.privateOnlyNotes ?? [])
-    addItem(sections, "Private/Internal Notes", item, subjectOptions);
+    addItem(sections, "Review-Only Cautions", item, subjectOptions);
   for (const item of note.notPublicYet ?? [])
     addShortWarning(sections, item, subjectOptions);
   for (const item of note.bestEvidenceToReview ?? [])
-    addItem(sections, "Best Evidence to Review", item, subjectOptions);
+    addItem(sections, "What BNL Found", item, subjectOptions);
   for (const item of note.observedChannels ?? [])
     addItem(sections, "Observed Channels / Activity", item, subjectOptions);
   for (const item of note.conversationHighlights ?? [])
-    addItem(sections, "Conversation Highlights", item, subjectOptions);
+    addItem(sections, "Public Activity Notes", item, subjectOptions);
   for (const item of note.musicSignals ?? [])
     addItem(sections, "Music / Show Signals", item, subjectOptions);
   for (const item of note.communitySignals ?? [])
@@ -561,9 +567,21 @@ export function createHumanReadableSourceFileNoteView(
   for (const item of note.bnlInteractionSignals ?? [])
     addItem(sections, "BNL Interaction Signals", item, subjectOptions);
   for (const item of note.topicBreakdown ?? [])
-    addItem(sections, "Topic Breakdown", item, subjectOptions);
+    addItem(sections, "Main Discussion Areas", item, subjectOptions);
   for (const item of note.evidenceDetails ?? [])
-    addItem(sections, "Evidence Details", item, subjectOptions);
+    addItem(sections, "Evidence Log", item, subjectOptions);
+  for (const item of note.representativeEvidence ?? [])
+    addItem(sections, "Representative Activity Details", item, subjectOptions);
+  for (const item of note.activityFrequencySummary ?? [])
+    addItem(sections, "Activity Frequency", item, subjectOptions);
+  for (const item of note.topChannels ?? [])
+    addItem(sections, "Top Channels", item, subjectOptions);
+  for (const item of note.topTopicDetails ?? [])
+    addItem(sections, "Main Discussion Areas", item, subjectOptions);
+  for (const item of note.recentActivitySummary ?? [])
+    addItem(sections, "Recent Activity", item, subjectOptions);
+  for (const item of note.authoredVsMentionedSummary ?? [])
+    addItem(sections, "Posted / Mentioned Balance", item, subjectOptions);
   for (const item of note.publicUseCandidates ?? [])
     addItem(
       sections,
@@ -572,7 +590,7 @@ export function createHumanReadableSourceFileNoteView(
       subjectOptions,
     );
   for (const item of note.reviewOnlyEvidence ?? [])
-    addItem(sections, "Review-Only Evidence", item, subjectOptions);
+    addItem(sections, "Review-Only Cautions", item, subjectOptions);
   for (const item of note.sourceCoverage ?? [])
     addItem(sections, "Source Coverage", item, subjectOptions);
   if (note.queueSubmissionStatus === "not_connected") {
@@ -593,7 +611,7 @@ export function createHumanReadableSourceFileNoteView(
   addItem(sections, "Queue / Submission Status", note.queueSubmissionNote, subjectOptions);
   addItem(sections, "Recommended Next Step", note.recommendedAction, subjectOptions);
   for (const item of note.sourceAuthority ?? [])
-    addItem(sections, "Source Authority / Confidence", item, subjectOptions);
+    addItem(sections, "Evidence Status", item, subjectOptions);
   addPattern(sections, note.reason, subjectOptions);
   if ((note.usefulEvidence ?? []).length === 0) {
     addItem(sections, "Useful Evidence", note.evidenceSummary, subjectOptions);
@@ -723,6 +741,24 @@ export function createHumanReadableRecommendationView(
       (recommendation.bnlInteractionSignals ?? [])
         .map((item) => `BNL interaction signal: ${item}`)
         .join("\n"),
+      (recommendation.representativeEvidence ?? [])
+        .map((item) => `Representative evidence: ${item}`)
+        .join("\n"),
+      (recommendation.activityFrequencySummary ?? [])
+        .map((item) => `Activity frequency: ${item}`)
+        .join("\n"),
+      (recommendation.topChannels ?? [])
+        .map((item) => `Top channel: ${item}`)
+        .join("\n"),
+      (recommendation.topTopicDetails ?? [])
+        .map((item) => `Main topic detail: ${item}`)
+        .join("\n"),
+      (recommendation.recentActivitySummary ?? [])
+        .map((item) => `Recent activity: ${item}`)
+        .join("\n"),
+      (recommendation.authoredVsMentionedSummary ?? [])
+        .map((item) => `Posted/mentioned balance: ${item}`)
+        .join("\n"),
       (recommendation.publicUseCandidates ?? [])
         .map((item) => `Public-use candidate pending owner review: ${item}`)
         .join("\n"),
@@ -773,6 +809,12 @@ export function createHumanReadableRecommendationView(
     communitySignals: recommendation.communitySignals,
     sourceCoverage: recommendation.sourceCoverage,
     evidenceDetails: recommendation.evidenceDetails,
+    representativeEvidence: recommendation.representativeEvidence,
+    activityFrequencySummary: recommendation.activityFrequencySummary,
+    topChannels: recommendation.topChannels,
+    topTopicDetails: recommendation.topTopicDetails,
+    recentActivitySummary: recommendation.recentActivitySummary,
+    authoredVsMentionedSummary: recommendation.authoredVsMentionedSummary,
     publicUseCandidates: recommendation.publicUseCandidates,
     reviewOnlyEvidence: recommendation.reviewOnlyEvidence,
     queueSubmissionStatus: recommendation.queueSubmissionStatus,

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -58,6 +58,12 @@ export type DossierSourceFileSummary = {
   communitySignals: string[];
   sourceCoverage: string[];
   evidenceDetails: string[];
+  representativeEvidence: string[];
+  activityFrequencySummary: string[];
+  topChannels: string[];
+  topTopicDetails: string[];
+  recentActivitySummary: string[];
+  authoredVsMentionedSummary: string[];
   publicUseCandidates: string[];
   reviewOnlyEvidence: string[];
   queueSubmissionStatus?: string;
@@ -348,6 +354,30 @@ export function createDossierSourceFileSummary(
     recommendations.flatMap((recommendation) => recommendation.evidenceDetails ?? []),
     6,
   );
+  const structuredRepresentativeEvidence = unique(
+    recommendations.flatMap((recommendation) => recommendation.representativeEvidence ?? []),
+    8,
+  );
+  const structuredActivityFrequencySummary = unique(
+    recommendations.flatMap((recommendation) => recommendation.activityFrequencySummary ?? []),
+    4,
+  );
+  const structuredTopChannels = unique(
+    recommendations.flatMap((recommendation) => recommendation.topChannels ?? []),
+    6,
+  );
+  const structuredTopTopicDetails = unique(
+    recommendations.flatMap((recommendation) => recommendation.topTopicDetails ?? []),
+    6,
+  );
+  const structuredRecentActivitySummary = unique(
+    recommendations.flatMap((recommendation) => recommendation.recentActivitySummary ?? []),
+    4,
+  );
+  const structuredAuthoredVsMentionedSummary = unique(
+    recommendations.flatMap((recommendation) => recommendation.authoredVsMentionedSummary ?? []),
+    4,
+  );
   const structuredPublicUseCandidates = unique(
     recommendations.flatMap(
       (recommendation) => recommendation.publicUseCandidates ?? [],
@@ -372,7 +402,7 @@ export function createDossierSourceFileSummary(
     recommendations.flatMap((recommendation) => [
       ...(recommendation.sourceAuthority ?? []),
       recommendation.confidence
-        ? `Confidence: ${recommendation.confidence}. Review source boundaries before public use.`
+        ? `Source confidence: ${recommendation.confidence}. Review source boundaries before public use.`
         : undefined,
     ]),
     5,
@@ -568,6 +598,12 @@ export function createDossierSourceFileSummary(
     communitySignals: structuredCommunitySignals,
     sourceCoverage: structuredSourceCoverage,
     evidenceDetails: structuredEvidenceDetails,
+    representativeEvidence: structuredRepresentativeEvidence,
+    activityFrequencySummary: structuredActivityFrequencySummary,
+    topChannels: structuredTopChannels,
+    topTopicDetails: structuredTopTopicDetails,
+    recentActivitySummary: structuredRecentActivitySummary,
+    authoredVsMentionedSummary: structuredAuthoredVsMentionedSummary,
     publicUseCandidates: structuredPublicUseCandidates,
     reviewOnlyEvidence: structuredReviewOnlyEvidence,
     queueSubmissionStatus: queueRecommendation?.queueSubmissionStatus,

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -757,6 +757,80 @@ function normalizeSourceCoverageInput(value: unknown): string[] | undefined {
   return items.length ? items : undefined;
 }
 
+
+function normalizeEvidenceReadoutItem(value: unknown): string | undefined {
+  if (typeof value === "string") return boundedText(value, 1000) || undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const item = value as Record<string, unknown>;
+  const allowed = new Set([
+    "summary",
+    "label",
+    "detail",
+    "topic",
+    "channel",
+    "channels",
+    "context",
+    "status",
+    "kind",
+    "type",
+    "activityType",
+    "relationship",
+    "visibility",
+    "window",
+    "recency",
+    "frequency",
+    "count",
+    "counts",
+    "postedCount",
+    "mentionedCount",
+    "publicCount",
+    "recentCount",
+    "firstSeen",
+    "lastSeen",
+  ]);
+  for (const key of Object.keys(item)) {
+    if (!allowed.has(key)) return undefined;
+  }
+  const textParts = [
+    boundedText(item.summary, 500) || boundedText(item.detail, 500) || boundedText(item.label, 500),
+    (boundedText(item.activityType, 80) || boundedText(item.type, 80) || boundedText(item.kind, 80))?.replace(/^authored$/i, "posted"),
+    boundedText(item.topic, 120) ? `about ${normalizeCoverageLabel(String(item.topic))}` : undefined,
+    boundedText(item.channel, 120) ? `in ${String(item.channel).startsWith("#") ? String(item.channel) : `#${normalizeCoverageLabel(String(item.channel))}`}` : undefined,
+    boundedText(item.context, 180) ? normalizeCoverageLabel(String(item.context)) : undefined,
+    boundedText(item.frequency, 160) || boundedText(item.recency, 160) || boundedText(item.window, 160),
+    boundedText(item.status, 80) || boundedText(item.visibility, 80),
+  ];
+  const countParts: string[] = [];
+  for (const [label, raw] of [
+    ["items", item.count],
+    ["posted items", item.postedCount],
+    ["mentions", item.mentionedCount],
+    ["approved public items", item.publicCount],
+    ["recent items", item.recentCount],
+  ] as const) {
+    const count = normalizeCoverageNumber(raw);
+    if (count !== undefined) countParts.push(`${count} ${label}`);
+  }
+  if (item.counts && typeof item.counts === "object" && !Array.isArray(item.counts)) {
+    for (const [key, rawCount] of Object.entries(item.counts).slice(0, 12)) {
+      const count = normalizeCoverageNumber(rawCount);
+      const cleanKey = boundedText(key, 80);
+      if (cleanKey && count !== undefined) countParts.push(`${normalizeCoverageLabel(cleanKey)} ${count}`);
+    }
+  }
+  if (countParts.length) textParts.push(countParts.join(", "));
+  return boundedText(textParts.filter(Boolean).join(" — "), 1000) || undefined;
+}
+
+function normalizeEvidenceReadoutArray(value: unknown): string[] | undefined {
+  const rawItems = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const items = rawItems
+    .slice(0, 25)
+    .map(normalizeEvidenceReadoutItem)
+    .filter((item): item is string => Boolean(item));
+  return items.length ? items : undefined;
+}
+
 function cloneJsonValue(value: unknown): unknown {
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value));
@@ -825,6 +899,12 @@ function normalizeRecommendationInput(
     communitySignals: normalizePacketStringArray(input.communitySignals),
     sourceCoverage: normalizeSourceCoverageInput(input.sourceCoverage),
     evidenceDetails: normalizePacketStringArray(input.evidenceDetails),
+    representativeEvidence: normalizeEvidenceReadoutArray(input.representativeEvidence),
+    activityFrequencySummary: normalizeEvidenceReadoutArray(input.activityFrequencySummary),
+    topChannels: normalizeEvidenceReadoutArray(input.topChannels),
+    topTopicDetails: normalizeEvidenceReadoutArray(input.topTopicDetails),
+    recentActivitySummary: normalizeEvidenceReadoutArray(input.recentActivitySummary),
+    authoredVsMentionedSummary: normalizeEvidenceReadoutArray(input.authoredVsMentionedSummary),
     publicUseCandidates: normalizePacketStringArray(input.publicUseCandidates),
     reviewOnlyEvidence: normalizePacketStringArray(input.reviewOnlyEvidence),
     queueSubmissionStatus: input.queueSubmissionStatus,
@@ -1517,6 +1597,12 @@ function recommendationSourceNoteText(
     ...packetLines("Community signal", recommendation.communitySignals),
     ...packetLines("Source coverage", recommendation.sourceCoverage),
     ...packetLines("Evidence detail", recommendation.evidenceDetails),
+    ...packetLines("Representative evidence", recommendation.representativeEvidence),
+    ...packetLines("Activity frequency", recommendation.activityFrequencySummary),
+    ...packetLines("Top channel", recommendation.topChannels),
+    ...packetLines("Main topic detail", recommendation.topTopicDetails),
+    ...packetLines("Recent activity", recommendation.recentActivitySummary),
+    ...packetLines("Posted/mentioned balance", recommendation.authoredVsMentionedSummary),
     ...packetLines("Public-use candidate pending owner review", recommendation.publicUseCandidates),
     ...packetLines("Review-only evidence", recommendation.reviewOnlyEvidence),
     recommendation.queueSubmissionStatus

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -758,6 +758,26 @@ function normalizeSourceCoverageInput(value: unknown): string[] | undefined {
 }
 
 
+
+function evidenceLooksLikeClassification(value?: string) {
+  return /\b(?:automated topic|topic label|classified|classification|evidence categor(?:y|ies)|topic breakdown|topic detail|source-file|dossier|BNL\/source-file|BNL source-file|BNL\/source file|source file\/dossier)\b/i.test(value ?? "");
+}
+
+function evidenceClassificationCopy(value?: string) {
+  const clean = boundedText(value, 240)
+    ?.replace(/\bauthored\b/gi, "")
+    .replace(/\bposted\b/gi, "")
+    .replace(/\bCrow\s+(?:discussed|posted about|talked about|authored)\b/gi, "")
+    .replace(/\bdiscussed\b/gi, "related to")
+    .replace(/\bhandling\b/gi, "context")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[-:;,\s]+|[-:;,\s]+$/g, "");
+  if (!clean) return undefined;
+  if (/\bclassified\b/i.test(clean) || /\bautomated topic/i.test(clean)) return clean;
+  return `Automated topic label: ${clean}. Needs human review before this becomes a subject claim.`;
+}
+
 function normalizeEvidenceReadoutItem(value: unknown): string | undefined {
   if (typeof value === "string") return boundedText(value, 1000) || undefined;
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
@@ -791,10 +811,16 @@ function normalizeEvidenceReadoutItem(value: unknown): string | undefined {
   for (const key of Object.keys(item)) {
     if (!allowed.has(key)) return undefined;
   }
+  const summary = boundedText(item.summary, 500) || boundedText(item.detail, 500) || boundedText(item.label, 500);
+  const topic = boundedText(item.topic, 120);
+  const classificationCopy = evidenceLooksLikeClassification(topic) || evidenceLooksLikeClassification(summary)
+    ? evidenceClassificationCopy(summary) ?? evidenceClassificationCopy(topic)
+    : undefined;
+  const activityType = boundedText(item.activityType, 80) || boundedText(item.type, 80) || boundedText(item.kind, 80);
   const textParts = [
-    boundedText(item.summary, 500) || boundedText(item.detail, 500) || boundedText(item.label, 500),
-    (boundedText(item.activityType, 80) || boundedText(item.type, 80) || boundedText(item.kind, 80))?.replace(/^authored$/i, "posted"),
-    boundedText(item.topic, 120) ? `about ${normalizeCoverageLabel(String(item.topic))}` : undefined,
+    classificationCopy ?? summary,
+    classificationCopy ? undefined : activityType?.replace(/^authored$/i, "posted"),
+    topic ? (classificationCopy ? `automated topic label ${normalizeCoverageLabel(topic)}` : `about ${normalizeCoverageLabel(topic)}`) : undefined,
     boundedText(item.channel, 120) ? `in ${String(item.channel).startsWith("#") ? String(item.channel) : `#${normalizeCoverageLabel(String(item.channel))}`}` : undefined,
     boundedText(item.context, 180) ? normalizeCoverageLabel(String(item.context)) : undefined,
     boundedText(item.frequency, 160) || boundedText(item.recency, 160) || boundedText(item.window, 160),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -407,6 +407,12 @@ export type DossierStructuredSourcePacket = {
   communitySignals?: string[];
   sourceCoverage?: DossierSourceCoverageInput;
   evidenceDetails?: string[];
+  representativeEvidence?: string[];
+  activityFrequencySummary?: string[];
+  topChannels?: string[];
+  topTopicDetails?: string[];
+  recentActivitySummary?: string[];
+  authoredVsMentionedSummary?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];
   queueSubmissionStatus?: DossierQueueSubmissionStatus;
@@ -445,6 +451,12 @@ export type DossierRecommendation = {
   communitySignals?: string[];
   sourceCoverage?: string[];
   evidenceDetails?: string[];
+  representativeEvidence?: string[];
+  activityFrequencySummary?: string[];
+  topChannels?: string[];
+  topTopicDetails?: string[];
+  recentActivitySummary?: string[];
+  authoredVsMentionedSummary?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];
   queueSubmissionStatus?: DossierQueueSubmissionStatus;
@@ -809,6 +821,12 @@ export type CreateDossierRecommendationInput = {
   communitySignals?: string[];
   sourceCoverage?: DossierSourceCoverageInput;
   evidenceDetails?: string[];
+  representativeEvidence?: string[];
+  activityFrequencySummary?: string[];
+  topChannels?: string[];
+  topTopicDetails?: string[];
+  recentActivitySummary?: string[];
+  authoredVsMentionedSummary?: string[];
   publicUseCandidates?: string[];
   reviewOnlyEvidence?: string[];
   queueSubmissionStatus?: DossierQueueSubmissionStatus;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -5514,9 +5514,9 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
     confidence: "high",
     sourceAuthority: ["Mixed BNL memory plus admin review; not owner-confirmed."],
     observedChannels: ["Activity observed in owner-reviewable BARCODE Radio planning context."],
-    conversationHighlights: ["Conversation highlight notes recurring support around show planning."],
-    topicBreakdown: ["Topic breakdown emphasizes radio support and community coordination."],
-    bestEvidenceToReview: ["Owner should review the recurring set-support source note first."],
+    conversationHighlights: ["Public activity note: subject explicitly shared a show-planning update in approved context."],
+    topicBreakdown: ["Automated topic label: radio support and community coordination. Needs human review before this becomes a subject claim."],
+    bestEvidenceToReview: ["Review item: owner should review the recurring set-support source note first."],
     bnlInteractionSignals: ["BNL interaction signal: recurring admin-side mention pattern."],
     musicSignals: ["Music/show signal: set-support work appears around radio planning."],
     communitySignals: ["Community signal: repeated collaborator mentions in review context."],
@@ -5533,16 +5533,20 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
     representativeEvidence: [
       {
         activityType: "authored",
-        topic: "BNL/source-file handling",
+        topic: "BNL/source-file/dossier discussion",
         channel: "barcode-bot",
-        summary: "Crow discussed source-file handling in approved public context.",
+        summary: "BNL classified this approved-context evidence as source-file/dossier-related.",
+        detail: "Automated topic classification; review before using as a subject claim.",
       },
     ],
     activityFrequencySummary: [
       { frequency: "Recurring approved public context", count: 5 },
     ],
     topChannels: [{ channel: "finished-tracks", count: 3 }],
-    topTopicDetails: [{ topic: "music/track-sharing", count: 4 }],
+    topTopicDetails: [
+      { topic: "music/track-sharing", count: 4 },
+      { topic: "BNL/source-file/dossier discussion", count: 1 },
+    ],
     recentActivitySummary: [{ recency: "Recent approved public context", recentCount: 2 }],
     authoredVsMentionedSummary: [{ postedCount: 4, mentionedCount: 1 }],
     publicUseCandidates: ["Possible collaborator wording pending owner review."],
@@ -5584,7 +5588,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.doesNotMatch(JSON.stringify(payload.recommendation.sourceCoverage), /\[object Object\]/);
   assert.deepEqual(payload.recommendation.publicUseCandidates, packet.publicUseCandidates);
   assert.deepEqual(payload.recommendation.reviewOnlyEvidence, packet.reviewOnlyEvidence);
-  assert.match(JSON.stringify(payload.recommendation.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(payload.recommendation.representativeEvidence), /BNL classified this approved-context evidence as source-file\/dossier-related/);
+  assert.doesNotMatch(JSON.stringify(payload.recommendation.representativeEvidence), /Crow discussed|Crow posted about|posted about source-file|posted.*BNL\/source-file/);
   assert.match(JSON.stringify(payload.recommendation.topChannels), /#finished tracks|#finished-tracks/);
   assert.match(JSON.stringify(payload.recommendation.topTopicDetails), /music\/track sharing|music track sharing/);
   assert.match(JSON.stringify(payload.recommendation.activityFrequencySummary), /Recurring approved public context/);
@@ -5606,7 +5611,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.deepEqual(savedRecommendation.musicSignals, packet.musicSignals);
   assert.deepEqual(savedRecommendation.communitySignals, packet.communitySignals);
   assert.deepEqual(savedRecommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
-  assert.match(JSON.stringify(savedRecommendation.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(savedRecommendation.representativeEvidence), /BNL classified this approved-context evidence as source-file\/dossier-related/);
+  assert.doesNotMatch(JSON.stringify(savedRecommendation.representativeEvidence), /Crow discussed|Crow posted about|posted about source-file|posted.*BNL\/source-file/);
   assert.match(JSON.stringify(savedRecommendation.topChannels), /finished/);
   assert.match(JSON.stringify(savedRecommendation.topTopicDetails), /music/);
   assert.match(JSON.stringify(savedRecommendation.activityFrequencySummary), /Recurring/);
@@ -5623,7 +5629,7 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.equal(sourceFile.sourceFileNotes.length, 1);
   assert.match(sourceFile.sourceFileNotes[0].text, /Useful evidence: Two reviewed source notes/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Relationship signal — private review/);
-  assert.match(sourceFile.sourceFileNotes[0].text, /Best evidence to review: Owner should review/);
+  assert.match(sourceFile.sourceFileNotes[0].text, /Best evidence to review: Review item: owner should review/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Observed channel\/activity: Activity observed/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Queue\/submission identity is not connected yet/);
   assert.match(sourceFile.sourceFileNotes[0].text, /Source coverage: channel policy: public home 12, public context 4 found/);
@@ -5634,17 +5640,19 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
     candidate: sourceFile,
     recommendations: [savedRecommendation],
   });
-  assert.match(JSON.stringify(summary.bestEvidenceToReview), /Owner should review/);
+  assert.match(JSON.stringify(summary.bestEvidenceToReview), /owner should review/i);
   assert.match(JSON.stringify(summary.observedChannels), /Activity observed/);
-  assert.match(JSON.stringify(summary.conversationHighlights), /Conversation highlight/);
+  assert.match(JSON.stringify(summary.conversationHighlights), /subject explicitly shared/);
   assert.match(JSON.stringify(summary.musicSignals), /Music\/show signal/);
   assert.match(JSON.stringify(summary.communitySignals), /Community signal/);
   assert.match(JSON.stringify(summary.bnlInteractionSignals), /BNL interaction signal/);
   assert.match(JSON.stringify(summary.sourceCoverage), /conversation: 14 source row\(s\) found/);
   assert.match(JSON.stringify(summary.sourceCoverage), /channel policy: public home 12, public context 4 found/);
-  assert.match(JSON.stringify(summary.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(summary.representativeEvidence), /BNL classified this approved-context evidence as source-file\/dossier-related/);
+  assert.doesNotMatch(JSON.stringify(summary.representativeEvidence), /Crow discussed|Crow posted about|posted about source-file|posted.*BNL\/source-file/);
   assert.match(JSON.stringify(summary.topChannels), /finished/);
   assert.match(JSON.stringify(summary.topTopicDetails), /music/);
+  assert.match(JSON.stringify(summary.topTopicDetails), /Automated topic label|BNL\/source-file\/dossier discussion/);
   assert.match(JSON.stringify(summary.activityFrequencySummary), /Recurring/);
   assert.match(JSON.stringify(summary.recentActivitySummary), /Recent/);
   assert.match(JSON.stringify(summary.authoredVsMentionedSummary), /posted item|mention/);
@@ -5662,6 +5670,20 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(summary.sourceAuthority), /Source confidence: high|Mixed BNL memory/);
   assert.doesNotMatch(JSON.stringify(summary), /raw-trace-structured-packet-v2/);
 
+  const structuredReadout = entityReadout.createDossierEntityActivityReadoutFromSourceFile({
+    summary,
+    recommendations: [savedRecommendation],
+    subjectName: sourceFile.name,
+  });
+  const panelText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    entityReadout: structuredReadout,
+  }));
+  assert.match(panelText, /BNL classification|Automated topic label|Main evidence categories/);
+  assert.match(panelText, /Topic labels are BNL classifications, not public facts/);
+  assert.match(panelText, /subject explicitly shared a show-planning update/);
+  assert.doesNotMatch(panelText, /Crow discussed source-file handling|Crow posted about source-file handling|Crow posted about BNL\/source-file|Crow authored BNL\/source-file|Crow talked about dossier/);
+
   const view = noteDisplay.createHumanReadableRecommendationView(savedRecommendation);
   assert.match(JSON.stringify(view.sections), /Two reviewed source notes/);
   assert.match(JSON.stringify(view.sections), /What BNL Found/);
@@ -5674,6 +5696,8 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(view.sections), /Queue\/submission identity is not connected yet/);
   assert.match(JSON.stringify(view.sections), /channel policy: public home 12, public context 4 found/);
   assert.match(JSON.stringify(view.sections), /Representative Activity Details|Activity Frequency|Top Channels|Main Discussion Areas|Recent Activity|Posted \/ Mentioned Balance/);
+  assert.match(JSON.stringify(view.sections), /Automated topic label|BNL classified/);
+  assert.doesNotMatch(JSON.stringify(view.sections), /Crow discussed|Crow posted about|posted about source-file|posted.*BNL\/source-file/);
   assert.doesNotMatch(JSON.stringify(view.sections), /\[object Object\]/);
   assert.match(JSON.stringify(view.sections), /Private Relationship Context/);
   assert.match(JSON.stringify(view.rawMetadata), /raw-trace-structured-packet-v2/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -902,10 +902,10 @@ test("admin Source File and recommendation pages render readable sections with c
     "HumanReadableNoteView",
     "Source File Summary",
     "Current Read",
-    "What BNL Actually Knows",
-    "Why This File Exists",
-    "Useful Evidence",
-    "Patterns / Themes",
+    "Admin Case Summary",
+    "What BNL Found",
+    "Why this source file exists",
+    "Evidence Log",
     "Open Questions",
     "Recommended Next Step",
     "Substance:",
@@ -919,7 +919,7 @@ test("admin Source File and recommendation pages render readable sections with c
     "Developer / Raw Source Audit",
     "warnings",
     "Open Questions",
-    "Claimed / Needs Review",
+    "Review-Only Cautions",
     "Pattern BNL Noticed",
     "Not Public Yet",
   ]) {
@@ -5321,14 +5321,14 @@ test("Source File page uses one consolidated Source File Snapshot / BNL Readout 
     sourceFilePage.indexOf("DossierSourceFileSummaryPanel") < sourceFilePage.indexOf("<form onSubmit={saveSourceFileSummary}"),
   );
   assert.match(summaryPanel, /Source File Snapshot \/ BNL Readout/);
-  assertIncludesCopy(summaryPanel, "Relationship Context — Review Only");
-  assertIncludesCopy(summaryPanel, "Public-Safe / Public-Use Candidates Pending Owner Review");
-  assertIncludesCopy(summaryPanel, "Private/Internal Notes");
-  assertIncludesCopy(summaryPanel, "Queue/submission not connected");
+  assertIncludesCopy(summaryPanel, "Review-Only Cautions");
+  assertIncludesCopy(summaryPanel, "Dossier Use / Public-Safe Possibilities");
+  assertIncludesCopy(summaryPanel, "Missing Before Public Dossier");
+  assertIncludesCopy(summaryPanel, "Queue/submission history is not connected yet");
   assertIncludesCopy(summaryPanel, "Review-only");
   assertIncludesCopy(summaryPanel, "Structured packet");
   assertIncludesCopy(summaryPanel, "Safe fallback");
-  assertIncludesCopy(summaryPanel, "Source Authority / Confidence");
+  assertIncludesCopy(summaryPanel, "Evidence Status");
   assertIncludesCopy(summaryPanel, "Developer / Raw Source Audit — internal debugging only");
   assert.doesNotMatch(summaryPanel, /rawProvenance/);
 
@@ -5413,9 +5413,9 @@ test("consolidated Source File Snapshot / BNL Readout collapses duplicate safe b
   assert.match(text, /Source File Snapshot \/ BNL Readout/);
   assert.match(text, /BNL found an internal local profile match for Crow/);
   assert.match(text, /BNL found prior relationship\/context notes connected to Crow/);
-  assert.match(text, /Confidence:\s+high/);
+  assert.match(text, /Source confidence:\s+High/);
   assert.match(text, /Review-only/);
-  assert.match(text, /Queue\/submission not connected/);
+  assert.match(text, /Queue\/submission history is not connected yet/);
   assert.equal((text.match(/profile match/gi) ?? []).length, 1);
   assert.equal((text.match(/relationship\/context/gi) ?? []).length, 1);
   assert.doesNotMatch(
@@ -5530,6 +5530,21 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
       "Legacy source coverage text remains accepted.",
     ],
     evidenceDetails: ["Evidence detail stays internal until owner-approved wording exists."],
+    representativeEvidence: [
+      {
+        activityType: "authored",
+        topic: "BNL/source-file handling",
+        channel: "barcode-bot",
+        summary: "Crow discussed source-file handling in approved public context.",
+      },
+    ],
+    activityFrequencySummary: [
+      { frequency: "Recurring approved public context", count: 5 },
+    ],
+    topChannels: [{ channel: "finished-tracks", count: 3 }],
+    topTopicDetails: [{ topic: "music/track-sharing", count: 4 }],
+    recentActivitySummary: [{ recency: "Recent approved public context", recentCount: 2 }],
+    authoredVsMentionedSummary: [{ postedCount: 4, mentionedCount: 1 }],
     publicUseCandidates: ["Possible collaborator wording pending owner review."],
     reviewOnlyEvidence: ["Review-only evidence: internal relationship context needs owner review."],
     queueSubmissionStatus: "not_connected",
@@ -5569,6 +5584,12 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.doesNotMatch(JSON.stringify(payload.recommendation.sourceCoverage), /\[object Object\]/);
   assert.deepEqual(payload.recommendation.publicUseCandidates, packet.publicUseCandidates);
   assert.deepEqual(payload.recommendation.reviewOnlyEvidence, packet.reviewOnlyEvidence);
+  assert.match(JSON.stringify(payload.recommendation.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(payload.recommendation.topChannels), /#finished tracks|#finished-tracks/);
+  assert.match(JSON.stringify(payload.recommendation.topTopicDetails), /music\/track sharing|music track sharing/);
+  assert.match(JSON.stringify(payload.recommendation.activityFrequencySummary), /Recurring approved public context/);
+  assert.match(JSON.stringify(payload.recommendation.recentActivitySummary), /Recent approved public context/);
+  assert.match(JSON.stringify(payload.recommendation.authoredVsMentionedSummary), /posted item|mention/);
   assert.equal(payload.recommendation.queueSubmissionStatus, "not_connected");
   assert.equal(payload.recommendation.queueSubmissionNote, packet.queueSubmissionNote);
   assert.deepEqual(payload.recommendation.rawProvenance, packet.rawProvenance);
@@ -5585,6 +5606,12 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.deepEqual(savedRecommendation.musicSignals, packet.musicSignals);
   assert.deepEqual(savedRecommendation.communitySignals, packet.communitySignals);
   assert.deepEqual(savedRecommendation.bnlInteractionSignals, packet.bnlInteractionSignals);
+  assert.match(JSON.stringify(savedRecommendation.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(savedRecommendation.topChannels), /finished/);
+  assert.match(JSON.stringify(savedRecommendation.topTopicDetails), /music/);
+  assert.match(JSON.stringify(savedRecommendation.activityFrequencySummary), /Recurring/);
+  assert.match(JSON.stringify(savedRecommendation.recentActivitySummary), /Recent/);
+  assert.match(JSON.stringify(savedRecommendation.authoredVsMentionedSummary), /posted item|mention/);
   assert.match(JSON.stringify(savedRecommendation.sourceCoverage), /channel policy: public home 12, public context 4 found/);
   assert.doesNotMatch(JSON.stringify(savedRecommendation.sourceCoverage), /\[object Object\]/);
   assert.equal(savedRecommendation.queueSubmissionStatus, "not_connected");
@@ -5615,6 +5642,12 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(summary.bnlInteractionSignals), /BNL interaction signal/);
   assert.match(JSON.stringify(summary.sourceCoverage), /conversation: 14 source row\(s\) found/);
   assert.match(JSON.stringify(summary.sourceCoverage), /channel policy: public home 12, public context 4 found/);
+  assert.match(JSON.stringify(summary.representativeEvidence), /Crow discussed source-file handling/);
+  assert.match(JSON.stringify(summary.topChannels), /finished/);
+  assert.match(JSON.stringify(summary.topTopicDetails), /music/);
+  assert.match(JSON.stringify(summary.activityFrequencySummary), /Recurring/);
+  assert.match(JSON.stringify(summary.recentActivitySummary), /Recent/);
+  assert.match(JSON.stringify(summary.authoredVsMentionedSummary), /posted item|mention/);
   assert.doesNotMatch(JSON.stringify(summary.sourceCoverage), /\[object Object\]/);
   assert.match(JSON.stringify(summary.publicUseCandidates), /pending owner review/);
   assert.match(JSON.stringify(summary.reviewOnlyEvidence), /Review-only evidence/);
@@ -5626,20 +5659,21 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(JSON.stringify(summary.publicSafePossibilities), /collaborator after owner review/);
   assert.match(JSON.stringify(summary.privateOnlyNotes), /internal contact path/);
   assert.match(JSON.stringify(summary.notPublicYet), /Do not publish the collaborator label|Private relationship context|internal contact path/);
-  assert.match(JSON.stringify(summary.sourceAuthority), /Confidence: high|Mixed BNL memory/);
+  assert.match(JSON.stringify(summary.sourceAuthority), /Source confidence: high|Mixed BNL memory/);
   assert.doesNotMatch(JSON.stringify(summary), /raw-trace-structured-packet-v2/);
 
   const view = noteDisplay.createHumanReadableRecommendationView(savedRecommendation);
   assert.match(JSON.stringify(view.sections), /Two reviewed source notes/);
-  assert.match(JSON.stringify(view.sections), /Best Evidence to Review/);
+  assert.match(JSON.stringify(view.sections), /What BNL Found/);
   assert.match(JSON.stringify(view.sections), /Observed Channels \/ Activity/);
   assert.match(JSON.stringify(view.sections), /Music \/ Show Signals/);
   assert.match(JSON.stringify(view.sections), /Community Signals/);
   assert.match(JSON.stringify(view.sections), /BNL Interaction Signals/);
   assert.match(JSON.stringify(view.sections), /Public-Use Candidates Pending Owner Review/);
-  assert.match(JSON.stringify(view.sections), /Review-Only Evidence/);
+  assert.match(JSON.stringify(view.sections), /Review-Only Cautions/);
   assert.match(JSON.stringify(view.sections), /Queue\/submission identity is not connected yet/);
   assert.match(JSON.stringify(view.sections), /channel policy: public home 12, public context 4 found/);
+  assert.match(JSON.stringify(view.sections), /Representative Activity Details|Activity Frequency|Top Channels|Main Discussion Areas|Recent Activity|Posted \/ Mentioned Balance/);
   assert.doesNotMatch(JSON.stringify(view.sections), /\[object Object\]/);
   assert.match(JSON.stringify(view.sections), /Private Relationship Context/);
   assert.match(JSON.stringify(view.rawMetadata), /raw-trace-structured-packet-v2/);


### PR DESCRIPTION
### Motivation

- Make the BNL Source File Snapshot readable and scannable for admins by replacing raw technical evidence rows with a short human-first case-file brief and clear section purposes. 
- Accept and persist the richer structured evidence the bot now sends so the UI can summarize channels, topics, frequency, recency, representative activity, and authored/mentioned balances.
- Clarify confidence/readiness labels and preserve strict review-only boundaries so nothing becomes public without owner/admin gating.

### Description

- Ingest & validation: add strict normalization and safe text extraction for new evidence fields (`representativeEvidence`, `activityFrequencySummary`, `topChannels`, `topTopicDetails`, `recentActivitySummary`, `authoredVsMentionedSummary`) including bounded lists, allowed object keys, numeric count checks, and blocking raw IDs/paths (`src/app/api/bnl/dossier-recommendations/route.ts`).
- Types & store: extend workflow types and the store normalization to persist the new readout fields and convert object-style evidence objects into bounded, human-readable strings (`src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`).
- UI / summary rewrite: replace the old technical snapshot with a compact admin case-file brief that includes sections Current Read, Admin Case Summary, What BNL Found, Activity Details, Dossier Use / Public-Safe Possibilities, Missing Before Public Dossier, Review-Only Cautions, Evidence Log, and Evidence Status; translate technical terms (e.g. “authored” → “posted”, hide raw provenance and IDs) and show clearer labels for evidence depth, public readiness, identity certainty, and source confidence (`src/components/DossierSourceFileSummaryPanel.tsx`, `src/components/DossierEntityActivityReadoutPanel.tsx`).
- Note / recommendation views: rename and reorganize sections and fields to match the brief (Evidence Log, What BNL Found, Public Activity Notes, Main Discussion Areas, Activity Details, Review-Only Cautions, Evidence Status) and surface the new evidence readouts in admin-only displays without leaking raw provenance (`src/lib/dossier-note-display.ts`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`).

Files changed (high-level): `src/app/api/bnl/dossier-recommendations/route.ts`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-source-file-summary.ts`, `src/lib/dossier-note-display.ts`, `src/lib/dossier-entity-activity-readout.ts`, `src/components/DossierSourceFileSummaryPanel.tsx`, `src/components/DossierEntityActivityReadoutPanel.tsx`, `src/app/admin/dossiers/recommendations/[recommendationId]/page.tsx`, and tests (`tests/admin-dossiers.test.mjs`).

### Testing

- Ran type check: `npx tsc --noEmit` — success.
- Ran unit/integration tests: `node --test tests/admin-dossiers.test.mjs` — all tests passed (tests exercising ingest, persistence, summary generation, humanized display, filtering of raw provenance, and review-only boundaries succeeded).
- Ran linting on changed files: `npx eslint ...` — OK (warnings addressed during the rollout).
- Attempted production build: `npm run build` — failed only due to a known Next/Turbopack Google font fetch issue (failed to fetch `Geist Mono` during Turbopack run); this is an unrelated environment/network font fetch timeout and not related to the code changes.

All automated tests that validate the new ingest paths, persisted fields, human-readable summary, translation of technical terms, and review-only protections were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208f1e390c8321bf787ca43698420b)