### PR TITLE
Upsert BNL Source File enrichment refreshes

### DIFF
--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1242,6 +1242,147 @@ function fallbackRecommendationDedupeKey(
   ].join("|");
 }
 
+function stableFingerprintValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map(stableFingerprintValue)
+      .filter((item) => item !== undefined);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .map(([key, item]) => [key, stableFingerprintValue(item)] as const)
+        .filter(([, item]) => item !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right)),
+    );
+  }
+  if (typeof value === "string") return value.trim().replace(/\s+/g, " ");
+  return value ?? undefined;
+}
+
+export function bnlSourceFileEnrichmentDigest(
+  recommendation: Pick<
+    DossierRecommendation,
+    | "reason"
+    | "evidenceSummary"
+    | "knownContext"
+    | "usefulEvidence"
+    | "relationshipSignals"
+    | "observedChannels"
+    | "conversationHighlights"
+    | "representativeEvidence"
+    | "activityFrequencySummary"
+    | "topChannels"
+    | "topTopicDetails"
+    | "recentActivitySummary"
+    | "authoredVsMentionedSummary"
+    | "topicBreakdown"
+    | "bestEvidenceToReview"
+    | "bnlInteractionSignals"
+    | "musicSignals"
+    | "communitySignals"
+    | "evidenceDetails"
+    | "publicUseCandidates"
+    | "reviewOnlyEvidence"
+    | "queueSubmissionStatus"
+    | "queueSubmissionNote"
+    | "missingInfo"
+    | "recommendedAction"
+    | "sourceCoverage"
+    | "publicSafePossibilities"
+    | "notPublicYet"
+    | "doNotSay"
+    | "sourceTypes"
+    | "sourceLanes"
+  >,
+): string {
+  return JSON.stringify(
+    stableFingerprintValue({
+      reason: recommendation.reason,
+      evidenceSummary: recommendation.evidenceSummary,
+      knownContext: recommendation.knownContext,
+      usefulEvidence: recommendation.usefulEvidence,
+      relationshipSignals: recommendation.relationshipSignals,
+      observedChannels: recommendation.observedChannels,
+      conversationHighlights: recommendation.conversationHighlights,
+      representativeEvidence: recommendation.representativeEvidence,
+      activityFrequencySummary: recommendation.activityFrequencySummary,
+      topChannels: recommendation.topChannels,
+      topTopicDetails: recommendation.topTopicDetails,
+      recentActivitySummary: recommendation.recentActivitySummary,
+      authoredVsMentionedSummary: recommendation.authoredVsMentionedSummary,
+      topicBreakdown: recommendation.topicBreakdown,
+      bestEvidenceToReview: recommendation.bestEvidenceToReview,
+      bnlInteractionSignals: recommendation.bnlInteractionSignals,
+      musicSignals: recommendation.musicSignals,
+      communitySignals: recommendation.communitySignals,
+      evidenceDetails: recommendation.evidenceDetails,
+      publicUseCandidates: recommendation.publicUseCandidates,
+      reviewOnlyEvidence: recommendation.reviewOnlyEvidence,
+      queueSubmissionStatus: recommendation.queueSubmissionStatus,
+      queueSubmissionNote: recommendation.queueSubmissionNote,
+      missingInfo: recommendation.missingInfo,
+      recommendedAction: recommendation.recommendedAction,
+      sourceCoverage: recommendation.sourceCoverage,
+      publicSafePossibilities: recommendation.publicSafePossibilities,
+      notPublicYet: recommendation.notPublicYet,
+      doNotSay: recommendation.doNotSay,
+      sourceTypes: recommendation.sourceTypes,
+      sourceLanes: recommendation.sourceLanes,
+    }),
+  );
+}
+
+const BNL_SOURCE_FILE_ENRICHMENT_REFRESH_NOTE =
+  "BNL Source File Enrichment was refreshed with newer review-only intelligence. No public dossier content was changed.";
+
+function sourceFileEnrichmentAttachmentStatus(
+  candidate: DossierCandidate,
+): DossierRecommendationStatus {
+  if (candidate.status === "candidate_intake") return "attached_to_candidate_intake";
+  if (candidate.status === "existing_dossier_update") {
+    return "attached_to_existing_dossier_update";
+  }
+  return "attached_to_source_file";
+}
+
+function upsertSourceFileEnrichmentNote(input: {
+  candidate: DossierCandidate;
+  recommendation: DossierRecommendation;
+  now: string;
+}): DossierCandidate {
+  const noteText = bnlAutoCandidateNoteText(input.recommendation);
+  const existingNote = (input.candidate.sourceFileNotes ?? []).find(
+    (note) =>
+      Boolean(input.recommendation.ingestKey) &&
+      note.ingestKey === input.recommendation.ingestKey &&
+      note.ingestSource === "bnl_source_file_enrichment",
+  );
+  const refreshedNote: DossierSourceFileNote = {
+    id: existingNote?.id ?? createSourceFileNoteId(),
+    candidateId: input.candidate.id,
+    type: "general_note",
+    text: noteText,
+    source: "bnl_recommendation",
+    status: "active",
+    publicSafe: false,
+    createdAt: existingNote?.createdAt ?? input.now,
+    updatedAt: input.now,
+    createdBy: input.recommendation.createdBy,
+    ingestKey: input.recommendation.ingestKey,
+    ingestedAt: input.recommendation.ingestedAt,
+    ingestSource: input.recommendation.ingestSource,
+  };
+  const otherNotes = (input.candidate.sourceFileNotes ?? []).filter(
+    (note) => note.id !== existingNote?.id,
+  );
+  return {
+    ...input.candidate,
+    sourceFileNotes: [refreshedNote, ...otherNotes],
+    updatedAt: input.now,
+  };
+}
+
 export async function createDossierRecommendationIdempotent(
   input: CreateDossierRecommendationInput,
 ): Promise<{
@@ -1308,6 +1449,102 @@ export async function createDossierRecommendationIdempotent(
         );
 
     if (existing) {
+      if (
+        isEnrichmentIngest &&
+        existing.ingestSource === "bnl_source_file_enrichment"
+      ) {
+        const existingDigest = bnlSourceFileEnrichmentDigest(existing);
+        const nextDigest = bnlSourceFileEnrichmentDigest(recommendation);
+        if (existingDigest === nextDigest) {
+          savedRecommendation = existing;
+          duplicate = true;
+          return currentState;
+        }
+
+        const targetCandidateId =
+          recommendation.targetCandidateId ?? existing.targetCandidateId;
+        const targetCandidate = targetCandidateId
+          ? currentState.candidates.find(
+              (candidate) => candidate.id === targetCandidateId,
+            )
+          : undefined;
+        const refreshedRecommendationBase: DossierRecommendation = {
+          ...recommendation,
+          id: existing.id,
+          status: existing.status,
+          targetCandidateId,
+          createdAt: existing.createdAt,
+          updatedAt: now,
+          publicSafetyNotes: uniqueStrings(recommendation.publicSafetyNotes, [
+            BNL_SOURCE_FILE_ENRICHMENT_REFRESH_NOTE,
+          ]),
+        };
+
+        if (targetCandidate) {
+          if (!isSourceFileEnrichmentAttachableCandidate(targetCandidate)) {
+            savedRecommendation = {
+              ...refreshedRecommendationBase,
+              publicSafetyNotes: uniqueStrings(
+                refreshedRecommendationBase.publicSafetyNotes,
+                [
+                  "Target exists but is not open for enrichment attachment. No Source File, Proposed Dossier, public page, alias, merge, or owner-review state was changed.",
+                ],
+              ),
+            };
+            autoAction = "left_for_review";
+            return {
+              ...currentState,
+              recommendations: currentState.recommendations.map((item) =>
+                item.id === existing.id ? savedRecommendation : item,
+              ),
+              updatedAt: now,
+            };
+          }
+
+          const updatedRecommendation: DossierRecommendation = {
+            ...refreshedRecommendationBase,
+            status: sourceFileEnrichmentAttachmentStatus(targetCandidate),
+            targetCandidateId: targetCandidate.id,
+          };
+          savedRecommendation = updatedRecommendation;
+          autoAction = "attached_existing";
+          return {
+            ...currentState,
+            recommendations: currentState.recommendations.map((item) =>
+              item.id === existing.id ? updatedRecommendation : item,
+            ),
+            candidates: currentState.candidates.map((candidate) =>
+              candidate.id === targetCandidate.id
+                ? upsertSourceFileEnrichmentNote({
+                    candidate,
+                    recommendation: updatedRecommendation,
+                    now,
+                  })
+                : candidate,
+            ),
+            updatedAt: now,
+          };
+        }
+
+        savedRecommendation = {
+          ...refreshedRecommendationBase,
+          publicSafetyNotes: uniqueStrings(
+            refreshedRecommendationBase.publicSafetyNotes,
+            [
+              `${bnlIngestLabel(recommendation)} has no target; refreshed in Recommendation Inbox for owner/admin review. No Candidate Intake, Source File, Proposed Dossier, alias, merge, or public content was created.`,
+            ],
+          ),
+        };
+        autoAction = "left_for_review";
+        return {
+          ...currentState,
+          recommendations: currentState.recommendations.map((item) =>
+            item.id === existing.id ? savedRecommendation : item,
+          ),
+          updatedAt: now,
+        };
+      }
+
       savedRecommendation = existing;
       duplicate = true;
       return currentState;
@@ -1358,21 +1595,6 @@ export async function createDossierRecommendationIdempotent(
             : targetCandidate.status === "existing_dossier_update"
               ? "attached_to_existing_dossier_update"
               : "attached_to_source_file";
-        const note: DossierSourceFileNote = {
-          id: createSourceFileNoteId(),
-          candidateId: targetCandidate.id,
-          type: "general_note",
-          text: bnlAutoCandidateNoteText(recommendation),
-          source: "bnl_recommendation",
-          status: "active",
-          publicSafe: false,
-          createdAt: now,
-          updatedAt: now,
-          createdBy: recommendation.createdBy,
-          ingestKey: recommendation.ingestKey,
-          ingestedAt: recommendation.ingestedAt,
-          ingestSource: recommendation.ingestSource,
-        };
         const updatedRecommendation: DossierRecommendation = {
           ...recommendation,
           status: updatedStatus,
@@ -1393,11 +1615,11 @@ export async function createDossierRecommendationIdempotent(
           ],
           candidates: currentState.candidates.map((candidate) =>
             candidate.id === targetCandidate.id
-              ? {
-                  ...candidate,
-                  sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
-                  updatedAt: now,
-                }
+              ? upsertSourceFileEnrichmentNote({
+                  candidate,
+                  recommendation: updatedRecommendation,
+                  now,
+                })
               : candidate,
           ),
           updatedAt: now,

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -4552,6 +4552,178 @@ test("BNL Source File enrichment preserves provenance and attaches to an active 
   assert.doesNotMatch(JSON.stringify(publicPayload), /Enrichment Active Subject|bnl_source_file_enrichment|source_file_note/);
 });
 
+
+
+test("BNL Source File enrichment upserts changed same-key content but still dedupes identical refreshes", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const publicSlugPageBefore = source("src/app/database/[slug]/page.tsx");
+
+  const intake = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Crow Source File Refresh",
+    reason: "BNL dynamic discovery found Crow for source-file review.",
+    evidenceSummary: "Starter discovery only.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:crow-source-refresh:discovery",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  await authedPost({
+    action: "promoteCandidateToSourceFile",
+    candidateId: intake.candidate.id,
+  });
+
+  const baseEnrichment = {
+    type: "modify_existing_dossier",
+    subjectName: "Crow Source File Refresh",
+    targetCandidateId: intake.candidate.id,
+    reason: "BNL generated source-file enrichment for Crow review.",
+    sourceLanes: ["active_source_file", "rd_knowledge_store"],
+    sourceTypes: ["source_file_note"],
+    ingestKey: "bnl:crow-source-refresh:enrichment",
+    ingestSource: "bnl_source_file_enrichment",
+    knownContext: ["Older generic BNL enrichment for Crow."],
+    usefulEvidence: ["Generic source-file context needs owner review."],
+    reviewOnlyEvidence: ["Older review-only packet."],
+    publicSafetyNotes: ["Review-only; not public copy."],
+    rawProvenance: {
+      backendId: "raw-old-backend-id",
+      fetchedAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+
+  const firstPayload = await (await bnlIngestPost(baseEnrichment)).json();
+  assert.equal(firstPayload.duplicate, false);
+  assert.equal(firstPayload.autoAction, "attached_existing");
+  const originalRecommendationId = firstPayload.recommendation.id;
+
+  const identicalPayload = await (await bnlIngestPost({
+    ...baseEnrichment,
+    rawProvenance: {
+      backendId: "raw-new-backend-id-that-should-not-affect-digest",
+      fetchedAt: "2026-06-03T00:00:00.000Z",
+    },
+  })).json();
+  assert.equal(identicalPayload.duplicate, true);
+  assert.equal(identicalPayload.recommendation.id, originalRecommendationId);
+
+  let state = await store.getDossierWorkflowState();
+  let sourceFile = state.candidates.find((candidate) => candidate.id === intake.candidate.id);
+  let enrichmentNotes = sourceFile.sourceFileNotes.filter(
+    (note) => note.ingestSource === "bnl_source_file_enrichment",
+  );
+  assert.equal(enrichmentNotes.length, 1);
+  assert.doesNotMatch(enrichmentNotes[0].text, /raw-old-backend-id|raw-new-backend-id/);
+
+  const changedEnrichment = {
+    ...baseEnrichment,
+    knownContext: ["Crow has recurring named Orion discussion in reviewed context."],
+    usefulEvidence: ["Recurring named topic: Orion appears across reviewed messages."],
+    conversationHighlights: ["Crow returned to Orion as an ongoing named topic."],
+    topTopicDetails: ["Recurring named topic / Orion in reviewed source-file context."],
+    musicSignals: ["Suno/tool mention appears in reviewed music-making context."],
+    bnlInteractionSignals: ["BNL interaction pattern: asks BNL for source-file readouts and follows up."],
+    reviewOnlyEvidence: ["Latest PR #226 fact extraction packet for owner review."],
+    recommendedAction: "Review Orion, Suno/tool, and BNL interaction pattern before public use.",
+    rawProvenance: {
+      backendId: "raw-latest-backend-id",
+      fetchedAt: "2026-06-03T12:00:00.000Z",
+    },
+  };
+  const changedPayload = await (await bnlIngestPost(changedEnrichment)).json();
+  assert.equal(changedPayload.duplicate, false);
+  assert.equal(changedPayload.autoAction, "attached_existing");
+  assert.equal(changedPayload.recommendation.id, originalRecommendationId);
+  assert.deepEqual(changedPayload.recommendation.knownContext, changedEnrichment.knownContext);
+  assert.match(changedPayload.recommendation.publicSafetyNotes.join(" "), /refreshed with newer review-only intelligence/);
+  assert.deepEqual(changedPayload.recommendation.rawProvenance, changedEnrichment.rawProvenance);
+
+  state = await store.getDossierWorkflowState();
+  const savedRecommendations = state.recommendations.filter(
+    (recommendation) => recommendation.ingestKey === baseEnrichment.ingestKey,
+  );
+  assert.equal(savedRecommendations.length, 1);
+  assert.equal(savedRecommendations[0].id, originalRecommendationId);
+  assert.deepEqual(savedRecommendations[0].knownContext, changedEnrichment.knownContext);
+  assert.equal(savedRecommendations[0].targetCandidateId, intake.candidate.id);
+  assert.deepEqual(savedRecommendations[0].rawProvenance, changedEnrichment.rawProvenance);
+
+  sourceFile = state.candidates.find((candidate) => candidate.id === intake.candidate.id);
+  enrichmentNotes = sourceFile.sourceFileNotes.filter(
+    (note) => note.ingestSource === "bnl_source_file_enrichment",
+  );
+  assert.equal(enrichmentNotes.length, 1);
+  const note = enrichmentNotes[0];
+  assert.equal(note.ingestKey, baseEnrichment.ingestKey);
+  assert.equal(note.publicSafe, false);
+  assert.match(note.text, /Recurring named topic: Orion/);
+  assert.match(note.text, /Suno\/tool mention/);
+  assert.match(note.text, /BNL interaction pattern/);
+  assert.doesNotMatch(note.text, /Older generic BNL enrichment|raw-latest-backend-id|rawProvenance/);
+
+  const protectedPayload = await (
+    await sourceFilesGet("?candidateId=" + encodeURIComponent(intake.candidate.id))
+  ).json();
+  assert.equal(protectedPayload.found, true);
+  const protectedEnrichmentNotes = protectedPayload.sourceFile.sourceFileNotes.filter(
+    (note) => note.ingestSource === "bnl_source_file_enrichment",
+  );
+  assert.equal(protectedEnrichmentNotes.length, 1);
+  assert.match(protectedEnrichmentNotes[0].summary, /Orion/);
+  const protectedEnrichmentRecommendation = protectedPayload.sourceFile.attachedRecommendations.find(
+    (recommendation) => recommendation.ingestKey === baseEnrichment.ingestKey,
+  );
+  assert.equal(protectedEnrichmentRecommendation.id, originalRecommendationId);
+  assert.equal(protectedEnrichmentRecommendation.updatedAt, savedRecommendations[0].updatedAt);
+
+  const publicPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  assert.equal(source("src/app/database/[slug]/page.tsx"), publicSlugPageBefore);
+  assert.doesNotMatch(
+    JSON.stringify(publicPayload),
+    /Crow Source File Refresh|Orion|Suno|bnl_source_file_enrichment|raw-latest-backend-id/,
+  );
+});
+
+test("non-enrichment ingest keys keep duplicate recommendation behavior", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const first = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Normal Duplicate Subject",
+    reason: "BNL discovery should keep ordinary idempotency.",
+    evidenceSummary: "Original ordinary recommendation.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:normal-duplicate-key",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+  const duplicate = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Normal Duplicate Subject",
+    reason: "BNL discovery changed but should still dedupe by ingest key.",
+    evidenceSummary: "Changed ordinary recommendation should not update.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "bnl:normal-duplicate-key",
+    ingestSource: "bnl_dynamic_candidate_discovery",
+  })).json();
+
+  assert.equal(first.duplicate, false);
+  assert.equal(duplicate.duplicate, true);
+  assert.equal(duplicate.recommendation.id, first.recommendation.id);
+  assert.equal(duplicate.recommendation.reason, first.recommendation.reason);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(
+    state.recommendations.filter((recommendation) => recommendation.ingestKey === "bnl:normal-duplicate-key").length,
+    1,
+  );
+  assert.equal(state.recommendations[0].reason, first.recommendation.reason);
+});
+
+
 test("BNL Source File enrichment attaches to Candidate Intake and Existing Dossier Update without promotion or public edits", async () => {
   await resetWorkflowStore();
   process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";


### PR DESCRIPTION
### Motivation

- Fix BNL enrichment idempotency so repeated `bnl_source_file_enrichment` with the same `ingestKey` can update review-only enrichment when the content meaningfully changes instead of being discarded as an indistinguishable duplicate. 
- Preserve existing dedupe behavior for all non-enrichment recommendation types and avoid mutating public dossier fields or creating repeated enrichment notes. 

### Description

- Add a stable fingerprint helper `stableFingerprintValue` and `bnlSourceFileEnrichmentDigest(...)` that computes a deterministic digest over review-safe enrichment fields (no raw provenance, ids, or timestamps) to detect meaningful content changes. (file: `src/lib/dossier-workflow-store.ts`)
- Add `upsertSourceFileEnrichmentNote(...)` to update/replace the single review-only Source File note keyed by `ingestKey` and keep `publicSafe: false`. (file: `src/lib/dossier-workflow-store.ts`)
- Special-case enrichment dedupe in `createDossierRecommendationIdempotent(...)` so identical-digest refreshes still return `duplicate: true` while changed-digest refreshes keep the existing recommendation ID, refresh `updatedAt`, add a refresh safety note (`BNL_SOURCE_FILE_ENRICHMENT_REFRESH_NOTE`), and update/attach the review-only Source File note instead of dropping the payload. (file: `src/lib/dossier-workflow-store.ts`)
- Reused the enrichment upsert path when attaching first-time or later enrichment to a target candidate while preserving all public read-model and dossier behavior unchanged. (file: `src/lib/dossier-workflow-store.ts`)
- Add tests exercising the behavior for identical refreshes (dedupes), changed same-key enrichment (updates recommendation and upserts source-file note), and ensuring non-enrichment ingest keys retain earlier dedupe semantics. (file: `tests/admin-dossiers.test.mjs`)

### Testing

- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran the full `node --test tests/admin-dossiers.test.mjs` test suite and all tests passed (118 tests, 0 failures). 
- Ran targeted `eslint` on changed files and it passed without errors. 
- Attempted `npm run build`; build failed due to an environment-only Next/Turbopack Google Fonts fetch error for `Geist Mono` (network/font fetch issue), which is a known non-blocking environment limitation and unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a6dbbb588321b8e9efe9963e7604)