### PR TITLE
Add Source File refresh request workflow

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -14,6 +14,7 @@ import {
   type DossierIdentityLinkType,
   type DossierIdentityLinkVisibility,
   type DossierRecommendation,
+  type DossierSourceFileRefreshRequest,
   type DossierSourceFileNoteType,
 } from "@/lib/dossier-workflow";
 import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
@@ -32,6 +33,7 @@ type WorkflowPayload = {
   drafts: DossierDraft[];
   duplicateGroups: DossierDuplicateGroup[];
   recommendations: DossierRecommendation[];
+  sourceFileRefreshRequests: DossierSourceFileRefreshRequest[];
   workflow: { status: string };
   publicDossiers?: Array<{ id: string; name: string }>;
 };
@@ -573,7 +575,17 @@ export default function CandidateReviewPage() {
           ? "Admin authentication required"
           : `Workflow API returned ${response.status}.`,
       );
-    setPayload((await response.json()) as WorkflowPayload);
+    const data = (await response.json()) as WorkflowPayload;
+    setPayload(data);
+
+    const openResponse = await fetch("/api/admin/dossiers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "recordSourceFileOpen", candidateId }),
+    });
+    if (openResponse.ok) {
+      setPayload((await openResponse.json()) as WorkflowPayload);
+    }
   }
 
   useEffect(() => {
@@ -649,6 +661,35 @@ export default function CandidateReviewPage() {
     .filter(Boolean)
     .sort()
     .at(-1);
+  const refreshRequests = (payload?.sourceFileRefreshRequests ?? []).filter(
+    (request) =>
+      request.candidateId === candidate?.id ||
+      request.normalizedSubjectKey ===
+        (candidate?.name ?? "")
+          .trim()
+          .toLowerCase()
+          .normalize("NFKD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .replace(/&/g, "and")
+          .replace(/[^a-z0-9]+/g, " ")
+          .replace(/\b(the|a|an)\b/g, " ")
+          .replace(/\s+/g, " ")
+          .trim(),
+  );
+  const latestRefreshRequest = [...refreshRequests].sort((a, b) =>
+    b.updatedAt.localeCompare(a.updatedAt),
+  )[0];
+  const refreshStatusLabel = latestRefreshRequest
+    ? latestRefreshRequest.status === "pending"
+      ? "BNL refresh pending"
+      : latestRefreshRequest.status === "claimed"
+        ? "Refresh requested"
+        : latestRefreshRequest.status === "completed"
+          ? "BNL refresh completed"
+          : latestRefreshRequest.status === "failed"
+            ? "Refresh failed"
+            : latestRefreshRequest.status
+    : "No refresh requested";
   const sourceFileSummary = candidate
     ? createDossierSourceFileSummary({
         candidate,
@@ -731,6 +772,27 @@ export default function CandidateReviewPage() {
       return data;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function requestBnlRefresh() {
+    if (!candidate) return;
+    try {
+      const data = await postWorkflow({
+        action: "requestSourceFileRefresh",
+        candidateId,
+        reason: "Manual admin requested a BNL Source File refresh.",
+      });
+      setNotice(
+        data.message ??
+          "BNL refresh requested. BNL will process this through the Source File refresh worker.",
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error
+          ? err.message
+          : "Failed to request BNL Source File refresh.",
+      );
     }
   }
 
@@ -997,6 +1059,12 @@ export default function CandidateReviewPage() {
             </div>
             <div className="border border-border bg-background/30 p-3">
               <p className="uppercase tracking-widest text-accent">
+                Refresh status
+              </p>
+              <p>{refreshStatusLabel}</p>
+            </div>
+            <div className="border border-border bg-background/30 p-3">
+              <p className="uppercase tracking-widest text-accent">
                 Source notes
               </p>
               <p>{sourceMetrics?.sourceNotesCount ?? 0}</p>
@@ -1031,6 +1099,31 @@ export default function CandidateReviewPage() {
                 </p>
               </div>
             )}
+          <div className="mt-4 border border-border bg-background/30 p-3 text-sm text-muted">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-widest text-accent">
+                  Source File Refresh
+                </p>
+                <p className="text-foreground">{refreshStatusLabel}</p>
+                {latestRefreshRequest && (
+                  <p className="mt-1">
+                    Reason: {latestRefreshRequest.reason} / Last completed: {formatDate(latestRefreshRequest.completedAt)}
+                  </p>
+                )}
+                {!latestRefreshRequest && <p className="mt-1">No refresh requested</p>}
+              </div>
+              <button
+                type="button"
+                onClick={() => void requestBnlRefresh()}
+                disabled={saving || !candidate}
+                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+              >
+                Request BNL Refresh
+              </button>
+            </div>
+          </div>
+
           <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
             <Link
               href="/admin/dossiers"

--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   getDossierSourceFileMetrics,
+  normalizeDossierSubjectName,
   type DossierCandidate,
   type DossierDraft,
   type DossierDuplicateGroup,
@@ -661,35 +662,52 @@ export default function CandidateReviewPage() {
     .filter(Boolean)
     .sort()
     .at(-1);
+  const candidateRefreshKey = candidate
+    ? normalizeDossierSubjectName(candidate.name)
+    : "";
   const refreshRequests = (payload?.sourceFileRefreshRequests ?? []).filter(
     (request) =>
       request.candidateId === candidate?.id ||
-      request.normalizedSubjectKey ===
-        (candidate?.name ?? "")
-          .trim()
-          .toLowerCase()
-          .normalize("NFKD")
-          .replace(/[\u0300-\u036f]/g, "")
-          .replace(/&/g, "and")
-          .replace(/[^a-z0-9]+/g, " ")
-          .replace(/\b(the|a|an)\b/g, " ")
-          .replace(/\s+/g, " ")
-          .trim(),
+      request.normalizedSubjectKey === candidateRefreshKey,
   );
-  const latestRefreshRequest = [...refreshRequests].sort((a, b) =>
-    b.updatedAt.localeCompare(a.updatedAt),
-  )[0];
+  const activeRefreshRequest = refreshRequests
+    .filter(
+      (request) => request.status === "pending" || request.status === "claimed",
+    )
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  const latestRefreshRequest =
+    activeRefreshRequest ??
+    [...refreshRequests].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
   const refreshStatusLabel = latestRefreshRequest
     ? latestRefreshRequest.status === "pending"
-      ? "BNL refresh pending"
+      ? "BNL refresh requested"
       : latestRefreshRequest.status === "claimed"
-        ? "Refresh requested"
+        ? "BNL refresh in progress"
         : latestRefreshRequest.status === "completed"
           ? "BNL refresh completed"
           : latestRefreshRequest.status === "failed"
-            ? "Refresh failed"
+            ? "BNL refresh failed"
             : latestRefreshRequest.status
     : "No refresh requested";
+  const refreshStatusDetail = latestRefreshRequest
+    ? latestRefreshRequest.status === "pending"
+      ? "Waiting for BNL. This Source File has not been refreshed yet."
+      : latestRefreshRequest.status === "claimed"
+        ? "BNL has claimed this request and is processing it. This Source File has not been marked refreshed yet."
+        : latestRefreshRequest.status === "completed"
+          ? `Completed ${formatDate(latestRefreshRequest.completedAt)}${
+              latestRefreshRequest.completedByRecommendationId
+                ? ` by recommendation ${latestRefreshRequest.completedByRecommendationId}`
+                : ""
+            }.`
+          : latestRefreshRequest.status === "failed"
+            ? `Refresh failed${
+                latestRefreshRequest.failureReason
+                  ? `: ${latestRefreshRequest.failureReason}`
+                  : "."
+              }`
+            : "Refresh request is no longer active."
+    : "No refresh requested.";
   const sourceFileSummary = candidate
     ? createDossierSourceFileSummary({
         candidate,
@@ -758,6 +776,10 @@ export default function CandidateReviewPage() {
         .catch(() => ({}))) as Partial<WorkflowPayload> & {
         candidate?: DossierCandidate;
         draft?: DossierDraft;
+        refresh?: {
+          created?: boolean;
+          request?: DossierSourceFileRefreshRequest;
+        };
         error?: string;
         message?: string;
       };
@@ -783,9 +805,12 @@ export default function CandidateReviewPage() {
         candidateId,
         reason: "Manual admin requested a BNL Source File refresh.",
       });
+      const refresh = data.refresh;
       setNotice(
-        data.message ??
-          "BNL refresh requested. BNL will process this through the Source File refresh worker.",
+        refresh?.created === false
+          ? "BNL refresh already requested. Waiting for BNL to process it through the Source File refresh worker."
+          : data.message ??
+              "BNL refresh requested. BNL will process this through the Source File refresh worker.",
       );
     } catch (err) {
       setNotice(
@@ -1106,12 +1131,10 @@ export default function CandidateReviewPage() {
                   Source File Refresh
                 </p>
                 <p className="text-foreground">{refreshStatusLabel}</p>
+                <p className="mt-1">{refreshStatusDetail}</p>
                 {latestRefreshRequest && (
-                  <p className="mt-1">
-                    Reason: {latestRefreshRequest.reason} / Last completed: {formatDate(latestRefreshRequest.completedAt)}
-                  </p>
+                  <p className="mt-1">Reason: {latestRefreshRequest.reason}</p>
                 )}
-                {!latestRefreshRequest && <p className="mt-1">No refresh requested</p>}
               </div>
               <button
                 type="button"

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -21,6 +21,7 @@ import {
   type DossierDraft,
   type DossierDuplicateGroup,
   type DossierRecommendation,
+  type DossierSourceFileRefreshRequest,
   type DossierWorkflowAction,
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
@@ -45,7 +46,9 @@ import {
   getDossierWorkflowState,
   getDossierWorkflowStorageMode,
   ignoreDossierRecommendation,
+  recordDossierSourceFileOpen,
   rejectDossierIdentityLink,
+  requestDossierSourceFileRefresh,
   retireDossierIdentityLink,
   mergeDossierCandidates,
   markCandidateAsExistingDossierUpdate,
@@ -66,6 +69,7 @@ type DossierWorkflowResponse = {
   candidates: DossierCandidate[];
   drafts: DossierDraft[];
   recommendations: DossierRecommendation[];
+  sourceFileRefreshRequests: DossierSourceFileRefreshRequest[];
   duplicateGroups: DossierDuplicateGroup[];
   workflow: {
     version: 1;
@@ -119,6 +123,8 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "mergeCandidates",
   "updateSourceFileSummary",
   "addSourceFileNote",
+  "requestSourceFileRefresh",
+  "recordSourceFileOpen",
   "addDossierIdentityLink",
   "createIdentityLinkFromRecommendation",
   "updateDossierIdentityLink",
@@ -320,6 +326,7 @@ async function workflowPayload(
     candidates: workflowState.candidates,
     drafts: workflowState.drafts,
     recommendations: workflowState.recommendations,
+    sourceFileRefreshRequests: workflowState.sourceFileRefreshRequests,
     duplicateGroups: buildDossierDuplicateGroups(workflowState),
     ownerReviewQueue: {
       waitingCount: waitingForOwnerReview.length,
@@ -446,6 +453,47 @@ export async function POST(req: Request) {
       const note = await addDossierSourceFileNote(input);
       const payload = await workflowPayload();
       return NextResponse.json({ ok: true, action, note, ...payload });
+    }
+
+    if (action === "recordSourceFileOpen") {
+      const candidateId = candidateIdFromBody(body);
+      if (!candidateId) {
+        return NextResponse.json(
+          { error: "Source File open tracking requires candidateId" },
+          { status: 400 },
+        );
+      }
+      const refresh = await recordDossierSourceFileOpen({
+        candidateId,
+        requestedBy: "admin_open_source_file",
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, refresh, ...payload });
+    }
+
+    if (action === "requestSourceFileRefresh") {
+      const candidateId = candidateIdFromBody(body);
+      if (!candidateId) {
+        return NextResponse.json(
+          { error: "BNL refresh request requires candidateId" },
+          { status: 400 },
+        );
+      }
+      const refresh = await requestDossierSourceFileRefresh({
+        candidateId,
+        reason: typeof body.reason === "string" ? body.reason : undefined,
+        requestSource: "manual_admin",
+        requestedBy: "admin_manual",
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({
+        ok: true,
+        action,
+        refresh,
+        message:
+          "BNL refresh requested. BNL will process this through the Source File refresh worker.",
+        ...payload,
+      });
     }
 
     if (action === "addDossierIdentityLink") {

--- a/src/app/api/bnl/source-files/refresh-requests/route.ts
+++ b/src/app/api/bnl/source-files/refresh-requests/route.ts
@@ -1,0 +1,112 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import {
+  listPendingDossierSourceFileRefreshRequests,
+  updateDossierSourceFileRefreshRequestStatus,
+} from "@/lib/dossier-workflow-store";
+import type { DossierSourceFileRefreshRequestStatus } from "@/lib/dossier-workflow";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const CACHE_CONTROL = "private, no-store";
+const BOT_MUTABLE_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
+  "claimed",
+  "completed",
+  "failed",
+  "skipped",
+]);
+
+function bearerToken(req: Request): string {
+  const authorization = req.headers.get("authorization") ?? "";
+  if (authorization.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+  return req.headers.get("x-bnl-source-file-read-token")?.trim() ?? "";
+}
+
+function tokenMatches(providedToken: string): boolean {
+  const expectedToken = process.env.BNL_SOURCE_FILE_READ_TOKEN?.trim() ?? "";
+  if (!expectedToken || !providedToken) return false;
+  const expected = Buffer.from(expectedToken);
+  const provided = Buffer.from(providedToken);
+  return (
+    expected.length === provided.length && timingSafeEqual(expected, provided)
+  );
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export async function GET(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const url = new URL(req.url);
+  const limit = Number.parseInt(url.searchParams.get("limit") ?? "25", 10);
+  const requests = await listPendingDossierSourceFileRefreshRequests(
+    Number.isFinite(limit) ? limit : 25,
+  );
+  return NextResponse.json(
+    {
+      ok: true,
+      scope: "bnl_source_file_refresh_requests",
+      mutation: false,
+      requests: requests.map((request) => ({
+        id: request.id,
+        candidateId: request.candidateId ?? null,
+        subjectName: request.subjectName,
+        normalizedSubjectKey: request.normalizedSubjectKey,
+        reason: request.reason,
+        priority: request.priority,
+        requestedAt: request.requestedAt,
+        requestSource: request.requestSource,
+        notBeforeAt: request.notBeforeAt ?? null,
+      })),
+      generatedAt: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}
+
+export async function POST(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+  const requestId = stringValue(body.requestId ?? body.id);
+  const status = stringValue(body.status) as DossierSourceFileRefreshRequestStatus;
+  if (!requestId || !BOT_MUTABLE_STATUSES.has(status)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "requestId and a supported bot status are required",
+        supportedStatuses: [...BOT_MUTABLE_STATUSES],
+      },
+      { status: 400, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+  const request = await updateDossierSourceFileRefreshRequestStatus({
+    requestId,
+    status,
+    completedByRecommendationId: stringValue(body.completedByRecommendationId) || undefined,
+    failureReason: stringValue(body.failureReason) || undefined,
+  });
+  if (!request) {
+    return NextResponse.json(
+      { ok: false, error: "Refresh request was not found" },
+      { status: 404, headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+  return NextResponse.json(
+    {
+      ok: true,
+      mutation: "internal_refresh_request_status_only",
+      publishesPublicDossier: false,
+      request,
+      generatedAt: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -338,9 +338,11 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
     recommendations: Array.isArray(candidateState.recommendations)
       ? candidateState.recommendations
       : [],
-    sourceFileRefreshRequests: Array.isArray(candidateState.sourceFileRefreshRequests)
-      ? candidateState.sourceFileRefreshRequests
-      : [],
+    sourceFileRefreshRequests: mergeActiveSourceFileRefreshRequests(
+      Array.isArray(candidateState.sourceFileRefreshRequests)
+        ? candidateState.sourceFileRefreshRequests
+        : [],
+    ),
     updatedAt:
       typeof candidateState.updatedAt === "string"
         ? candidateState.updatedAt
@@ -1460,6 +1462,70 @@ function latestCompletedRefreshRequest(input: {
   );
 }
 
+function sourceFileRefreshDedupeKey(
+  request: Pick<DossierSourceFileRefreshRequest, "candidateId" | "normalizedSubjectKey" | "subjectName">,
+): string {
+  const candidateKey = request.candidateId?.trim();
+  if (candidateKey) return `candidate:${candidateKey}`;
+  const normalizedSubjectKey = request.normalizedSubjectKey?.trim()
+    ? request.normalizedSubjectKey.trim()
+    : normalizeName(request.subjectName);
+  return `subject:${normalizedSubjectKey}`;
+}
+
+function mergeActiveSourceFileRefreshRequests(
+  requests: DossierSourceFileRefreshRequest[],
+): DossierSourceFileRefreshRequest[] {
+  const merged = new Map<string, DossierSourceFileRefreshRequest>();
+  const output: DossierSourceFileRefreshRequest[] = [];
+
+  for (const request of requests) {
+    if (!OPEN_REQUEST_STATUSES.has(request.status)) {
+      output.push(request);
+      continue;
+    }
+
+    const key = sourceFileRefreshDedupeKey(request);
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, request);
+      output.push(request);
+      continue;
+    }
+
+    const mergedRequest: DossierSourceFileRefreshRequest = {
+      ...existing,
+      candidateId: existing.candidateId ?? request.candidateId,
+      subjectName: existing.subjectName || request.subjectName,
+      normalizedSubjectKey:
+        existing.normalizedSubjectKey || request.normalizedSubjectKey,
+      reason: request.updatedAt >= existing.updatedAt ? request.reason : existing.reason,
+      requestSource:
+        request.updatedAt >= existing.updatedAt
+          ? request.requestSource
+          : existing.requestSource,
+      priority: Math.max(existing.priority ?? 0, request.priority ?? 0),
+      requestedAt:
+        request.requestedAt < existing.requestedAt
+          ? request.requestedAt
+          : existing.requestedAt,
+      requestedBy: request.requestedBy ?? existing.requestedBy,
+      updatedAt:
+        request.updatedAt > existing.updatedAt ? request.updatedAt : existing.updatedAt,
+      lastAttemptAt:
+        request.lastAttemptAt &&
+        (!existing.lastAttemptAt || request.lastAttemptAt > existing.lastAttemptAt)
+          ? request.lastAttemptAt
+          : existing.lastAttemptAt,
+    };
+    merged.set(key, mergedRequest);
+    const outputIndex = output.findIndex((item) => item.id === existing.id);
+    if (outputIndex >= 0) output[outputIndex] = mergedRequest;
+  }
+
+  return output;
+}
+
 export function evaluateDossierSourceFileRefresh(input: {
   candidate: DossierCandidate;
   recommendations: DossierRecommendation[];
@@ -1552,14 +1618,20 @@ function upsertSourceFileRefreshRequestInState(input: {
   now: string;
   force?: boolean;
 }): { state: DossierWorkflowState; request: DossierSourceFileRefreshRequest; created: boolean } {
+  const state = {
+    ...input.state,
+    sourceFileRefreshRequests: mergeActiveSourceFileRefreshRequests(
+      input.state.sourceFileRefreshRequests,
+    ),
+  };
   const normalizedSubjectKey = normalizeName(input.candidate.name);
-  const existingIndex = input.state.sourceFileRefreshRequests.findIndex(
+  const existingIndex = state.sourceFileRefreshRequests.findIndex(
     (request) =>
       OPEN_REQUEST_STATUSES.has(request.status) &&
       (request.candidateId === input.candidate.id || request.normalizedSubjectKey === normalizedSubjectKey),
   );
   if (existingIndex >= 0) {
-    const existing = input.state.sourceFileRefreshRequests[existingIndex];
+    const existing = state.sourceFileRefreshRequests[existingIndex];
     const updated: DossierSourceFileRefreshRequest = {
       ...existing,
       candidateId: existing.candidateId ?? input.candidate.id,
@@ -1571,10 +1643,10 @@ function upsertSourceFileRefreshRequestInState(input: {
       requestedBy: input.requestedBy ?? existing.requestedBy,
       updatedAt: input.now,
     };
-    const requests = [...input.state.sourceFileRefreshRequests];
+    const requests = [...state.sourceFileRefreshRequests];
     requests[existingIndex] = updated;
     return {
-      state: { ...input.state, sourceFileRefreshRequests: requests, updatedAt: input.now },
+      state: { ...state, sourceFileRefreshRequests: requests, updatedAt: input.now },
       request: updated,
       created: false,
     };
@@ -1582,13 +1654,13 @@ function upsertSourceFileRefreshRequestInState(input: {
 
   if (!input.force) {
     const recentCompleted = latestCompletedRefreshRequest({
-      requests: input.state.sourceFileRefreshRequests,
+      requests: state.sourceFileRefreshRequests,
       candidate: input.candidate,
     });
     const completedAt = recentCompleted?.completedAt ? Date.parse(recentCompleted.completedAt) : NaN;
     const nowTime = Date.parse(input.now);
     if (!Number.isNaN(completedAt) && !Number.isNaN(nowTime) && nowTime - completedAt < OPEN_REFRESH_RECENT_COMPLETED_MS) {
-      return { state: input.state, request: recentCompleted!, created: false };
+      return { state, request: recentCompleted!, created: false };
     }
   }
 
@@ -1607,8 +1679,8 @@ function upsertSourceFileRefreshRequestInState(input: {
   };
   return {
     state: {
-      ...input.state,
-      sourceFileRefreshRequests: [request, ...input.state.sourceFileRefreshRequests],
+      ...state,
+      sourceFileRefreshRequests: [request, ...state.sourceFileRefreshRequests],
       updatedAt: input.now,
     },
     request,
@@ -1638,9 +1710,22 @@ export async function recordDossierSourceFileOpen(input: {
       refreshRequests: currentState.sourceFileRefreshRequests,
       now,
     });
-    if (!decision.needed || latestOpenRefreshRequest({ requests: currentState.sourceFileRefreshRequests, candidate })) {
-      result = { request: latestOpenRefreshRequest({ requests: currentState.sourceFileRefreshRequests, candidate }) ?? null, decision, created: false };
-      return currentState;
+    const existingOpenRequest = latestOpenRefreshRequest({
+      requests: mergeActiveSourceFileRefreshRequests(
+        currentState.sourceFileRefreshRequests,
+      ),
+      candidate,
+    });
+    if (!decision.needed || existingOpenRequest) {
+      result = { request: existingOpenRequest ?? null, decision, created: false };
+      return existingOpenRequest
+        ? {
+            ...currentState,
+            sourceFileRefreshRequests: mergeActiveSourceFileRefreshRequests(
+              currentState.sourceFileRefreshRequests,
+            ),
+          }
+        : currentState;
     }
     const upserted = upsertSourceFileRefreshRequestInState({
       state: currentState,
@@ -1704,7 +1789,10 @@ export async function updateDossierSourceFileRefreshRequestStatus(input: {
   const now = new Date().toISOString();
   let updated: DossierSourceFileRefreshRequest | null = null;
   await updateDossierWorkflowState((currentState) => {
-    const requests = currentState.sourceFileRefreshRequests.map((request) => {
+    const activeDedupedRequests = mergeActiveSourceFileRefreshRequests(
+      currentState.sourceFileRefreshRequests,
+    );
+    const requests = activeDedupedRequests.map((request) => {
       if (request.id !== input.requestId) return request;
       updated = {
         ...request,
@@ -1733,7 +1821,10 @@ function completeMatchingRefreshRequestsInState(input: {
   );
   const targetCandidateId = input.recommendation.targetCandidateId;
   let changed = false;
-  const requests = input.state.sourceFileRefreshRequests.map((request) => {
+  const activeDedupedRequests = mergeActiveSourceFileRefreshRequests(
+    input.state.sourceFileRefreshRequests,
+  );
+  const requests = activeDedupedRequests.map((request) => {
     const matches =
       COMPLETABLE_REFRESH_STATUSES.has(request.status) &&
       ((targetCandidateId && request.candidateId === targetCandidateId) ||

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -27,6 +27,10 @@ import {
   type DossierRecommendationSourceLane,
   type DossierRecommendationStatus,
   type DossierRecommendationType,
+  type DossierSourceFileRefreshDecision,
+  type DossierSourceFileRefreshRequest,
+  type DossierSourceFileRefreshRequestSource,
+  type DossierSourceFileRefreshRequestStatus,
   type DossierSourceFileNote,
   type DossierSourceFileNoteSource,
   type DossierSourceFileNoteType,
@@ -44,6 +48,7 @@ export type DossierWorkflowState = {
   candidates: DossierCandidate[];
   drafts: DossierDraft[];
   recommendations: DossierRecommendation[];
+  sourceFileRefreshRequests: DossierSourceFileRefreshRequest[];
   updatedAt: string;
 };
 
@@ -71,6 +76,7 @@ function emptyWorkflowState(): DossierWorkflowState {
     candidates: [],
     drafts: [],
     recommendations: [],
+    sourceFileRefreshRequests: [],
     updatedAt: new Date(0).toISOString(),
   };
 }
@@ -332,6 +338,9 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
     recommendations: Array.isArray(candidateState.recommendations)
       ? candidateState.recommendations
       : [],
+    sourceFileRefreshRequests: Array.isArray(candidateState.sourceFileRefreshRequests)
+      ? candidateState.sourceFileRefreshRequests
+      : [],
     updatedAt:
       typeof candidateState.updatedAt === "string"
         ? candidateState.updatedAt
@@ -353,6 +362,10 @@ function createRecommendationId(): string {
 
 function createSourceFileNoteId(): string {
   return `source_file_note_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createSourceFileRefreshRequestId(): string {
+  return `source_file_refresh_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function createIdentityLinkId(): string {
@@ -1383,6 +1396,362 @@ function upsertSourceFileEnrichmentNote(input: {
   };
 }
 
+
+const OPEN_REFRESH_RECENT_COMPLETED_MS = 60 * 60 * 1000;
+const DEFAULT_REFRESH_STALE_MS = 24 * 60 * 60 * 1000;
+const OPEN_REQUEST_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
+  "pending",
+  "claimed",
+]);
+const COMPLETABLE_REFRESH_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
+  "pending",
+  "claimed",
+]);
+
+function latestBnlSourceFileRecommendation(input: {
+  candidate: DossierCandidate;
+  recommendations: DossierRecommendation[];
+}): DossierRecommendation | undefined {
+  return input.recommendations
+    .filter(
+      (recommendation) =>
+        recommendation.targetCandidateId === input.candidate.id &&
+        recommendation.ingestSource === "bnl_source_file_enrichment",
+    )
+    .sort((a, b) =>
+      (b.ingestedAt ?? b.updatedAt ?? b.createdAt).localeCompare(
+        a.ingestedAt ?? a.updatedAt ?? a.createdAt,
+      ),
+    )[0];
+}
+
+function latestActiveSourceNoteTimestamp(candidate: DossierCandidate): string | undefined {
+  return (candidate.sourceFileNotes ?? [])
+    .filter((note) => note.status === "active")
+    .map((note) => note.updatedAt ?? note.createdAt)
+    .filter(Boolean)
+    .sort()
+    .at(-1);
+}
+
+function latestOpenRefreshRequest(input: {
+  requests: DossierSourceFileRefreshRequest[];
+  candidate: DossierCandidate;
+}): DossierSourceFileRefreshRequest | undefined {
+  const normalized = normalizeName(input.candidate.name);
+  return input.requests.find(
+    (request) =>
+      OPEN_REQUEST_STATUSES.has(request.status) &&
+      (request.candidateId === input.candidate.id ||
+        request.normalizedSubjectKey === normalized),
+  );
+}
+
+function latestCompletedRefreshRequest(input: {
+  requests: DossierSourceFileRefreshRequest[];
+  candidate: DossierCandidate;
+}): DossierSourceFileRefreshRequest | undefined {
+  const normalized = normalizeName(input.candidate.name);
+  return input.requests.find(
+    (request) =>
+      request.status === "completed" &&
+      (request.candidateId === input.candidate.id ||
+        request.normalizedSubjectKey === normalized),
+  );
+}
+
+export function evaluateDossierSourceFileRefresh(input: {
+  candidate: DossierCandidate;
+  recommendations: DossierRecommendation[];
+  refreshRequests?: DossierSourceFileRefreshRequest[];
+  now?: string;
+  staleAfterMs?: number;
+}): DossierSourceFileRefreshDecision {
+  const now = input.now ?? new Date().toISOString();
+  const staleAfterMs = input.staleAfterMs ?? DEFAULT_REFRESH_STALE_MS;
+  const latestRecommendation = latestBnlSourceFileRecommendation(input);
+  const latestRecommendationTimestamp = latestRecommendation
+    ? (latestRecommendation.ingestedAt ?? latestRecommendation.updatedAt ?? latestRecommendation.createdAt)
+    : undefined;
+  const latestSourceNoteTimestamp = latestActiveSourceNoteTimestamp(input.candidate);
+  const completed = latestCompletedRefreshRequest({
+    requests: input.refreshRequests ?? [],
+    candidate: input.candidate,
+  });
+  const completedAt = completed?.completedAt ? Date.parse(completed.completedAt) : NaN;
+  const nowTime = Date.parse(now);
+
+  if (
+    completed &&
+    !Number.isNaN(completedAt) &&
+    !Number.isNaN(nowTime) &&
+    nowTime - completedAt < OPEN_REFRESH_RECENT_COMPLETED_MS
+  ) {
+    return {
+      needed: false,
+      reason: "A BNL refresh completed recently.",
+      requestSource: "opened_source_file",
+      priority: 1,
+      latestRecommendationTimestamp,
+      latestSourceNoteTimestamp,
+    };
+  }
+
+  if (!latestRecommendationTimestamp) {
+    return {
+      needed: true,
+      reason: "No BNL Source File enrichment recommendation exists yet.",
+      requestSource: "missing_bnl_refresh",
+      priority: input.candidate.status === "existing_dossier_update" ? 70 : 60,
+      latestRecommendationTimestamp,
+      latestSourceNoteTimestamp,
+    };
+  }
+
+  const recommendationTime = Date.parse(latestRecommendationTimestamp);
+  const noteTime = latestSourceNoteTimestamp ? Date.parse(latestSourceNoteTimestamp) : NaN;
+  if (!Number.isNaN(noteTime) && !Number.isNaN(recommendationTime) && noteTime > recommendationTime) {
+    return {
+      needed: true,
+      reason: "Source file notes are newer than the latest BNL enrichment.",
+      requestSource: "source_notes_newer_than_bnl",
+      priority: 80,
+      latestRecommendationTimestamp,
+      latestSourceNoteTimestamp,
+    };
+  }
+
+  if (!Number.isNaN(recommendationTime) && !Number.isNaN(nowTime) && nowTime - recommendationTime > staleAfterMs) {
+    return {
+      needed: true,
+      reason: "Latest BNL Source File enrichment is older than the refresh policy threshold.",
+      requestSource: input.candidate.status === "existing_dossier_update" ? "existing_dossier_update_review" : "stale_source_file",
+      priority: input.candidate.status === "existing_dossier_update" ? 75 : 50,
+      latestRecommendationTimestamp,
+      latestSourceNoteTimestamp,
+    };
+  }
+
+  return {
+    needed: false,
+    reason: "Latest BNL Source File enrichment is fresh for the current source file notes.",
+    requestSource: "opened_source_file",
+    priority: 1,
+    latestRecommendationTimestamp,
+    latestSourceNoteTimestamp,
+  };
+}
+
+function upsertSourceFileRefreshRequestInState(input: {
+  state: DossierWorkflowState;
+  candidate: DossierCandidate;
+  reason: string;
+  requestSource: DossierSourceFileRefreshRequestSource;
+  priority: number;
+  requestedBy?: string;
+  now: string;
+  force?: boolean;
+}): { state: DossierWorkflowState; request: DossierSourceFileRefreshRequest; created: boolean } {
+  const normalizedSubjectKey = normalizeName(input.candidate.name);
+  const existingIndex = input.state.sourceFileRefreshRequests.findIndex(
+    (request) =>
+      OPEN_REQUEST_STATUSES.has(request.status) &&
+      (request.candidateId === input.candidate.id || request.normalizedSubjectKey === normalizedSubjectKey),
+  );
+  if (existingIndex >= 0) {
+    const existing = input.state.sourceFileRefreshRequests[existingIndex];
+    const updated: DossierSourceFileRefreshRequest = {
+      ...existing,
+      candidateId: existing.candidateId ?? input.candidate.id,
+      subjectName: existing.subjectName || input.candidate.name,
+      normalizedSubjectKey: existing.normalizedSubjectKey || normalizedSubjectKey,
+      reason: input.reason || existing.reason,
+      requestSource: input.requestSource,
+      priority: Math.max(existing.priority ?? 0, input.priority),
+      requestedBy: input.requestedBy ?? existing.requestedBy,
+      updatedAt: input.now,
+    };
+    const requests = [...input.state.sourceFileRefreshRequests];
+    requests[existingIndex] = updated;
+    return {
+      state: { ...input.state, sourceFileRefreshRequests: requests, updatedAt: input.now },
+      request: updated,
+      created: false,
+    };
+  }
+
+  if (!input.force) {
+    const recentCompleted = latestCompletedRefreshRequest({
+      requests: input.state.sourceFileRefreshRequests,
+      candidate: input.candidate,
+    });
+    const completedAt = recentCompleted?.completedAt ? Date.parse(recentCompleted.completedAt) : NaN;
+    const nowTime = Date.parse(input.now);
+    if (!Number.isNaN(completedAt) && !Number.isNaN(nowTime) && nowTime - completedAt < OPEN_REFRESH_RECENT_COMPLETED_MS) {
+      return { state: input.state, request: recentCompleted!, created: false };
+    }
+  }
+
+  const request: DossierSourceFileRefreshRequest = {
+    id: createSourceFileRefreshRequestId(),
+    candidateId: input.candidate.id,
+    subjectName: input.candidate.name,
+    normalizedSubjectKey,
+    status: "pending",
+    reason: input.reason,
+    requestedBy: input.requestedBy,
+    requestedAt: input.now,
+    updatedAt: input.now,
+    requestSource: input.requestSource,
+    priority: input.priority,
+  };
+  return {
+    state: {
+      ...input.state,
+      sourceFileRefreshRequests: [request, ...input.state.sourceFileRefreshRequests],
+      updatedAt: input.now,
+    },
+    request,
+    created: true,
+  };
+}
+
+export async function recordDossierSourceFileOpen(input: {
+  candidateId: string;
+  requestedBy?: string;
+}): Promise<{ request: DossierSourceFileRefreshRequest | null; decision: DossierSourceFileRefreshDecision; created: boolean }> {
+  const now = new Date().toISOString();
+  let result: { request: DossierSourceFileRefreshRequest | null; decision: DossierSourceFileRefreshDecision; created: boolean } | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const candidate = currentState.candidates.find((item) => item.id === input.candidateId);
+    if (!candidate || !isSourceFileEnrichmentAttachableCandidate(candidate)) {
+      result = {
+        request: null,
+        decision: { needed: false, reason: "Source File candidate was not found or is closed.", requestSource: "opened_source_file", priority: 1 },
+        created: false,
+      };
+      return currentState;
+    }
+    const decision = evaluateDossierSourceFileRefresh({
+      candidate,
+      recommendations: currentState.recommendations,
+      refreshRequests: currentState.sourceFileRefreshRequests,
+      now,
+    });
+    if (!decision.needed || latestOpenRefreshRequest({ requests: currentState.sourceFileRefreshRequests, candidate })) {
+      result = { request: latestOpenRefreshRequest({ requests: currentState.sourceFileRefreshRequests, candidate }) ?? null, decision, created: false };
+      return currentState;
+    }
+    const upserted = upsertSourceFileRefreshRequestInState({
+      state: currentState,
+      candidate,
+      reason: decision.reason,
+      requestSource: decision.requestSource === "opened_source_file" ? "opened_source_file" : decision.requestSource,
+      priority: decision.priority,
+      requestedBy: input.requestedBy ?? "admin_open_source_file",
+      now,
+    });
+    result = { request: upserted.request, decision, created: upserted.created };
+    return upserted.state;
+  });
+  return result!;
+}
+
+export async function requestDossierSourceFileRefresh(input: {
+  candidateId: string;
+  reason?: string;
+  requestSource?: DossierSourceFileRefreshRequestSource;
+  requestedBy?: string;
+  priority?: number;
+}): Promise<{ request: DossierSourceFileRefreshRequest; created: boolean }> {
+  const now = new Date().toISOString();
+  let result: { request: DossierSourceFileRefreshRequest; created: boolean } | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const candidate = currentState.candidates.find((item) => item.id === input.candidateId);
+    if (!candidate || !isSourceFileEnrichmentAttachableCandidate(candidate)) {
+      throw new DossierWorkflowInputError("Source File candidate was not found or cannot be refreshed");
+    }
+    const upserted = upsertSourceFileRefreshRequestInState({
+      state: currentState,
+      candidate,
+      reason: input.reason?.trim() || "Manual admin requested a BNL Source File refresh.",
+      requestSource: input.requestSource ?? "manual_admin",
+      priority: input.priority ?? 90,
+      requestedBy: input.requestedBy ?? "admin_manual",
+      now,
+      force: true,
+    });
+    result = { request: upserted.request, created: upserted.created };
+    return upserted.state;
+  });
+  return result!;
+}
+
+export async function listPendingDossierSourceFileRefreshRequests(limit = 25): Promise<DossierSourceFileRefreshRequest[]> {
+  const state = await getDossierWorkflowState();
+  return state.sourceFileRefreshRequests
+    .filter((request) => request.status === "pending")
+    .sort((a, b) => (b.priority - a.priority) || a.requestedAt.localeCompare(b.requestedAt))
+    .slice(0, Math.max(1, Math.min(100, limit)));
+}
+
+export async function updateDossierSourceFileRefreshRequestStatus(input: {
+  requestId: string;
+  status: DossierSourceFileRefreshRequestStatus;
+  completedByRecommendationId?: string;
+  failureReason?: string;
+}): Promise<DossierSourceFileRefreshRequest | null> {
+  const now = new Date().toISOString();
+  let updated: DossierSourceFileRefreshRequest | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const requests = currentState.sourceFileRefreshRequests.map((request) => {
+      if (request.id !== input.requestId) return request;
+      updated = {
+        ...request,
+        status: input.status,
+        updatedAt: now,
+        lastAttemptAt: input.status === "claimed" ? now : request.lastAttemptAt,
+        completedAt: input.status === "completed" || input.status === "skipped" ? now : request.completedAt,
+        completedByRecommendationId: input.completedByRecommendationId ?? request.completedByRecommendationId,
+        failureReason: input.failureReason ?? request.failureReason,
+      };
+      return updated;
+    });
+    return updated ? { ...currentState, sourceFileRefreshRequests: requests, updatedAt: now } : currentState;
+  });
+  return updated;
+}
+
+function completeMatchingRefreshRequestsInState(input: {
+  state: DossierWorkflowState;
+  recommendation: DossierRecommendation;
+  now: string;
+}): DossierWorkflowState {
+  if (input.recommendation.ingestSource !== "bnl_source_file_enrichment") return input.state;
+  const normalizedSubjectKey = normalizeName(
+    input.recommendation.subjectKey || input.recommendation.subjectName,
+  );
+  const targetCandidateId = input.recommendation.targetCandidateId;
+  let changed = false;
+  const requests = input.state.sourceFileRefreshRequests.map((request) => {
+    const matches =
+      COMPLETABLE_REFRESH_STATUSES.has(request.status) &&
+      ((targetCandidateId && request.candidateId === targetCandidateId) ||
+        request.normalizedSubjectKey === normalizedSubjectKey ||
+        normalizeName(request.subjectName) === normalizeName(input.recommendation.subjectName));
+    if (!matches) return request;
+    changed = true;
+    return {
+      ...request,
+      status: "completed" as const,
+      completedAt: input.now,
+      completedByRecommendationId: input.recommendation.id,
+      updatedAt: input.now,
+    };
+  });
+  return changed ? { ...input.state, sourceFileRefreshRequests: requests, updatedAt: input.now } : input.state;
+}
+
 export async function createDossierRecommendationIdempotent(
   input: CreateDossierRecommendationInput,
 ): Promise<{
@@ -1806,6 +2175,16 @@ export async function createDossierRecommendationIdempotent(
       updatedAt: now,
     };
   });
+
+  if (savedRecommendation.ingestSource === "bnl_source_file_enrichment") {
+    await updateDossierWorkflowState((currentState) =>
+      completeMatchingRefreshRequestsInState({
+        state: currentState,
+        recommendation: savedRecommendation,
+        now,
+      }),
+    );
+  }
 
   return {
     recommendation: savedRecommendation,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -372,6 +372,51 @@ export type DossierRecommendationIngestSource =
   | "system"
   | "unknown";
 
+
+export type DossierSourceFileRefreshRequestStatus =
+  | "pending"
+  | "claimed"
+  | "completed"
+  | "failed"
+  | "skipped"
+  | "cancelled";
+
+export type DossierSourceFileRefreshRequestSource =
+  | "opened_source_file"
+  | "manual_admin"
+  | "stale_source_file"
+  | "missing_bnl_refresh"
+  | "source_notes_newer_than_bnl"
+  | "existing_dossier_update_review";
+
+export type DossierSourceFileRefreshRequest = {
+  id: string;
+  candidateId?: string;
+  subjectName: string;
+  normalizedSubjectKey: string;
+  status: DossierSourceFileRefreshRequestStatus;
+  reason: string;
+  requestedBy?: string;
+  requestedAt: string;
+  updatedAt: string;
+  lastAttemptAt?: string;
+  completedAt?: string;
+  completedByRecommendationId?: string;
+  failureReason?: string;
+  requestSource: DossierSourceFileRefreshRequestSource;
+  priority: number;
+  notBeforeAt?: string;
+};
+
+export type DossierSourceFileRefreshDecision = {
+  needed: boolean;
+  reason: string;
+  requestSource: DossierSourceFileRefreshRequestSource;
+  priority: number;
+  latestRecommendationTimestamp?: string;
+  latestSourceNoteTimestamp?: string;
+};
+
 export type DossierQueueSubmissionStatus =
   | "not_connected"
   | "connected"
@@ -874,6 +919,8 @@ export type DossierWorkflowAction =
   | "markNeedsMoreEvidence"
   | "updateSourceFileSummary"
   | "addSourceFileNote"
+  | "requestSourceFileRefresh"
+  | "recordSourceFileOpen"
   | "addDossierIdentityLink"
   | "createIdentityLinkFromRecommendation"
   | "updateDossierIdentityLink"
@@ -921,6 +968,8 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "markNeedsMoreEvidence",
   "updateSourceFileSummary",
   "addSourceFileNote",
+  "requestSourceFileRefresh",
+  "recordSourceFileOpen",
   "addDossierIdentityLink",
   "createIdentityLinkFromRecommendation",
   "updateDossierIdentityLink",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -361,6 +361,24 @@ test("Source File open refresh workflow dedupes, exposes bot polling, and comple
   assert.equal(secondOpen.sourceFileRefreshRequests.length, 1);
   assert.equal(secondOpen.refresh.created, false);
 
+  const thirdOpen = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+  assert.equal(thirdOpen.sourceFileRefreshRequests.filter((request) => request.status === "pending" || request.status === "claimed").length, 1);
+  assert.equal(thirdOpen.sourceFileRefreshRequests[0].id, firstOpen.sourceFileRefreshRequests[0].id);
+
+  const duplicateState = await store.getDossierWorkflowState();
+  await store.saveDossierWorkflowState({
+    ...duplicateState,
+    sourceFileRefreshRequests: [
+      ...duplicateState.sourceFileRefreshRequests,
+      {
+        ...duplicateState.sourceFileRefreshRequests[0],
+        id: "legacy-duplicate-refresh-request",
+        updatedAt: new Date(Date.now() + 1).toISOString(),
+      },
+    ],
+  });
+  assert.equal((await store.getDossierWorkflowState()).sourceFileRefreshRequests.filter((request) => request.status === "pending" || request.status === "claimed").length, 1);
+
   const manual = await (await authedPost({
     action: "requestSourceFileRefresh",
     candidateId,
@@ -370,6 +388,18 @@ test("Source File open refresh workflow dedupes, exposes bot polling, and comple
   assert.equal(manual.sourceFileRefreshRequests.length, 1);
   assert.equal(manual.sourceFileRefreshRequests[0].reason, "Manual test refresh request.");
   assert.equal(manual.sourceFileRefreshRequests[0].requestSource, "manual_admin");
+  const manualRequestId = manual.sourceFileRefreshRequests[0].id;
+
+  const manualReload = await (await authedPost({
+    action: "requestSourceFileRefresh",
+    candidateId,
+    reason: "Manual test refresh request clicked again.",
+  })).json();
+  const manualActiveRequests = manualReload.sourceFileRefreshRequests.filter((request) => request.status === "pending" || request.status === "claimed");
+  assert.equal(manualReload.refresh.created, false);
+  assert.equal(manualActiveRequests.length, 1);
+  assert.equal(manualActiveRequests[0].id, manualRequestId);
+  assert.equal(manualActiveRequests[0].reason, "Manual test refresh request clicked again.");
 
   const poll = await (await refreshRequestsGet("?limit=5")).json();
   assert.equal(poll.ok, true);
@@ -870,6 +900,14 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Source strength",
     "Current draft status",
     "Recommendations",
+    "Refresh status",
+    "Source File Refresh",
+    "BNL refresh requested",
+    "Waiting for BNL",
+    "BNL refresh in progress",
+    "BNL refresh completed",
+    "This Source File has not been refreshed yet",
+    "Request BNL Refresh",
     "Source notes",
     "Unapplied notes",
     "Next action",
@@ -910,6 +948,9 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
+  assert.match(page, /latestRefreshRequest\.status === "pending"[\s\S]*"BNL refresh requested"/);
+  assert.match(page, /latestRefreshRequest\.status === "claimed"[\s\S]*"BNL refresh in progress"/);
+  assert.match(page, /Waiting for BNL\.[\s\S]*has not been refreshed yet/);
   assert.doesNotMatch(pageCopy, /Persistent Source File Draft/);
   assert.doesNotMatch(pageCopy, /Internal Operator Summary/);
   assert.doesNotMatch(pageCopy, /Save Internal Summary/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -52,6 +52,7 @@ const store = require("../src/lib/dossier-workflow-store.ts");
 const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
+const sourceFileRefreshRequestsRoute = require("../src/app/api/bnl/source-files/refresh-requests/route.ts");
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
 const entityReadout = require("../src/lib/dossier-entity-activity-readout.ts");
@@ -265,6 +266,29 @@ async function sourceFilesGet(query, token = "test-source-file-read-token") {
   );
 }
 
+async function refreshRequestsGet(query = "", token = "test-source-file-read-token") {
+  return sourceFileRefreshRequestsRoute.GET(
+    new Request(`https://example.test/api/bnl/source-files/refresh-requests${query}`, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    }),
+  );
+}
+
+async function refreshRequestsPost(body, token = "test-source-file-read-token") {
+  return sourceFileRefreshRequestsRoute.POST(
+    new Request("https://example.test/api/bnl/source-files/refresh-requests", {
+      method: "POST",
+      headers: token
+        ? {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          }
+        : { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
 async function bnlIngestPost(body, token = "test-bnl-ingest-token") {
   return bnlIngestRoute.POST(
     new Request("https://example.test/api/bnl/dossier-recommendations", {
@@ -308,6 +332,179 @@ const manualCandidateInput = {
     publicSafe: true,
   },
 };
+
+
+test("Source File open refresh workflow dedupes, exposes bot polling, and completes on BNL enrichment", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Refresh Fixture Subject",
+      candidateType: "artist",
+      reason: "Operator wants a refresh workflow fixture.",
+      whyNow: "The source file needs BNL review.",
+      evidenceSummary: "Admin fixture evidence.",
+    },
+  })).json();
+  const candidateId = created.candidate.id;
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+
+  const firstOpen = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+  assert.equal(firstOpen.refresh.request.status, "pending");
+  assert.equal(firstOpen.sourceFileRefreshRequests.length, 1);
+  assert.equal(firstOpen.sourceFileRefreshRequests[0].requestSource, "missing_bnl_refresh");
+
+  const secondOpen = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+  assert.equal(secondOpen.sourceFileRefreshRequests.length, 1);
+  assert.equal(secondOpen.refresh.created, false);
+
+  const manual = await (await authedPost({
+    action: "requestSourceFileRefresh",
+    candidateId,
+    reason: "Manual test refresh request.",
+  })).json();
+  assert.equal(manual.message, "BNL refresh requested. BNL will process this through the Source File refresh worker.");
+  assert.equal(manual.sourceFileRefreshRequests.length, 1);
+  assert.equal(manual.sourceFileRefreshRequests[0].reason, "Manual test refresh request.");
+  assert.equal(manual.sourceFileRefreshRequests[0].requestSource, "manual_admin");
+
+  const poll = await (await refreshRequestsGet("?limit=5")).json();
+  assert.equal(poll.ok, true);
+  assert.equal(poll.requests.length, 1);
+  assert.equal(poll.requests[0].candidateId, candidateId);
+  assert.equal(poll.requests[0].subjectName, "Refresh Fixture Subject");
+
+  const claimed = await (await refreshRequestsPost({
+    requestId: poll.requests[0].id,
+    status: "claimed",
+  })).json();
+  assert.equal(claimed.request.status, "claimed");
+  assert.ok(claimed.request.lastAttemptAt);
+
+  const completed = await (await refreshRequestsPost({
+    requestId: poll.requests[0].id,
+    status: "completed",
+    completedByRecommendationId: "manual-complete-rec",
+  })).json();
+  assert.equal(completed.request.status, "completed");
+  assert.equal(completed.request.completedByRecommendationId, "manual-complete-rec");
+
+  const afterRecentCompletion = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+  assert.equal(afterRecentCompletion.sourceFileRefreshRequests.length, 1);
+  assert.equal(afterRecentCompletion.refresh.request, null);
+
+  const manualAgain = await (await authedPost({
+    action: "requestSourceFileRefresh",
+    candidateId,
+    reason: "Manual refresh after completion.",
+  })).json();
+  assert.equal(manualAgain.sourceFileRefreshRequests.filter((request) => request.status === "pending").length, 1);
+
+  const ingest = await (await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Refresh Fixture Subject",
+    targetCandidateId: candidateId,
+    reason: "BNL refreshed this source file.",
+    evidenceSummary: "Fresh enrichment evidence.",
+    sourceLanes: ["rd_context"],
+    ingestKey: "refresh-fixture-enrichment-1",
+    ingestSource: "bnl_source_file_enrichment",
+  })).json();
+  assert.equal(ingest.ok, true);
+
+  const finalState = await store.getDossierWorkflowState();
+  const finalRequest = finalState.sourceFileRefreshRequests.find((request) => request.reason === "Manual refresh after completion.");
+  assert.equal(finalRequest.status, "completed");
+  assert.equal(finalRequest.completedByRecommendationId, ingest.recommendation.id);
+});
+
+test("fresh Source File open does not auto-request refresh and public read model stays read-only", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+
+  const now = new Date().toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [{
+      id: "fresh-source-candidate",
+      name: "Fresh Fixture Subject",
+      candidateType: "artist",
+      source: "manual",
+      tier: "review_candidate",
+      score: 5,
+      whyNow: "Fresh test fixture.",
+      reason: "Fresh test fixture.",
+      evidenceSummary: "Fresh source file evidence.",
+      sourceFileNotes: [],
+      status: "active_source_file",
+      createdAt: now,
+      updatedAt: now,
+    }],
+    drafts: [],
+    recommendations: [{
+      id: "fresh-source-rec",
+      type: "new_subject",
+      subjectName: "Fresh Fixture Subject",
+      targetCandidateId: "fresh-source-candidate",
+      status: "attached_to_source_file",
+      reason: "Fresh BNL enrichment.",
+      sourceLanes: ["rd_context"],
+      createdAt: now,
+      updatedAt: now,
+      ingestSource: "bnl_source_file_enrichment",
+      ingestedAt: now,
+    }],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const opened = await (await authedPost({ action: "recordSourceFileOpen", candidateId: "fresh-source-candidate" })).json();
+  assert.equal(opened.refresh.decision.needed, false);
+  assert.equal(opened.sourceFileRefreshRequests.length, 0);
+
+  const beforePublicRead = await store.getDossierWorkflowState();
+  const publicRead = await (await sourceFilesGet("?subject=Fresh%20Fixture%20Subject")).json();
+  assert.equal(publicRead.ok, true);
+  assert.equal(publicRead.mutation, false);
+  assert.deepEqual(await store.getDossierWorkflowState(), beforePublicRead);
+});
+
+test("bot can mark Source File refresh request failed without public workflow side effects", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Failed Refresh Fixture",
+      reason: "Operator wants failure status coverage.",
+      whyNow: "Testing refresh request failure.",
+      evidenceSummary: "Failure fixture evidence.",
+    },
+  })).json();
+  const candidateId = created.candidate.id;
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+  const requested = await (await authedPost({ action: "requestSourceFileRefresh", candidateId })).json();
+  const requestId = requested.refresh.request.id;
+
+  const failed = await (await refreshRequestsPost({
+    requestId,
+    status: "failed",
+    failureReason: "Bot worker test failure.",
+  })).json();
+  assert.equal(failed.request.status, "failed");
+  assert.equal(failed.request.failureReason, "Bot worker test failure.");
+  assert.equal(failed.publishesPublicDossier, false);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.drafts.length, 0);
+  assert.equal(state.recommendations.length, 0);
+  assert.equal(state.candidates.some((candidate) => candidate.id === candidateId), true);
+});
 
 test("taxonomy source types, entry annotations, and tag aliases are present", () => {
   const contentSource = source("src/content.ts");


### PR DESCRIPTION
### Motivation
- Admins need the site to automatically and manually request BNL Source File refreshes when a Source File is opened or when notes/recommendations are stale, and provide a bot-consumable queue for processing and completion tracking.

### Description
- Added durable refresh request types, evaluation logic, dedupe and upsert helpers, and automatic completion when matching BNL enrichment is ingested in `src/lib/dossier-workflow.ts` and `src/lib/dossier-workflow-store.ts`.
- Exposed admin workflow actions `recordSourceFileOpen` and `requestSourceFileRefresh` via the admin API in `src/app/api/admin/dossiers/route.ts` so opening a Source File or clicking a manual button creates/updates requests without publishing anything.
- Added a BNL-protected polling/status API at `/api/bnl/source-files/refresh-requests` for the bot to GET pending requests and POST status updates (claimed/completed/failed/skipped) at `src/app/api/bnl/source-files/refresh-requests/route.ts`.
- Updated admin Source File UI to record opens, display compact refresh status, and provide a `Request BNL Refresh` control in `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`.
- Tests added/updated in `tests/admin-dossiers.test.mjs` to cover open-created dedupe, manual requests, bot polling/status updates, ingest-driven completion, fresh no-op behavior, and bot failure handling.
- Files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`, `src/app/api/bnl/source-files/refresh-requests/route.ts`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, and `tests/admin-dossiers.test.mjs` to implement and validate the workflow.

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and the admin-focused suite passed; the refresh request flows (open->pending, dedupe, manual request, bot claim/complete/fail, and ingest completion) behaved as expected.
- Ran `node --test tests/bnl-read-model.test.mjs` and the BNL read-model suite passed in the final run after local fixes to normalization usage introduced during integration.
- Ran `npx tsc --noEmit` which completed successfully with no type errors.
- Ran `npm run build` which failed due to a Next/font Google Fonts fetch error in this environment (external network fetch for Geist Mono failed); this build failure is environmental and unrelated to the workflow logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22209712848321a520dba5b33d59a3)