### PR TITLE
Refresh admin Source File data after BNL completion

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   getDossierSourceFileMetrics,
@@ -20,7 +20,10 @@ import {
 } from "@/lib/dossier-workflow";
 import { DossierSourceFileSummaryPanel } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
-import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
+import {
+  createDossierSourceFileSummary,
+  selectDossierSourceFileDisplayRecommendations,
+} from "@/lib/dossier-source-file-summary";
 import { createDossierEntityActivityReadoutFromSourceFile } from "@/lib/dossier-entity-activity-readout";
 import {
   sanitizeMeaningFirstItems,
@@ -555,6 +558,7 @@ function PhaseRail() {
 
 export default function CandidateReviewPage() {
   const params = useParams();
+  const router = useRouter();
   const candidateId = routeParam(params?.candidateId);
   const [payload, setPayload] = useState<WorkflowPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -568,7 +572,7 @@ export default function CandidateReviewPage() {
   const [selectedExistingDossierId, setSelectedExistingDossierId] =
     useState("");
 
-  async function loadWorkflow() {
+  async function fetchWorkflowPayload() {
     const response = await fetch("/api/admin/dossiers", { cache: "no-store" });
     if (!response.ok)
       throw new Error(
@@ -576,8 +580,14 @@ export default function CandidateReviewPage() {
           ? "Admin authentication required"
           : `Workflow API returned ${response.status}.`,
       );
-    const data = (await response.json()) as WorkflowPayload;
+    return (await response.json()) as WorkflowPayload;
+  }
+
+  async function loadWorkflow(options: { recordOpen?: boolean } = {}) {
+    const data = await fetchWorkflowPayload();
     setPayload(data);
+
+    if (options.recordOpen === false) return;
 
     const openResponse = await fetch("/api/admin/dossiers", {
       method: "POST",
@@ -591,7 +601,7 @@ export default function CandidateReviewPage() {
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      void loadWorkflow()
+      void loadWorkflow({ recordOpen: true })
         .catch((err) =>
           setError(
             err instanceof Error
@@ -603,6 +613,67 @@ export default function CandidateReviewPage() {
     }, 0);
     return () => window.clearTimeout(timer);
   }, [candidateId]);
+
+  useEffect(() => {
+    const candidateSubjectKey = payload?.candidates.find(
+      (item) => item.id === candidateId,
+    )?.name;
+    if (!candidateSubjectKey) return;
+    const normalizedSubjectKey =
+      normalizeDossierSubjectName(candidateSubjectKey);
+    const pendingRefreshRequest = payload?.sourceFileRefreshRequests
+      .filter(
+        (request) =>
+          (request.candidateId === candidateId ||
+            request.normalizedSubjectKey === normalizedSubjectKey) &&
+          (request.status === "pending" || request.status === "claimed"),
+      )
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+    if (!pendingRefreshRequest) return;
+
+    let cancelled = false;
+    const pollForRefreshCompletion = async () => {
+      try {
+        const freshPayload = await fetchWorkflowPayload();
+        if (cancelled) return;
+        setPayload(freshPayload);
+        const latestMatchingRefresh = freshPayload.sourceFileRefreshRequests
+          .filter(
+            (request) =>
+              request.candidateId === candidateId ||
+              request.normalizedSubjectKey === normalizedSubjectKey,
+          )
+          .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+        if (
+          latestMatchingRefresh &&
+          latestMatchingRefresh.status !== "pending" &&
+          latestMatchingRefresh.status !== "claimed"
+        ) {
+          router.refresh();
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setNotice(
+            err instanceof Error
+              ? err.message
+              : "Failed to check BNL Source File refresh status.",
+          );
+        }
+      }
+    };
+    const interval = window.setInterval(() => {
+      void pollForRefreshCompletion();
+    }, 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [
+    candidateId,
+    payload?.candidates,
+    payload?.sourceFileRefreshRequests,
+    router,
+  ]);
 
   const candidate = useMemo(
     () => payload?.candidates.find((item) => item.id === candidateId) ?? null,
@@ -652,9 +723,13 @@ export default function CandidateReviewPage() {
         recommendations: payload?.recommendations ?? [],
       })
     : null;
-  const attachedRecommendations = (payload?.recommendations ?? []).filter(
-    (recommendation) => recommendation.targetCandidateId === candidate?.id,
-  );
+  const attachedRecommendations = candidate
+    ? selectDossierSourceFileDisplayRecommendations({
+        candidate,
+        recommendations: payload?.recommendations ?? [],
+        refreshRequests: payload?.sourceFileRefreshRequests ?? [],
+      })
+    : [];
   const latestRecommendationTimestamp = attachedRecommendations
     .map(
       (recommendation) => recommendation.updatedAt ?? recommendation.createdAt,
@@ -677,7 +752,9 @@ export default function CandidateReviewPage() {
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
   const latestRefreshRequest =
     activeRefreshRequest ??
-    [...refreshRequests].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+    [...refreshRequests].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    )[0];
   const refreshStatusLabel = latestRefreshRequest
     ? latestRefreshRequest.status === "pending"
       ? "BNL refresh requested"
@@ -809,8 +886,8 @@ export default function CandidateReviewPage() {
       setNotice(
         refresh?.created === false
           ? "BNL refresh already requested. Waiting for BNL to process it through the Source File refresh worker."
-          : data.message ??
-              "BNL refresh requested. BNL will process this through the Source File refresh worker.",
+          : (data.message ??
+              "BNL refresh requested. BNL will process this through the Source File refresh worker."),
       );
     } catch (err) {
       setNotice(

--- a/src/lib/dossier-source-file-summary.ts
+++ b/src/lib/dossier-source-file-summary.ts
@@ -2,7 +2,9 @@ import type {
   DossierCandidate,
   DossierDraft,
   DossierRecommendation,
+  DossierSourceFileRefreshRequest,
 } from "./dossier-workflow";
+import { normalizeDossierSubjectName } from "./dossier-workflow";
 import {
   containsDossierBackendJunk,
   hasDossierMeaningfulPattern,
@@ -230,6 +232,130 @@ function nextActionCopy(action: DossierSourceFileNextAction) {
   return "Add real context: repeated appearances, channel notes, public-safe facts, missing history, and owner/admin review notes.";
 }
 
+function recommendationTimestamp(recommendation: DossierRecommendation) {
+  return (
+    recommendation.ingestedAt ??
+    recommendation.updatedAt ??
+    recommendation.createdAt ??
+    ""
+  );
+}
+
+function sortRecommendationsNewestFirst(
+  recommendations: DossierRecommendation[],
+): DossierRecommendation[] {
+  return [...recommendations].sort((a, b) => {
+    const timestampComparison = recommendationTimestamp(b).localeCompare(
+      recommendationTimestamp(a),
+    );
+    if (timestampComparison !== 0) return timestampComparison;
+    return b.id.localeCompare(a.id);
+  });
+}
+
+function isBnlSourceFileEnrichment(recommendation: DossierRecommendation) {
+  return recommendation.ingestSource === "bnl_source_file_enrichment";
+}
+
+function isRecommendationRelevantToCandidate(input: {
+  recommendation: DossierRecommendation;
+  candidate: DossierCandidate;
+}) {
+  const { recommendation, candidate } = input;
+  if (recommendation.targetCandidateId) {
+    return recommendation.targetCandidateId === candidate.id;
+  }
+  return (
+    normalizeDossierSubjectName(
+      recommendation.subjectKey || recommendation.subjectName,
+    ) === normalizeDossierSubjectName(candidate.name)
+  );
+}
+
+function latestCompletedRefreshRequest(input: {
+  candidate: DossierCandidate;
+  refreshRequests?: DossierSourceFileRefreshRequest[];
+}) {
+  const candidateSubjectKey = normalizeDossierSubjectName(input.candidate.name);
+  return (input.refreshRequests ?? [])
+    .filter(
+      (request) =>
+        request.status === "completed" &&
+        (request.candidateId === input.candidate.id ||
+          request.normalizedSubjectKey === candidateSubjectKey),
+    )
+    .sort((a, b) =>
+      (b.completedAt ?? b.updatedAt).localeCompare(
+        a.completedAt ?? a.updatedAt,
+      ),
+    )[0];
+}
+
+export function selectDossierSourceFileDisplayRecommendations(input: {
+  candidate: DossierCandidate;
+  recommendations?: DossierRecommendation[];
+  refreshRequests?: DossierSourceFileRefreshRequest[];
+}): DossierRecommendation[] {
+  const recommendations = input.recommendations ?? [];
+  const relevantRecommendations = recommendations.filter((recommendation) =>
+    isRecommendationRelevantToCandidate({
+      recommendation,
+      candidate: input.candidate,
+    }),
+  );
+  const completedRefresh = latestCompletedRefreshRequest({
+    candidate: input.candidate,
+    refreshRequests: input.refreshRequests,
+  });
+  const completedRefreshRecommendation =
+    completedRefresh?.completedByRecommendationId
+      ? relevantRecommendations.find(
+          (recommendation) =>
+            recommendation.id ===
+              completedRefresh.completedByRecommendationId &&
+            isBnlSourceFileEnrichment(recommendation),
+        )
+      : undefined;
+  const newestTargetedEnrichment = sortRecommendationsNewestFirst(
+    relevantRecommendations.filter(
+      (recommendation) =>
+        isBnlSourceFileEnrichment(recommendation) &&
+        recommendation.targetCandidateId === input.candidate.id,
+    ),
+  )[0];
+  const candidateSubjectKey = normalizeDossierSubjectName(input.candidate.name);
+  const newestSubjectKeyEnrichment = sortRecommendationsNewestFirst(
+    relevantRecommendations.filter(
+      (recommendation) =>
+        isBnlSourceFileEnrichment(recommendation) &&
+        !recommendation.targetCandidateId &&
+        normalizeDossierSubjectName(
+          recommendation.subjectKey || recommendation.subjectName,
+        ) === candidateSubjectKey,
+    ),
+  )[0];
+
+  const selectedEnrichment =
+    completedRefreshRecommendation ??
+    newestTargetedEnrichment ??
+    newestSubjectKeyEnrichment;
+
+  if (!selectedEnrichment) {
+    return sortRecommendationsNewestFirst(relevantRecommendations);
+  }
+
+  return [
+    selectedEnrichment,
+    ...sortRecommendationsNewestFirst(
+      relevantRecommendations.filter(
+        (recommendation) =>
+          recommendation.id !== selectedEnrichment.id &&
+          !isBnlSourceFileEnrichment(recommendation),
+      ),
+    ),
+  ];
+}
+
 export function createDossierSourceFileSummary(
   input: SummaryInput,
 ): DossierSourceFileSummary {
@@ -304,14 +430,16 @@ export function createDossierSourceFileSummary(
     6,
   );
   const structuredNotPublicYet = unique(
-    recommendations.flatMap((recommendation) =>
-      recommendation.notPublicYet ?? [],
+    recommendations.flatMap(
+      (recommendation) => recommendation.notPublicYet ?? [],
     ),
     6,
   );
 
   const structuredObservedChannels = unique(
-    recommendations.flatMap((recommendation) => recommendation.observedChannels ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.observedChannels ?? [],
+    ),
     6,
   );
   const structuredConversationHighlights = unique(
@@ -321,7 +449,9 @@ export function createDossierSourceFileSummary(
     6,
   );
   const structuredTopicBreakdown = unique(
-    recommendations.flatMap((recommendation) => recommendation.topicBreakdown ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.topicBreakdown ?? [],
+    ),
     6,
   );
   const structuredBestEvidenceToReview = unique(
@@ -337,7 +467,9 @@ export function createDossierSourceFileSummary(
     6,
   );
   const structuredMusicSignals = unique(
-    recommendations.flatMap((recommendation) => recommendation.musicSignals ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.musicSignals ?? [],
+    ),
     6,
   );
   const structuredCommunitySignals = unique(
@@ -347,35 +479,51 @@ export function createDossierSourceFileSummary(
     6,
   );
   const structuredSourceCoverage = unique(
-    recommendations.flatMap((recommendation) => recommendation.sourceCoverage ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.sourceCoverage ?? [],
+    ),
     6,
   );
   const structuredEvidenceDetails = unique(
-    recommendations.flatMap((recommendation) => recommendation.evidenceDetails ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.evidenceDetails ?? [],
+    ),
     6,
   );
   const structuredRepresentativeEvidence = unique(
-    recommendations.flatMap((recommendation) => recommendation.representativeEvidence ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.representativeEvidence ?? [],
+    ),
     8,
   );
   const structuredActivityFrequencySummary = unique(
-    recommendations.flatMap((recommendation) => recommendation.activityFrequencySummary ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.activityFrequencySummary ?? [],
+    ),
     4,
   );
   const structuredTopChannels = unique(
-    recommendations.flatMap((recommendation) => recommendation.topChannels ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.topChannels ?? [],
+    ),
     6,
   );
   const structuredTopTopicDetails = unique(
-    recommendations.flatMap((recommendation) => recommendation.topTopicDetails ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.topTopicDetails ?? [],
+    ),
     6,
   );
   const structuredRecentActivitySummary = unique(
-    recommendations.flatMap((recommendation) => recommendation.recentActivitySummary ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.recentActivitySummary ?? [],
+    ),
     4,
   );
   const structuredAuthoredVsMentionedSummary = unique(
-    recommendations.flatMap((recommendation) => recommendation.authoredVsMentionedSummary ?? []),
+    recommendations.flatMap(
+      (recommendation) => recommendation.authoredVsMentionedSummary ?? [],
+    ),
     4,
   );
   const structuredPublicUseCandidates = unique(
@@ -392,7 +540,8 @@ export function createDossierSourceFileSummary(
   );
   const queueRecommendation = recommendations.find(
     (recommendation) =>
-      recommendation.queueSubmissionStatus || recommendation.queueSubmissionNote,
+      recommendation.queueSubmissionStatus ||
+      recommendation.queueSubmissionNote,
   );
   const structuredRecommendedAction = unique(
     recommendations.map((recommendation) => recommendation.recommendedAction),
@@ -562,7 +711,9 @@ export function createDossierSourceFileSummary(
     privateRelationshipContext:
       structuredRelationshipSignals.length > 0
         ? structuredRelationshipSignals
-        : ["No private relationship/context signals are recorded in the structured packet."],
+        : [
+            "No private relationship/context signals are recorded in the structured packet.",
+          ],
     publicSafePossibilities:
       structuredPublicSafePossibilities.length > 0
         ? structuredPublicSafePossibilities
@@ -613,7 +764,9 @@ export function createDossierSourceFileSummary(
         ? structuredSourceAuthority
         : ["Source authority has not been separated from confidence yet."],
     recommendedNextAction:
-      operatorNextAction ?? structuredRecommendedAction ?? nextActionCopy(action),
+      operatorNextAction ??
+      structuredRecommendedAction ??
+      nextActionCopy(action),
     substanceLevel: level,
     publicReadiness: readiness,
     existingPublicDossier: candidate.existingDossierMatch

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -536,6 +536,152 @@ test("bot can mark Source File refresh request failed without public workflow si
   assert.equal(state.candidates.some((candidate) => candidate.id === candidateId), true);
 });
 
+
+test("Source File display recommendations prefer completed and newest BNL enrichments without pending false refresh", () => {
+  const now = "2026-06-01T00:00:00.000Z";
+  const candidate = {
+    id: "source-refresh-candidate",
+    name: "Source Refresh Subject",
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 5,
+    whyNow: "Refresh selection test.",
+    reason: "Refresh selection test.",
+    evidenceSummary: "Existing source-file fallback evidence.",
+    sourceFileNotes: [],
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const olderBnl = {
+    id: "older-bnl-rec",
+    type: "new_subject",
+    subjectName: candidate.name,
+    targetCandidateId: candidate.id,
+    status: "attached_to_source_file",
+    reason: "Older BNL refresh reason.",
+    evidenceSummary: "Older BNL evidence should not control the Source File.",
+    knownContext: ["Older BNL known context."],
+    usefulEvidence: ["Older BNL useful evidence."],
+    sourceLanes: ["rd_context"],
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    ingestedAt: "2026-06-01T00:00:00.000Z",
+    ingestSource: "bnl_source_file_enrichment",
+  };
+  const newerBnl = {
+    ...olderBnl,
+    id: "newer-bnl-rec",
+    reason: "Newer BNL refresh reason.",
+    evidenceSummary: "Newer BNL evidence controls the Source File.",
+    knownContext: ["Newer BNL known context."],
+    usefulEvidence: ["Newer BNL useful evidence."],
+    createdAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+    ingestedAt: "2026-06-02T00:00:00.000Z",
+  };
+  const pendingRequest = {
+    id: "pending-refresh-request",
+    candidateId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: workflow.normalizeDossierSubjectName(candidate.name),
+    status: "pending",
+    reason: "Pending refresh should not claim fresh data yet.",
+    requestedAt: "2026-06-03T00:00:00.000Z",
+    updatedAt: "2026-06-03T00:00:00.000Z",
+    requestSource: "manual_admin",
+    priority: 90,
+  };
+  const completedRequest = {
+    ...pendingRequest,
+    id: "completed-refresh-request",
+    status: "completed",
+    completedAt: "2026-06-04T00:00:00.000Z",
+    updatedAt: "2026-06-04T00:00:00.000Z",
+    completedByRecommendationId: newerBnl.id,
+  };
+
+  const completedSelection = sourceFileSummary.selectDossierSourceFileDisplayRecommendations({
+    candidate,
+    recommendations: [olderBnl, newerBnl],
+    refreshRequests: [completedRequest],
+  });
+  assert.equal(completedSelection[0].id, newerBnl.id);
+  const completedSummary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate,
+    recommendations: completedSelection,
+  });
+  assert.deepEqual(completedSummary.knownContext, ["Newer BNL known context."]);
+  assert.match(completedSummary.usefulEvidence.join(" "), /Newer BNL evidence controls/);
+  assert.doesNotMatch(completedSummary.knownContext.join(" "), /Older BNL/);
+
+  const newestFallbackSelection = sourceFileSummary.selectDossierSourceFileDisplayRecommendations({
+    candidate,
+    recommendations: [olderBnl, newerBnl],
+    refreshRequests: [],
+  });
+  assert.equal(newestFallbackSelection[0].id, newerBnl.id);
+
+  const subjectKeyFallbackSelection = sourceFileSummary.selectDossierSourceFileDisplayRecommendations({
+    candidate,
+    recommendations: [
+      olderBnl,
+      {
+        ...newerBnl,
+        id: "subject-key-bnl-rec",
+        targetCandidateId: undefined,
+        subjectKey: workflow.normalizeDossierSubjectName(candidate.name),
+        knownContext: ["Subject-key BNL known context."],
+        updatedAt: "2026-06-05T00:00:00.000Z",
+        ingestedAt: "2026-06-05T00:00:00.000Z",
+      },
+    ],
+    refreshRequests: [],
+  });
+  assert.equal(subjectKeyFallbackSelection[0].id, olderBnl.id);
+
+  const pendingSelection = sourceFileSummary.selectDossierSourceFileDisplayRecommendations({
+    candidate,
+    recommendations: [olderBnl],
+    refreshRequests: [pendingRequest],
+  });
+  const pendingSummary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate,
+    recommendations: pendingSelection,
+  });
+  assert.equal(pendingSelection[0].id, olderBnl.id);
+  assert.match(pendingSummary.usefulEvidence.join(" "), /Older BNL evidence/);
+});
+
+test("admin Source File page polls pending refreshes, stops on terminal state, and preserves UI sections", () => {
+  const page = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const pageCopy = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${normalizedSource("src/components/DossierSourceFileSummaryPanel.tsx")}`;
+
+  assert.match(page, /window\.setInterval/);
+  assert.match(page, /pollForRefreshCompletion/);
+  assert.match(page, /request\.status === "pending" \|\| request\.status === "claimed"/);
+  assert.match(page, /fetchWorkflowPayload\(\)/);
+  assert.match(page, /router\.refresh\(\)/);
+  assert.match(page, /window\.clearInterval\(interval\)/);
+  assert.match(page, /latestRefreshRequest\.status === "completed"[\s\S]*Completed/);
+  assert.match(page, /latestRefreshRequest\.status === "failed"[\s\S]*failureReason/);
+  assert.match(page, /completedByRecommendationId/);
+
+  for (const label of [
+    "Review Snapshot",
+    "What BNL Knows",
+    "Evidence receipts",
+    "Source Notes / Admin Addendums",
+    "Identity / Alias Review",
+    "Phase 4 — Owner Review",
+    "Diagnostics — collapsed by default",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+  assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
+});
+
 test("taxonomy source types, entry annotations, and tag aliases are present", () => {
   const contentSource = source("src/content.ts");
   const tagSource = source("src/lib/dossier-tags.ts");


### PR DESCRIPTION
### Motivation
- The admin Source File page showed stale BNL enrichment data after the backend refresh completed, leaving operators unsure whether BNL work finished. 
- The UI needed deterministic selection of the most-relevant BNL enrichment and an automatic revalidation/polling flow so completed refreshes surface refreshed data without manual guessing.

### Description
- Always prefer the completed refresh’s `completedByRecommendationId`, then the newest `bnl_source_file_enrichment` targeted to the candidate, then the newest subject-key enrichment when deciding which recommendation controls the Source File display by adding `selectDossierSourceFileDisplayRecommendations` and sorting helpers in `src/lib/dossier-source-file-summary.ts`.
- Wire the admin page to use the new selection logic so the Source File summary displays the selected recommendation first by updating `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` to call `selectDossierSourceFileDisplayRecommendations` when building `attachedRecommendations`.
- Add lightweight polling while a matching refresh request is `pending`/`claimed` and stop on terminal state, reloading server data via `router.refresh()` after completion/failure, implemented in `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` with a `fetchWorkflowPayload` helper and guarded interval polling.
- Preserve UI semantics: pending/claimed states do not claim new data, completed requests show `completedAt` and `completedByRecommendationId`, failed requests surface `failureReason`, and manual refresh button behavior remains unchanged.
- Tests updated/added in `tests/admin-dossiers.test.mjs` to assert selection priority, pending-not-refreshed behavior, polling/stop-on-terminal-state, completion-driven data selection, failure visibility, duplicate-request protection, and that the admin page does not call public BNL endpoints directly.
- No public routes, publishing, queue/payment, artist accounts, canonical profile, or identity-alias code was changed.

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` which passed and verifies selection, polling, and UI behavior for Source File refreshes. 
- Ran `node --test tests/bnl-read-model.test.mjs` which surfaced unrelated public read-model expectations (three assertions) outside the admin refresh scope and therefore failed in CI during development. 
- Ran type check with `npx tsc --noEmit` which passed. 
- Attempted `npm run build` but the build was blocked in this environment by a network fetch of Google Fonts (`Geist Mono`) via `next/font`, producing a non-code build error unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23330aa9e0832183d84e52338e4760)