### PR TITLE
Immediate server-side BNL Source File refresh on admin open — status/retry UI

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -42,6 +42,13 @@ type WorkflowPayload = {
   publicDossiers?: Array<{ id: string; name: string }>;
 };
 
+type ImmediateRefreshResult = {
+  ok: boolean;
+  status: "success" | "failed" | "skipped" | "timeout" | "unavailable";
+  recommendationId?: string;
+  failureReason?: string;
+};
+
 type SourceNoteForm = {
   type: DossierSourceFileNoteType;
   text: string;
@@ -140,6 +147,7 @@ const openRefreshStatuses = new Set<DossierSourceFileRefreshRequest["status"]>([
   "pending",
   "claimed",
 ]);
+const STALE_OPEN_REFRESH_REQUEST_MS = 5 * 60 * 1000;
 
 function isOpenRefreshRequest(request?: DossierSourceFileRefreshRequest | null) {
   return Boolean(request && openRefreshStatuses.has(request.status));
@@ -150,10 +158,16 @@ function refreshRequestMatchesCandidate(input: {
   candidateId: string;
   normalizedSubjectKey: string;
 }) {
-  return (
-    input.request.candidateId === input.candidateId ||
-    input.request.normalizedSubjectKey === input.normalizedSubjectKey
-  );
+  if (input.request.candidateId) {
+    return input.request.candidateId === input.candidateId;
+  }
+  return input.request.normalizedSubjectKey === input.normalizedSubjectKey;
+}
+
+function isStaleOpenRefreshRequest(request?: DossierSourceFileRefreshRequest | null) {
+  if (!request || !isOpenRefreshRequest(request)) return false;
+  const updatedAt = Date.parse(request.updatedAt || request.requestedAt);
+  return !Number.isNaN(updatedAt) && Date.now() - updatedAt > STALE_OPEN_REFRESH_REQUEST_MS;
 }
 
 function latestMatchingRefreshRequest(input: {
@@ -684,6 +698,11 @@ export default function CandidateReviewPage() {
     requestId?: string;
     candidateId: string;
   } | null>(null);
+  const [sourceFileOpenState, setSourceFileOpenState] = useState<{
+    openedAt?: string;
+    immediateRefresh?: ImmediateRefreshResult;
+    running: boolean;
+  }>({ running: false });
 
   async function fetchWorkflowPayload(options: { cacheBust?: boolean } = {}) {
     const response = await fetch(
@@ -702,43 +721,65 @@ export default function CandidateReviewPage() {
   }
 
   async function loadWorkflow(options: { recordOpen?: boolean } = {}) {
-    const data = await fetchWorkflowPayload();
-    setPayload(data);
+    if (options.recordOpen === false) {
+      const data = await fetchWorkflowPayload();
+      setPayload(data);
+      return;
+    }
 
-    if (options.recordOpen === false) return;
-
+    setSourceFileOpenState({ running: true });
     const openResponse = await fetch("/api/admin/dossiers", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action: "recordSourceFileOpen", candidateId }),
     });
-    if (openResponse.ok) {
-      const openPayload = (await openResponse.json()) as WorkflowPayload & {
-        refresh?: { request?: DossierSourceFileRefreshRequest | null };
-      };
-      setPayload(openPayload);
-      if (
-        openPayload.refresh?.request &&
-        isOpenRefreshRequest(openPayload.refresh.request)
-      ) {
-        setRefreshPollingTarget({
-          candidateId,
-          requestId: openPayload.refresh.request.id,
-        });
-      }
+    if (!openResponse.ok) {
+      throw new Error(`Workflow API returned ${openResponse.status}.`);
+    }
+    const openPayload = (await openResponse.json()) as WorkflowPayload & {
+      openedAt?: string;
+      refresh?: { request?: DossierSourceFileRefreshRequest | null };
+      immediateRefresh?: ImmediateRefreshResult;
+    };
+    setPayload(openPayload);
+    setSourceFileOpenState({
+      openedAt: openPayload.openedAt,
+      immediateRefresh: openPayload.immediateRefresh,
+      running: false,
+    });
+    if (
+      openPayload.refresh?.request &&
+      isOpenRefreshRequest(openPayload.refresh.request)
+    ) {
+      setRefreshPollingTarget({
+        candidateId,
+        requestId: openPayload.refresh.request.id,
+      });
     }
   }
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
       void loadWorkflow({ recordOpen: true })
-        .catch((err) =>
+        .catch((err) => {
+          setSourceFileOpenState((current) => ({
+            ...current,
+            running: false,
+            immediateRefresh: {
+              ok: false,
+              status: "failed",
+              failureReason:
+                err instanceof Error
+                  ? err.message
+                  : "Failed to load internal record.",
+            },
+          }));
           setError(
             err instanceof Error
               ? err.message
               : "Failed to load internal record.",
-          ),
-        )
+          );
+        })
         .finally(() => setLoading(false));
     }, 0);
     return () => window.clearTimeout(timer);
@@ -911,8 +952,12 @@ export default function CandidateReviewPage() {
     : "";
   const refreshRequests = (payload?.sourceFileRefreshRequests ?? []).filter(
     (request) =>
-      request.candidateId === candidate?.id ||
-      request.normalizedSubjectKey === candidateRefreshKey,
+      candidate &&
+      refreshRequestMatchesCandidate({
+        request,
+        candidateId: candidate.id,
+        normalizedSubjectKey: candidateRefreshKey,
+      }),
   );
   const latestEnrichmentForRefreshStatus = candidate
     ? latestBnlSourceFileEnrichment({
@@ -920,82 +965,68 @@ export default function CandidateReviewPage() {
         recommendations: payload?.recommendations ?? [],
       })
     : undefined;
-  const activeRefreshRequest = refreshRequests
-    .filter((request) => isOpenRefreshRequest(request))
+  const nonStaleActiveRefreshRequest = refreshRequests
+    .filter(
+      (request) => isOpenRefreshRequest(request) && !isStaleOpenRefreshRequest(request),
+    )
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
   const activeRefreshResolvedByEnrichment = requestResolvedByNewerEnrichment({
-    request: activeRefreshRequest,
+    request: nonStaleActiveRefreshRequest,
     recommendation: latestEnrichmentForRefreshStatus,
   });
   const latestRefreshRequest =
-    activeRefreshRequest ??
+    nonStaleActiveRefreshRequest ??
     [...refreshRequests].sort((a, b) =>
       b.updatedAt.localeCompare(a.updatedAt),
     )[0];
-  const refreshStatusLabel = activeRefreshResolvedByEnrichment
-    ? "BNL refresh completed"
-    : latestRefreshRequest
-      ? latestRefreshRequest.status === "pending"
-        ? "BNL refresh requested"
-        : latestRefreshRequest.status === "claimed"
-          ? "BNL refresh in progress"
-          : latestRefreshRequest.status === "completed"
-            ? "BNL refresh completed"
-            : latestRefreshRequest.status === "failed"
-              ? "BNL refresh failed"
-              : latestRefreshRequest.status === "skipped"
-                ? "BNL refresh skipped"
-                : latestRefreshRequest.status === "cancelled"
-                  ? "BNL refresh cancelled"
-                  : latestRefreshRequest.status
-      : "No active request";
-  const refreshStatusDetail = activeRefreshResolvedByEnrichment
-    ? `Completed / refreshed by latest BNL Source File enrichment ${
-        latestEnrichmentForRefreshStatus?.id ?? "—"
-      }. Latest enrichment is newer than the request timestamp, so the page is no longer waiting for BNL.`
-    : latestRefreshRequest
-      ? latestRefreshRequest.status === "pending"
-        ? "Waiting for BNL. This Source File has not been refreshed yet."
-        : latestRefreshRequest.status === "claimed"
-          ? "BNL has claimed this request and is processing it. This Source File has not been marked refreshed yet."
-          : latestRefreshRequest.status === "completed"
-            ? `Completed ${formatDate(latestRefreshRequest.completedAt)}${
-                latestRefreshRequest.completedByRecommendationId
-                  ? ` by recommendation ${latestRefreshRequest.completedByRecommendationId}`
-                  : ""
-              }.`
-            : latestRefreshRequest.status === "failed"
-              ? `Refresh failed${
-                  latestRefreshRequest.failureReason
-                    ? `: ${latestRefreshRequest.failureReason}`
-                    : "."
-                }`
-              : latestRefreshRequest.status === "skipped"
-                ? `Refresh skipped${
-                    latestRefreshRequest.failureReason
-                      ? `: ${latestRefreshRequest.failureReason}`
-                      : "."
-                  }`
-                : latestRefreshRequest.status === "cancelled"
-                  ? `Refresh cancelled${
-                      latestRefreshRequest.failureReason
-                        ? `: ${latestRefreshRequest.failureReason}`
-                        : "."
-                    }`
-                  : "Refresh request is no longer active."
-      : "No active request.";
-  const manualRefreshDisabled =
-    saving ||
-    !candidate ||
-    (Boolean(activeRefreshRequest) && !activeRefreshResolvedByEnrichment);
-  const manualRefreshButtonLabel =
-    activeRefreshRequest && !activeRefreshResolvedByEnrichment
-      ? activeRefreshRequest.status === "claimed"
-        ? "Refresh In Progress"
-        : "Refresh Requested"
-      : latestRefreshRequest?.status === "failed"
-        ? "Retry BNL Refresh"
-        : "Request BNL Refresh";
+  const openTimestamp = sourceFileOpenState.openedAt;
+  const latestEnrichmentTimestamp = latestEnrichmentForRefreshStatus
+    ? recommendationTimestamp(latestEnrichmentForRefreshStatus)
+    : undefined;
+  const latestEnrichmentNewerThanOpen = Boolean(
+    openTimestamp &&
+      latestEnrichmentTimestamp &&
+      Date.parse(latestEnrichmentTimestamp) > Date.parse(openTimestamp),
+  );
+  const immediateRecommendationVisible = Boolean(
+    sourceFileOpenState.immediateRefresh?.recommendationId &&
+      attachedRecommendations.some(
+        (recommendation) =>
+          recommendation.id === sourceFileOpenState.immediateRefresh?.recommendationId,
+      ),
+  );
+  const sourceFileFreshForOpen = Boolean(
+    latestEnrichmentNewerThanOpen ||
+      (sourceFileOpenState.immediateRefresh?.ok && immediateRecommendationVisible),
+  );
+  const refreshStatusLabel = sourceFileOpenState.running
+    ? "UPDATING SOURCE FILE"
+    : sourceFileFreshForOpen
+      ? "FILE UPDATED"
+      : "FILE NOT UPDATED";
+  const refreshStatusDetail = sourceFileOpenState.running
+    ? "BNL is updating this Source File now through the server-side immediate refresh endpoint."
+    : sourceFileFreshForOpen
+      ? "Latest BNL enrichment is fresh for this page open."
+      : "This page is not treating older BNL Source File data as current. Use FILE NOT UPDATED to retry the immediate update.";
+  const refreshFailureReason =
+    sourceFileOpenState.immediateRefresh?.failureReason ??
+    latestRefreshRequest?.failureReason ??
+    (!sourceFileFreshForOpen && !sourceFileOpenState.running
+      ? "No fresh BNL enrichment is visible for this page open."
+      : undefined);
+  const manualRefreshDisabled = saving || !candidate || sourceFileOpenState.running || sourceFileFreshForOpen;
+  const manualRefreshButtonLabel = sourceFileOpenState.running
+    ? sourceFileOpenState.immediateRefresh
+      ? "RETRYING UPDATE"
+      : "UPDATING SOURCE FILE"
+    : sourceFileFreshForOpen
+      ? "FILE UPDATED"
+      : "FILE NOT UPDATED";
+  const manualRefreshButtonClass = sourceFileFreshForOpen
+    ? "border border-border bg-muted/20 px-4 py-2 text-xs uppercase tracking-widest text-muted disabled:opacity-70"
+    : "border border-red-500 px-4 py-2 text-xs uppercase tracking-widest text-red-400 hover:bg-red-500 hover:text-background disabled:opacity-50";
+  const staleDataWarning = !sourceFileFreshForOpen;
   const sourceFileSummary = candidate
     ? createDossierSourceFileSummary({
         candidate,
@@ -1069,6 +1100,7 @@ export default function CandidateReviewPage() {
           request?: DossierSourceFileRefreshRequest;
         };
         error?: string;
+        immediateRefresh?: ImmediateRefreshResult;
         message?: string;
       };
       if (!response.ok)
@@ -1087,25 +1119,41 @@ export default function CandidateReviewPage() {
 
   async function requestBnlRefresh() {
     if (!candidate) return;
+    setSourceFileOpenState((current) => ({ ...current, running: true }));
     try {
       const data = await postWorkflow({
         action: "requestSourceFileRefresh",
         candidateId,
-        reason: "Manual admin requested a BNL Source File refresh.",
+        reason: "Manual admin requested a BNL Source File immediate update retry.",
       });
       const refresh = data.refresh;
       if (refresh?.request && isOpenRefreshRequest(refresh.request)) {
         setRefreshPollingTarget({ candidateId, requestId: refresh.request.id });
       }
+      setSourceFileOpenState({
+        openedAt: new Date().toISOString(),
+        immediateRefresh: data.immediateRefresh,
+        running: false,
+      });
       setNotice(
-        refresh?.request && !isOpenRefreshRequest(refresh.request)
-          ? `BNL refresh request is ${refresh.request.status}. You can retry if another refresh is needed.`
-          : refresh?.created === false
-            ? "BNL refresh already requested. Waiting for BNL to process it through the Source File refresh worker."
-            : (data.message ??
-                "BNL refresh requested. BNL will process this through the Source File refresh worker."),
+        data.immediateRefresh?.ok
+          ? "BNL Source File updated immediately."
+          : (data.immediateRefresh?.failureReason ??
+              "BNL Source File immediate update did not complete. Retry from FILE NOT UPDATED."),
       );
     } catch (err) {
+      setSourceFileOpenState((current) => ({
+        ...current,
+        running: false,
+        immediateRefresh: {
+          ok: false,
+          status: "failed",
+          failureReason:
+            err instanceof Error
+              ? err.message
+              : "Failed to request BNL Source File refresh.",
+        },
+      }));
       setNotice(
         err instanceof Error
           ? err.message
@@ -1425,15 +1473,27 @@ export default function CandidateReviewPage() {
                 </p>
                 <p className="text-foreground">{refreshStatusLabel}</p>
                 <p className="mt-1">{refreshStatusDetail}</p>
-                {latestRefreshRequest && (
-                  <p className="mt-1">Reason: {latestRefreshRequest.reason}</p>
+                {refreshFailureReason && (
+                  <p className="mt-1 text-red-300">Reason: {refreshFailureReason}</p>
                 )}
+                {staleDataWarning && (
+                  <p className="mt-2 border border-red-500/60 bg-red-500/10 p-2 text-xs uppercase tracking-widest text-red-300">
+                    Last-known BNL data is not current for this page open.
+                  </p>
+                )}
+                <p className="mt-2 text-xs">
+                  Diagnostics: request {latestRefreshRequest?.id ?? "—"} / status{" "}
+                  {latestRefreshRequest?.status ?? "—"} / latest enrichment{" "}
+                  {latestEnrichmentTimestamp ?? "—"} / immediate{" "}
+                  {sourceFileOpenState.immediateRefresh?.status ??
+                    (sourceFileOpenState.running ? "running" : "—")}
+                </p>
               </div>
               <button
                 type="button"
                 onClick={() => void requestBnlRefresh()}
                 disabled={manualRefreshDisabled}
-                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                className={manualRefreshButtonClass}
               >
                 {manualRefreshButtonLabel}
               </button>
@@ -1700,7 +1760,7 @@ export default function CandidateReviewPage() {
               <button
                 type="submit"
                 disabled={saving}
-                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                className={manualRefreshButtonClass}
               >
                 Save Info
               </button>

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
 import { databasePage } from "@/content";
 import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
+import { refreshBnlSourceFileNow } from "@/lib/bnl-source-file-refresh-now";
 import { buildDossierTagRegistry } from "@/lib/dossier-tags";
 import {
   DOSSIER_CANDIDATE_SCORING_POLICY,
@@ -59,6 +60,7 @@ import {
   submitDraftForOwnerReview,
   updateDossierCandidateStatus,
   updateDossierIdentityLink,
+  updateDossierSourceFileRefreshRequestStatus,
   validateDossierDraftFieldsForOwnerReview,
   type DossierWorkflowState,
 } from "@/lib/dossier-workflow-store";
@@ -463,12 +465,44 @@ export async function POST(req: Request) {
           { status: 400 },
         );
       }
+      const openedAt = new Date().toISOString();
       const refresh = await recordDossierSourceFileOpen({
         candidateId,
         requestedBy: "admin_open_source_file",
       });
+      const immediateRefresh = refresh.request
+        ? await refreshBnlSourceFileNow({
+            request: refresh.request,
+            source: "admin_open_source_file",
+          })
+        : {
+            ok: false,
+            status: "skipped" as const,
+            failureReason: refresh.decision.reason,
+          };
+      if (refresh.request && immediateRefresh.ok) {
+        await updateDossierSourceFileRefreshRequestStatus({
+          requestId: refresh.request.id,
+          status: "completed",
+          completedByRecommendationId: immediateRefresh.recommendationId,
+        });
+      } else if (refresh.request && immediateRefresh.status !== "unavailable") {
+        await updateDossierSourceFileRefreshRequestStatus({
+          requestId: refresh.request.id,
+          status:
+            immediateRefresh.status === "skipped" ? "skipped" : "failed",
+          failureReason: immediateRefresh.failureReason,
+        });
+      }
       const payload = await workflowPayload();
-      return NextResponse.json({ ok: true, action, refresh, ...payload });
+      return NextResponse.json({
+        ok: true,
+        action,
+        openedAt,
+        refresh,
+        immediateRefresh,
+        ...payload,
+      });
     }
 
     if (action === "requestSourceFileRefresh") {
@@ -485,13 +519,33 @@ export async function POST(req: Request) {
         requestSource: "manual_admin",
         requestedBy: "admin_manual",
       });
+      const immediateRefresh = await refreshBnlSourceFileNow({
+        request: refresh.request,
+        source: "admin_manual",
+      });
+      if (immediateRefresh.ok) {
+        await updateDossierSourceFileRefreshRequestStatus({
+          requestId: refresh.request.id,
+          status: "completed",
+          completedByRecommendationId: immediateRefresh.recommendationId,
+        });
+      } else if (immediateRefresh.status !== "unavailable") {
+        await updateDossierSourceFileRefreshRequestStatus({
+          requestId: refresh.request.id,
+          status:
+            immediateRefresh.status === "skipped" ? "skipped" : "failed",
+          failureReason: immediateRefresh.failureReason,
+        });
+      }
       const payload = await workflowPayload();
       return NextResponse.json({
         ok: true,
         action,
         refresh,
-        message:
-          "BNL refresh requested. BNL will process this through the Source File refresh worker.",
+        immediateRefresh,
+        message: immediateRefresh.ok
+          ? "BNL Source File updated immediately."
+          : "BNL Source File immediate update did not complete. Retry from the status button.",
         ...payload,
       });
     }

--- a/src/lib/bnl-source-file-refresh-now.ts
+++ b/src/lib/bnl-source-file-refresh-now.ts
@@ -1,0 +1,148 @@
+import type { DossierSourceFileRefreshRequest } from "@/lib/dossier-workflow";
+
+export type BnlSourceFileImmediateRefreshStatus =
+  | "success"
+  | "failed"
+  | "skipped"
+  | "timeout"
+  | "unavailable";
+
+export type BnlSourceFileImmediateRefreshResult = {
+  ok: boolean;
+  status: BnlSourceFileImmediateRefreshStatus;
+  recommendationId?: string;
+  failureReason?: string;
+};
+
+export type BnlSourceFileImmediateRefreshInput = {
+  request: DossierSourceFileRefreshRequest;
+  source?: string;
+  timeoutMs?: number;
+};
+
+const DEFAULT_REFRESH_NOW_TIMEOUT_MS = 25_000;
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function timeoutFromEnv(): number {
+  const raw = process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_REFRESH_NOW_TIMEOUT_MS;
+  return Math.min(Math.max(parsed, 1_000), 30_000);
+}
+
+function recommendationIdFromPayload(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const record = payload as Record<string, unknown>;
+  return (
+    stringValue(record.recommendationId) ??
+    stringValue(record.completedByRecommendationId) ??
+    stringValue(record.id) ??
+    (record.recommendation && typeof record.recommendation === "object"
+      ? stringValue((record.recommendation as Record<string, unknown>).id)
+      : undefined)
+  );
+}
+
+function failureReasonFromPayload(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const record = payload as Record<string, unknown>;
+  return (
+    stringValue(record.failureReason) ??
+    stringValue(record.reason) ??
+    stringValue(record.error) ??
+    stringValue(record.message)
+  );
+}
+
+export async function refreshBnlSourceFileNow(
+  input: BnlSourceFileImmediateRefreshInput,
+): Promise<BnlSourceFileImmediateRefreshResult> {
+  const url = process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL?.trim();
+  const token = process.env.BNL_SOURCE_FILE_REFRESH_TOKEN?.trim();
+  if (!url || !token) {
+    return {
+      ok: false,
+      status: "unavailable",
+      failureReason: "BNL immediate refresh is not configured.",
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    input.timeoutMs ?? timeoutFromEnv(),
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-BNL-REFRESH-TOKEN": token,
+      },
+      body: JSON.stringify({
+        requestId: input.request.id,
+        candidateId: input.request.candidateId,
+        subjectName: input.request.subjectName,
+        normalizedSubjectKey: input.request.normalizedSubjectKey,
+        reason: input.request.reason,
+        source: input.source ?? input.request.requestSource,
+      }),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    const payload = (await response.json().catch(() => null)) as unknown;
+    const recommendationId = recommendationIdFromPayload(payload);
+    const failureReason = failureReasonFromPayload(payload);
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status === 503 ? "unavailable" : "failed",
+        recommendationId,
+        failureReason:
+          failureReason ?? `BNL immediate refresh returned HTTP ${response.status}.`,
+      };
+    }
+
+    const payloadStatus =
+      payload && typeof payload === "object"
+        ? stringValue((payload as Record<string, unknown>).status)
+        : undefined;
+    if (payloadStatus === "skipped") {
+      return { ok: false, status: "skipped", recommendationId, failureReason };
+    }
+    if (payloadStatus === "failed") {
+      return { ok: false, status: "failed", recommendationId, failureReason };
+    }
+
+    return {
+      ok: true,
+      status: "success",
+      recommendationId,
+      failureReason,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return {
+        ok: false,
+        status: "timeout",
+        failureReason: "BNL immediate refresh timed out.",
+      };
+    }
+    return {
+      ok: false,
+      status: "unavailable",
+      failureReason:
+        error instanceof Error
+          ? error.message
+          : "BNL immediate refresh could not be reached.",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1401,6 +1401,7 @@ function upsertSourceFileEnrichmentNote(input: {
 
 const OPEN_REFRESH_RECENT_COMPLETED_MS = 60 * 60 * 1000;
 const DEFAULT_REFRESH_STALE_MS = 24 * 60 * 60 * 1000;
+const STALE_OPEN_REFRESH_REQUEST_MS = 5 * 60 * 1000;
 const OPEN_REQUEST_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
   "pending",
   "claimed",
@@ -1436,16 +1437,24 @@ function latestActiveSourceNoteTimestamp(candidate: DossierCandidate): string | 
     .at(-1);
 }
 
+function sourceFileRefreshRequestMatchesCandidate(input: {
+  request: DossierSourceFileRefreshRequest;
+  candidate: DossierCandidate;
+}): boolean {
+  if (input.request.candidateId) {
+    return input.request.candidateId === input.candidate.id;
+  }
+  return input.request.normalizedSubjectKey === normalizeName(input.candidate.name);
+}
+
 function latestOpenRefreshRequest(input: {
   requests: DossierSourceFileRefreshRequest[];
   candidate: DossierCandidate;
 }): DossierSourceFileRefreshRequest | undefined {
-  const normalized = normalizeName(input.candidate.name);
   return input.requests.find(
     (request) =>
       OPEN_REQUEST_STATUSES.has(request.status) &&
-      (request.candidateId === input.candidate.id ||
-        request.normalizedSubjectKey === normalized),
+      sourceFileRefreshRequestMatchesCandidate({ request, candidate: input.candidate }),
   );
 }
 
@@ -1453,12 +1462,10 @@ function latestCompletedRefreshRequest(input: {
   requests: DossierSourceFileRefreshRequest[];
   candidate: DossierCandidate;
 }): DossierSourceFileRefreshRequest | undefined {
-  const normalized = normalizeName(input.candidate.name);
   return input.requests.find(
     (request) =>
       request.status === "completed" &&
-      (request.candidateId === input.candidate.id ||
-        request.normalizedSubjectKey === normalized),
+      sourceFileRefreshRequestMatchesCandidate({ request, candidate: input.candidate }),
   );
 }
 
@@ -1608,6 +1615,32 @@ export function evaluateDossierSourceFileRefresh(input: {
   };
 }
 
+function expireStaleOpenRefreshRequests(
+  requests: DossierSourceFileRefreshRequest[],
+  now: string,
+): DossierSourceFileRefreshRequest[] {
+  const nowTime = Date.parse(now);
+  return requests.map((request) => {
+    const updatedAt = Date.parse(request.updatedAt || request.requestedAt);
+    if (
+      OPEN_REQUEST_STATUSES.has(request.status) &&
+      !Number.isNaN(nowTime) &&
+      !Number.isNaN(updatedAt) &&
+      nowTime - updatedAt > STALE_OPEN_REFRESH_REQUEST_MS
+    ) {
+      return {
+        ...request,
+        status: "failed" as const,
+        updatedAt: now,
+        failureReason:
+          request.failureReason ??
+          "Refresh request expired before immediate BNL update completed.",
+      };
+    }
+    return request;
+  });
+}
+
 function upsertSourceFileRefreshRequestInState(input: {
   state: DossierWorkflowState;
   candidate: DossierCandidate;
@@ -1621,14 +1654,14 @@ function upsertSourceFileRefreshRequestInState(input: {
   const state = {
     ...input.state,
     sourceFileRefreshRequests: mergeActiveSourceFileRefreshRequests(
-      input.state.sourceFileRefreshRequests,
+      expireStaleOpenRefreshRequests(input.state.sourceFileRefreshRequests, input.now),
     ),
   };
   const normalizedSubjectKey = normalizeName(input.candidate.name);
   const existingIndex = state.sourceFileRefreshRequests.findIndex(
     (request) =>
       OPEN_REQUEST_STATUSES.has(request.status) &&
-      (request.candidateId === input.candidate.id || request.normalizedSubjectKey === normalizedSubjectKey),
+      sourceFileRefreshRequestMatchesCandidate({ request, candidate: input.candidate }),
   );
   if (existingIndex >= 0) {
     const existing = state.sourceFileRefreshRequests[existingIndex];
@@ -1710,31 +1743,17 @@ export async function recordDossierSourceFileOpen(input: {
       refreshRequests: currentState.sourceFileRefreshRequests,
       now,
     });
-    const existingOpenRequest = latestOpenRefreshRequest({
-      requests: mergeActiveSourceFileRefreshRequests(
-        currentState.sourceFileRefreshRequests,
-      ),
-      candidate,
-    });
-    if (!decision.needed || existingOpenRequest) {
-      result = { request: existingOpenRequest ?? null, decision, created: false };
-      return existingOpenRequest
-        ? {
-            ...currentState,
-            sourceFileRefreshRequests: mergeActiveSourceFileRefreshRequests(
-              currentState.sourceFileRefreshRequests,
-            ),
-          }
-        : currentState;
-    }
     const upserted = upsertSourceFileRefreshRequestInState({
       state: currentState,
       candidate,
-      reason: decision.reason,
+      reason: decision.needed
+        ? decision.reason
+        : "Admin opened the Source File and requested an immediate BNL freshness check.",
       requestSource: decision.requestSource === "opened_source_file" ? "opened_source_file" : decision.requestSource,
-      priority: decision.priority,
+      priority: Math.max(decision.priority, 60),
       requestedBy: input.requestedBy ?? "admin_open_source_file",
       now,
+      force: true,
     });
     result = { request: upserted.request, decision, created: upserted.created };
     return upserted.state;
@@ -1827,9 +1846,10 @@ function completeMatchingRefreshRequestsInState(input: {
   const requests = activeDedupedRequests.map((request) => {
     const matches =
       COMPLETABLE_REFRESH_STATUSES.has(request.status) &&
-      ((targetCandidateId && request.candidateId === targetCandidateId) ||
-        request.normalizedSubjectKey === normalizedSubjectKey ||
-        normalizeName(request.subjectName) === normalizeName(input.recommendation.subjectName));
+      (request.candidateId
+        ? Boolean(targetCandidateId && request.candidateId === targetCandidateId)
+        : request.normalizedSubjectKey === normalizedSubjectKey ||
+          normalizeName(request.subjectName) === normalizeName(input.recommendation.subjectName));
     if (!matches) return request;
     changed = true;
     return {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -384,7 +384,8 @@ test("Source File open refresh workflow dedupes, exposes bot polling, and comple
     candidateId,
     reason: "Manual test refresh request.",
   })).json();
-  assert.equal(manual.message, "BNL refresh requested. BNL will process this through the Source File refresh worker.");
+  assert.equal(manual.message, "BNL Source File immediate update did not complete. Retry from the status button.");
+  assert.equal(manual.immediateRefresh.status, "unavailable");
   assert.equal(manual.sourceFileRefreshRequests.length, 1);
   assert.equal(manual.sourceFileRefreshRequests[0].reason, "Manual test refresh request.");
   assert.equal(manual.sourceFileRefreshRequests[0].requestSource, "manual_admin");
@@ -423,8 +424,9 @@ test("Source File open refresh workflow dedupes, exposes bot polling, and comple
   assert.equal(completed.request.completedByRecommendationId, "manual-complete-rec");
 
   const afterRecentCompletion = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
-  assert.equal(afterRecentCompletion.sourceFileRefreshRequests.length, 1);
-  assert.equal(afterRecentCompletion.refresh.request, null);
+  assert.equal(afterRecentCompletion.sourceFileRefreshRequests.length, 2);
+  assert.equal(afterRecentCompletion.refresh.request.status, "pending");
+  assert.equal(afterRecentCompletion.immediateRefresh.status, "unavailable");
 
   const manualAgain = await (await authedPost({
     action: "requestSourceFileRefresh",
@@ -451,7 +453,128 @@ test("Source File open refresh workflow dedupes, exposes bot polling, and comple
   assert.equal(finalRequest.completedByRecommendationId, ingest.recommendation.id);
 });
 
-test("fresh Source File open does not auto-request refresh and public read model stays read-only", async () => {
+
+
+test("Source File open and retry call BNL refresh-now server-side with safe status results", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    assert.equal(String(url), process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL);
+    assert.equal(options.headers["X-BNL-REFRESH-TOKEN"], "test-refresh-token");
+    const body = JSON.parse(options.body);
+    assert.equal(body.source, calls.length === 1 ? "admin_open_source_file" : "admin_manual");
+    assert.ok(body.requestId);
+    assert.equal(body.candidateId, body.candidateId);
+    if (calls.length === 1) {
+      return Response.json({ ok: true, status: "success", recommendationId: "fresh-rec-id" });
+    }
+    return Response.json({ ok: false, status: "failed", failureReason: "BNL fixture failure" }, { status: 500 });
+  };
+
+  try {
+    const created = await (await authedPost({
+      action: "createManualCandidate",
+      input: {
+        name: "Immediate Refresh Fixture",
+        candidateType: "artist",
+        reason: "Operator wants immediate refresh coverage.",
+        whyNow: "The source file should update on open.",
+        evidenceSummary: "Admin fixture evidence.",
+      },
+    })).json();
+    const candidateId = created.candidate.id;
+    await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+
+    const opened = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+    assert.equal(opened.immediateRefresh.ok, true);
+    assert.equal(opened.immediateRefresh.status, "success");
+    assert.equal(opened.immediateRefresh.recommendationId, "fresh-rec-id");
+    assert.equal(opened.sourceFileRefreshRequests[0].status, "completed");
+    assert.equal(opened.sourceFileRefreshRequests[0].completedByRecommendationId, "fresh-rec-id");
+
+    const retry = await (await authedPost({
+      action: "requestSourceFileRefresh",
+      candidateId,
+      reason: "Retry immediate refresh after failed visible state.",
+    })).json();
+    assert.equal(retry.immediateRefresh.ok, false);
+    assert.equal(retry.immediateRefresh.status, "failed");
+    assert.equal(retry.immediateRefresh.failureReason, "BNL fixture failure");
+    assert.equal(calls.length, 2);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  }
+});
+
+test("Source File immediate refresh timeout/unavailable and stale open requests do not trap retries or cross-file matching", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "5";
+  const originalFetch = global.fetch;
+  global.fetch = async (_url, options = {}) =>
+    new Promise((_resolve, reject) => {
+      options.signal?.addEventListener("abort", () => {
+        const error = new Error("aborted");
+        error.name = "AbortError";
+        reject(error);
+      });
+    });
+
+  try {
+    const first = await (await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Candidate Match Alpha" },
+    })).json();
+    const second = await (await authedPost({
+      action: "createManualCandidate",
+      input: { ...manualCandidateInput, name: "Candidate Match Alpha" },
+    })).json();
+    await authedPost({ action: "promoteCandidateToSourceFile", candidateId: first.candidate.id });
+    await authedPost({ action: "promoteCandidateToSourceFile", candidateId: second.candidate.id });
+
+    const old = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const state = await store.getDossierWorkflowState();
+    await store.saveDossierWorkflowState({
+      ...state,
+      sourceFileRefreshRequests: [{
+        id: "old-claimed-for-other-candidate",
+        candidateId: first.candidate.id,
+        subjectName: "Candidate Match Alpha",
+        normalizedSubjectKey: workflow.normalizeDossierSubjectName("Candidate Match Alpha"),
+        status: "claimed",
+        reason: "Old claimed request should expire for display.",
+        requestedAt: old,
+        updatedAt: old,
+        requestSource: "manual_admin",
+        priority: 90,
+      }],
+    });
+
+    const openedSecond = await (await authedPost({ action: "recordSourceFileOpen", candidateId: second.candidate.id })).json();
+    assert.equal(openedSecond.immediateRefresh.status, "timeout");
+    assert.equal(openedSecond.sourceFileRefreshRequests.some((request) => request.candidateId === second.candidate.id), true);
+    const oldRequest = openedSecond.sourceFileRefreshRequests.find((request) => request.id === "old-claimed-for-other-candidate");
+    assert.equal(oldRequest.status, "failed");
+    assert.equal(openedSecond.sourceFileRefreshRequests.filter((request) => request.candidateId === second.candidate.id).length, 1);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  }
+});
+
+test("fresh Source File open still asks BNL immediately and public read model stays read-only", async () => {
   await resetWorkflowStore();
   process.env.BNL_SOURCE_FILE_READ_TOKEN = "test-source-file-read-token";
 
@@ -494,7 +617,9 @@ test("fresh Source File open does not auto-request refresh and public read model
 
   const opened = await (await authedPost({ action: "recordSourceFileOpen", candidateId: "fresh-source-candidate" })).json();
   assert.equal(opened.refresh.decision.needed, false);
-  assert.equal(opened.sourceFileRefreshRequests.length, 0);
+  assert.equal(opened.immediateRefresh.status, "unavailable");
+  assert.equal(opened.sourceFileRefreshRequests.length, 1);
+  assert.equal(opened.sourceFileRefreshRequests[0].requestSource, "opened_source_file");
 
   const beforePublicRead = await store.getDossierWorkflowState();
   const publicRead = await (await sourceFilesGet("?subject=Fresh%20Fixture%20Subject")).json();
@@ -671,7 +796,7 @@ test("Source File display recommendations prefer completed and newest BNL enrich
   assert.match(pendingSummary.usefulEvidence.join(" "), /Older BNL evidence/);
 });
 
-test("admin Source File page polls pending refreshes, stops on terminal state, and preserves UI sections", () => {
+test("admin Source File page uses immediate refresh status/retry UI and preserves sections", () => {
   const page = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
   const pageCopy = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${normalizedSource("src/components/DossierSourceFileSummaryPanel.tsx")}`;
 
@@ -683,14 +808,16 @@ test("admin Source File page polls pending refreshes, stops on terminal state, a
   assert.match(page, /router\.refresh\(\)/);
   assert.match(page, /window\.location\.reload\(\)/);
   assert.match(page, /window\.clearInterval\(interval\)/);
-  assert.match(page, /latestRefreshRequest\.status === "completed"[\s\S]*Completed/);
-  assert.match(page, /latestRefreshRequest\.status === "failed"[\s\S]*failureReason/);
   assert.match(page, /completedByRecommendationId/);
   assert.match(page, /setRefreshPollingTarget\(\{ candidateId, requestId: refresh\.request\.id \}\)/);
-  assert.match(page, /Refresh Requested/);
-  assert.match(page, /Retry BNL Refresh/);
-  assert.match(page, /activeRefreshResolvedByEnrichment/);
-  assert.match(page, /No active request/);
+  assert.match(page, /UPDATING SOURCE FILE/);
+  assert.match(page, /FILE UPDATED/);
+  assert.match(page, /FILE NOT UPDATED/);
+  assert.match(page, /RETRYING UPDATE/);
+  assert.match(page, /Last-known BNL data is not current for this page open/);
+  assert.match(page, /Diagnostics: request/);
+  assert.doesNotMatch(page, /Refresh Requested/);
+  assert.doesNotMatch(page, /Waiting for BNL/);
 
   for (const label of [
     "Review Snapshot",
@@ -1072,12 +1199,11 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Recommendations",
     "Refresh status",
     "Source File Refresh",
-    "BNL refresh requested",
-    "Waiting for BNL",
-    "BNL refresh in progress",
-    "BNL refresh completed",
-    "This Source File has not been refreshed yet",
-    "Request BNL Refresh",
+    "UPDATING SOURCE FILE",
+    "FILE UPDATED",
+    "FILE NOT UPDATED",
+    "RETRYING UPDATE",
+    "Last-known BNL data is not current for this page open",
     "Source notes",
     "Unapplied notes",
     "Next action",
@@ -1118,9 +1244,9 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
-  assert.match(page, /latestRefreshRequest\.status === "pending"[\s\S]*"BNL refresh requested"/);
-  assert.match(page, /latestRefreshRequest\.status === "claimed"[\s\S]*"BNL refresh in progress"/);
-  assert.match(page, /Waiting for BNL\.[\s\S]*has not been refreshed yet/);
+  assert.match(page, /sourceFileFreshForOpen/);
+  assert.match(page, /sourceFileOpenState\.running/);
+  assert.match(page, /isStaleOpenRefreshRequest/);
   assert.doesNotMatch(pageCopy, /Persistent Source File Draft/);
   assert.doesNotMatch(pageCopy, /Internal Operator Summary/);
   assert.doesNotMatch(pageCopy, /Save Internal Summary/);


### PR DESCRIPTION
### Motivation
- Admin Source File pages could show stale BNL data and the refresh button could be stuck in a queue-state; the intent is to make opening a Source File trigger an immediate server-side BNL refresh and present a simple status/retry UI so no admin sees stale data as current.

### Description
- Added a server-side immediate refresh helper `refreshBnlSourceFileNow` that calls `process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL` with header `X-BNL-REFRESH-TOKEN` and returns a bounded, structured result (`success|failed|skipped|timeout|unavailable`). (new: `src/lib/bnl-source-file-refresh-now.ts`)
- Made admin open and manual retry actions call the helper from the server/API layer and update the internal refresh request status accordingly; unavailable results keep the worker fallback but do not expose the token to the browser. (updated: `src/app/api/admin/dossiers/route.ts`)
- Reworked UI/state on the candidate Source File page to start an immediate update when opened, show a compact admin diagnostics line, and use the requested simple status labels and retry behavior (`UPDATING SOURCE FILE`, `FILE UPDATED`, `FILE NOT UPDATED`, `RETRYING UPDATE`). (updated: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Tightened refresh-request matching and display logic so `candidateId` is authoritative, subject-key fallback only used when request lacks `candidateId`, and stale pending/claimed requests older than the short threshold (5 minutes) are expired for display so they do not permanently block retry. (updated: `src/lib/dossier-workflow-store.ts`)
- Tests updated/added to assert immediate server-side calls, success/failure/timeout handling, retry behavior, stale request expiry, and that worker fallback remains available while UI uses immediate path. (updated/added: `tests/admin-dossiers.test.mjs`)

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and the suite passed after updates (✅ success). 
- Ran `node --test tests/bnl-read-model.test.mjs` and it reported unrelated failures in static public dossier page expectations (legacy public-page checks for `entry.tags.map`, `getDossierPrimaryLink(entry)`, and an authoring-guide assertion) that are not part of this admin refresh change (❌ failing; unrelated to immediate refresh). 
- Type-checked with `npx tsc --noEmit` (✅ success). 
- Attempted `npm run build`; the Next/Turbopack build was blocked by an external Google Fonts fetch for `Geist Mono` in this environment (⚠ build blocked by network font fetch). 

Files changed (high level):
- Added: `src/lib/bnl-source-file-refresh-now.ts` (server-side immediate refresh helper).
- Modified: `src/app/api/admin/dossiers/route.ts` (call immediate refresh on open and manual retry; update refresh-request status based on helper result).
- Modified: `src/lib/dossier-workflow-store.ts` (stale open-request expiry, stricter candidate-id matching, force immediate upsert on open).
- Modified: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (UI/state for UPDATING/FILE UPDATED/FILE NOT UPDATED/RETRYING, diagnostics, retry behavior, avoid showing stale data as current).
- Modified: `tests/admin-dossiers.test.mjs` (added/updated tests to cover immediate refresh, retry, timeout/unavailable, and stale request expiry).

Notes and boundaries: no bot code or public publishing behavior changed; the BNL token is only used server-side and never sent to the browser or logs; readme/AGENTS protected content and public routes were intentionally left untouched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f6c741b88321a750d87452dd1a03)