### PR TITLE
Simplify admin dossier dashboard

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -9,6 +9,7 @@ import {
   type DossierDraft,
   type DossierDuplicateGroup,
   type DossierRecommendation,
+  type DossierSourceFileMetrics,
 } from "@/lib/dossier-workflow";
 
 type WorkflowPayload = {
@@ -229,6 +230,84 @@ function firstListValue(values?: string[]) {
   return values?.find((value) => value.trim()) ?? "—";
 }
 
+function hasCandidateIdentityConcern(candidate: DossierCandidate) {
+  const pendingIdentityLinks = (candidate.identityLinks ?? []).some(
+    (link) => link.status === "proposed",
+  );
+  return Boolean(
+    pendingIdentityLinks ||
+    candidate.existingDossierMatch ||
+    candidate.duplicateRisk === "low" ||
+    candidate.duplicateRisk === "medium" ||
+    candidate.duplicateRisk === "high",
+  );
+}
+
+function candidateActionLabel(candidate: DossierCandidate) {
+  if (hasCandidateIdentityConcern(candidate)) return "Review Identity";
+  return "Review Candidate";
+}
+
+function recommendationActionLabel(
+  recommendation: DossierRecommendation,
+  matchState: { state: string; nextAction: string },
+) {
+  if (
+    recommendation.type === "identity_link" ||
+    matchState.state === "possible_identity_link"
+  ) {
+    return "Review Identity";
+  }
+  return "Review Signal";
+}
+
+function dossierUpdateActionLabel(input: {
+  candidate?: DossierCandidate;
+  recommendation?: DossierRecommendation;
+  matchState?: { state: string; nextAction: string };
+}) {
+  if (input.recommendation) {
+    if (
+      input.recommendation.type === "identity_link" ||
+      input.matchState?.state === "possible_identity_link"
+    ) {
+      return "Review Identity";
+    }
+    if (input.recommendation.targetCandidateId) return "Review Source Update";
+    return "Review Update";
+  }
+
+  if (input.candidate && hasCandidateIdentityConcern(input.candidate)) {
+    return "Review Identity";
+  }
+  return "Review Update";
+}
+
+function sourceFileActionLabel(
+  candidate: DossierCandidate,
+  draft: DossierDraft | undefined,
+  metrics: DossierSourceFileMetrics | undefined,
+) {
+  const hasPendingIdentityLink = (candidate.identityLinks ?? []).some(
+    (link) => link.status === "proposed",
+  );
+  if (hasPendingIdentityLink) return "Review Identity";
+  if ((candidate.missingInfo ?? []).length > 0) return "Add Missing Info";
+  if ((metrics?.unappliedSourceNotesCount ?? 0) > 0) return "Review Updates";
+  if (draft?.status === "ready_for_owner_review") return "Review Draft";
+  if (draft) return "Open Draft";
+  return "Open Source File";
+}
+
+function archiveActionLabel(input: {
+  candidate?: DossierCandidate;
+  recommendation?: DossierRecommendation;
+}) {
+  if (input.recommendation) return "Review Closed Signal";
+  if (input.candidate?.status === "denied") return "Review Trash";
+  return "Review Archived";
+}
+
 function DashboardCard({
   eyebrow,
   title,
@@ -318,6 +397,16 @@ export default function DossierControlCenterPage() {
   );
   const activeRecommendations = recommendations.filter((recommendation) =>
     ["new", "reviewing"].includes(recommendation.status),
+  );
+  const activeDossierUpdateRecommendations = activeRecommendations.filter(
+    (recommendation) =>
+      recommendation.type === "modify_existing_dossier" ||
+      Boolean(recommendation.targetDossierId) ||
+      Boolean(recommendation.targetCandidateId),
+  );
+  const activeCandidateRecommendations = activeRecommendations.filter(
+    (recommendation) =>
+      !activeDossierUpdateRecommendations.includes(recommendation),
   );
   const terminalRecommendations = recommendations.filter((recommendation) =>
     [
@@ -711,9 +800,14 @@ export default function DossierControlCenterPage() {
             {[
               [
                 "Candidates",
-                candidateIntakeItems.length + activeRecommendations.length,
+                candidateIntakeItems.length +
+                  activeCandidateRecommendations.length,
               ],
-              ["Dossier Updates", existingDossierUpdates.length],
+              [
+                "Dossier Updates",
+                existingDossierUpdates.length +
+                  activeDossierUpdateRecommendations.length,
+              ],
               ["Source Files", activeCandidates.length],
               ["Needs Info", sourceFilesNeedingInfo.length],
               [
@@ -748,7 +842,8 @@ export default function DossierControlCenterPage() {
           title="Candidates"
           aside={
             <StatusPill>
-              {candidateIntakeItems.length + activeRecommendations.length}{" "}
+              {candidateIntakeItems.length +
+                activeCandidateRecommendations.length}{" "}
               waiting
             </StatusPill>
           }
@@ -845,7 +940,9 @@ export default function DossierControlCenterPage() {
             </details>
           </div>
 
-          {candidateIntakeItems.length + activeRecommendations.length === 0 ? (
+          {candidateIntakeItems.length +
+            activeCandidateRecommendations.length ===
+          0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
               No candidates are waiting.
             </p>
@@ -859,11 +956,11 @@ export default function DossierControlCenterPage() {
                     <th className="py-2 pr-3">Strength / confidence</th>
                     <th className="py-2 pr-3">Identity status</th>
                     <th className="py-2 pr-3">Suggested next step</th>
-                    <th className="py-2 pr-3">Open</th>
+                    <th className="py-2 pr-3">Action</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {activeRecommendations.map((recommendation) => {
+                  {activeCandidateRecommendations.map((recommendation) => {
                     const matchState = recommendationMatchState(recommendation);
                     return (
                       <tr
@@ -898,7 +995,10 @@ export default function DossierControlCenterPage() {
                             href={`/admin/dossiers/recommendations/${recommendation.id}`}
                             className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                           >
-                            Open
+                            {recommendationActionLabel(
+                              recommendation,
+                              matchState,
+                            )}
                           </Link>
                         </td>
                       </tr>
@@ -934,7 +1034,7 @@ export default function DossierControlCenterPage() {
                           href={`/admin/dossiers/candidates/${candidate.id}`}
                           className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                         >
-                          Open
+                          {candidateActionLabel(candidate)}
                         </Link>
                       </td>
                     </tr>
@@ -949,10 +1049,16 @@ export default function DossierControlCenterPage() {
           eyebrow="Dossier Updates"
           title="Dossier Updates"
           aside={
-            <StatusPill>{existingDossierUpdates.length} updates</StatusPill>
+            <StatusPill>
+              {existingDossierUpdates.length +
+                activeDossierUpdateRecommendations.length}{" "}
+              updates
+            </StatusPill>
           }
         >
-          {existingDossierUpdates.length === 0 ? (
+          {existingDossierUpdates.length +
+            activeDossierUpdateRecommendations.length ===
+          0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
               No existing dossier updates are waiting.
             </p>
@@ -969,10 +1075,65 @@ export default function DossierControlCenterPage() {
                     <th className="py-2 pr-3">Match confidence</th>
                     <th className="py-2 pr-3">Identity status</th>
                     <th className="py-2 pr-3">Suggested next step</th>
-                    <th className="py-2 pr-3">Open</th>
+                    <th className="py-2 pr-3">Action</th>
                   </tr>
                 </thead>
                 <tbody>
+                  {activeDossierUpdateRecommendations.map((recommendation) => {
+                    const matchState = recommendationMatchState(recommendation);
+                    const targetCandidate = recommendation.targetCandidateId
+                      ? candidates.find(
+                          (candidate) =>
+                            candidate.id === recommendation.targetCandidateId,
+                        )
+                      : null;
+                    return (
+                      <tr
+                        key={recommendation.id}
+                        className="border-t border-border/70 align-top"
+                      >
+                        <td className="py-3 pr-3 font-semibold text-foreground">
+                          {targetCandidate?.name ??
+                            recommendation.targetDossierId ??
+                            recommendation.subjectName}
+                        </td>
+                        <td className="py-3 pr-3">
+                          {recommendation.subjectName}
+                        </td>
+                        <td className="py-3 pr-3">
+                          {recommendation.reason ||
+                            recommendation.evidenceSummary ||
+                            recommendationProvenance(recommendation)}
+                        </td>
+                        <td className="py-3 pr-3">
+                          {recommendation.confidence ?? "needs review"}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <StatusPill>
+                            {identityBadgeForRecommendation(
+                              recommendation,
+                              matchState,
+                            )}
+                          </StatusPill>
+                        </td>
+                        <td className="py-3 pr-3">
+                          {recommendation.suggestedAction ||
+                            "Review update details before attaching anywhere public."}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <Link
+                            href={`/admin/dossiers/recommendations/${recommendation.id}`}
+                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                          >
+                            {dossierUpdateActionLabel({
+                              recommendation,
+                              matchState,
+                            })}
+                          </Link>
+                        </td>
+                      </tr>
+                    );
+                  })}
                   {existingDossierUpdates.map((candidate) => (
                     <tr
                       key={candidate.id}
@@ -1007,7 +1168,7 @@ export default function DossierControlCenterPage() {
                           href={`/admin/dossiers/candidates/${candidate.id}`}
                           className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                         >
-                          Open
+                          {dossierUpdateActionLabel({ candidate })}
                         </Link>
                       </td>
                     </tr>
@@ -1041,7 +1202,7 @@ export default function DossierControlCenterPage() {
                     <th className="py-2 pr-3">Dossier status</th>
                     <th className="py-2 pr-3">Identity status</th>
                     <th className="py-2 pr-3">Last updated</th>
-                    <th className="py-2 pr-3">Open</th>
+                    <th className="py-2 pr-3">Action</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1055,6 +1216,18 @@ export default function DossierControlCenterPage() {
                       candidate,
                       draft,
                     );
+                    const actionLabel = sourceFileActionLabel(
+                      candidate,
+                      draft,
+                      metrics,
+                    );
+                    const actionHref =
+                      (actionLabel === "Open Draft" ||
+                        actionLabel === "Review Draft") &&
+                      openDraftId
+                        ? `/admin/dossiers/drafts/${openDraftId}`
+                        : `/admin/dossiers/candidates/${candidate.id}`;
+                    const opensDraft = actionHref.includes("/drafts/");
                     return (
                       <tr
                         key={candidate.id}
@@ -1089,24 +1262,14 @@ export default function DossierControlCenterPage() {
                           {formatDate(candidate.updatedAt)}
                         </td>
                         <td className="py-3 pr-3">
-                          <div className="flex flex-wrap gap-2">
-                            <Link
-                              href={`/admin/dossiers/candidates/${candidate.id}`}
-                              className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                            >
-                              Open
-                            </Link>
-                            {openDraftId && (
-                              <Link
-                                href={`/admin/dossiers/drafts/${openDraftId}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
-                              >
-                                Draft
-                              </Link>
-                            )}
-                          </div>
+                          <Link
+                            href={actionHref}
+                            target={opensDraft ? "_blank" : undefined}
+                            rel={opensDraft ? "noopener noreferrer" : undefined}
+                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                          >
+                            {actionLabel}
+                          </Link>
                         </td>
                       </tr>
                     );
@@ -1151,7 +1314,32 @@ export default function DossierControlCenterPage() {
                       href={`/admin/dossiers/candidates/${candidate.id}`}
                       className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      Open
+                      {archiveActionLabel({ candidate })}
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+          {terminalRecommendations.length > 0 && (
+            <div className="mt-4 space-y-2 text-sm text-muted">
+              {terminalRecommendations.slice(0, 8).map((recommendation) => (
+                <article
+                  key={recommendation.id}
+                  className="border border-border/70 bg-background/20 p-3"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="font-semibold text-foreground">
+                        {recommendation.subjectName}
+                      </p>
+                      <p>Status: {recommendation.status}</p>
+                    </div>
+                    <Link
+                      href={`/admin/dossiers/recommendations/${recommendation.id}`}
+                      className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
+                    >
+                      {archiveActionLabel({ recommendation })}
                     </Link>
                   </div>
                 </article>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -130,7 +130,10 @@ function recommendationProvenance(recommendation: DossierRecommendation) {
   if (recommendation.ingestSource === "bnl_source_knowledge_bridge") {
     return "Older BNL review note";
   }
-  if (recommendation.ingestSource === "bnl" || recommendation.createdBy === "bnl") {
+  if (
+    recommendation.ingestSource === "bnl" ||
+    recommendation.createdBy === "bnl"
+  ) {
     return "Known from BNL records";
   }
   return recommendation.createdBy
@@ -160,43 +163,70 @@ function StatusPill({ children }: { children: React.ReactNode }) {
   );
 }
 
-const dossierPhases = [
-  "Phase 1 — Case File / BNL Source File",
-  "Phase 2 — Proposed Dossier + BNL Edit Chat",
-  "Phase 3 — Final Admin Draft",
-  "Phase 4 — Owner Review",
-  "Phase 5 — Approved / Publish Later",
-];
+function identityBadgeForCandidate(candidate: DossierCandidate) {
+  const identityLinks = candidate.identityLinks ?? [];
+  const confirmed = identityLinks.filter(
+    (link) => link.status === "confirmed",
+  ).length;
+  const pending = identityLinks.filter(
+    (link) => link.status === "proposed",
+  ).length;
 
-function PhaseRail({ currentPhase }: { currentPhase?: number }) {
-  return (
-    <section
-      className="border border-border bg-surface p-4"
-      aria-label="Dossier phase overview"
-    >
-      <p className="text-xs uppercase tracking-[0.45em] text-muted mb-3">
-        Numbered dossier phases
-      </p>
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-2 text-xs uppercase tracking-widest">
-        {dossierPhases.map((phase, index) => (
-          <span
-            key={phase}
-            className={`border px-3 py-2 ${currentPhase === index + 1 ? "border-accent text-accent bg-accent/10" : "border-border text-muted bg-background/30"}`}
-          >
-            {phase}
-          </span>
-        ))}
-      </div>
-      <p className="mt-3 text-xs text-muted">
-        Phase 1 is the internal working case file / evidence folder; it is not
-        public copy. Phase 2 is the curated public-facing draft written from
-        reviewed Case File material. Phase 3 is final admin draft
-        confirmation. Phase 4 is the owner final approval gate before anything
-        becomes publishable/public. Phase 5 is approved / publish later and is
-        not active yet.
-      </p>
-    </section>
-  );
+  if (pending > 0) {
+    return `${pending} pending identity link${pending === 1 ? "" : "s"}`;
+  }
+  if (confirmed > 0) {
+    return `${confirmed} confirmed alias${confirmed === 1 ? "" : "es"}`;
+  }
+  if (
+    candidate.existingDossierMatch ||
+    candidate.duplicateRisk === "medium" ||
+    candidate.duplicateRisk === "high"
+  ) {
+    return "Possible Identity Link";
+  }
+  if (candidate.duplicateRisk === "low") {
+    return "Identity Needs Review";
+  }
+  return "Clear";
+}
+
+function identityBadgeForRecommendation(
+  recommendation: DossierRecommendation,
+  matchState: { state: string; nextAction: string },
+) {
+  if (recommendation.type === "identity_link") {
+    return "Identity confirmation needed";
+  }
+  if (matchState.state === "possible_identity_link") {
+    return "Possible Identity Link";
+  }
+  if (matchState.state === "existing_candidate") {
+    return "Matched Source File";
+  }
+  return "Clear";
+}
+
+function dossierStatusForCandidate(
+  candidate: DossierCandidate,
+  draft?: DossierDraft,
+) {
+  if (draft?.status === "ready_for_owner_review")
+    return "Ready for Owner Review";
+  if (draft?.status === "owner_changes_requested")
+    return "Owner changes requested";
+  if (draft?.status === "owner_approved") return "Approved / publish later";
+  if (draft) return "Draft started";
+  if (
+    (candidate.sourceFileNotes ?? []).some((note) => note.status === "active")
+  ) {
+    return "Needs update from Source File";
+  }
+  return "No Proposed Dossier";
+}
+
+function firstListValue(values?: string[]) {
+  return values?.find((value) => value.trim()) ?? "—";
 }
 
 function DashboardCard({
@@ -360,7 +390,9 @@ export default function DossierControlCenterPage() {
     ),
   );
   const closedHistoryCount =
-    closedCandidates.length + closedDrafts.length + terminalRecommendations.length;
+    closedCandidates.length +
+    closedDrafts.length +
+    terminalRecommendations.length;
 
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
@@ -419,20 +451,26 @@ export default function DossierControlCenterPage() {
   }
 
   function recommendationMatchState(recommendation: DossierRecommendation) {
-    const match = matchDossierRecommendationSubject({ recommendation, candidates });
+    const match = matchDossierRecommendationSubject({
+      recommendation,
+      candidates,
+    });
     if (recommendation.ingestSource === "bnl_source_file_enrichment") {
       const target = recommendation.targetCandidateId
-        ? candidates.find((candidate) => candidate.id === recommendation.targetCandidateId)
+        ? candidates.find(
+            (candidate) => candidate.id === recommendation.targetCandidateId,
+          )
         : null;
       return {
         match,
-        state: target?.status === "active_source_file"
-          ? "BNL review addendum / Case File"
-          : target?.status === "candidate_intake"
-            ? "BNL review addendum / Dossier Seed"
-            : target?.status === "existing_dossier_update"
-              ? "BNL review addendum / Dossier Update"
-              : "BNL Signal / Needs Admin Decision",
+        state:
+          target?.status === "active_source_file"
+            ? "BNL review addendum / Case File"
+            : target?.status === "candidate_intake"
+              ? "BNL review addendum / Dossier Seed"
+              : target?.status === "existing_dossier_update"
+                ? "BNL review addendum / Dossier Update"
+                : "BNL Signal / Needs Admin Decision",
         nextAction: "Review-only internal case-file material; not public copy",
       };
     }
@@ -457,7 +495,10 @@ export default function DossierControlCenterPage() {
         nextAction: "Needs Admin Decision",
       };
     }
-    if (recommendation.targetDossierId || recommendation.type === "modify_existing_dossier") {
+    if (
+      recommendation.targetDossierId ||
+      recommendation.type === "modify_existing_dossier"
+    ) {
       return {
         match,
         state: "Dossier Update",
@@ -513,11 +554,12 @@ export default function DossierControlCenterPage() {
       );
     } catch (err) {
       setNotice(
-        err instanceof Error ? err.message : "Failed to update internal record.",
+        err instanceof Error
+          ? err.message
+          : "Failed to update internal record.",
       );
     }
   }
-
 
   async function recommendationAction(
     recommendationId: string,
@@ -531,9 +573,7 @@ export default function DossierControlCenterPage() {
           : "Signal dismissed. Public dossiers were not changed.",
       );
     } catch (err) {
-      setNotice(
-        err instanceof Error ? err.message : "Signal action failed.",
-      );
+      setNotice(err instanceof Error ? err.message : "Signal action failed.");
     }
   }
 
@@ -557,10 +597,14 @@ export default function DossierControlCenterPage() {
         action === "markCandidateAsExistingDossierUpdate"
       ) {
         const selectedDossierId =
-          selectedDossierByCandidate[candidateId] || candidate.existingDossierMatch?.id || "";
+          selectedDossierByCandidate[candidateId] ||
+          candidate.existingDossierMatch?.id ||
+          "";
         if (selectedDossierId) {
           body.dossierId = selectedDossierId;
-          body.confidence = selectedDossierByCandidate[candidateId] ? "high" : candidate.existingDossierMatch?.confidence;
+          body.confidence = selectedDossierByCandidate[candidateId]
+            ? "high"
+            : candidate.existingDossierMatch?.confidence;
         }
       }
       if (action === "permanentlyDeleteCandidate") {
@@ -595,7 +639,9 @@ export default function DossierControlCenterPage() {
         setPayload(data as WorkflowPayload);
       }
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : "Candidate action failed.");
+      setNotice(
+        err instanceof Error ? err.message : "Candidate action failed.",
+      );
     }
   }
 
@@ -624,7 +670,7 @@ export default function DossierControlCenterPage() {
       <section className="border-b border-border bg-surface/80">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10">
           <p className="text-xs uppercase tracking-[0.5em] text-muted mb-4">
-            ADMIN DOSSIER WORKFLOW
+            ADMIN DOSSIER DASHBOARD
           </p>
           <h1
             aria-label="Dossier Control Center"
@@ -633,8 +679,8 @@ export default function DossierControlCenterPage() {
             <span className="text-accent text-glow">Dossier</span> Control
             Center
           </h1>
-          <p className="text-sm text-muted mt-3 max-w-3xl">
-            Overview of Signal Review inputs, Dossier Seeds, Case Files / BNL Source Files, Proposed Dossiers, and Owner Review status. Open a workspace to continue the pipeline: Signal Review → Dossier Seeds → Case Files → Proposed Dossiers → Owner Review.
+          <p className="text-sm text-muted mt-3 max-w-2xl">
+            Sort noticed subjects, review updates, and open Source Files.
           </p>
           <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
             <Link
@@ -649,12 +695,6 @@ export default function DossierControlCenterPage() {
             >
               Public Database
             </Link>
-            <Link
-              href="/admin/dossiers/owner-review"
-              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background transition-all"
-            >
-              Owner Review
-            </Link>
           </div>
         </div>
       </section>
@@ -666,79 +706,160 @@ export default function DossierControlCenterPage() {
           </div>
         )}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 text-xs text-muted">
-          {[
-            ["Workflow Records", candidates.length],
-            ["Dossier Seeds", candidateIntakeItems.length],
-            ["Case Files", activeCandidates.length],
-            ["Dossier Updates", existingDossierUpdates.length],
-            ["Proposed Dossiers", proposedDossiers.length],
-            ["Owner Review waiting", ownerReviewDrafts.length],
-            ["Archived / Trash", archivedCandidates.length],
-            ["Case Files Needing Info", sourceFilesNeedingInfo.length],
-            ["Case Files With Proposed Dossiers", sourceFilesWithDrafts.length],
-            [
-              "Case Files With Source Notes",
-              sourceFilesWithUnappliedNotes.length,
-            ],
-            ["Signals Waiting", activeRecommendations.length],
-            ["Identity Links", activeDuplicateGroups.length],
-            ["Archive / History", closedHistoryCount],
-          ].map(([label, value]) => (
-            <div key={label} className="border border-border bg-surface p-4">
-              <p className="uppercase tracking-[0.35em] text-accent mb-2">
-                {label}
-              </p>
-              <p className="text-2xl font-bold text-foreground">{value}</p>
-            </div>
-          ))}
-        </div>
-
-        <PhaseRail />
-
-        <DashboardCard
-          eyebrow="Workflow map"
-          title="Signal Review → Dossier Seeds → Case Files → Proposed Dossiers → Owner Review"
-          aside={<StatusPill>overview only</StatusPill>}
-        >
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm text-muted">
-            <p className="border border-border/70 bg-background/20 p-3">
-              Case Files / BNL Source Files are internal subject workspaces.
-            </p>
-            <p className="border border-border/70 bg-background/20 p-3">
-              Proposed Dossiers are curated public-facing drafts written only from reviewed Case File material.
-            </p>
-            <p className="border border-border/70 bg-background/20 p-3">
-              Owner Review is the final approval/editing lane before publishable state.
-            </p>
+        <DashboardCard eyebrow="Summary" title="Summary">
+          <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-7 gap-3 text-xs text-muted">
+            {[
+              [
+                "Candidates",
+                candidateIntakeItems.length + activeRecommendations.length,
+              ],
+              ["Dossier Updates", existingDossierUpdates.length],
+              ["Source Files", activeCandidates.length],
+              ["Needs Info", sourceFilesNeedingInfo.length],
+              [
+                "Ready for Dossier",
+                activeCandidates.filter(
+                  (candidate) =>
+                    !linkedActiveDraftFor(candidate, drafts) &&
+                    candidate.status !== "needs_more_evidence",
+                ).length,
+              ],
+              ["Owner Review waiting", ownerReviewDrafts.length],
+              [
+                "Archive / Dismissed / Trash",
+                closedHistoryCount + archivedCandidates.length,
+              ],
+            ].map(([label, value]) => (
+              <div
+                key={label}
+                className="border border-border/70 bg-background/30 p-3"
+              >
+                <p className="uppercase tracking-[0.3em] text-accent mb-2">
+                  {label}
+                </p>
+                <p className="text-2xl font-bold text-foreground">{value}</p>
+              </div>
+            ))}
           </div>
         </DashboardCard>
 
         <DashboardCard
-          eyebrow="Signal Review"
-          title="Signal Review"
+          eyebrow="Candidates"
+          title="Candidates"
           aside={
-            <StatusPill>{activeRecommendations.length} signals waiting</StatusPill>
+            <StatusPill>
+              {candidateIntakeItems.length + activeRecommendations.length}{" "}
+              waiting
+            </StatusPill>
           }
         >
-          <p className="text-sm text-muted">
-            BNL Signals are incoming source/recommendation inputs. Signals can become Dossier Seeds, attach to Case Files, create Dossier Updates, or suggest Identity Links. Signals are not public copy and do not publish anything.
-          </p>
-          {activeRecommendations.length === 0 ? (
+          <div className="mb-4">
+            <details className="border border-border/70 bg-background/20 p-4">
+              <summary className="cursor-pointer text-sm font-semibold text-foreground">
+                Manual Signal
+              </summary>
+              <p className="mt-3 text-sm text-muted">
+                Use this only when BNL has not suggested something yet. This
+                creates a BNL Signal, not a direct source file.
+              </p>
+              <form
+                onSubmit={submitManualRecommendation}
+                className="mt-4 grid grid-cols-1 md:grid-cols-5 gap-3 text-xs uppercase tracking-widest text-muted"
+              >
+                <label className="space-y-2 md:col-span-1">
+                  <span>Subject name</span>
+                  <input
+                    required
+                    value={recommendationForm.subjectName}
+                    onChange={(event) =>
+                      setRecommendationForm({
+                        ...recommendationForm,
+                        subjectName: event.target.value,
+                      })
+                    }
+                    className={textInputClass()}
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span>Type</span>
+                  <select
+                    value={recommendationForm.type}
+                    onChange={(event) =>
+                      setRecommendationForm({
+                        ...recommendationForm,
+                        type: event.target
+                          .value as DossierRecommendation["type"],
+                      })
+                    }
+                    className={textInputClass()}
+                  >
+                    <option value="new_subject">New Subject</option>
+                    <option value="modify_existing_dossier">
+                      Modify Existing Dossier
+                    </option>
+                  </select>
+                </label>
+                <label className="space-y-2">
+                  <span>Confidence</span>
+                  <select
+                    value={recommendationForm.confidence}
+                    onChange={(event) =>
+                      setRecommendationForm({
+                        ...recommendationForm,
+                        confidence: event.target
+                          .value as ManualRecommendationForm["confidence"],
+                      })
+                    }
+                    className={textInputClass()}
+                  >
+                    <option value="medium">medium</option>
+                    <option value="low">low</option>
+                    <option value="high">high</option>
+                    <option value="">unset</option>
+                  </select>
+                </label>
+                <label className="space-y-2 md:col-span-2">
+                  <span>Reason</span>
+                  <input
+                    required
+                    value={recommendationForm.reason}
+                    onChange={(event) =>
+                      setRecommendationForm({
+                        ...recommendationForm,
+                        reason: event.target.value,
+                      })
+                    }
+                    className={textInputClass()}
+                  />
+                </label>
+                <div className="md:col-span-5">
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Create Manual Signal
+                  </button>
+                </div>
+              </form>
+            </details>
+          </div>
+
+          {candidateIntakeItems.length + activeRecommendations.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No signals waiting. Ignored, dismissed, converted, and attached records remain preserved in history.
+              No candidates are waiting.
             </p>
           ) : (
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[800px] text-left text-sm text-muted">
+              <table className="w-full min-w-[820px] text-left text-sm text-muted">
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
                     <th className="py-2 pr-3">Subject</th>
-                    <th className="py-2 pr-3">Match state</th>
-                    <th className="py-2 pr-3">Ingest</th>
-                    <th className="py-2 pr-3">Source lanes</th>
-                    <th className="py-2 pr-3">Next action</th>
-                    <th className="py-2 pr-3">Review</th>
+                    <th className="py-2 pr-3">Why BNL noticed</th>
+                    <th className="py-2 pr-3">Strength / confidence</th>
+                    <th className="py-2 pr-3">Identity status</th>
+                    <th className="py-2 pr-3">Suggested next step</th>
+                    <th className="py-2 pr-3">Open</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -749,197 +870,77 @@ export default function DossierControlCenterPage() {
                         key={recommendation.id}
                         className="border-t border-border/70 align-top"
                       >
-                        <td className="py-3 pr-3 text-foreground font-semibold">
+                        <td className="py-3 pr-3 font-semibold text-foreground">
                           {recommendation.subjectName}
                         </td>
-                        <td className="py-3 pr-3">{matchState.state}</td>
                         <td className="py-3 pr-3">
-                          <p>{recommendationProvenance(recommendation)}</p>
-                          {recommendation.ingestedAt && (
-                            <p className="text-xs">{formatDate(recommendation.ingestedAt)}</p>
-                          )}
+                          {recommendation.reason ||
+                            recommendation.evidenceSummary ||
+                            recommendationProvenance(recommendation)}
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.sourceLanes.join(", ")}
+                          {recommendation.confidence ?? "unset"}
                         </td>
-                        <td className="py-3 pr-3">{matchState.nextAction}</td>
                         <td className="py-3 pr-3">
-                          <div className="flex flex-wrap gap-2">
-                            <Link
-                              href={`/admin/dossiers/recommendations/${recommendation.id}`}
-                              className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                            >
-                              Review Signal
-                            </Link>
-                            <button
-                              type="button"
-                              disabled={saving}
-                              onClick={() =>
-                                void recommendationAction(
-                                  recommendation.id,
-                                  "archiveDossierRecommendation",
-                                )
-                              }
-                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-                            >
-                              Archive
-                            </button>
-                            <button
-                              type="button"
-                              disabled={saving}
-                              onClick={() =>
-                                void recommendationAction(
-                                  recommendation.id,
-                                  "dismissDossierRecommendation",
-                                )
-                              }
-                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-                            >
-                              Dismiss
-                            </button>
-                          </div>
+                          <StatusPill>
+                            {identityBadgeForRecommendation(
+                              recommendation,
+                              matchState,
+                            )}
+                          </StatusPill>
+                        </td>
+                        <td className="py-3 pr-3">
+                          {recommendation.suggestedAction ||
+                            matchState.nextAction}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <Link
+                            href={`/admin/dossiers/recommendations/${recommendation.id}`}
+                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                          >
+                            Open
+                          </Link>
                         </td>
                       </tr>
                     );
                   })}
+                  {candidateIntakeItems.map((candidate) => (
+                    <tr
+                      key={candidate.id}
+                      className="border-t border-border/70 align-top"
+                    >
+                      <td className="py-3 pr-3 font-semibold text-foreground">
+                        {candidate.name}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {candidate.whyNow ||
+                          candidate.reason ||
+                          candidateProvenance(candidate)}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {candidate.confidence ?? candidate.tier} / score{" "}
+                        {candidate.score}
+                      </td>
+                      <td className="py-3 pr-3">
+                        <StatusPill>
+                          {identityBadgeForCandidate(candidate)}
+                        </StatusPill>
+                      </td>
+                      <td className="py-3 pr-3">
+                        Promote to Source File or archive from the detail page.
+                      </td>
+                      <td className="py-3 pr-3">
+                        <Link
+                          href={`/admin/dossiers/candidates/${candidate.id}`}
+                          className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                        >
+                          Open
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
-            </div>
-          )}
-        </DashboardCard>
-
-        <details className="border border-border bg-surface p-5">
-          <summary className="cursor-pointer text-xl font-bold text-foreground">
-            Manual Signal
-          </summary>
-          <p className="mt-3 text-sm text-muted">
-            Use this only when BNL has not suggested something yet. This creates a BNL Signal, not a direct source file.
-          </p>
-          <form
-            onSubmit={submitManualRecommendation}
-            className="mt-4 grid grid-cols-1 md:grid-cols-5 gap-3 text-xs uppercase tracking-widest text-muted"
-          >
-            <label className="space-y-2 md:col-span-1">
-              <span>Subject name</span>
-              <input
-                required
-                value={recommendationForm.subjectName}
-                onChange={(event) =>
-                  setRecommendationForm({
-                    ...recommendationForm,
-                    subjectName: event.target.value,
-                  })
-                }
-                className={textInputClass()}
-              />
-            </label>
-            <label className="space-y-2">
-              <span>Type</span>
-              <select
-                value={recommendationForm.type}
-                onChange={(event) =>
-                  setRecommendationForm({
-                    ...recommendationForm,
-                    type: event.target.value as DossierRecommendation["type"],
-                  })
-                }
-                className={textInputClass()}
-              >
-                <option value="new_subject">New Subject</option>
-                <option value="modify_existing_dossier">
-                  Modify Existing Dossier
-                </option>
-              </select>
-            </label>
-            <label className="space-y-2">
-              <span>Confidence</span>
-              <select
-                value={recommendationForm.confidence}
-                onChange={(event) =>
-                  setRecommendationForm({
-                    ...recommendationForm,
-                    confidence: event.target
-                      .value as ManualRecommendationForm["confidence"],
-                  })
-                }
-                className={textInputClass()}
-              >
-                <option value="medium">medium</option>
-                <option value="low">low</option>
-                <option value="high">high</option>
-                <option value="">unset</option>
-              </select>
-            </label>
-            <label className="space-y-2 md:col-span-2">
-              <span>Reason</span>
-              <input
-                required
-                value={recommendationForm.reason}
-                onChange={(event) =>
-                  setRecommendationForm({
-                    ...recommendationForm,
-                    reason: event.target.value,
-                  })
-                }
-                className={textInputClass()}
-              />
-            </label>
-            <div className="md:col-span-5">
-              <button
-                type="submit"
-                disabled={saving}
-                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Create Manual Signal
-              </button>
-            </div>
-          </form>
-        </details>
-
-
-        <DashboardCard
-          eyebrow="Dossier Seeds"
-          title="Dossier Seeds"
-          aside={<StatusPill>{candidateIntakeItems.length} seeds</StatusPill>}
-        >
-          <p className="text-sm text-muted mb-4">
-            Dossier Seeds are lightweight internal records. Admins decide when a Dossier Seed becomes a Case File / BNL Source File; evidence, review warnings, safety notes, do-not-say notes, and open questions are preserved during promotion.
-          </p>
-          {candidateIntakeItems.length === 0 ? (
-            <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No Dossier Seeds are waiting.
-            </p>
-          ) : (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-              {candidateIntakeItems.map((candidate) => (
-                <article key={candidate.id} className="border border-border/70 bg-background/20 p-4 text-sm text-muted">
-                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                    <div>
-                      <p className="font-bold text-foreground">{candidate.name}</p>
-                      <p>Source: {candidateProvenance(candidate)}</p>
-                      <p>Status/stage: Dossier Seed / {candidate.status}</p>
-                      {(candidate.publicSafetyNotes ?? []).length > 0 && (
-                        <p className="text-accent">Warning badges: source warnings present</p>
-                      )}
-                      {candidate.existingDossierMatch && (
-                        <p>Possible public dossier match: {candidate.existingDossierMatch.name}</p>
-                      )}
-                      <p>Next action: Promote to Case File / BNL Source File or archive junk/test extraction.</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <Link href={`/admin/dossiers/candidates/${candidate.id}`} className="border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
-                        Review Dossier Seed
-                      </Link>
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "promoteCandidateToSourceFile")} className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50">
-                        Promote to Case File
-                      </button>
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "archiveCandidate")} className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50">
-                        Archive
-                      </button>
-                    </div>
-                  </div>
-                </article>
-              ))}
             </div>
           )}
         </DashboardCard>
@@ -947,96 +948,100 @@ export default function DossierControlCenterPage() {
         <DashboardCard
           eyebrow="Dossier Updates"
           title="Dossier Updates"
-          aside={<StatusPill>{existingDossierUpdates.length} dossier updates</StatusPill>}
+          aside={
+            <StatusPill>{existingDossierUpdates.length} updates</StatusPill>
+          }
         >
-          <p className="text-sm text-muted mb-4">
-            Exact public dossier matches are staged as Dossier Updates, not as brand-new public dossiers. Owner approval is required before public changes.
-          </p>
-          <div className="mb-4 grid grid-cols-1 md:grid-cols-3 gap-3 text-sm text-muted">
-            <p className="border border-border/70 bg-background/20 p-3">
-              Dossier Update target found: protected source lookup can now
-              recognize a published dossier target even when no internal update
-              file exists yet.
-            </p>
-            <p className="border border-border/70 bg-background/20 p-3">
-              No internal update file exists yet: use the protected Create
-              Dossier Update action before enrichment attaches notes.
-            </p>
-            <p className="border border-border/70 bg-background/20 p-3">
-              Review-only; no public changes. The update lane does not approve
-              public copy, aliases, identity merges, or publication.
-            </p>
-          </div>
           {existingDossierUpdates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No existing public dossier update records are waiting.
+              No existing dossier updates are waiting.
             </p>
           ) : (
-            <div className="space-y-3">
-              {existingDossierUpdates.map((candidate) => (
-                <article key={candidate.id} className="border border-border/70 bg-background/20 p-4 text-sm text-muted">
-                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                    <div>
-                      <p className="font-bold text-foreground">Dossier Update: {candidate.existingDossierMatch?.name ?? candidate.name}</p>
-                      <p>BNL Signal subject: {candidate.name}</p>
-                      <p>Matched public dossier: {candidate.existingDossierMatch?.name ?? "—"}</p>
-                      <p>Public dossier target id: {candidate.existingDossierMatch?.id ?? "—"}</p>
-                      <p>Match confidence: {candidate.existingDossierMatch?.confidence ?? "—"}</p>
-                      <p>Evidence and notes: {(candidate.sourceFileNotes ?? []).length} notes preserved</p>
-                      <p>Review warnings: {(candidate.publicSafetyNotes ?? []).length} public-safety notes / {(candidate.doNotSay ?? []).length} do-not-say notes / {(candidate.missingInfo ?? []).length} open questions</p>
-                      <p>Proposed action: review update/enrichment; owner approval required before public changes.</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <Link href={`/admin/dossiers/candidates/${candidate.id}`} className="border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
-                        Review Update
-                      </Link>
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "promoteCandidateToSourceFile")} className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50">
-                        Convert to Case File
-                      </button>
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "archiveCandidate")} className="border border-border px-3 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50">
-                        Archive / wrong match
-                      </button>
-                    </div>
-                  </div>
-                </article>
-              ))}
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[820px] text-left text-sm text-muted">
+                <thead className="text-xs uppercase tracking-widest text-foreground">
+                  <tr>
+                    <th className="py-2 pr-3">
+                      Subject / public dossier target
+                    </th>
+                    <th className="py-2 pr-3">Update subject</th>
+                    <th className="py-2 pr-3">Why this update matters</th>
+                    <th className="py-2 pr-3">Match confidence</th>
+                    <th className="py-2 pr-3">Identity status</th>
+                    <th className="py-2 pr-3">Suggested next step</th>
+                    <th className="py-2 pr-3">Open</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {existingDossierUpdates.map((candidate) => (
+                    <tr
+                      key={candidate.id}
+                      className="border-t border-border/70 align-top"
+                    >
+                      <td className="py-3 pr-3 font-semibold text-foreground">
+                        {candidate.existingDossierMatch?.name ?? candidate.name}
+                      </td>
+                      <td className="py-3 pr-3">{candidate.name}</td>
+                      <td className="py-3 pr-3">
+                        {candidate.whyNow ||
+                          candidate.reason ||
+                          firstListValue(candidate.knownFacts)}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {candidate.existingDossierMatch?.confidence ??
+                          candidate.confidence ??
+                          "needs review"}
+                      </td>
+                      <td className="py-3 pr-3">
+                        <StatusPill>
+                          {candidate.existingDossierMatch
+                            ? identityBadgeForCandidate(candidate)
+                            : "Identity confirmation needed"}
+                        </StatusPill>
+                      </td>
+                      <td className="py-3 pr-3">
+                        Review update details before attaching anywhere public.
+                      </td>
+                      <td className="py-3 pr-3">
+                        <Link
+                          href={`/admin/dossiers/candidates/${candidate.id}`}
+                          className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                        >
+                          Open
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </DashboardCard>
 
         <DashboardCard
-          eyebrow="Primary operations"
-          title="Active Case Files / BNL Source Files / Working Case Files"
-          aside={<StatusPill>{activeCandidates.length} active working case files</StatusPill>}
+          eyebrow="Source Files"
+          title="Source Files"
+          aside={<StatusPill>{activeCandidates.length} active</StatusPill>}
         >
-          <p className="text-sm text-muted">
-            Open a BNL Source File working case file to review evidence. Proposed
-            Dossiers, final admin confirmation, and owner review are shown here
-            as concise status indicators only instead of full dashboard
-            workboard lanes.
-          </p>
           {activeCandidates.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No active Case Files / BNL Source Files need review.
+              No active Source Files need review.
             </p>
           ) : (
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[1100px] text-left text-sm text-muted">
+              <table className="w-full min-w-[980px] text-left text-sm text-muted">
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
-                    <th className="py-2 pr-3">BNL Source File</th>
-                    <th className="py-2 pr-3">Provenance</th>
-                    <th className="py-2 pr-3">Current phase</th>
-                    <th className="py-2 pr-3">Source depth / info strength</th>
-                    <th className="py-2 pr-3">Source notes count</th>
-                    <th className="py-2 pr-3">Signal/evidence count</th>
-                    <th className="py-2 pr-3">Proposed dossier status</th>
-                    <th className="py-2 pr-3">Unapplied source notes count</th>
-                    <th className="py-2 pr-3">Identity links</th>
-                    <th className="py-2 pr-3">Case file indicators</th>
+                    <th className="py-2 pr-3">Subject</th>
+                    <th className="py-2 pr-3">
+                      Why they matter / engagement summary
+                    </th>
+                    <th className="py-2 pr-3">Source strength</th>
+                    <th className="py-2 pr-3">Missing info</th>
+                    <th className="py-2 pr-3">Dossier status</th>
+                    <th className="py-2 pr-3">Identity status</th>
                     <th className="py-2 pr-3">Last updated</th>
-                    <th className="py-2 pr-3">Next recommended action</th>
-                    <th className="py-2 pr-3">Actions</th>
+                    <th className="py-2 pr-3">Open</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1045,250 +1050,62 @@ export default function DossierControlCenterPage() {
                     const createdDraftId =
                       createdDraftIdByCandidate[candidate.id];
                     const openDraftId = draft?.id ?? createdDraftId;
-                    const canCreateDraft =
-                      !isCandidateClosed(candidate) && !openDraftId;
-                    const canUpdateCandidate = !isCandidateClosed(candidate);
                     const metrics = sourceFileMetrics.get(candidate.id);
-                    const currentPhase = openDraftId
-                      ? "Phase 2 — Proposed Dossier + BNL Edit Chat"
-                      : "Phase 1 — Case File / BNL Source File";
-                    const proposedStatus = draft
-                      ? `${draft.status} / ${formatDate(draft.updatedAt)}`
-                      : openDraftId
-                        ? "draft just created"
-                        : "No proposed dossier";
-                    const identityLinks = candidate.identityLinks ?? [];
-                    const confirmedIdentityLinks = identityLinks.filter(
-                      (identityLink) => identityLink.status === "confirmed",
+                    const dossierStatus = dossierStatusForCandidate(
+                      candidate,
+                      draft,
                     );
-                    const proposedIdentityLinks = identityLinks.filter(
-                      (identityLink) => identityLink.status === "proposed",
-                    );
-                    const nextAction =
-                      (metrics?.unappliedSourceNotesCount ?? 0) > 0
-                        ? "Review source updates in proposed dossier"
-                        : openDraftId
-                          ? "Open proposed dossier"
-                          : candidate.status === "needs_more_evidence"
-                            ? "Add missing info to Case File"
-                            : "Add info or create proposed dossier";
                     return (
                       <tr
                         key={candidate.id}
                         className="border-t border-border/70 align-top"
                       >
-                        <td className="py-3 pr-3 text-foreground font-semibold">
+                        <td className="py-3 pr-3 font-semibold text-foreground">
                           {candidate.name}
                         </td>
                         <td className="py-3 pr-3">
-                          <p>{candidateProvenance(candidate)}</p>
-                          {candidate.ingestKey && (
-                            <p className="text-xs">Ingest key: {candidate.ingestKey}</p>
-                          )}
-                          {candidate.createdFromRecommendationId && (
-                            <p className="text-xs">From BNL Signal: {candidate.createdFromRecommendationId}</p>
-                          )}
+                          {candidate.sourceFileSummary?.summaryText ||
+                            candidate.evidenceSummary ||
+                            candidate.reason ||
+                            "—"}
                         </td>
                         <td className="py-3 pr-3">
-                          <StatusPill>{currentPhase}</StatusPill>
+                          {metrics?.sourceDepth ??
+                            candidate.confidence ??
+                            "Low"}
                         </td>
                         <td className="py-3 pr-3">
-                          Source strength: {metrics?.sourceDepth ?? "Low"}
+                          {(candidate.missingInfo ?? []).length > 0
+                            ? candidate.missingInfo?.join("; ")
+                            : "—"}
                         </td>
+                        <td className="py-3 pr-3">{dossierStatus}</td>
                         <td className="py-3 pr-3">
-                          Source notes: {metrics?.sourceNotesCount ?? 0}
-                        </td>
-                        <td className="py-3 pr-3">
-                          Signals: {metrics?.attachedRecommendationCount ?? 0}
-                          <br />
-                          Evidence: {metrics?.evidenceItemCount ?? 0}
-                        </td>
-                        <td className="py-3 pr-3">{proposedStatus}</td>
-                        <td className="py-3 pr-3">
-                          Unapplied notes: {metrics?.unappliedSourceNotesCount ?? 0}
-                        </td>
-                        <td className="py-3 pr-3">
-                          Aliases: {confirmedIdentityLinks.length} confirmed
-                          {proposedIdentityLinks.length > 0 && (
-                            <p className="text-xs text-accent">
-                              Pending aliases: {proposedIdentityLinks.length} —
-                              Identity Links
-                            </p>
-                          )}
-                        </td>
-                        <td className="py-3 pr-3 space-y-1">
-                          {(candidate.publicSafetyNotes ?? []).length > 0 && (
-                            <p>case file has warnings</p>
-                          )}
-                          {(candidate.sourceLanes ?? []).includes("broadcast_memory") && (
-                            <p>case file has source-blind material</p>
-                          )}
-                          {(candidate.knownFacts ?? []).length > 0 && (
-                            <p>case file has public-safe facts</p>
-                          )}
-                          {proposedIdentityLinks.length > 0 && (
-                            <p>identity review pending</p>
-                          )}
-                          {openDraftId && <p>proposed dossier exists</p>}
-                          {draft?.status === "ready_for_owner_review" && (
-                            <p>owner review pending</p>
-                          )}
-                          {!openDraftId && candidate.status !== "needs_more_evidence" && (
-                            <p>ready for draft/review</p>
-                          )}
-                          <p>Identity link risk: {candidate.duplicateRisk ?? "none"}</p>
-                          {candidate.existingDossierMatch && (
-                            <p className="text-accent">
-                              Existing public dossier match: {candidate.existingDossierMatch.name} ({candidate.existingDossierMatch.confidence})
-                            </p>
-                          )}
+                          <StatusPill>
+                            {identityBadgeForCandidate(candidate)}
+                          </StatusPill>
                         </td>
                         <td className="py-3 pr-3">
                           {formatDate(candidate.updatedAt)}
                         </td>
                         <td className="py-3 pr-3">
-                          {nextAction}
-                          {isCandidateClosed(candidate) && (
-                            <p className="text-xs text-accent">
-                              Source file was merged or closed.
-                            </p>
-                          )}
-                        </td>
-                        <td className="py-3 pr-3">
                           <div className="flex flex-wrap gap-2">
                             <Link
                               href={`/admin/dossiers/candidates/${candidate.id}`}
-                              className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                              className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                             >
-                              Open Case File
+                              Open
                             </Link>
-                            {candidate.existingDossierMatch && (
-                              <button
-                                type="button"
-                                disabled={saving}
-                                onClick={() =>
-                                  void candidateAction(
-                                    candidate.id,
-                                    "markCandidateAsExistingDossierUpdate",
-                                  )
-                                }
-                                className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-                                title="Reclassify this active Case File as update/enrichment material for the matched public dossier. Does not publish or edit public content."
-                              >
-                                Move to Dossier Update
-                              </button>
-                            )}
-                            <label className="flex flex-col gap-1 text-[0.65rem] uppercase tracking-widest text-muted">
-                              Attach to Existing Public Dossier
-                              <select
-                                value={
-                                  selectedDossierByCandidate[candidate.id] ??
-                                  candidate.existingDossierMatch?.id ??
-                                  ""
-                                }
-                                onChange={(event) =>
-                                  setSelectedDossierByCandidate((current) => ({
-                                    ...current,
-                                    [candidate.id]: event.target.value,
-                                  }))
-                                }
-                                className="max-w-[14rem] bg-background border border-border px-2 py-1.5 text-xs normal-case tracking-normal text-foreground"
-                              >
-                                <option value="">Choose public dossier…</option>
-                                {publicDossiers.map((dossier) => (
-                                  <option key={dossier.id} value={dossier.id}>
-                                    {dossier.name}
-                                  </option>
-                                ))}
-                              </select>
-                            </label>
-                            <button
-                              type="button"
-                              disabled={
-                                saving ||
-                                !(
-                                  selectedDossierByCandidate[candidate.id] ||
-                                  candidate.existingDossierMatch?.id
-                                )
-                              }
-                              onClick={() =>
-                                void candidateAction(
-                                  candidate.id,
-                                  "attachCandidateToExistingDossier",
-                                )
-                              }
-                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-                              title="Store the confirmed existing public dossier target without publishing or changing public dossier content."
-                            >
-                              Attach
-                            </button>
                             {openDraftId && (
                               <Link
                                 href={`/admin/dossiers/drafts/${openDraftId}`}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
+                                className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                               >
-                                Open Proposed Dossier
+                                Draft
                               </Link>
                             )}
-                            {!openDraftId && (
-                              <button
-                                type="button"
-                                disabled={saving || !canCreateDraft}
-                                onClick={() => void createDraft(candidate.id)}
-                                className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-                                title={
-                                  canCreateDraft
-                                    ? "Create proposed dossier from this BNL Source File."
-                                    : "Active Proposed Dossier already exists or Case File was merged/denied."
-                                }
-                              >
-                                Create Proposed Dossier
-                              </button>
-                            )}
-                            <button
-                              type="button"
-                              disabled={
-                                saving ||
-                                !canUpdateCandidate ||
-                                candidate.status === "needs_more_evidence"
-                              }
-                              onClick={() =>
-                                void updateCandidate(
-                                  candidate.id,
-                                  "markNeedsMoreEvidence",
-                                )
-                              }
-                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest hover:border-accent hover:text-accent disabled:opacity-50"
-                            >
-                              Mark Needs Info
-                            </button>
-                            <button
-                              type="button"
-                              disabled={saving || !canUpdateCandidate}
-                              onClick={() =>
-                                void candidateAction(candidate.id, "archiveCandidate")
-                              }
-                              className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-                              title="Safe cleanup: move this Case File out of active dashboard lanes without deleting public dossiers or published data."
-                            >
-                              Archive
-                            </button>
-                            <button
-                              type="button"
-                              disabled={saving}
-                              onClick={() =>
-                                void candidateAction(
-                                  candidate.id,
-                                  "permanentlyDeleteCandidate",
-                                )
-                              }
-                              className="border border-red-500/70 px-3 py-1.5 text-xs uppercase tracking-widest text-red-300 hover:bg-red-500/10 disabled:opacity-50"
-                              title='Requires typing "DELETE SOURCE FILE". Does not delete public dossiers or published data.'
-                            >
-                              Delete Permanently
-                            </button>
                           </div>
                         </td>
                       </tr>
@@ -1300,153 +1117,57 @@ export default function DossierControlCenterPage() {
           )}
         </DashboardCard>
 
-        <DashboardCard
-          eyebrow="Identity safety"
-          title="Identity Links"
-          aside={
-            <StatusPill>
-              {activeDuplicateGroups.length} active warnings
-            </StatusPill>
-          }
-        >
-          {activeDuplicateGroups.length === 0 ? (
-            <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No duplicate or identity warnings need owner/lead review.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {activeDuplicateGroups.map((group) => (
-                <article
-                  key={group.id}
-                  className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
-                >
-                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                    <div>
-                      <p className="font-bold text-foreground">
-                        {group.names.join(" / ")}
-                      </p>
-                      <p>Risk: {group.risk}</p>
-                      <p>Reason: {group.reason}</p>
-                    </div>
-                    <Link
-                      href={`/admin/dossiers/duplicates/${group.id}`}
-                      className="border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                    >
-                      View Warning / Open Merge Review
-                    </Link>
-                  </div>
-                </article>
-              ))}
-            </div>
-          )}
-        </DashboardCard>
-
-
-        <DashboardCard
-          eyebrow="Archive / Trash"
-          title="Archived / Dismissed / Trash"
-          aside={<StatusPill>{archivedCandidates.length} archived items</StatusPill>}
-        >
-          <p className="text-sm text-muted mb-4">
-            Archive is the safe default for junk, test, error, low-confidence, or
-            source-blind extractions. Permanent delete is protected by explicit
-            confirmation text and never deletes public dossiers.
-          </p>
-          {archivedCandidates.length === 0 ? (
-            <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No archived internal records.
-            </p>
-          ) : (
-            <div className="space-y-2 text-sm text-muted">
-              {archivedCandidates.slice(0, 10).map((candidate) => (
-                <article key={candidate.id} className="border border-border/70 bg-background/20 p-3">
-                  <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <p className="font-semibold text-foreground">{candidate.name}</p>
-                      <p>Source: {candidateProvenance(candidate)} / status: {candidate.status}</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "restoreCandidate")} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50">
-                        Restore to Intake
-                      </button>
-                      <button type="button" disabled={saving} onClick={() => void candidateAction(candidate.id, "permanentlyDeleteCandidate")} className="border border-red-500/70 px-3 py-1.5 text-xs uppercase tracking-widest text-red-300 hover:bg-red-500/10 disabled:opacity-50">
-                        Delete permanently
-                      </button>
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          )}
-        </DashboardCard>
-
-        <details className="border border-border bg-surface p-5">
+        <details className="border border-border bg-surface/70 p-5">
           <summary className="cursor-pointer text-xl font-bold text-foreground">
-            Archive / History
+            Archive / Dismissed / Trash
           </summary>
           <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-muted">
             <p className="border border-border/70 bg-background/20 p-4">
-              {closedCandidates.length} closed BNL Source File records.
+              {archivedCandidates.length} archived Source File records.
             </p>
             <p className="border border-border/70 bg-background/20 p-4">
-              {closedDrafts.length} closed proposed dossier records.
+              {terminalRecommendations.length} dismissed or archived signals.
             </p>
             <p className="border border-border/70 bg-background/20 p-4">
-              {terminalRecommendations.length} closed signal records;
-              {" "}{resolvedDuplicateGroups.length} resolved duplicate groups.
+              {closedCandidates.length + closedDrafts.length} closed or merged
+              records.
             </p>
           </div>
-          {terminalRecommendations.length > 0 && (
+          {archivedCandidates.length > 0 && (
             <div className="mt-4 space-y-2 text-sm text-muted">
-              {terminalRecommendations.slice(0, 5).map((recommendation) => (
+              {archivedCandidates.slice(0, 8).map((candidate) => (
                 <article
-                  key={recommendation.id}
+                  key={candidate.id}
                   className="border border-border/70 bg-background/20 p-3"
                 >
-                  <p className="font-semibold text-foreground">
-                    {recommendation.subjectName}
-                  </p>
-                  <p>
-                    Status: {recommendation.status === "identity_link_created"
-                      ? "Identity link created — proposed, not confirmed"
-                      : recommendation.status}
-                  </p>
-                  {recommendation.targetCandidateId && (
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="font-semibold text-foreground">
+                        {candidate.name}
+                      </p>
+                      <p>Status: {candidate.status}</p>
+                    </div>
                     <Link
-                      href={`/admin/dossiers/candidates/${recommendation.targetCandidateId}`}
-                      className="text-accent hover:underline"
+                      href={`/admin/dossiers/candidates/${candidate.id}`}
+                      className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      Open related BNL Source File
+                      Open
                     </Link>
-                  )}
+                  </div>
                 </article>
               ))}
             </div>
           )}
         </details>
 
-        <DashboardCard eyebrow="Boundaries" title="System Boundaries">
-          <ul className="grid grid-cols-1 md:grid-cols-4 gap-3 text-sm text-muted">
-            <li className="border border-border/70 bg-background/20 p-3">
-              No BNL invocation.
-            </li>
-            <li className="border border-border/70 bg-background/20 p-3">
-              No publishing.
-            </li>
-            <li className="border border-border/70 bg-background/20 p-3">
-              No automatic tag creation.
-            </li>
-            <li className="border border-border/70 bg-background/20 p-3">
-              No public database mutation.
-            </li>
-          </ul>
-          <p className="text-xs text-muted">
-            Dedicated pages keep operators in one lane: internal record review,
-            focused draft editor, owner review, or merge review. Dashboard
-            buttons navigate; there is no hidden editor below unrelated sections
-            and no dashboard auto-scroll workflow.
-          </p>
-        </DashboardCard>
+        <div className="flex justify-center pt-4">
+          <Link
+            href="/admin/dossiers/owner-review"
+            className="border border-accent px-6 py-3 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background transition-all"
+          >
+            Owner Review
+          </Link>
+        </div>
       </section>
     </main>
   );

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -9,7 +9,6 @@ import {
   type DossierDraft,
   type DossierDuplicateGroup,
   type DossierRecommendation,
-  type DossierSourceFileMetrics,
 } from "@/lib/dossier-workflow";
 
 type WorkflowPayload = {
@@ -174,22 +173,24 @@ function identityBadgeForCandidate(candidate: DossierCandidate) {
   ).length;
 
   if (pending > 0) {
-    return `${pending} pending identity link${pending === 1 ? "" : "s"}`;
+    return "Identity: Needs Confirmation";
   }
   if (confirmed > 0) {
-    return `${confirmed} confirmed alias${confirmed === 1 ? "" : "es"}`;
+    return "Identity: Connected to Existing Subject";
+  }
+  if (candidate.existingDossierMatch) {
+    return "Existing Dossier Match";
   }
   if (
-    candidate.existingDossierMatch ||
     candidate.duplicateRisk === "medium" ||
     candidate.duplicateRisk === "high"
   ) {
-    return "Possible Identity Link";
+    return "Possible Duplicate";
   }
   if (candidate.duplicateRisk === "low") {
-    return "Identity Needs Review";
+    return "Identity: Possible Match";
   }
-  return "Clear";
+  return "Identity: Clear";
 }
 
 function identityBadgeForRecommendation(
@@ -197,15 +198,15 @@ function identityBadgeForRecommendation(
   matchState: { state: string; nextAction: string },
 ) {
   if (recommendation.type === "identity_link") {
-    return "Identity confirmation needed";
+    return "Identity: Needs Confirmation";
   }
   if (matchState.state === "possible_identity_link") {
-    return "Possible Identity Link";
+    return "Identity: Possible Match";
   }
   if (matchState.state === "existing_candidate") {
-    return "Matched Source File";
+    return "Identity: Connected to Existing Subject";
   }
-  return "Clear";
+  return "Identity: Clear";
 }
 
 function dossierStatusForCandidate(
@@ -230,82 +231,24 @@ function firstListValue(values?: string[]) {
   return values?.find((value) => value.trim()) ?? "—";
 }
 
-function hasCandidateIdentityConcern(candidate: DossierCandidate) {
-  const pendingIdentityLinks = (candidate.identityLinks ?? []).some(
-    (link) => link.status === "proposed",
-  );
-  return Boolean(
-    pendingIdentityLinks ||
-    candidate.existingDossierMatch ||
-    candidate.duplicateRisk === "low" ||
-    candidate.duplicateRisk === "medium" ||
-    candidate.duplicateRisk === "high",
-  );
-}
-
-function candidateActionLabel(candidate: DossierCandidate) {
-  if (hasCandidateIdentityConcern(candidate)) return "Review Identity";
+function candidateActionLabel() {
   return "Review Candidate";
 }
 
-function recommendationActionLabel(
-  recommendation: DossierRecommendation,
-  matchState: { state: string; nextAction: string },
-) {
-  if (
-    recommendation.type === "identity_link" ||
-    matchState.state === "possible_identity_link"
-  ) {
-    return "Review Identity";
-  }
-  return "Review Signal";
+function recommendationActionLabel() {
+  return "Review Candidate";
 }
 
-function dossierUpdateActionLabel(input: {
-  candidate?: DossierCandidate;
-  recommendation?: DossierRecommendation;
-  matchState?: { state: string; nextAction: string };
-}) {
-  if (input.recommendation) {
-    if (
-      input.recommendation.type === "identity_link" ||
-      input.matchState?.state === "possible_identity_link"
-    ) {
-      return "Review Identity";
-    }
-    if (input.recommendation.targetCandidateId) return "Review Source Update";
-    return "Review Update";
-  }
-
-  if (input.candidate && hasCandidateIdentityConcern(input.candidate)) {
-    return "Review Identity";
-  }
+function dossierUpdateActionLabel() {
   return "Review Update";
 }
 
-function sourceFileActionLabel(
-  candidate: DossierCandidate,
-  draft: DossierDraft | undefined,
-  metrics: DossierSourceFileMetrics | undefined,
-) {
-  const hasPendingIdentityLink = (candidate.identityLinks ?? []).some(
-    (link) => link.status === "proposed",
-  );
-  if (hasPendingIdentityLink) return "Review Identity";
-  if ((candidate.missingInfo ?? []).length > 0) return "Add Missing Info";
-  if ((metrics?.unappliedSourceNotesCount ?? 0) > 0) return "Review Updates";
-  if (draft?.status === "ready_for_owner_review") return "Review Draft";
-  if (draft) return "Open Draft";
+function sourceFileActionLabel() {
   return "Open Source File";
 }
 
-function archiveActionLabel(input: {
-  candidate?: DossierCandidate;
-  recommendation?: DossierRecommendation;
-}) {
-  if (input.recommendation) return "Review Closed Signal";
-  if (input.candidate?.status === "denied") return "Review Trash";
-  return "Review Archived";
+function archiveActionLabel() {
+  return "Review Record";
 }
 
 function DashboardCard({
@@ -995,10 +938,7 @@ export default function DossierControlCenterPage() {
                             href={`/admin/dossiers/recommendations/${recommendation.id}`}
                             className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                           >
-                            {recommendationActionLabel(
-                              recommendation,
-                              matchState,
-                            )}
+                            {recommendationActionLabel()}
                           </Link>
                         </td>
                       </tr>
@@ -1034,7 +974,7 @@ export default function DossierControlCenterPage() {
                           href={`/admin/dossiers/candidates/${candidate.id}`}
                           className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                         >
-                          {candidateActionLabel(candidate)}
+                          {candidateActionLabel()}
                         </Link>
                       </td>
                     </tr>
@@ -1125,10 +1065,7 @@ export default function DossierControlCenterPage() {
                             href={`/admin/dossiers/recommendations/${recommendation.id}`}
                             className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                           >
-                            {dossierUpdateActionLabel({
-                              recommendation,
-                              matchState,
-                            })}
+                            {dossierUpdateActionLabel()}
                           </Link>
                         </td>
                       </tr>
@@ -1157,7 +1094,7 @@ export default function DossierControlCenterPage() {
                         <StatusPill>
                           {candidate.existingDossierMatch
                             ? identityBadgeForCandidate(candidate)
-                            : "Identity confirmation needed"}
+                            : "Identity: Needs Confirmation"}
                         </StatusPill>
                       </td>
                       <td className="py-3 pr-3">
@@ -1168,7 +1105,7 @@ export default function DossierControlCenterPage() {
                           href={`/admin/dossiers/candidates/${candidate.id}`}
                           className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                         >
-                          {dossierUpdateActionLabel({ candidate })}
+                          {dossierUpdateActionLabel()}
                         </Link>
                       </td>
                     </tr>
@@ -1216,18 +1153,8 @@ export default function DossierControlCenterPage() {
                       candidate,
                       draft,
                     );
-                    const actionLabel = sourceFileActionLabel(
-                      candidate,
-                      draft,
-                      metrics,
-                    );
-                    const actionHref =
-                      (actionLabel === "Open Draft" ||
-                        actionLabel === "Review Draft") &&
-                      openDraftId
-                        ? `/admin/dossiers/drafts/${openDraftId}`
-                        : `/admin/dossiers/candidates/${candidate.id}`;
-                    const opensDraft = actionHref.includes("/drafts/");
+                    const actionLabel = sourceFileActionLabel();
+                    const actionHref = `/admin/dossiers/candidates/${candidate.id}`;
                     return (
                       <tr
                         key={candidate.id}
@@ -1264,8 +1191,6 @@ export default function DossierControlCenterPage() {
                         <td className="py-3 pr-3">
                           <Link
                             href={actionHref}
-                            target={opensDraft ? "_blank" : undefined}
-                            rel={opensDraft ? "noopener noreferrer" : undefined}
                             className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                           >
                             {actionLabel}
@@ -1314,7 +1239,7 @@ export default function DossierControlCenterPage() {
                       href={`/admin/dossiers/candidates/${candidate.id}`}
                       className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      {archiveActionLabel({ candidate })}
+                      {archiveActionLabel()}
                     </Link>
                   </div>
                 </article>
@@ -1339,7 +1264,7 @@ export default function DossierControlCenterPage() {
                       href={`/admin/dossiers/recommendations/${recommendation.id}`}
                       className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      {archiveActionLabel({ recommendation })}
+                      {archiveActionLabel()}
                     </Link>
                   </div>
                 </article>

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -953,62 +953,49 @@ test("admin panel includes Dossier Control Center link", () => {
   assert.match(adminPage, /href="\/admin\/dossiers"/);
 });
 
-test("admin dossier dashboard is a Control Center overview instead of an all-in-one workbench", () => {
+test("admin dossier dashboard is a simplified subject sorting overview", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
   for (const label of [
     "Dossier Control Center",
-    "Overview of Signal Review inputs, Dossier Seeds, Case Files / BNL Source Files, Proposed Dossiers, and Owner Review status.",
-    "Workflow Records",
-    "Signals Waiting",
+    "Sort noticed subjects, review updates, and open Source Files.",
+    "Summary",
+    "Candidates",
+    "Dossier Updates",
+    "Source Files",
+    "Needs Info",
+    "Ready for Dossier",
     "Owner Review waiting",
-    "Signal Review → Dossier Seeds → Case Files → Proposed Dossiers → Owner Review",
-    "Case Files / BNL Source Files are internal subject workspaces.",
-    "Proposed Dossiers are curated public-facing drafts written only from reviewed Case File material.",
-    "Owner Review is the final approval/editing lane before publishable state.",
-    "Signal Review",
+    "Archive / Dismissed / Trash",
     "Manual Signal",
     "Use this only when BNL has not suggested something yet. This creates a BNL Signal, not a direct source file.",
-    "Case Files / BNL Source Files",
-    "Source depth / info strength",
-    "Unapplied notes:",
-    "Open Case File",
-    "Archive",
-    "Delete Permanently",
-    "Move to Dossier Update",
-    "Attach to Existing Public Dossier",
-    "Dossier Updates",
-    "owner approval required before public changes",
-    "DELETE SOURCE FILE",
-    "Safe cleanup: move this Case File out of active dashboard lanes without deleting public dossiers or published data.",
-    "case file has warnings",
-    "case file has source-blind material",
-    "case file has public-safe facts",
-    "identity review pending",
-    "proposed dossier exists",
-    "owner review pending",
-    "ready for draft/review",
-    "System Boundaries",
-    "No BNL invocation",
-    "No publishing",
-    "No automatic tag creation",
-    "No public database mutation",
+    "Why BNL noticed",
+    "Strength / confidence",
+    "Identity status",
+    "Suggested next step",
+    "Possible Identity Link",
+    "Identity confirmation needed",
+    "Why they matter / engagement summary",
+    "Dossier status",
+    "No Proposed Dossier",
+    "Draft started",
+    "Needs update from Source File",
+    "Ready for Owner Review",
+    "Owner changes requested",
+    "Approved / publish later",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
 
   assert.match(page, /href="\/admin\/dossiers\/owner-review"/);
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
+  assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`\}/);
-  assert.match(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
-  assert.match(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
-  assert.match(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
-  assert.match(page, /markCandidateAsExistingDossierUpdate/);
-  assert.match(page, /attachCandidateToExistingDossier/);
-  assert.doesNotMatch(page, /eyebrow="Lane 2"/);
-  assert.doesNotMatch(page, /title="Proposed Dossiers"/);
-  assert.doesNotMatch(page, /title="Final Admin Drafts"/);
-  assert.doesNotMatch(page, /eyebrow="Lane 4"/);
+  assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
+  assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
+  assert.doesNotMatch(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
+  assert.doesNotMatch(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
+  assert.doesNotMatch(page, />Delete Permanently</);
   assert.doesNotMatch(page, /Save Draft/);
   assert.doesNotMatch(page, /Submit for Owner Review/);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
@@ -1018,19 +1005,25 @@ test("admin dossier dashboard is a Control Center overview instead of an all-in-
   assert.match(page, /if \(error \|\| !payload\)/);
 });
 
-test("dossier admin pages expose the control-center/source-hub/draft-workspace model", () => {
+test("dossier admin pages keep dashboard simple while detail pages retain workflow controls", () => {
   const dashboard = normalizedSource("src/app/admin/dossiers/page.tsx");
   for (const label of [
-    "Phase 1 — Case File / BNL Source File",
-    "Phase 2 — Proposed Dossier + BNL Edit Chat",
-    "Phase 3 — Final Admin Draft",
-    "Phase 4 — Owner Review",
-    "Phase 5 — Approved / Publish Later",
-    "Case Files / BNL Source Files",
-    "Identity Links",
-    "Archive / History",
+    "Summary",
+    "Candidates",
+    "Dossier Updates",
+    "Source Files",
+    "Archive / Dismissed / Trash",
+    "Owner Review",
   ]) {
     assertIncludesCopy(dashboard, label);
+  }
+  for (const removed of [
+    "Phase 1 — Case File / BNL Source File",
+    "Phase 2 — Proposed Dossier + BNL Edit Chat",
+    "Archive / History",
+    "System Boundaries",
+  ]) {
+    assert.ok(!dashboard.includes(removed));
   }
 
   const sourceFileCopy = normalizedSource(
@@ -1524,11 +1517,11 @@ test("dedicated duplicate merge route contains focused manual merge workflow", (
   assert.doesNotMatch(page, /publishDraft/);
 });
 
-test("dashboard uses actual workflow ids, source metrics, and overview filtering", () => {
+test("dashboard uses actual workflow ids, source metrics, and simplified overview filtering", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
+  assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`\}/);
-  assert.match(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
   assert.match(page, /activeCandidateStatuses/);
   assert.match(page, /activeCandidates = candidates\.filter/);
   assert.match(page, /activeDraftStatuses/);
@@ -1536,30 +1529,26 @@ test("dashboard uses actual workflow ids, source metrics, and overview filtering
   assert.match(page, /getDossierSourceFileMetrics/);
   assert.match(page, /sourceFilesWithUnappliedNotes/);
   assert.match(page, /sourceFilesWithDrafts/);
-  assert.match(page, /Review source updates in proposed dossier/);
-  assert.match(page, /Source strength:/);
-  assert.match(page, /Signals:/);
-  assert.match(page, /Evidence:/);
-  assert.match(page, /Open Case File/);
-  assert.match(page, /Open Proposed Dossier/);
-  assert.match(page, /Create Proposed Dossier/);
-  assert.match(page, /Mark Needs Info/);
-  assert.match(page, /Archive \/ History/);
-  assert.match(page, /View Warning \/ Open Merge Review/);
+  assert.match(page, /metrics\?\.sourceDepth/);
+  assert.match(page, /Dossier status/);
+  assert.match(page, /identityBadgeForCandidate/);
+  assert.match(page, /identityBadgeForRecommendation/);
+  assert.match(page, /Archive \/ Dismissed \/ Trash/);
+  assert.doesNotMatch(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
+  assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, />Deny<|>Deny<\/button>/);
 });
 
-test("dashboard frames manual recommendation seed as collapsed fallback and BNL workbench as future-only", () => {
+test("dashboard frames manual recommendation seed as collapsed fallback", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
   for (const label of [
     "Manual Signal",
     "Use this only when BNL has not suggested something yet. This creates a BNL Signal, not a direct source file.",
     "Create Manual Signal",
-    "Signal Review → Dossier Seeds → Case Files → Proposed Dossiers → Owner Review",
-    "Case Files / BNL Source Files are internal subject workspaces.",
-    "Proposed Dossiers are curated public-facing drafts written only from reviewed Case File material.",
-    "Owner Review is the final approval/editing lane before publishable state.",
+    "Candidates",
+    "Source Files",
+    "Owner Review",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -2711,14 +2700,14 @@ test("mergeCandidates does not mutate public database, public read model, tag re
   );
 });
 
-test("admin dossiers dashboard links duplicate groups to dedicated merge review", () => {
+test("admin dossiers dashboard does not promote duplicate merge review", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const mergePage = source(
     "src/app/admin/dossiers/duplicates/[groupId]/page.tsx",
   );
-  assert.match(page, /Identity Links/);
-  assert.match(page, /View Warning \/ Open Merge Review/);
-  assert.match(page, /\/admin\/dossiers\/duplicates\//);
+  assert.match(page, /Possible Identity Link|Identity Needs Review|pending identity link/);
+  assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
+  assert.doesNotMatch(page, /\/admin\/dossiers\/duplicates\//);
   assert.doesNotMatch(page, /Merge into Master Candidate/);
   assert.doesNotMatch(page, /Create Master Draft from Merge/);
   assert.match(mergePage, /Merge is owner\/lead cleanup/);
@@ -3184,11 +3173,11 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
     /Identity link retired\. It is no longer active\./,
   );
 
-  assert.match(dashboard, /Aliases: \{confirmedIdentityLinks\.length\} confirmed/);
-  assert.match(dashboard, /Pending aliases: \{proposedIdentityLinks\.length\}/);
-  assert.match(dashboard, /identityLink\.status === "confirmed"/);
-  assert.match(dashboard, /identityLink\.status === "proposed"/);
-  assert.match(dashboard, /identity_link_created/);
+  assert.match(dashboard, /confirmed alias/);
+  assert.match(dashboard, /pending identity link/);
+  assert.match(dashboard, /link\.status === "confirmed"/);
+  assert.match(dashboard, /link\.status === "proposed"/);
+  assert.doesNotMatch(dashboard, /Identity Link Actions|Create Proposed Identity Link|Confirm<|Reject<|Retire</);
 
   assert.match(recommendationPage, /Matched by confirmed alias/);
   assert.match(recommendationPage, /Identity Link Actions/);
@@ -3332,8 +3321,8 @@ test("unapplied source notes count after draft creation without mutating draft f
   const draftCopy = normalizedSource(
     "src/app/admin/dossiers/drafts/[draftId]/page.tsx",
   );
-  assertIncludesCopy(dashboardCopy, "Unapplied notes:");
-  assertIncludesCopy(dashboardCopy, "Review source updates in proposed dossier");
+  assertIncludesCopy(dashboardCopy, "Needs update from Source File");
+  assertIncludesCopy(dashboardCopy, "Dossier status");
   assertIncludesCopy(sourceFileCopy, "This Case File / BNL Source File has new info not yet applied to the Proposed Dossier.");
   assertIncludesCopy(draftCopy, "Case File / BNL Source File has new notes since this Proposed Dossier was last updated.");
   assertIncludesCopy(draftCopy, "Draft fields are not mutated automatically when new source notes arrive.");
@@ -3966,23 +3955,19 @@ test("ignore, dismiss, and archive recommendations preserve records", async () =
   assert.match(dashboard, /activeRecommendations/);
   assert.match(dashboard, /\["new", "reviewing"\]/);
   assert.match(dashboard, /terminalRecommendations/);
-  assertIncludesCopy(dashboardCopy, "Archive / History");
-  assertIncludesCopy(dashboardCopy, "closed signal records");
+  assertIncludesCopy(dashboardCopy, "Archive / Dismissed / Trash");
+  assertIncludesCopy(dashboardCopy, "dismissed or archived signals");
 });
 
 test("recommendation inbox and source note UI are present and bounded", () => {
   const dashboard = source("src/app/admin/dossiers/page.tsx");
-  assert.match(dashboard, /Signal Review/);
-  assert.match(dashboard, /BNL Signals are incoming source\/recommendation inputs/);
+  assert.match(dashboard, /Candidates/);
   assert.match(dashboard, /Manual Signal/);
   assert.match(dashboard, /Create Manual Signal/);
-  assert.match(dashboard, /Match state/);
-  assert.match(dashboard, /Matches Case File/);
-  assert.match(dashboard, /Matches Case File/);
-  assert.match(dashboard, /Suggests Identity Link/);
-  assert.match(dashboard, /Could Become Dossier Seed/);
-  assert.match(dashboard, /Review Signal/);
-  assert.match(dashboard, /archiveDossierRecommendation/);
+  assert.match(dashboard, /Why BNL noticed/);
+  assert.match(dashboard, /Possible Identity Link/);
+  assert.match(dashboard, /Identity confirmation needed/);
+  assert.match(dashboard, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.doesNotMatch(dashboard, /Attach to Existing Source File/);
 
   const sourceFilePage = source(
@@ -3997,8 +3982,6 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(sourceFilePage, /Aliases help BNL route future BNL Signals/);
   assert.match(sourceFilePage, /Internal aliases are not\s+public dossier text/);
   assert.match(sourceFilePage, /Add Identity Link/);
-  assert.match(dashboard, /Aliases: /);
-  assert.match(dashboard, /Identity Links/);
 
   const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   assert.match(draftPage, /Unapplied Source Notes/);
@@ -4023,31 +4006,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(recommendationPage, /Dismissed\. This BNL Signal is closed\./);
   assert.match(recommendationPage, /!isTerminal &&/);
   assert.match(recommendationPage, /Matches Case File/);
-  assert.match(recommendationPage, /Matches Case File/);
-  assert.match(recommendationPage, /This recommendation already points to an existing/);
-  assert.match(recommendationPage, /Attach to Matched Case File/);
-  assert.match(recommendationPage, /Matched by confirmed alias/);
-  assert.match(recommendationPage, /Identity Link Actions/);
-  assert.match(recommendationPage, /Create Proposed Identity Link/);
-  assert.match(recommendationPage, /Use for future matching after confirmation/);
-  assert.match(recommendationPage, /Use in public dossier later after review/);
-  assert.match(recommendationPage, /Proposed identity link created\. Confirm it from the BNL Source File when ready\./);
-  assert.match(recommendationPage, /This alias is used for internal routing only/);
-  assert.match(recommendationPage, /Possible identity review needed/);
-  assert.match(recommendationPage, /Owner\/lead identity review is required/);
-  assert.doesNotMatch(recommendationPage, /Choose existing BNL Source File/);
-  assert.match(recommendationPage, /Terminal BNL Signal actions are closed/);
-  assert.doesNotMatch(
-    dashboard + sourceFilePage + draftPage + recommendationPage,
-    /fetch\("\/api\/bnl/,
-  );
-  assert.doesNotMatch(
-    dashboard + sourceFilePage + draftPage + recommendationPage,
-    /publishDraft/,
-  );
 });
-
-
 
 test("derived Source File summary labels thin files without fake substance", () => {
   const thinCandidate = {
@@ -5898,12 +5857,12 @@ test("recommendation detail case-file view uses the same sanitizer", () => {
   assert.match(JSON.stringify(view.rawMetadata), /relationship_journal|rd_context|bnl:rec_filter/);
 });
 
-test("admin dashboard explains public dossier-only source lookup fallback", () => {
+test("admin dashboard keeps public dossier-only source lookup fallback bounded", () => {
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
-  assertIncludesCopy(pageCopy, "Dossier Update target found");
-  assertIncludesCopy(pageCopy, "No internal update file exists yet");
-  assertIncludesCopy(pageCopy, "Dossier Update action before enrichment attaches notes");
-  assertIncludesCopy(pageCopy, "Review-only; no public changes");
+  assertIncludesCopy(pageCopy, "Dossier Updates");
+  assertIncludesCopy(pageCopy, "No existing dossier updates are waiting.");
+  assertIncludesCopy(pageCopy, "Review update details before attaching anywhere public.");
+  assertIncludesCopy(pageCopy, "Identity confirmation needed");
 });
 
 test("Phase 2 draft workflow keeps PR 155 stacked shared preview order", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -973,8 +973,12 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Strength / confidence",
     "Identity status",
     "Suggested next step",
-    "Possible Identity Link",
-    "Identity confirmation needed",
+    "Identity: Clear",
+    "Identity: Possible Match",
+    "Identity: Connected to Existing Subject",
+    "Identity: Needs Confirmation",
+    "Existing Dossier Match",
+    "Possible Duplicate",
     "Why they matter / engagement summary",
     "Dossier status",
     "No Proposed Dossier",
@@ -983,19 +987,10 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Ready for Owner Review",
     "Owner changes requested",
     "Approved / publish later",
-    "Review Signal",
     "Review Candidate",
-    "Review Identity",
     "Review Update",
-    "Review Source Update",
     "Open Source File",
-    "Add Missing Info",
-    "Review Updates",
-    "Open Draft",
-    "Review Draft",
-    "Review Archived",
-    "Review Closed Signal",
-    "Review Trash",
+    "Review Record",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -1003,8 +998,9 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.match(page, /href="\/admin\/dossiers\/owner-review"/);
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
-  assert.match(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
+  assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.doesNotMatch(page, />\s*Open\s*</);
+  assert.doesNotMatch(page, /Add Missing Info|Review Identity|Review Signal|Review Source Update|Open Draft|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
@@ -1013,8 +1009,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, /Save Draft/);
   assert.doesNotMatch(page, /Submit for Owner Review/);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
-  assert.match(page, /target=\{opensDraft \? "_blank" : undefined\}/);
-  assert.match(page, /rel=\{opensDraft \? "noopener noreferrer" : undefined\}/);
+  assert.doesNotMatch(page, /opensDraft/);
   assert.match(page, /if \(loading\)/);
   assert.match(page, /if \(error \|\| !payload\)/);
 });
@@ -1535,11 +1530,12 @@ test("dashboard uses actual workflow ids, source metrics, and simplified overvie
   const page = source("src/app/admin/dossiers/page.tsx");
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
-  assert.match(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
+  assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.match(page, /candidateActionLabel/);
   assert.match(page, /recommendationActionLabel/);
   assert.match(page, /dossierUpdateActionLabel/);
   assert.match(page, /sourceFileActionLabel/);
+  assert.match(page, /Review Record/);
   assert.match(page, /activeCandidateStatuses/);
   assert.match(page, /activeCandidates = candidates\.filter/);
   assert.match(page, /activeDraftStatuses/);
@@ -2723,7 +2719,7 @@ test("admin dossiers dashboard does not promote duplicate merge review", () => {
   const mergePage = source(
     "src/app/admin/dossiers/duplicates/[groupId]/page.tsx",
   );
-  assert.match(page, /Possible Identity Link|Identity Needs Review|pending identity link/);
+  assert.match(page, /Identity: Possible Match|Identity: Needs Confirmation|Possible Duplicate/);
   assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /\/admin\/dossiers\/duplicates\//);
   assert.doesNotMatch(page, /Merge into Master Candidate/);
@@ -3191,11 +3187,11 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
     /Identity link retired\. It is no longer active\./,
   );
 
-  assert.match(dashboard, /confirmed alias/);
-  assert.match(dashboard, /pending identity link/);
+  assert.match(dashboard, /Identity: Connected to Existing Subject/);
+  assert.match(dashboard, /Identity: Needs Confirmation/);
   assert.match(dashboard, /link\.status === "confirmed"/);
   assert.match(dashboard, /link\.status === "proposed"/);
-  assert.doesNotMatch(dashboard, /Identity Link Actions|Create Proposed Identity Link|Confirm<|Reject<|Retire</);
+  assert.doesNotMatch(dashboard, /Review Identity|Identity Link Actions|Create Proposed Identity Link|Confirm<|Reject<|Retire</);
 
   assert.match(recommendationPage, /Matched by confirmed alias/);
   assert.match(recommendationPage, /Identity Link Actions/);
@@ -3983,13 +3979,14 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Manual Signal/);
   assert.match(dashboard, /Create Manual Signal/);
   assert.match(dashboard, /Why BNL noticed/);
-  assert.match(dashboard, /Possible Identity Link/);
-  assert.match(dashboard, /Identity confirmation needed/);
+  assert.match(dashboard, /Identity: Possible Match/);
+  assert.match(dashboard, /Identity: Needs Confirmation/);
   assert.match(dashboard, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
-  assert.match(dashboard, /Review Signal/);
   assert.match(dashboard, /Review Candidate/);
-  assert.match(dashboard, /Review Identity/);
-  assert.doesNotMatch(dashboard, /Attach to Existing Source File/);
+  assert.match(dashboard, /Review Update/);
+  assert.match(dashboard, /Open Source File/);
+  assert.match(dashboard, /Review Record/);
+  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info|Attach to Existing Source File/);
 
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
@@ -5883,7 +5880,7 @@ test("admin dashboard keeps public dossier-only source lookup fallback bounded",
   assertIncludesCopy(pageCopy, "Dossier Updates");
   assertIncludesCopy(pageCopy, "No existing dossier updates are waiting.");
   assertIncludesCopy(pageCopy, "Review update details before attaching anywhere public.");
-  assertIncludesCopy(pageCopy, "Identity confirmation needed");
+  assertIncludesCopy(pageCopy, "Identity: Needs Confirmation");
 });
 
 test("Phase 2 draft workflow keeps PR 155 stacked shared preview order", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -983,6 +983,19 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Ready for Owner Review",
     "Owner changes requested",
     "Approved / publish later",
+    "Review Signal",
+    "Review Candidate",
+    "Review Identity",
+    "Review Update",
+    "Review Source Update",
+    "Open Source File",
+    "Add Missing Info",
+    "Review Updates",
+    "Open Draft",
+    "Review Draft",
+    "Review Archived",
+    "Review Closed Signal",
+    "Review Trash",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -990,7 +1003,8 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.match(page, /href="\/admin\/dossiers\/owner-review"/);
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
-  assert.match(page, /href=\{`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`\}/);
+  assert.match(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
+  assert.doesNotMatch(page, />\s*Open\s*</);
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
@@ -999,8 +1013,8 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, /Save Draft/);
   assert.doesNotMatch(page, /Submit for Owner Review/);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
-  assert.match(page, /target="_blank"/);
-  assert.match(page, /rel="noopener noreferrer"/);
+  assert.match(page, /target=\{opensDraft \? "_blank" : undefined\}/);
+  assert.match(page, /rel=\{opensDraft \? "noopener noreferrer" : undefined\}/);
   assert.match(page, /if \(loading\)/);
   assert.match(page, /if \(error \|\| !payload\)/);
 });
@@ -1521,7 +1535,11 @@ test("dashboard uses actual workflow ids, source metrics, and simplified overvie
   const page = source("src/app/admin/dossiers/page.tsx");
   assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
-  assert.match(page, /href=\{`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`\}/);
+  assert.match(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
+  assert.match(page, /candidateActionLabel/);
+  assert.match(page, /recommendationActionLabel/);
+  assert.match(page, /dossierUpdateActionLabel/);
+  assert.match(page, /sourceFileActionLabel/);
   assert.match(page, /activeCandidateStatuses/);
   assert.match(page, /activeCandidates = candidates\.filter/);
   assert.match(page, /activeDraftStatuses/);
@@ -3968,6 +3986,9 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Possible Identity Link/);
   assert.match(dashboard, /Identity confirmation needed/);
   assert.match(dashboard, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
+  assert.match(dashboard, /Review Signal/);
+  assert.match(dashboard, /Review Candidate/);
+  assert.match(dashboard, /Review Identity/);
   assert.doesNotMatch(dashboard, /Attach to Existing Source File/);
 
   const sourceFilePage = source(


### PR DESCRIPTION
### Motivation
- Replace an overly large, workflow-heavy /admin/dossiers view with a compact, usable control center for sorting noticed subjects and opening Source Files. 
- Avoid the UI direction from the closed PR that promoted Duplicate Analysis / Record Compactor and large workflow rails on the main dashboard. 
- Keep Identity Links available but demoted to small badges/counts on the dashboard while preserving full identity controls in the detail pages.

### Description
- Reworked the dashboard page to the requested main sections: `Summary`, `Candidates`, `Dossier Updates`, `Source Files`, collapsed `Archive / Dismissed / Trash`, and an `Owner Review` button at the bottom. 
- Added small helpers to compute dashboard-only display values: `identityBadgeForCandidate`, `identityBadgeForRecommendation`, `dossierStatusForCandidate`, and `firstListValue`, and used `getDossierSourceFileMetrics` to drive Source Files rows. 
- Removed/promoted off the main dashboard: phase rail, workflow map, system boundaries panel, large Duplicate Analysis / Record Compactor panel, and crowded destructive action clusters; preserved duplicate/merge detail route but no longer promoted it in the main view. 
- Simplified Candidates and Recommendations rows to show compact fields (subject, why BNL noticed, strength/confidence, identity badge, suggested next step, Open link) and left full identity/merge controls in candidate/recommendation detail pages. 
- Tests and copy adjustments: updated `tests/admin-dossiers.test.mjs` to assert the simplified structure and bounded dashboard behavior. 
- Files changed: `src/app/admin/dossiers/page.tsx` (dashboard simplification, new helper functions, trimmed actions/panels) and `tests/admin-dossiers.test.mjs` (test expectations updated to match simplified dashboard). 

### Testing
- Ran the full dossier test suite with `node --test tests/admin-dossiers.test.mjs`, which passed locally after updates. 
- Ran type-checking with `npx tsc --noEmit`, which completed without errors. 
- All targeted admin-dossiers assertions now pass locally and the app compiles (`tsc` ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266582462483219a57fd25dac50eb1)