### PR TITLE
Prevent duplicate dossier subject routing

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -172,6 +172,13 @@ function identityBadgeForCandidate(candidate: DossierCandidate) {
     (link) => link.status === "proposed",
   ).length;
 
+  if (candidate.identityReviewStatus === "needs_confirmation") {
+    return candidate.possibleMatchCandidateIds?.length
+      ? `Possible match to ${candidate.possibleMatchCandidateIds.length} subject${
+          candidate.possibleMatchCandidateIds.length === 1 ? "" : "s"
+        }`
+      : "Identity: Needs Confirmation";
+  }
   if (pending > 0) {
     return "Identity: Needs Confirmation";
   }
@@ -197,6 +204,13 @@ function identityBadgeForRecommendation(
   recommendation: DossierRecommendation,
   matchState: { state: string; nextAction: string },
 ) {
+  if (recommendation.identityReviewStatus === "needs_confirmation") {
+    return recommendation.possibleMatchCandidateIds?.length
+      ? `Possible match to ${recommendation.possibleMatchCandidateIds.length} subject${
+          recommendation.possibleMatchCandidateIds.length === 1 ? "" : "s"
+        }`
+      : "Identity: Needs Confirmation";
+  }
   if (recommendation.type === "identity_link") {
     return "Identity: Needs Confirmation";
   }
@@ -930,7 +944,8 @@ export default function DossierControlCenterPage() {
                           </StatusPill>
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.suggestedAction ||
+                          {recommendation.routingReason ||
+                            recommendation.suggestedAction ||
                             matchState.nextAction}
                         </td>
                         <td className="py-3 pr-3">
@@ -967,7 +982,8 @@ export default function DossierControlCenterPage() {
                         </StatusPill>
                       </td>
                       <td className="py-3 pr-3">
-                        Promote to Source File or archive from the detail page.
+                        {candidate.routingReason ||
+                          "Promote to Source File or archive from the detail page."}
                       </td>
                       <td className="py-3 pr-3">
                         <Link

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1703,6 +1703,143 @@ function upsertSourceFileEnrichmentNote(input: {
   };
 }
 
+function attachmentStatusForCandidate(
+  candidate: DossierCandidate,
+): DossierRecommendationStatus {
+  if (candidate.status === "candidate_intake")
+    return "attached_to_candidate_intake";
+  if (candidate.status === "existing_dossier_update") {
+    return "attached_to_existing_dossier_update";
+  }
+  return "attached_to_source_file";
+}
+
+function routingNote(input: {
+  candidateId: string;
+  text: string;
+  now: string;
+  source?: DossierSourceFileNoteSource;
+  createdBy?: string;
+  ingestKey?: string;
+  ingestedAt?: string;
+  ingestSource?: DossierRecommendation["ingestSource"];
+}): DossierSourceFileNote {
+  return {
+    id: createSourceFileNoteId(),
+    candidateId: input.candidateId,
+    type: "general_note",
+    text: input.text.slice(0, 4000),
+    source: input.source ?? "admin_manual",
+    status: "active",
+    publicSafe: false,
+    createdAt: input.now,
+    updatedAt: input.now,
+    createdBy: input.createdBy,
+    ingestKey: input.ingestKey,
+    ingestedAt: input.ingestedAt,
+    ingestSource: input.ingestSource,
+  };
+}
+
+function manualCandidateRoutingNote(input: {
+  name: string;
+  reason: string;
+  whyNow?: string;
+  evidenceSummary?: string;
+  knownFacts?: string[];
+  routingReason: string;
+}): string {
+  return [
+    `Manual signal routed into existing workflow record: ${input.name}.`,
+    `Routing reason: ${input.routingReason}`,
+    `Reason: ${input.reason}`,
+    input.whyNow ? `Why now: ${input.whyNow}` : "",
+    input.evidenceSummary ? `Evidence: ${input.evidenceSummary}` : "",
+    ...(input.knownFacts ?? []).map((fact) => `Known fact: ${fact}`),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function mergeCandidateSignal(input: {
+  candidate: DossierCandidate;
+  now: string;
+  note: DossierSourceFileNote;
+  evidenceSummary?: string;
+  knownFacts?: string[];
+  missingInfo?: string[];
+  publicSafetyNotes?: string[];
+  doNotSay?: string[];
+  connectedRecommendationId?: string;
+  possibleMatchCandidateIds?: string[];
+  routingReason: string;
+  identityReviewStatus?: DossierCandidate["identityReviewStatus"];
+}): DossierCandidate {
+  const evidenceSummary = combineTextValues([
+    input.candidate.evidenceSummary,
+    input.evidenceSummary,
+  ]);
+  const connectedRecommendationIds = uniqueStrings(
+    input.candidate.connectedRecommendationIds,
+    input.connectedRecommendationId ? [input.connectedRecommendationId] : [],
+  );
+  return {
+    ...input.candidate,
+    lastSeenAt: input.now,
+    evidenceSummary,
+    evidenceCount:
+      (input.candidate.evidenceCount ??
+        input.candidate.evidenceItems?.length ??
+        0) + (input.evidenceSummary?.trim() ? 1 : 0),
+    knownFacts: uniqueStrings(input.candidate.knownFacts, input.knownFacts),
+    missingInfo: uniqueStrings(input.candidate.missingInfo, input.missingInfo),
+    publicSafetyNotes: uniqueStrings(
+      input.candidate.publicSafetyNotes,
+      input.publicSafetyNotes,
+    ),
+    doNotSay: uniqueStrings(input.candidate.doNotSay, input.doNotSay),
+    sourceFileNotes: [input.note, ...(input.candidate.sourceFileNotes ?? [])],
+    connectedCandidateId:
+      input.candidate.connectedCandidateId ??
+      input.possibleMatchCandidateIds?.[0] ??
+      undefined,
+    connectedSourceFileCandidateId:
+      input.candidate.connectedSourceFileCandidateId ??
+      input.possibleMatchCandidateIds?.[0] ??
+      undefined,
+    connectedRecommendationIds: connectedRecommendationIds.length
+      ? connectedRecommendationIds
+      : input.candidate.connectedRecommendationIds,
+    possibleMatchCandidateIds: uniqueStrings(
+      input.candidate.possibleMatchCandidateIds,
+      input.possibleMatchCandidateIds,
+    ),
+    identityReviewStatus:
+      input.identityReviewStatus ?? input.candidate.identityReviewStatus,
+    routingReason: input.routingReason,
+    updatedAt: input.now,
+  };
+}
+
+function samePossibleMatchReview(input: {
+  candidate: DossierCandidate;
+  subjectName: string;
+  possibleCandidateIds: string[];
+}): boolean {
+  const existingPossible = input.candidate.possibleMatchCandidateIds ?? [];
+  if (existingPossible.length === 0) return false;
+  const sameSubject =
+    normalizeName(input.candidate.name) === normalizeName(input.subjectName);
+  const left = [...existingPossible].sort().join("|");
+  const right = [...input.possibleCandidateIds].sort().join("|");
+  return sameSubject && left === right;
+}
+
+function matchingPublicDossierForSubject(subjectName: string) {
+  const duplicate = findExistingDossierMatch(subjectName);
+  return duplicate.match?.confidence === "high" ? duplicate.match : null;
+}
+
 const OPEN_REFRESH_RECENT_COMPLETED_MS = 60 * 60 * 1000;
 const DEFAULT_REFRESH_STALE_MS = 24 * 60 * 60 * 1000;
 const STALE_OPEN_REFRESH_REQUEST_MS = 5 * 60 * 1000;
@@ -2749,7 +2886,7 @@ export async function createDossierRecommendationIdempotent(
         };
         const updatedRecommendation: DossierRecommendation = {
           ...recommendation,
-          status: "attached_to_source_file",
+          status: attachmentStatusForCandidate(ingestKeyCandidate),
           targetCandidateId: ingestKeyCandidate.id,
           publicSafetyNotes: [
             ...(recommendation.publicSafetyNotes ?? []),
@@ -2801,11 +2938,15 @@ export async function createDossierRecommendationIdempotent(
         };
         const updatedRecommendation: DossierRecommendation = {
           ...recommendation,
-          status: "attached_to_source_file",
+          status: attachmentStatusForCandidate(
+            currentState.candidates.find(
+              (candidate) => candidate.id === match.exactCandidateId,
+            )!,
+          ),
           targetCandidateId: match.exactCandidateId,
           publicSafetyNotes: [
             ...(recommendation.publicSafetyNotes ?? []),
-            `${bnlIngestLabel(recommendation)} matched an existing exact same-subject source file and was attached without creating a duplicate candidate.`,
+            `${bnlIngestLabel(recommendation)} matched an existing exact same-subject workflow record and was attached without creating a duplicate candidate.`,
           ],
           updatedAt: now,
         };
@@ -2866,12 +3007,63 @@ export async function createDossierRecommendationIdempotent(
         };
       }
 
+      const possibleMatchRecommendation = currentState.recommendations.find(
+        (item) =>
+          isActiveRecommendation(item) &&
+          item.identityReviewStatus === "needs_confirmation" &&
+          normalizeName(item.subjectName) ===
+            normalizeName(recommendation.subjectName) &&
+          [...(item.possibleMatchCandidateIds ?? [])].sort().join("|") ===
+            [...match.possibleCandidateIds].sort().join("|"),
+      );
+      const possibleSafetyNote = `${bnlIngestLabel(recommendation)} found possible existing source files; left in Recommendation Inbox for owner/lead duplicate or identity review.`;
+      if (possibleMatchRecommendation) {
+        savedRecommendation = {
+          ...possibleMatchRecommendation,
+          reason: recommendation.reason || possibleMatchRecommendation.reason,
+          evidenceSummary:
+            recommendation.evidenceSummary ??
+            possibleMatchRecommendation.evidenceSummary,
+          publicSafetyNotes: uniqueStrings(
+            possibleMatchRecommendation.publicSafetyNotes,
+            recommendation.publicSafetyNotes,
+            [possibleSafetyNote],
+          ),
+          connectedRecommendationIds: uniqueStrings(
+            possibleMatchRecommendation.connectedRecommendationIds,
+            [recommendation.id],
+          ),
+          sourceRecommendationIds: uniqueStrings(
+            possibleMatchRecommendation.sourceRecommendationIds,
+            [recommendation.id],
+          ),
+          routingReason: match.reason,
+          updatedAt: now,
+        };
+        duplicate = true;
+        autoAction = "left_for_review";
+        return {
+          ...currentState,
+          recommendations: currentState.recommendations.map((item) =>
+            item.id === possibleMatchRecommendation.id
+              ? savedRecommendation
+              : item,
+          ),
+          updatedAt: now,
+        };
+      }
+
       savedRecommendation = {
         ...recommendation,
-        publicSafetyNotes: [
-          ...(recommendation.publicSafetyNotes ?? []),
-          `${bnlIngestLabel(recommendation)} found possible existing source files; left in Recommendation Inbox for owner/lead duplicate or identity review.`,
-        ],
+        type: "possible_connection_review",
+        publicSafetyNotes: uniqueStrings(recommendation.publicSafetyNotes, [
+          possibleSafetyNote,
+        ]),
+        possibleMatchCandidateIds: match.possibleCandidateIds,
+        connectedCandidateId: match.possibleCandidateIds[0],
+        connectedSourceFileCandidateId: match.possibleCandidateIds[0],
+        identityReviewStatus: "needs_confirmation",
+        routingReason: match.reason,
       };
       autoAction = "left_for_review";
       return {
@@ -3784,17 +3976,56 @@ export async function convertRecommendationToCandidate(
       candidates: currentState.candidates,
     });
     if (match.exactCandidateId) {
-      throw new DossierWorkflowInputError(
-        "An exact same-subject BNL Source File already exists for this recommendation",
-        400,
-        "recommendation_existing_source_file_match",
-        {
-          exactCandidateId: match.exactCandidateId,
-          exactMatchKind: match.exactMatchKind,
-          possibleCandidateIds: match.possibleCandidateIds,
-          reason: match.reason,
-        },
+      const existingCandidate = currentState.candidates.find(
+        (item) => item.id === match.exactCandidateId,
       );
+      if (existingCandidate) {
+        const updatedRecommendation: DossierRecommendation = {
+          ...recommendation,
+          status: attachmentStatusForCandidate(existingCandidate),
+          targetCandidateId: existingCandidate.id,
+          connectedCandidateId: existingCandidate.id,
+          connectedSourceFileCandidateId: existingCandidate.id,
+          identityReviewStatus: "not_required",
+          routingReason: match.reason,
+          updatedAt: now,
+        };
+        const note = routingNote({
+          candidateId: existingCandidate.id,
+          now,
+          text: recommendation.ingestSource?.startsWith("bnl")
+            ? bnlAutoCandidateNoteText(updatedRecommendation)
+            : recommendationSourceNoteText(updatedRecommendation),
+          source: "bnl_recommendation",
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        });
+        const updatedCandidate = mergeCandidateSignal({
+          candidate: existingCandidate,
+          now,
+          note,
+          evidenceSummary: recommendation.evidenceSummary,
+          connectedRecommendationId: recommendation.id,
+          routingReason: match.reason,
+          identityReviewStatus: "not_required",
+        });
+        result = {
+          recommendation: updatedRecommendation,
+          candidate: updatedCandidate,
+        };
+        return {
+          ...currentState,
+          recommendations: currentState.recommendations.map((item) =>
+            item.id === recommendation.id ? updatedRecommendation : item,
+          ),
+          candidates: currentState.candidates.map((item) =>
+            item.id === existingCandidate.id ? updatedCandidate : item,
+          ),
+          updatedAt: now,
+        };
+      }
     }
     const candidate = buildCandidateFromRecommendation({
       recommendation,
@@ -4097,13 +4328,193 @@ export async function createManualDossierCandidate(
     updatedAt: now,
   };
 
-  await updateDossierWorkflowState((currentState) => ({
-    ...currentState,
-    candidates: [candidate, ...currentState.candidates],
-    updatedAt: now,
-  }));
+  let savedCandidate: DossierCandidate = candidate;
 
-  return candidate;
+  await updateDossierWorkflowState((currentState) => {
+    const subjectMatch = matchDossierRecommendationSubject({
+      recommendation: {
+        subjectName: name,
+        subjectKey: undefined,
+        targetCandidateId: undefined,
+      },
+      candidates: currentState.candidates,
+    });
+
+    if (subjectMatch.exactCandidateId) {
+      const routingReason = `Manual signal reused existing record: ${subjectMatch.reason}`;
+      const note = routingNote({
+        candidateId: subjectMatch.exactCandidateId,
+        now,
+        text: manualCandidateRoutingNote({
+          name,
+          reason,
+          whyNow: input.whyNow,
+          evidenceSummary: input.evidenceSummary,
+          knownFacts,
+          routingReason,
+        }),
+        source: "admin_manual",
+      });
+      return {
+        ...currentState,
+        candidates: currentState.candidates.map((item) => {
+          if (item.id !== subjectMatch.exactCandidateId) return item;
+          savedCandidate = mergeCandidateSignal({
+            candidate: item,
+            now,
+            note,
+            evidenceSummary: input.evidenceSummary?.trim(),
+            knownFacts,
+            missingInfo: missingInfoInput,
+            publicSafetyNotes: publicSafetyNotesInput,
+            doNotSay,
+            routingReason,
+            identityReviewStatus:
+              item.identityReviewStatus === "needs_confirmation"
+                ? "needs_confirmation"
+                : "not_required",
+          });
+          return savedCandidate;
+        }),
+        updatedAt: now,
+      };
+    }
+
+    const publicDossierMatch = matchingPublicDossierForSubject(name);
+    if (publicDossierMatch) {
+      const existingUpdate = currentState.candidates.find(
+        (item) =>
+          item.status === "existing_dossier_update" &&
+          item.existingDossierMatch?.id === publicDossierMatch.id,
+      );
+      const routingReason = `Manual signal matched existing public dossier ${publicDossierMatch.id} / ${publicDossierMatch.name}; routed to Dossier Updates.`;
+      if (existingUpdate) {
+        const note = routingNote({
+          candidateId: existingUpdate.id,
+          now,
+          text: manualCandidateRoutingNote({
+            name,
+            reason,
+            whyNow: input.whyNow,
+            evidenceSummary: input.evidenceSummary,
+            knownFacts,
+            routingReason,
+          }),
+          source: "admin_manual",
+        });
+        return {
+          ...currentState,
+          candidates: currentState.candidates.map((item) => {
+            if (item.id !== existingUpdate.id) return item;
+            savedCandidate = mergeCandidateSignal({
+              candidate: item,
+              now,
+              note,
+              evidenceSummary: input.evidenceSummary?.trim(),
+              knownFacts,
+              missingInfo: missingInfoInput,
+              publicSafetyNotes: publicSafetyNotesInput,
+              doNotSay,
+              routingReason,
+              identityReviewStatus: "not_required",
+            });
+            return savedCandidate;
+          }),
+          updatedAt: now,
+        };
+      }
+      savedCandidate = {
+        ...candidate,
+        name: publicDossierMatch.name,
+        status: "existing_dossier_update",
+        existingDossierMatch: publicDossierMatch,
+        duplicateRisk: "high",
+        routingReason,
+        identityReviewStatus: "not_required",
+      };
+      return {
+        ...currentState,
+        candidates: [savedCandidate, ...currentState.candidates],
+        updatedAt: now,
+      };
+    }
+
+    if (subjectMatch.possibleCandidateIds.length > 0) {
+      const routingReason = subjectMatch.reason;
+      const existingReview = currentState.candidates.find((item) =>
+        samePossibleMatchReview({
+          candidate: item,
+          subjectName: name,
+          possibleCandidateIds: subjectMatch.possibleCandidateIds,
+        }),
+      );
+      if (existingReview) {
+        const note = routingNote({
+          candidateId: existingReview.id,
+          now,
+          text: manualCandidateRoutingNote({
+            name,
+            reason,
+            whyNow: input.whyNow,
+            evidenceSummary: input.evidenceSummary,
+            knownFacts,
+            routingReason,
+          }),
+          source: "admin_manual",
+        });
+        return {
+          ...currentState,
+          candidates: currentState.candidates.map((item) => {
+            if (item.id !== existingReview.id) return item;
+            savedCandidate = mergeCandidateSignal({
+              candidate: item,
+              now,
+              note,
+              evidenceSummary: input.evidenceSummary?.trim(),
+              knownFacts,
+              missingInfo: missingInfoInput,
+              publicSafetyNotes: publicSafetyNotesInput,
+              doNotSay,
+              possibleMatchCandidateIds: subjectMatch.possibleCandidateIds,
+              routingReason,
+              identityReviewStatus: "needs_confirmation",
+            });
+            return savedCandidate;
+          }),
+          updatedAt: now,
+        };
+      }
+      savedCandidate = {
+        ...candidate,
+        duplicateRisk:
+          riskRank(candidate.duplicateRisk ?? "none") >= riskRank("medium")
+            ? candidate.duplicateRisk
+            : "medium",
+        possibleMatchCandidateIds: subjectMatch.possibleCandidateIds,
+        connectedCandidateId: subjectMatch.possibleCandidateIds[0],
+        connectedSourceFileCandidateId: subjectMatch.possibleCandidateIds[0],
+        identityReviewStatus: "needs_confirmation",
+        routingReason,
+        missingInfo: uniqueStrings(candidate.missingInfo, [
+          `Possible match to existing subject ${subjectMatch.possibleCandidateIds.join(", ")}. Identity needs confirmation before merge or attach.`,
+        ]),
+      };
+      return {
+        ...currentState,
+        candidates: [savedCandidate, ...currentState.candidates],
+        updatedAt: now,
+      };
+    }
+
+    savedCandidate = candidate;
+    return {
+      ...currentState,
+      candidates: [candidate, ...currentState.candidates],
+      updatedAt: now,
+    };
+  });
+
+  return savedCandidate;
 }
 
 export async function promoteCandidateToSourceFile(

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -179,6 +179,15 @@ export type DossierSourceFileNote = {
   ingestKey?: string;
   ingestedAt?: string;
   ingestSource?: DossierRecommendationIngestSource;
+  connectedCandidateId?: string;
+  connectedSourceFileCandidateId?: string;
+  connectedRecommendationIds?: string[];
+  possibleMatchCandidateIds?: string[];
+  possibleMatchDossierIds?: string[];
+  identityReviewStatus?: "not_required" | "needs_confirmation" | "confirmed";
+  routingReason?: string;
+  routedFromRecommendationId?: string;
+  sourceRecommendationIds?: string[];
 };
 
 export type DossierIdentityLinkType =
@@ -280,6 +289,15 @@ export type DossierCandidate = {
   ingestKey?: string;
   ingestSource?: DossierRecommendationIngestSource;
   createdFromRecommendationId?: string;
+  connectedCandidateId?: string;
+  connectedSourceFileCandidateId?: string;
+  connectedRecommendationIds?: string[];
+  possibleMatchCandidateIds?: string[];
+  possibleMatchDossierIds?: string[];
+  identityReviewStatus?: "not_required" | "needs_confirmation" | "confirmed";
+  routingReason?: string;
+  routedFromRecommendationId?: string;
+  sourceRecommendationIds?: string[];
   mergedIntoCandidateId?: string;
   mergedAt?: string;
   mergeNote?: string;
@@ -559,6 +577,15 @@ export type DossierRecommendation = {
   ingestKey?: string;
   ingestedAt?: string;
   ingestSource?: DossierRecommendationIngestSource;
+  connectedCandidateId?: string;
+  connectedSourceFileCandidateId?: string;
+  connectedRecommendationIds?: string[];
+  possibleMatchCandidateIds?: string[];
+  possibleMatchDossierIds?: string[];
+  identityReviewStatus?: "not_required" | "needs_confirmation" | "confirmed";
+  routingReason?: string;
+  routedFromRecommendationId?: string;
+  sourceRecommendationIds?: string[];
 };
 
 export type DossierSourceDepthLabel = "Low" | "Medium" | "Strong";
@@ -721,7 +748,23 @@ export function isSourceFileEnrichmentAttachableCandidate(
 }
 
 function isActiveSubjectCandidate(candidate: DossierCandidate): boolean {
-  return isActiveSourceFileCandidate(candidate);
+  return isSourceFileEnrichmentAttachableCandidate(candidate);
+}
+
+function subjectMatchPriority(candidate: DossierCandidate): number {
+  if (isActiveSourceFileCandidate(candidate)) return 0;
+  if (candidate.status === "existing_dossier_update") return 1;
+  return 2;
+}
+
+function sortedSubjectCandidates(
+  candidates: DossierCandidate[],
+): DossierCandidate[] {
+  return [...candidates].sort((left, right) => {
+    const priority = subjectMatchPriority(left) - subjectMatchPriority(right);
+    if (priority !== 0) return priority;
+    return right.updatedAt.localeCompare(left.updatedAt);
+  });
 }
 
 function hasPossibleSubjectOverlap(
@@ -757,7 +800,9 @@ export function matchDossierRecommendationSubject(input: {
   >;
   candidates: DossierCandidate[];
 }): DossierSubjectMatchResult {
-  const activeCandidates = input.candidates.filter(isActiveSubjectCandidate);
+  const activeCandidates = sortedSubjectCandidates(
+    input.candidates.filter(isActiveSubjectCandidate),
+  );
   const subjectName = input.recommendation.subjectName;
   const normalizedSubject = normalizeDossierSubjectName(subjectName);
   const compactSubject = compactDossierSubjectName(subjectName);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -303,6 +303,21 @@ async function bnlIngestPost(body, token = "test-bnl-ingest-token") {
   );
 }
 
+async function cloneCandidateForTest(candidate, overrides = {}) {
+  const state = await store.getDossierWorkflowState();
+  const clone = {
+    ...candidate,
+    id: overrides.id ?? `${candidate.id}-duplicate`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+  await store.saveDossierWorkflowState({
+    ...state,
+    candidates: [clone, ...state.candidates],
+  });
+  return clone;
+}
 
 async function bnlArchivePost(body, token = "test-bnl-ingest-token") {
   return bnlArchiveIngestRoute.POST(
@@ -532,6 +547,93 @@ test("Source File open and retry call BNL refresh-now server-side with safe stat
   }
 });
 
+
+test("routing guard prevents exact duplicate manual candidates and preserves new info", async () => {
+  await resetWorkflowStore();
+
+  const first = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat", evidenceSummary: "First Hellcat signal." } })).json();
+  const second = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat", evidenceSummary: "Second Hellcat signal." } })).json();
+
+  assert.equal(second.candidate.id, first.candidate.id);
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.filter((candidate) => workflow.compactDossierSubjectName(candidate.name) === "hellcat").length, 1);
+  assert.match(state.candidates[0].sourceFileNotes.map((note) => note.text).join("\n"), /Second Hellcat signal/);
+});
+
+test("routing guard treats safe compact and case-insensitive subjects as one active record", async () => {
+  await resetWorkflowStore();
+
+  const first = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat" } })).json();
+  const lower = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "hellcat", evidenceSummary: "Lowercase signal." } })).json();
+  const spaced = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hell Cat", evidenceSummary: "Compact-name signal." } })).json();
+
+  assert.equal(lower.candidate.id, first.candidate.id);
+  assert.equal(spaced.candidate.id, first.candidate.id);
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.match(state.candidates[0].sourceFileNotes.map((note) => note.text).join("\n"), /Lowercase signal|Compact-name signal/);
+});
+
+test("routing guard prioritizes an active Source File over creating a new Candidate", async () => {
+  await resetWorkflowStore();
+
+  const created = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat" } })).json();
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId: created.candidate.id });
+  const routed = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat", evidenceSummary: "Source File follow-up." } })).json();
+
+  assert.equal(routed.candidate.id, created.candidate.id);
+  assert.equal(routed.candidate.status, "active_source_file");
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.match(state.candidates[0].sourceFileNotes[0].text, /Source File follow-up/);
+});
+
+test("routing guard sends exact public dossier signals to Dossier Updates instead of Candidates", async () => {
+  await resetWorkflowStore();
+
+  const routed = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "6 Bit", evidenceSummary: "Existing dossier update signal." } })).json();
+
+  assert.equal(routed.candidate.status, "existing_dossier_update");
+  assert.equal(routed.candidate.existingDossierMatch.name, "6 Bit");
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 1);
+  assert.equal(state.candidates[0].status, "existing_dossier_update");
+});
+
+test("routing guard reuses one connected uncertain identity review record", async () => {
+  await resetWorkflowStore();
+
+  const existing = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat" } })).json();
+  const possible = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat Annex", evidenceSummary: "Possible annex signal." } })).json();
+  const repeat = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat Annex", evidenceSummary: "Repeated possible annex signal." } })).json();
+
+  assert.notEqual(possible.candidate.id, existing.candidate.id);
+  assert.equal(repeat.candidate.id, possible.candidate.id);
+  assert.equal(repeat.candidate.identityReviewStatus, "needs_confirmation");
+  assert.deepEqual(repeat.candidate.possibleMatchCandidateIds, [existing.candidate.id]);
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates.length, 2);
+  assert.match(state.candidates.find((candidate) => candidate.id === possible.candidate.id).sourceFileNotes[0].text, /Repeated possible annex signal/);
+});
+
+test("confirmed aliases are safe matches, but proposed/rejected/retired aliases are not", async () => {
+  await resetWorkflowStore();
+
+  const sourceFile = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hellcat" } })).json();
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId: sourceFile.candidate.id });
+  const proposed = await store.addDossierIdentityLink({ candidateId: sourceFile.candidate.id, label: "Hell Kitty", type: "alias", visibility: "internal_only", source: "admin_manual", useForMatching: true });
+  await store.confirmDossierIdentityLink({ candidateId: sourceFile.candidate.id, identityLinkId: proposed.id });
+
+  const alias = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hell Kitty", evidenceSummary: "Confirmed alias signal." } })).json();
+  assert.equal(alias.candidate.id, sourceFile.candidate.id);
+
+  const proposedOnly = await store.addDossierIdentityLink({ candidateId: sourceFile.candidate.id, label: "Hell Kitten", type: "alias", visibility: "internal_only", source: "admin_manual", useForMatching: true });
+  const proposedAlias = await (await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Hell Kitten" } })).json();
+  assert.notEqual(proposedAlias.candidate.id, sourceFile.candidate.id);
+  assert.equal(proposedAlias.candidate.possibleMatchCandidateIds, undefined);
+  await store.rejectDossierIdentityLink({ candidateId: sourceFile.candidate.id, identityLinkId: proposedOnly.id });
+});
+
 test("Source File immediate refresh timeout/unavailable and stale open requests do not trap retries or cross-file matching", async () => {
   await resetWorkflowStore();
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
@@ -554,7 +656,7 @@ test("Source File immediate refresh timeout/unavailable and stale open requests 
     })).json();
     const second = await (await authedPost({
       action: "createManualCandidate",
-      input: { ...manualCandidateInput, name: "Candidate Match Alpha" },
+      input: { ...manualCandidateInput, name: "Candidate Match Beta" },
     })).json();
     await authedPost({ action: "promoteCandidateToSourceFile", candidateId: first.candidate.id });
     await authedPost({ action: "promoteCandidateToSourceFile", candidateId: second.candidate.id });
@@ -2349,16 +2451,12 @@ test("workflow duplicate group detection returns deterministic high-risk groups"
       input: { ...manualCandidateInput, name: "Signal Witch" },
     })
   ).json();
-  const second = await (
-    await authedPost({
-      action: "createManualCandidate",
-      input: {
-        ...manualCandidateInput,
-        name: "Signal Witch",
-        reason: "Queue/session context.",
-      },
-    })
-  ).json();
+  const second = {
+    candidate: await cloneCandidateForTest(first.candidate, {
+      id: `${first.candidate.id}-queue`,
+      reason: "Queue/session context.",
+    }),
+  };
 
   const payload = await (await authedGet()).json();
   assert.equal(payload.duplicateGroups.length, 1);
@@ -2379,12 +2477,12 @@ test("workflow duplicate group detection catches compact near duplicates", async
       input: { ...manualCandidateInput, name: "Signal Witch" },
     })
   ).json();
-  const second = await (
-    await authedPost({
-      action: "createManualCandidate",
-      input: { ...manualCandidateInput, name: "signalwitch" },
-    })
-  ).json();
+  const second = {
+    candidate: await cloneCandidateForTest(first.candidate, {
+      id: `${first.candidate.id}-compact`,
+      name: "signalwitch",
+    }),
+  };
 
   const payload = await (await authedGet()).json();
   assert.equal(payload.duplicateGroups.length, 1);
@@ -2426,22 +2524,18 @@ test("mergeCandidates preserves sources and unions candidate review fields", asy
       },
     })
   ).json();
-  const second = await (
-    await authedPost({
-      action: "createManualCandidate",
-      input: {
-        ...manualCandidateInput,
-        name: "Signal Witch",
-        reason: "Queue/session context.",
-        knownFacts: ["Fact B", "Fact A"],
-        missingInfo: ["Missing B"],
-        doNotSay: ["Do not say B"],
-        publicSafetyNotes: ["Safety B"],
-        recommendedTags: ["queue"],
-        proposedTags: ["draft-b"],
-      },
-    })
-  ).json();
+  const second = {
+    candidate: await cloneCandidateForTest(first.candidate, {
+      id: `${first.candidate.id}-merge`,
+      reason: "Queue/session context.",
+      knownFacts: ["Fact B", "Fact A"],
+      missingInfo: ["Missing B"],
+      doNotSay: ["Do not say B"],
+      publicSafetyNotes: ["Safety B"],
+      recommendedTags: ["queue"],
+      proposedTags: ["draft-b"],
+    }),
+  };
 
   const response = await authedPost({
     action: "mergeCandidates",
@@ -2501,19 +2595,15 @@ test("mergeCandidates prefers primary taxonomy and fills missing taxonomy from s
       },
     })
   ).json();
-  const second = await (
-    await authedPost({
-      action: "createManualCandidate",
-      input: {
-        ...manualCandidateInput,
-        name: "Taxonomy Merge Subject",
-        recommendedCategory: "Entity",
-        recommendedKind: "radio_entity",
-        recommendedEcosystemLane: "community_artist",
-        recommendedIdentityAuthority: "community_owned",
-      },
-    })
-  ).json();
+  const second = {
+    candidate: await cloneCandidateForTest(first.candidate, {
+      id: `${first.candidate.id}-taxonomy`,
+      recommendedCategory: "Entity",
+      recommendedKind: "radio_entity",
+      recommendedEcosystemLane: "community_artist",
+      recommendedIdentityAuthority: "community_owned",
+    }),
+  };
 
   const payload = await (
     await authedPost({
@@ -2539,16 +2629,12 @@ test("mergeCandidates can create/update a master draft and supersede secondary d
       input: { ...manualCandidateInput, name: "Draft Merge Subject" },
     })
   ).json();
-  const second = await (
-    await authedPost({
-      action: "createManualCandidate",
-      input: {
-        ...manualCandidateInput,
-        name: "Draft Merge Subject",
-        recommendedKind: "radio_entity",
-      },
-    })
-  ).json();
+  const second = {
+    candidate: await cloneCandidateForTest(first.candidate, {
+      id: `${first.candidate.id}-draft`,
+      recommendedKind: "radio_entity",
+    }),
+  };
   const firstDraft = await (
     await authedPost({
       action: "createDraftFromCandidate",
@@ -3280,10 +3366,10 @@ test("confirmed alias match allows attach and blocks duplicate conversion", asyn
     action: "convertRecommendationToCandidate",
     recommendationId: secondRec.recommendation.id,
   });
-  assert.equal(convertResponse.status, 400);
-  const errorPayload = await convertResponse.json();
-  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
-  assert.equal(errorPayload.exactMatchKind, "confirmed_alias");
+  assert.equal(convertResponse.status, 200);
+  const routedPayload = await convertResponse.json();
+  assert.equal(routedPayload.recommendation.status, "attached_to_source_file");
+  assert.equal(routedPayload.recommendation.targetCandidateId, candidateId);
 });
 
 test("unapplied source notes count after draft creation without mutating draft fields", async () => {
@@ -3656,7 +3742,7 @@ test("arbitrary recommendation attach is blocked by same-subject guardrails", as
     createSourceNote: true,
   });
   assert.equal(response.status, 400);
-  assert.equal((await response.json()).code, "recommendation_subject_mismatch");
+  assert.equal((await response.json()).code, "candidate_not_attachable");
 
   const finalPayload = await (await authedGet()).json();
   const macModem = finalPayload.candidates.find(
@@ -3743,7 +3829,7 @@ test("pre-targeted recommendation cannot attach to a different source file", asy
     createSourceNote: true,
   });
   assert.equal(response.status, 400);
-  assert.equal((await response.json()).code, "recommendation_subject_mismatch");
+  assert.equal((await response.json()).code, "candidate_not_attachable");
 
   const finalPayload = await (await authedGet()).json();
   const other = finalPayload.candidates.find(
@@ -3781,11 +3867,10 @@ test("pre-targeted recommendation cannot convert to duplicate source file", asyn
     action: "convertRecommendationToCandidate",
     recommendationId: recPayload.recommendation.id,
   });
-  assert.equal(response.status, 400);
-  const errorPayload = await response.json();
-  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
-  assert.equal(errorPayload.exactCandidateId, targetPayload.candidate.id);
-  assert.equal(errorPayload.exactMatchKind, "pre_targeted");
+  assert.equal(response.status, 200);
+  const routedPayload = await response.json();
+  assert.equal(routedPayload.recommendation.targetCandidateId, targetPayload.candidate.id);
+  assert.equal(routedPayload.candidates.length, 1);
 
   const finalPayload = await (await authedGet()).json();
   assert.equal(finalPayload.candidates.length, 1);
@@ -3826,7 +3911,7 @@ test("pre-targeted recommendation target must be active", async () => {
   assert.equal((await response.json()).code, "candidate_not_attachable");
 });
 
-test("convert recommendation is blocked when exact source file match exists", async () => {
+test("convert recommendation routes when exact workflow match exists", async () => {
   await resetWorkflowStore();
   await authedPost({
     action: "createManualCandidate",
@@ -3848,10 +3933,10 @@ test("convert recommendation is blocked when exact source file match exists", as
     action: "convertRecommendationToCandidate",
     recommendationId: recPayload.recommendation.id,
   });
-  assert.equal(response.status, 400);
-  const errorPayload = await response.json();
-  assert.equal(errorPayload.code, "recommendation_existing_source_file_match");
-  assert.ok(errorPayload.exactCandidateId);
+  assert.equal(response.status, 200);
+  const routedPayload = await response.json();
+  assert.equal(routedPayload.recommendation.status, "attached_to_source_file");
+  assert.ok(routedPayload.recommendation.targetCandidateId);
 
   const finalPayload = await (await authedGet()).json();
   assert.equal(finalPayload.candidates.length, 1);


### PR DESCRIPTION
### Motivation

- Avoid creating exact-duplicate active Candidates when the same subject is ingested or manually signaled and instead route new signals into the correct existing workflow record. 
- Prioritize active Source Files and Existing Dossier Updates when attaching new information so the dashboard sections (Candidates, Dossier Updates, Source Files) reflect true workflow lanes. 
- Preserve provenance and evidence as notes/attached recommendations and surface possible-match identity review metadata instead of silently merging.

### Description

- Added connected-record routing metadata and fields on workflow types to store `connectedCandidateId`, `connectedSourceFileCandidateId`, `connectedRecommendationIds`, `possibleMatchCandidateIds`, `identityReviewStatus`, `routingReason`, and related IDs. (edited `src/lib/dossier-workflow.ts`)
- Implemented priority-aware subject matching that prefers active Source Files, then Existing Dossier Updates, then intake Candidates, and sorts candidate match candidates accordingly. (edited `src/lib/dossier-workflow.ts`)
- Introduced routing helpers that merge incoming signals into existing records (creating source notes, updating evidence/known facts/missingInfo/publicSafetyNotes) and reuse or create a single connected review record for uncertain identity matches. (edited `src/lib/dossier-workflow-store.ts`)
- Updated BNL recommendation handling and `convertRecommendationToCandidate` paths to attach to exact workflow matches or route to Dossier Updates/Source Files per the new priority rules, and to reuse possible-match recommendations for uncertain cases. (edited `src/lib/dossier-workflow-store.ts`)
- Updated manual intake (`createManualDossierCandidate`) to use the routing guard so manual signals attach to existing records when safe and create or reuse possible-match review records when uncertain. (edited `src/lib/dossier-workflow-store.ts`)
- Updated admin dashboard identity/status UI to surface connected/possible-match indicators and routing reason text while preserving the simplified PR #177 dashboard structure and button labels. (edited `src/app/admin/dossiers/page.tsx`)
- Added and adapted unit tests to cover exact duplicate prevention, compact/case-insensitive matching, Source File priority, public-dossier update routing, possible-match reuse, and alias matching behavior; adjusted some tests to use cloned candidates for deterministic duplicate-group scenarios. (edited `tests/admin-dossiers.test.mjs`)

### Testing

- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed locally (`139 passed`).
- Ran `npx tsc --noEmit` and TypeScript type-check succeeded with no errors.
- The test suite exercises BNL ingest flows, manual intake, recommendation conversion/attachment, duplicate-group detection, merge behavior, identity-link confirmation rules, and dashboard readouts; these automations all passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274b853f8c8321a9cbe41a24c4d22d)