### PR TITLE
Add contextual dossier dashboard notification chips

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   getDossierSourceFileMetrics,
@@ -31,6 +31,12 @@ import {
   sourceFileReasonMeaning,
   sourceFileWhyNowMeaning,
 } from "@/lib/dossier-source-memory-meaning";
+import {
+  buildSourceFileNotifications,
+  dossierSourceFileFocusSectionIds,
+  sourceFileFocusHref,
+  type DossierSourceFileFocus,
+} from "@/lib/dossier-workflow-notifications";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -341,14 +347,116 @@ function recommendationEvidenceItems(recommendation: DossierRecommendation) {
 function Section({
   title,
   children,
+  id,
+  focused,
 }: {
   title: string;
   children: React.ReactNode;
+  id?: string;
+  focused?: boolean;
 }) {
   return (
-    <section className="border border-border/70 bg-background/20 p-4 text-sm text-muted">
+    <section
+      id={id}
+      className={`border p-4 text-sm text-muted scroll-mt-24 ${
+        focused
+          ? "border-accent bg-accent/10"
+          : "border-border/70 bg-background/20"
+      }`}
+    >
       <h2 className="font-bold text-foreground mb-2">{title}</h2>
       {children}
+    </section>
+  );
+}
+
+
+const sourceFileFocusValues: DossierSourceFileFocus[] = [
+  "overview",
+  "identity",
+  "missing-info",
+  "signals",
+  "archive",
+  "dossier",
+  "refresh",
+];
+
+function validSourceFileFocus(
+  value: string | null,
+): DossierSourceFileFocus | null {
+  return sourceFileFocusValues.includes(value as DossierSourceFileFocus)
+    ? (value as DossierSourceFileFocus)
+    : null;
+}
+
+function hasNotification(
+  notifications: ReturnType<typeof buildSourceFileNotifications>,
+  id: string,
+) {
+  return notifications.some((notification) => notification.id === id);
+}
+
+function sourceFileSectionId(focus: DossierSourceFileFocus) {
+  return dossierSourceFileFocusSectionIds[focus];
+}
+
+function focusSectionClass(focused: boolean) {
+  return `scroll-mt-24 border ${
+    focused ? "border-accent bg-accent/10" : "border-border bg-surface"
+  }`;
+}
+
+
+type SourceFileStatusMapSection = {
+  title: string;
+  focus: DossierSourceFileFocus;
+  statuses: string[];
+};
+
+function SourceFileStatusMap({
+  candidateId,
+  sections,
+  focusedSection,
+}: {
+  candidateId: string;
+  sections: SourceFileStatusMapSection[];
+  focusedSection: DossierSourceFileFocus | null;
+}) {
+  return (
+    <section
+      id={sourceFileSectionId("overview")}
+      className="border border-border bg-surface p-5 space-y-4 scroll-mt-24"
+    >
+      <div>
+        <p className="text-xs uppercase tracking-[0.4em] text-muted mb-2">
+          Workspace Map
+        </p>
+        <h2 className="text-2xl font-bold text-foreground">
+          Source File Status Map
+        </h2>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3 text-sm">
+        {sections.map((section) => (
+          <Link
+            key={section.focus}
+            href={sourceFileFocusHref(candidateId, section.focus)}
+            className={`border p-3 transition-all ${
+              focusedSection === section.focus
+                ? "border-accent bg-accent/10"
+                : "border-border/70 bg-background/20 hover:border-accent"
+            }`}
+          >
+            <p className="text-xs uppercase tracking-widest text-accent">
+              {section.title}
+            </p>
+            <ul className="mt-2 space-y-1 text-muted">
+              {uniqueLabels(section.statuses).map((status) => (
+                <li key={status}>{status}</li>
+              ))}
+            </ul>
+          </Link>
+        ))}
+      </div>
     </section>
   );
 }
@@ -682,7 +790,11 @@ function PhaseRail() {
 export default function CandidateReviewPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const candidateId = routeParam(params?.candidateId);
+  const focusedSourceFileSection = validSourceFileFocus(
+    searchParams.get("focus"),
+  );
   const [payload, setPayload] = useState<WorkflowPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -784,6 +896,20 @@ export default function CandidateReviewPage() {
     }, 0);
     return () => window.clearTimeout(timer);
   }, [candidateId]);
+
+  useEffect(() => {
+    if (!focusedSourceFileSection || loading) return;
+    const sectionId = sourceFileSectionId(focusedSourceFileSection);
+    const element = document.getElementById(sectionId);
+    if (!element) return;
+    const details = element.closest("details");
+    if (details instanceof HTMLDetailsElement) {
+      details.open = true;
+    }
+    window.requestAnimationFrame(() => {
+      element.scrollIntoView({ block: "start" });
+    });
+  }, [focusedSourceFileSection, loading, candidateId]);
 
   useEffect(() => {
     const candidate = payload?.candidates.find((item) => item.id === candidateId);
@@ -1068,6 +1194,95 @@ export default function CandidateReviewPage() {
     : isCandidateIntake
       ? "Dossier Seed"
       : "Case File / BNL Source File";
+  const sourceFileNotifications = candidate
+    ? buildSourceFileNotifications(candidate, {
+        candidates: payload?.candidates ?? [],
+        drafts: payload?.drafts ?? [],
+        duplicateGroups: payload?.duplicateGroups ?? [],
+        recommendations: payload?.recommendations ?? [],
+        publicDossiers,
+        sourceFileRefreshRequests: payload?.sourceFileRefreshRequests ?? [],
+      })
+    : [];
+  const sourceFileStatusMapSections: SourceFileStatusMapSection[] = candidate
+    ? [
+        {
+          title: "Overview",
+          focus: "overview",
+          statuses: [
+            isCandidateIntake ? "Candidate intake / Dossier Seed" : "Active Source File",
+            isExistingDossierUpdate ? "Existing live dossier update record" : "",
+            hasNotification(sourceFileNotifications, "system-record")
+              ? "System record"
+              : "",
+          ],
+        },
+        {
+          title: "Identity",
+          focus: "identity",
+          statuses: [
+            confirmedIdentityLinks.length > 0 ? "Confirmed aliases" : "",
+            hasNotification(sourceFileNotifications, "identity-review-pending")
+              ? "Possible identity link"
+              : "",
+            hasNotification(sourceFileNotifications, "possible-duplicate")
+              ? "Possible duplicate"
+              : "",
+            confirmedIdentityLinks.length === 0 &&
+            !hasNotification(sourceFileNotifications, "identity-review-pending") &&
+            !hasNotification(sourceFileNotifications, "possible-duplicate")
+              ? "No known match"
+              : "",
+          ],
+        },
+        {
+          title: "BNL Signals",
+          focus: "signals",
+          statuses: [
+            hasNotification(sourceFileNotifications, "new-bnl-signal")
+              ? "New BNL signals attached"
+              : "No active BNL signals",
+          ],
+        },
+        {
+          title: "Missing Info",
+          focus: "missing-info",
+          statuses: [
+            hasNotification(sourceFileNotifications, "missing-info")
+              ? "Missing info"
+              : "No missing info",
+          ],
+        },
+        {
+          title: "Archive",
+          focus: "archive",
+          statuses: [
+            hasNotification(sourceFileNotifications, "bnl-archive-available")
+              ? "BNL archive available"
+              : "No BNL archive",
+          ],
+        },
+        {
+          title: "Dossier",
+          focus: "dossier",
+          statuses: [
+            hasOwnerReviewDraft
+              ? "Proposed Dossier ready for Owner Review"
+              : primaryDraft
+                ? "Proposed Dossier in progress"
+                : "No Proposed Dossier",
+            hasNotification(sourceFileNotifications, "live-dossier-exists")
+              ? "Live dossier exists"
+              : "",
+          ],
+        },
+        {
+          title: "Refresh",
+          focus: "refresh",
+          statuses: [refreshStatusLabel],
+        },
+      ]
+    : [];
   const closedIdentityLinks = identityLinks.filter(
     (identityLink) =>
       identityLink.status === "rejected" || identityLink.status === "retired",
@@ -1468,7 +1683,12 @@ export default function CandidateReviewPage() {
                 </p>
               </div>
             )}
-          <div className="mt-4 border border-border bg-background/30 p-3 text-sm text-muted">
+          <div
+            id={sourceFileSectionId("refresh")}
+            className={`mt-4 p-3 text-sm text-muted ${focusSectionClass(
+              focusedSourceFileSection === "refresh",
+            )}`}
+          >
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div>
                 <p className="text-xs uppercase tracking-widest text-accent">
@@ -1646,8 +1866,16 @@ export default function CandidateReviewPage() {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
+        <SourceFileStatusMap
+          candidateId={candidate.id}
+          sections={sourceFileStatusMapSections}
+          focusedSection={focusedSourceFileSection}
+        />
         {sourceFileSummary && (
-          <>
+          <section
+            id={sourceFileSectionId("archive")}
+            className={focusSectionClass(focusedSourceFileSection === "archive")}
+          >
             <DossierSourceFileSummaryPanel
               summary={sourceFileSummary}
               entityReadout={entityActivityReadout}
@@ -1664,9 +1892,13 @@ export default function CandidateReviewPage() {
               }
             />
             {/* Case File / BNL Source File Summary */}
-          </>
+          </section>
         )}
-        <Section title="Proposed Dossier Status">
+        <Section
+          id={sourceFileSectionId("dossier")}
+          focused={focusedSourceFileSection === "dossier"}
+          title="Proposed Dossier Status"
+        >
           {!primaryDraft ? (
             <div className="space-y-2">
               <p>No Proposed Dossier exists yet.</p>
@@ -1775,7 +2007,11 @@ export default function CandidateReviewPage() {
           </form>
         </section>
 
-        <Section title="Source Notes / Admin Addendums">
+        <Section
+          id={sourceFileSectionId("signals")}
+          focused={focusedSourceFileSection === "signals"}
+          title="Source Notes / Admin Addendums"
+        >
           {sourceNotes.length === 0 ? (
             <p>No saved source notes yet.</p>
           ) : (
@@ -1796,7 +2032,11 @@ export default function CandidateReviewPage() {
           )}
         </Section>
 
-        <Section title="Identity Link Actions">
+        <Section
+          id={sourceFileSectionId("identity")}
+          focused={focusedSourceFileSection === "identity"}
+          title="Identity Link Actions"
+        >
           <div className="space-y-5">
             <div className="space-y-2">
               <p>
@@ -2242,7 +2482,11 @@ export default function CandidateReviewPage() {
             <Section title="Corrections / extra notes">
               <p>Saved notes now live in Case File / BNL Source File Notes above.</p>
             </Section>
-            <Section title="Missing Info">
+            <Section
+              id={sourceFileSectionId("missing-info")}
+              focused={focusedSourceFileSection === "missing-info"}
+              title="Missing Info"
+            >
               {meaningFirstList(candidate.missingInfo, "—", candidate.name)}
             </Section>
             <Section title="Do Not Say">

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -16,7 +16,6 @@ import {
   buildSourceFileNotifications,
   isLiveDossierUpdateRecommendation,
   type DossierWorkflowNotification,
-  type DossierWorkflowNotificationTone,
 } from "@/lib/dossier-workflow-notifications";
 
 type WorkflowPayload = {
@@ -172,45 +171,47 @@ function StatusPill({ children }: { children: React.ReactNode }) {
   );
 }
 
-const notificationToneClass: Record<DossierWorkflowNotificationTone, string> = {
-  info: "border-accent/50 bg-accent/10 text-accent",
-  warning: "border-yellow-400/50 bg-yellow-400/10 text-yellow-200",
-  success: "border-emerald-400/50 bg-emerald-400/10 text-emerald-200",
-  danger: "border-red-400/50 bg-red-400/10 text-red-200",
-  muted: "border-border bg-background/40 text-muted",
-};
+function uniqueStatusLabels(
+  notifications: DossierWorkflowNotification[],
+  ids: string[],
+  fallback: string,
+) {
+  const idSet = new Set(ids);
+  const labels = notifications
+    .filter((notification) => idSet.has(notification.id))
+    .map((notification) => notification.label);
+  return Array.from(new Set(labels.length > 0 ? labels : [fallback]));
+}
 
-function NotificationChips({
-  notifications,
-}: {
-  notifications: DossierWorkflowNotification[];
-}) {
-  if (notifications.length === 0) return null;
+function RowStatusList({ labels }: { labels: string[] }) {
   return (
-    <div className="mt-2 flex flex-wrap gap-1.5">
-      {notifications.map((notification) => (
+    <div className="flex flex-col gap-1.5">
+      {labels.map((label) => (
         <span
-          key={notification.id}
-          title={notification.reason}
-          className={`inline-flex border px-2 py-1 text-[0.62rem] uppercase tracking-widest ${notificationToneClass[notification.tone]}`}
+          key={label}
+          className="inline-flex w-fit border border-border bg-background/40 px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted"
         >
-          {notification.label}
+          {label}
         </span>
       ))}
     </div>
   );
 }
 
-function NotificationActions({
+function RowActions({
   notifications,
-  fallbackHref,
-  fallbackLabel,
+  primaryHref,
+  primaryLabel,
 }: {
   notifications: DossierWorkflowNotification[];
-  fallbackHref: string;
-  fallbackLabel: string;
+  primaryHref: string;
+  primaryLabel: string;
 }) {
   const actionByKey = new Map<string, { label: string; href: string }>();
+  actionByKey.set(`${primaryLabel}:${primaryHref}`, {
+    label: primaryLabel,
+    href: primaryHref,
+  });
   for (const notification of notifications) {
     if (!notification.actionLabel || !notification.actionHref) continue;
     actionByKey.set(`${notification.actionLabel}:${notification.actionHref}`, {
@@ -218,16 +219,10 @@ function NotificationActions({
       href: notification.actionHref,
     });
   }
-  if (actionByKey.size === 0) {
-    actionByKey.set(`${fallbackLabel}:${fallbackHref}`, {
-      label: fallbackLabel,
-      href: fallbackHref,
-    });
-  }
   return (
     <div className="flex flex-wrap gap-2">
       {Array.from(actionByKey.values())
-        .slice(0, 3)
+        .slice(0, 4)
         .map((action) => (
           <Link
             key={`${action.label}:${action.href}`}
@@ -241,82 +236,12 @@ function NotificationActions({
   );
 }
 
-function identityBadgeForCandidate(candidate: DossierCandidate) {
-  const identityLinks = candidate.identityLinks ?? [];
-  const confirmed = identityLinks.filter(
+function confirmedAliasStatus(candidate: DossierCandidate) {
+  return (candidate.identityLinks ?? []).some(
     (link) => link.status === "confirmed",
-  ).length;
-  const pending = identityLinks.filter(
-    (link) => link.status === "proposed",
-  ).length;
-
-  if (candidate.identityReviewStatus === "needs_confirmation") {
-    return candidate.possibleMatchCandidateIds?.length
-      ? `Possible match to ${candidate.possibleMatchCandidateIds.length} subject${
-          candidate.possibleMatchCandidateIds.length === 1 ? "" : "s"
-        }`
-      : "Identity: Needs Confirmation";
-  }
-  if (pending > 0) {
-    return "Identity: Needs Confirmation";
-  }
-  if (confirmed > 0) {
-    return "Identity: Connected to Existing Subject";
-  }
-  if (candidate.existingDossierMatch) {
-    return "Existing Dossier Match";
-  }
-  if (
-    candidate.duplicateRisk === "medium" ||
-    candidate.duplicateRisk === "high"
-  ) {
-    return "Possible Duplicate";
-  }
-  if (candidate.duplicateRisk === "low") {
-    return "Identity: Possible Match";
-  }
-  return "Identity: Clear";
-}
-
-function identityBadgeForRecommendation(
-  recommendation: DossierRecommendation,
-  matchState: { state: string; nextAction: string },
-) {
-  if (recommendation.identityReviewStatus === "needs_confirmation") {
-    return recommendation.possibleMatchCandidateIds?.length
-      ? `Possible match to ${recommendation.possibleMatchCandidateIds.length} subject${
-          recommendation.possibleMatchCandidateIds.length === 1 ? "" : "s"
-        }`
-      : "Identity: Needs Confirmation";
-  }
-  if (recommendation.type === "identity_link") {
-    return "Identity: Needs Confirmation";
-  }
-  if (matchState.state === "possible_identity_link") {
-    return "Identity: Possible Match";
-  }
-  if (matchState.state === "existing_candidate") {
-    return "Identity: Connected to Existing Subject";
-  }
-  return "Identity: Clear";
-}
-
-function dossierStatusForCandidate(
-  candidate: DossierCandidate,
-  draft?: DossierDraft,
-) {
-  if (draft?.status === "ready_for_owner_review")
-    return "Ready for Owner Review";
-  if (draft?.status === "owner_changes_requested")
-    return "Owner changes requested";
-  if (draft?.status === "owner_approved") return "Approved / publish later";
-  if (draft) return "Draft started";
-  if (
-    (candidate.sourceFileNotes ?? []).some((note) => note.status === "active")
-  ) {
-    return "Needs update from Source File";
-  }
-  return "No Proposed Dossier";
+  )
+    ? "Confirmed aliases"
+    : "No known match";
 }
 
 function firstListValue(values?: string[]) {
@@ -331,16 +256,12 @@ function recommendationActionLabel() {
   return "Review Candidate";
 }
 
-function dossierUpdateActionLabel() {
-  return "Review Update";
-}
-
 function sourceFileActionLabel() {
   return "Open Source File";
 }
 
 function archiveActionLabel() {
-  return "Review Record";
+  return "Open Source File";
 }
 
 function DashboardCard({
@@ -997,16 +918,14 @@ export default function DossierControlCenterPage() {
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
                     <th className="py-2 pr-3">Subject</th>
-                    <th className="py-2 pr-3">Why BNL noticed</th>
-                    <th className="py-2 pr-3">Strength / confidence</th>
-                    <th className="py-2 pr-3">Identity status</th>
-                    <th className="py-2 pr-3">Suggested next step</th>
-                    <th className="py-2 pr-3">Action</th>
+                    <th className="py-2 pr-3">Signal</th>
+                    <th className="py-2 pr-3">Identity / Match</th>
+                    <th className="py-2 pr-3">Dossier / Source Status</th>
+                    <th className="py-2 pr-3">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {activeCandidateRecommendations.map((recommendation) => {
-                    const matchState = recommendationMatchState(recommendation);
                     const notifications = buildRecommendationNotifications(
                       recommendation,
                       notificationContext,
@@ -1018,7 +937,6 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {recommendation.subjectName}
-                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
                           {recommendation.reason ||
@@ -1026,26 +944,31 @@ export default function DossierControlCenterPage() {
                             recommendationProvenance(recommendation)}
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.confidence ?? "unset"}
-                        </td>
-                        <td className="py-3 pr-3">
-                          <StatusPill>
-                            {identityBadgeForRecommendation(
-                              recommendation,
-                              matchState,
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "possible-identity-link",
+                                "existing-source-file-match",
+                              ],
+                              "No known match",
                             )}
-                          </StatusPill>
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.routingReason ||
-                            recommendation.suggestedAction ||
-                            matchState.nextAction}
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              ["existing-live-dossier-match"],
+                              "No Proposed Dossier",
+                            )}
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          <NotificationActions
+                          <RowActions
                             notifications={notifications}
-                            fallbackHref={`/admin/dossiers/recommendations/${recommendation.id}`}
-                            fallbackLabel={recommendationActionLabel()}
+                            primaryHref={`/admin/dossiers/recommendations/${recommendation.id}`}
+                            primaryLabel={recommendationActionLabel()}
                           />
                         </td>
                       </tr>
@@ -1063,7 +986,6 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {candidate.name}
-                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
                           {candidate.whyNow ||
@@ -1071,23 +993,34 @@ export default function DossierControlCenterPage() {
                             candidateProvenance(candidate)}
                         </td>
                         <td className="py-3 pr-3">
-                          {candidate.confidence ?? candidate.tier} / score{" "}
-                          {candidate.score}
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "possible-identity-link",
+                                "existing-source-file-match",
+                              ],
+                              confirmedAliasStatus(candidate),
+                            )}
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          <StatusPill>
-                            {identityBadgeForCandidate(candidate)}
-                          </StatusPill>
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "existing-live-dossier-match",
+                                "bnl-signal-attached",
+                              ],
+                              "No Proposed Dossier",
+                            )}
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          {candidate.routingReason ||
-                            "Promote to Source File or archive from the detail page."}
-                        </td>
-                        <td className="py-3 pr-3">
-                          <NotificationActions
+                          <RowActions
                             notifications={notifications}
-                            fallbackHref={`/admin/dossiers/candidates/${candidate.id}`}
-                            fallbackLabel={candidateActionLabel()}
+                            primaryHref={`/admin/dossiers/candidates/${candidate.id}`}
+                            primaryLabel={candidateActionLabel()}
                           />
                         </td>
                       </tr>
@@ -1114,26 +1047,14 @@ export default function DossierControlCenterPage() {
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
                     <th className="py-2 pr-3">Subject</th>
-                    <th className="py-2 pr-3">
-                      Why they matter / engagement summary
-                    </th>
-                    <th className="py-2 pr-3">Source strength</th>
-                    <th className="py-2 pr-3">Missing info</th>
-                    <th className="py-2 pr-3">Dossier status</th>
-                    <th className="py-2 pr-3">Identity status</th>
-                    <th className="py-2 pr-3">Last updated</th>
-                    <th className="py-2 pr-3">Action</th>
+                    <th className="py-2 pr-3">Source File Status</th>
+                    <th className="py-2 pr-3">Dossier Status</th>
+                    <th className="py-2 pr-3">Identity / Match</th>
+                    <th className="py-2 pr-3">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {sourceFileRows.map((candidate) => {
-                    const draft = linkedActiveDraftFor(candidate, drafts);
-                    const metrics = sourceFileMetrics.get(candidate.id);
-                    const dossierStatus = dossierStatusForCandidate(
-                      candidate,
-                      draft,
-                    );
-                    const actionLabel = sourceFileActionLabel();
                     const actionHref = `/admin/dossiers/candidates/${candidate.id}`;
                     const notifications = buildSourceFileNotifications(
                       candidate,
@@ -1146,38 +1067,53 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {candidate.name}
-                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
-                          {candidate.sourceFileSummary?.summaryText ||
-                            candidate.evidenceSummary ||
-                            candidate.reason ||
-                            "—"}
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "system-record",
+                                "bnl-archive-available",
+                                "missing-info",
+                                "new-bnl-signal",
+                              ],
+                              "Active Source File",
+                            )}
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          {metrics?.sourceDepth ??
-                            candidate.confidence ??
-                            "Low"}
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "live-dossier-exists",
+                                "owner-review-ready",
+                                "draft-in-progress",
+                                "draft-revision",
+                              ],
+                              "No Proposed Dossier",
+                            )}
+                          />
                         </td>
                         <td className="py-3 pr-3">
-                          {(candidate.missingInfo ?? []).length > 0
-                            ? candidate.missingInfo?.join("; ")
-                            : "—"}
+                          <RowStatusList
+                            labels={uniqueStatusLabels(
+                              notifications,
+                              [
+                                "possible-identity-link",
+                                "identity-review-pending",
+                                "existing-source-file-match",
+                              ],
+                              confirmedAliasStatus(candidate),
+                            )}
+                          />
                         </td>
-                        <td className="py-3 pr-3">{dossierStatus}</td>
                         <td className="py-3 pr-3">
-                          <StatusPill>
-                            {identityBadgeForCandidate(candidate)}
-                          </StatusPill>
-                        </td>
-                        <td className="py-3 pr-3">
-                          {formatDate(candidate.updatedAt)}
-                        </td>
-                        <td className="py-3 pr-3">
-                          <NotificationActions
+                          <RowActions
                             notifications={notifications}
-                            fallbackHref={actionHref}
-                            fallbackLabel={actionLabel}
+                            primaryHref={actionHref}
+                            primaryLabel={sourceFileActionLabel()}
                           />
                         </td>
                       </tr>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -10,6 +10,13 @@ import {
   type DossierDuplicateGroup,
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
+import {
+  buildCandidateNotifications,
+  buildRecommendationNotifications,
+  buildSourceFileNotifications,
+  type DossierWorkflowNotification,
+  type DossierWorkflowNotificationTone,
+} from "@/lib/dossier-workflow-notifications";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -60,6 +67,7 @@ const activeCandidateStatuses = new Set<DossierCandidate["status"]>([
 const activeDraftStatuses = new Set<DossierDraft["status"]>([
   "draft",
   "owner_changes_requested",
+  "ready_for_owner_review",
 ]);
 const closedDraftStatuses = new Set<DossierDraft["status"]>([
   "denied",
@@ -160,6 +168,75 @@ function StatusPill({ children }: { children: React.ReactNode }) {
     <span className="border border-border bg-background/40 px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted">
       {children}
     </span>
+  );
+}
+
+const notificationToneClass: Record<DossierWorkflowNotificationTone, string> = {
+  info: "border-accent/50 bg-accent/10 text-accent",
+  warning: "border-yellow-400/50 bg-yellow-400/10 text-yellow-200",
+  success: "border-emerald-400/50 bg-emerald-400/10 text-emerald-200",
+  danger: "border-red-400/50 bg-red-400/10 text-red-200",
+  muted: "border-border bg-background/40 text-muted",
+};
+
+function NotificationChips({
+  notifications,
+}: {
+  notifications: DossierWorkflowNotification[];
+}) {
+  if (notifications.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      {notifications.map((notification) => (
+        <span
+          key={notification.id}
+          title={notification.reason}
+          className={`inline-flex border px-2 py-1 text-[0.62rem] uppercase tracking-widest ${notificationToneClass[notification.tone]}`}
+        >
+          {notification.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function NotificationActions({
+  notifications,
+  fallbackHref,
+  fallbackLabel,
+}: {
+  notifications: DossierWorkflowNotification[];
+  fallbackHref: string;
+  fallbackLabel: string;
+}) {
+  const actionByKey = new Map<string, { label: string; href: string }>();
+  for (const notification of notifications) {
+    if (!notification.actionLabel || !notification.actionHref) continue;
+    actionByKey.set(`${notification.actionLabel}:${notification.actionHref}`, {
+      label: notification.actionLabel,
+      href: notification.actionHref,
+    });
+  }
+  if (actionByKey.size === 0) {
+    actionByKey.set(`${fallbackLabel}:${fallbackHref}`, {
+      label: fallbackLabel,
+      href: fallbackHref,
+    });
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {Array.from(actionByKey.values())
+        .slice(0, 3)
+        .map((action) => (
+          <Link
+            key={`${action.label}:${action.href}`}
+            href={action.href}
+            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+          >
+            {action.label}
+          </Link>
+        ))}
+    </div>
   );
 }
 
@@ -384,6 +461,7 @@ export default function DossierControlCenterPage() {
   const existingDossierUpdates = candidates.filter(
     (candidate) => candidate.status === "existing_dossier_update",
   );
+  const sourceFileRows = [...activeCandidates, ...existingDossierUpdates];
   const archivedCandidates = candidates.filter(
     (candidate) => candidate.status === "archived",
   );
@@ -439,6 +517,13 @@ export default function DossierControlCenterPage() {
     closedCandidates.length +
     closedDrafts.length +
     terminalRecommendations.length;
+  const notificationContext = {
+    candidates,
+    drafts,
+    duplicateGroups,
+    recommendations,
+    publicDossiers,
+  };
 
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
@@ -678,7 +763,7 @@ export default function DossierControlCenterPage() {
               : action === "attachCandidateToExistingDossier"
                 ? `${candidate.name} attached to an existing public dossier target. Public dossier content was not changed.`
                 : action === "markCandidateAsExistingDossierUpdate"
-                  ? `${candidate.name} moved to Dossier Updates / Enrichment. Public dossier content was not changed.`
+                  ? `${candidate.name} moved to live dossier update review. Public dossier content was not changed.`
                   : `${candidate.name} promoted to a Case File / BNL Source File. Public dossiers were not changed.`;
       setNotice(actionNotice);
       if (data.candidates && data.drafts && data.workflow) {
@@ -761,7 +846,7 @@ export default function DossierControlCenterPage() {
                   activeCandidateRecommendations.length,
               ],
               [
-                "Dossier Updates",
+                "Live dossier update signals",
                 existingDossierUpdates.length +
                   activeDossierUpdateRecommendations.length,
               ],
@@ -919,6 +1004,10 @@ export default function DossierControlCenterPage() {
                 <tbody>
                   {activeCandidateRecommendations.map((recommendation) => {
                     const matchState = recommendationMatchState(recommendation);
+                    const notifications = buildRecommendationNotifications(
+                      recommendation,
+                      notificationContext,
+                    );
                     return (
                       <tr
                         key={recommendation.id}
@@ -926,6 +1015,7 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {recommendation.subjectName}
+                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
                           {recommendation.reason ||
@@ -949,183 +1039,57 @@ export default function DossierControlCenterPage() {
                             matchState.nextAction}
                         </td>
                         <td className="py-3 pr-3">
-                          <Link
-                            href={`/admin/dossiers/recommendations/${recommendation.id}`}
-                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                          >
-                            {recommendationActionLabel()}
-                          </Link>
+                          <NotificationActions
+                            notifications={notifications}
+                            fallbackHref={`/admin/dossiers/recommendations/${recommendation.id}`}
+                            fallbackLabel={recommendationActionLabel()}
+                          />
                         </td>
                       </tr>
                     );
                   })}
-                  {candidateIntakeItems.map((candidate) => (
-                    <tr
-                      key={candidate.id}
-                      className="border-t border-border/70 align-top"
-                    >
-                      <td className="py-3 pr-3 font-semibold text-foreground">
-                        {candidate.name}
-                      </td>
-                      <td className="py-3 pr-3">
-                        {candidate.whyNow ||
-                          candidate.reason ||
-                          candidateProvenance(candidate)}
-                      </td>
-                      <td className="py-3 pr-3">
-                        {candidate.confidence ?? candidate.tier} / score{" "}
-                        {candidate.score}
-                      </td>
-                      <td className="py-3 pr-3">
-                        <StatusPill>
-                          {identityBadgeForCandidate(candidate)}
-                        </StatusPill>
-                      </td>
-                      <td className="py-3 pr-3">
-                        {candidate.routingReason ||
-                          "Promote to Source File or archive from the detail page."}
-                      </td>
-                      <td className="py-3 pr-3">
-                        <Link
-                          href={`/admin/dossiers/candidates/${candidate.id}`}
-                          className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                        >
-                          {candidateActionLabel()}
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </DashboardCard>
-
-        <DashboardCard
-          eyebrow="Dossier Updates"
-          title="Dossier Updates"
-          aside={
-            <StatusPill>
-              {existingDossierUpdates.length +
-                activeDossierUpdateRecommendations.length}{" "}
-              updates
-            </StatusPill>
-          }
-        >
-          {existingDossierUpdates.length +
-            activeDossierUpdateRecommendations.length ===
-          0 ? (
-            <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
-              No existing dossier updates are waiting.
-            </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[820px] text-left text-sm text-muted">
-                <thead className="text-xs uppercase tracking-widest text-foreground">
-                  <tr>
-                    <th className="py-2 pr-3">
-                      Subject / public dossier target
-                    </th>
-                    <th className="py-2 pr-3">Update subject</th>
-                    <th className="py-2 pr-3">Why this update matters</th>
-                    <th className="py-2 pr-3">Match confidence</th>
-                    <th className="py-2 pr-3">Identity status</th>
-                    <th className="py-2 pr-3">Suggested next step</th>
-                    <th className="py-2 pr-3">Action</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activeDossierUpdateRecommendations.map((recommendation) => {
-                    const matchState = recommendationMatchState(recommendation);
-                    const targetCandidate = recommendation.targetCandidateId
-                      ? candidates.find(
-                          (candidate) =>
-                            candidate.id === recommendation.targetCandidateId,
-                        )
-                      : null;
+                  {candidateIntakeItems.map((candidate) => {
+                    const notifications = buildCandidateNotifications(
+                      candidate,
+                      notificationContext,
+                    );
                     return (
                       <tr
-                        key={recommendation.id}
+                        key={candidate.id}
                         className="border-t border-border/70 align-top"
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
-                          {targetCandidate?.name ??
-                            recommendation.targetDossierId ??
-                            recommendation.subjectName}
+                          {candidate.name}
+                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.subjectName}
+                          {candidate.whyNow ||
+                            candidate.reason ||
+                            candidateProvenance(candidate)}
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.reason ||
-                            recommendation.evidenceSummary ||
-                            recommendationProvenance(recommendation)}
-                        </td>
-                        <td className="py-3 pr-3">
-                          {recommendation.confidence ?? "needs review"}
+                          {candidate.confidence ?? candidate.tier} / score{" "}
+                          {candidate.score}
                         </td>
                         <td className="py-3 pr-3">
                           <StatusPill>
-                            {identityBadgeForRecommendation(
-                              recommendation,
-                              matchState,
-                            )}
+                            {identityBadgeForCandidate(candidate)}
                           </StatusPill>
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.suggestedAction ||
-                            "Review update details before attaching anywhere public."}
+                          {candidate.routingReason ||
+                            "Promote to Source File or archive from the detail page."}
                         </td>
                         <td className="py-3 pr-3">
-                          <Link
-                            href={`/admin/dossiers/recommendations/${recommendation.id}`}
-                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                          >
-                            {dossierUpdateActionLabel()}
-                          </Link>
+                          <NotificationActions
+                            notifications={notifications}
+                            fallbackHref={`/admin/dossiers/candidates/${candidate.id}`}
+                            fallbackLabel={candidateActionLabel()}
+                          />
                         </td>
                       </tr>
                     );
                   })}
-                  {existingDossierUpdates.map((candidate) => (
-                    <tr
-                      key={candidate.id}
-                      className="border-t border-border/70 align-top"
-                    >
-                      <td className="py-3 pr-3 font-semibold text-foreground">
-                        {candidate.existingDossierMatch?.name ?? candidate.name}
-                      </td>
-                      <td className="py-3 pr-3">{candidate.name}</td>
-                      <td className="py-3 pr-3">
-                        {candidate.whyNow ||
-                          candidate.reason ||
-                          firstListValue(candidate.knownFacts)}
-                      </td>
-                      <td className="py-3 pr-3">
-                        {candidate.existingDossierMatch?.confidence ??
-                          candidate.confidence ??
-                          "needs review"}
-                      </td>
-                      <td className="py-3 pr-3">
-                        <StatusPill>
-                          {candidate.existingDossierMatch
-                            ? identityBadgeForCandidate(candidate)
-                            : "Identity: Needs Confirmation"}
-                        </StatusPill>
-                      </td>
-                      <td className="py-3 pr-3">
-                        Review update details before attaching anywhere public.
-                      </td>
-                      <td className="py-3 pr-3">
-                        <Link
-                          href={`/admin/dossiers/candidates/${candidate.id}`}
-                          className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                        >
-                          {dossierUpdateActionLabel()}
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
                 </tbody>
               </table>
             </div>
@@ -1135,9 +1099,9 @@ export default function DossierControlCenterPage() {
         <DashboardCard
           eyebrow="Source Files"
           title="Source Files"
-          aside={<StatusPill>{activeCandidates.length} active</StatusPill>}
+          aside={<StatusPill>{sourceFileRows.length} active</StatusPill>}
         >
-          {activeCandidates.length === 0 ? (
+          {sourceFileRows.length === 0 ? (
             <p className="text-sm text-muted border border-border/70 bg-background/30 p-4">
               No active Source Files need review.
             </p>
@@ -1159,11 +1123,8 @@ export default function DossierControlCenterPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {activeCandidates.map((candidate) => {
+                  {sourceFileRows.map((candidate) => {
                     const draft = linkedActiveDraftFor(candidate, drafts);
-                    const createdDraftId =
-                      createdDraftIdByCandidate[candidate.id];
-                    const openDraftId = draft?.id ?? createdDraftId;
                     const metrics = sourceFileMetrics.get(candidate.id);
                     const dossierStatus = dossierStatusForCandidate(
                       candidate,
@@ -1171,6 +1132,10 @@ export default function DossierControlCenterPage() {
                     );
                     const actionLabel = sourceFileActionLabel();
                     const actionHref = `/admin/dossiers/candidates/${candidate.id}`;
+                    const notifications = buildSourceFileNotifications(
+                      candidate,
+                      notificationContext,
+                    );
                     return (
                       <tr
                         key={candidate.id}
@@ -1178,6 +1143,7 @@ export default function DossierControlCenterPage() {
                       >
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {candidate.name}
+                          <NotificationChips notifications={notifications} />
                         </td>
                         <td className="py-3 pr-3">
                           {candidate.sourceFileSummary?.summaryText ||
@@ -1205,12 +1171,11 @@ export default function DossierControlCenterPage() {
                           {formatDate(candidate.updatedAt)}
                         </td>
                         <td className="py-3 pr-3">
-                          <Link
-                            href={actionHref}
-                            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-                          >
-                            {actionLabel}
-                          </Link>
+                          <NotificationActions
+                            notifications={notifications}
+                            fallbackHref={actionHref}
+                            fallbackLabel={actionLabel}
+                          />
                         </td>
                       </tr>
                     );

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -14,6 +14,7 @@ import {
   buildCandidateNotifications,
   buildRecommendationNotifications,
   buildSourceFileNotifications,
+  isLiveDossierUpdateRecommendation,
   type DossierWorkflowNotification,
   type DossierWorkflowNotificationTone,
 } from "@/lib/dossier-workflow-notifications";
@@ -434,13 +435,15 @@ export default function DossierControlCenterPage() {
   );
   const activeDossierUpdateRecommendations = activeRecommendations.filter(
     (recommendation) =>
-      recommendation.type === "modify_existing_dossier" ||
-      Boolean(recommendation.targetDossierId) ||
-      Boolean(recommendation.targetCandidateId),
+      isLiveDossierUpdateRecommendation(recommendation, {
+        candidates,
+        publicDossiers,
+      }),
   );
   const activeCandidateRecommendations = activeRecommendations.filter(
     (recommendation) =>
-      !activeDossierUpdateRecommendations.includes(recommendation),
+      !activeDossierUpdateRecommendations.includes(recommendation) &&
+      !recommendation.targetCandidateId,
   );
   const terminalRecommendations = recommendations.filter((recommendation) =>
     [

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -953,6 +953,7 @@ export default function DossierControlCenterPage() {
                               notifications,
                               [
                                 "possible-identity-link",
+                                "possible-duplicate",
                                 "existing-source-file-match",
                               ],
                               "No known match",
@@ -1002,6 +1003,7 @@ export default function DossierControlCenterPage() {
                               notifications,
                               [
                                 "possible-identity-link",
+                                "possible-duplicate",
                                 "existing-source-file-match",
                               ],
                               confirmedAliasStatus(candidate),
@@ -1107,6 +1109,7 @@ export default function DossierControlCenterPage() {
                               [
                                 "possible-identity-link",
                                 "identity-review-pending",
+                                "possible-duplicate",
                                 "existing-source-file-match",
                               ],
                               confirmedAliasStatus(candidate),

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -9,12 +9,16 @@ import {
   type DossierDraft,
   type DossierDuplicateGroup,
   type DossierRecommendation,
+  type DossierSourceFileRefreshRequest,
 } from "@/lib/dossier-workflow";
 import {
   buildCandidateNotifications,
   buildRecommendationNotifications,
   buildSourceFileNotifications,
+  dedupeDossierDashboardActions,
   isLiveDossierUpdateRecommendation,
+  sourceFileFocusHref,
+  type DossierDashboardAction,
   type DossierWorkflowNotification,
 } from "@/lib/dossier-workflow-notifications";
 
@@ -37,6 +41,7 @@ type WorkflowPayload = {
   authoringGuide?: { version: string };
   tagRegistry?: { totalUniqueTags: number; totalTagAssignments: number };
   publicDossiers?: Array<{ id: string; name: string }>;
+  sourceFileRefreshRequests?: DossierSourceFileRefreshRequest[];
 };
 
 type ManualRecommendationForm = {
@@ -198,40 +203,37 @@ function RowStatusList({ labels }: { labels: string[] }) {
   );
 }
 
-function RowActions({
-  notifications,
-  primaryHref,
-  primaryLabel,
-}: {
-  notifications: DossierWorkflowNotification[];
-  primaryHref: string;
-  primaryLabel: string;
-}) {
-  const actionByKey = new Map<string, { label: string; href: string }>();
-  actionByKey.set(`${primaryLabel}:${primaryHref}`, {
-    label: primaryLabel,
-    href: primaryHref,
-  });
-  for (const notification of notifications) {
-    if (!notification.actionLabel || !notification.actionHref) continue;
-    actionByKey.set(`${notification.actionLabel}:${notification.actionHref}`, {
-      label: notification.actionLabel,
-      href: notification.actionHref,
-    });
-  }
+function notificationActions(
+  notifications: DossierWorkflowNotification[],
+): DossierDashboardAction[] {
+  return notifications
+    .filter(
+      (notification) =>
+        notification.actionLabel &&
+        notification.actionHref &&
+        notification.actionDestinationKey,
+    )
+    .map((notification) => ({
+      label: notification.actionLabel ?? "Open Source File",
+      href: notification.actionHref ?? "#",
+      destinationKey: notification.actionDestinationKey ?? notification.id,
+      group: notification.actionGroup,
+    }));
+}
+
+function RowActions({ actions }: { actions: DossierDashboardAction[] }) {
+  const dedupedActions = dedupeDossierDashboardActions(actions);
   return (
     <div className="flex flex-wrap gap-2">
-      {Array.from(actionByKey.values())
-        .slice(0, 4)
-        .map((action) => (
-          <Link
-            key={`${action.label}:${action.href}`}
-            href={action.href}
-            className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
-          >
-            {action.label}
-          </Link>
-        ))}
+      {dedupedActions.map((action) => (
+        <Link
+          key={`${action.destinationKey}:${action.href}`}
+          href={action.href}
+          className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+        >
+          {action.label}
+        </Link>
+      ))}
     </div>
   );
 }
@@ -451,6 +453,7 @@ export default function DossierControlCenterPage() {
     duplicateGroups,
     recommendations,
     publicDossiers,
+    sourceFileRefreshRequests: payload?.sourceFileRefreshRequests ?? [],
   };
 
   async function postWorkflow(body: Record<string, unknown>) {
@@ -971,9 +974,15 @@ export default function DossierControlCenterPage() {
                         </td>
                         <td className="py-3 pr-3">
                           <RowActions
-                            notifications={notifications}
-                            primaryHref={`/admin/dossiers/recommendations/${recommendation.id}`}
-                            primaryLabel={recommendationActionLabel()}
+                            actions={[
+                              {
+                                label: recommendationActionLabel(),
+                                href: `/admin/dossiers/recommendations/${recommendation.id}`,
+                                destinationKey: "candidate-signal",
+                                group: "primary",
+                              },
+                              ...notificationActions(notifications),
+                            ]}
                           />
                         </td>
                       </tr>
@@ -1024,9 +1033,15 @@ export default function DossierControlCenterPage() {
                         </td>
                         <td className="py-3 pr-3">
                           <RowActions
-                            notifications={notifications}
-                            primaryHref={`/admin/dossiers/candidates/${candidate.id}`}
-                            primaryLabel={candidateActionLabel()}
+                            actions={[
+                              {
+                                label: candidateActionLabel(),
+                                href: sourceFileFocusHref(candidate.id, "overview"),
+                                destinationKey: "source-file-overview",
+                                group: "primary",
+                              },
+                              ...notificationActions(notifications),
+                            ]}
                           />
                         </td>
                       </tr>
@@ -1061,7 +1076,7 @@ export default function DossierControlCenterPage() {
                 </thead>
                 <tbody>
                   {sourceFileRows.map((candidate) => {
-                    const actionHref = `/admin/dossiers/candidates/${candidate.id}`;
+                    const actionHref = sourceFileFocusHref(candidate.id, "overview");
                     const notifications = buildSourceFileNotifications(
                       candidate,
                       notificationContext,
@@ -1118,9 +1133,15 @@ export default function DossierControlCenterPage() {
                         </td>
                         <td className="py-3 pr-3">
                           <RowActions
-                            notifications={notifications}
-                            primaryHref={actionHref}
-                            primaryLabel={sourceFileActionLabel()}
+                            actions={[
+                              {
+                                label: sourceFileActionLabel(),
+                                href: actionHref,
+                                destinationKey: "source-file-overview",
+                                group: "primary",
+                              },
+                              ...notificationActions(notifications),
+                            ]}
                           />
                         </td>
                       </tr>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -260,8 +260,12 @@ function sourceFileActionLabel() {
   return "Open Source File";
 }
 
-function archiveActionLabel() {
+function archivedCandidateActionLabel() {
   return "Open Source File";
+}
+
+function archivedSignalActionLabel() {
+  return "Open Archived Signal";
 }
 
 function DashboardCard({
@@ -1159,7 +1163,7 @@ export default function DossierControlCenterPage() {
                       href={`/admin/dossiers/candidates/${candidate.id}`}
                       className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      {archiveActionLabel()}
+                      {archivedCandidateActionLabel()}
                     </Link>
                   </div>
                 </article>
@@ -1184,7 +1188,7 @@ export default function DossierControlCenterPage() {
                       href={`/admin/dossiers/recommendations/${recommendation.id}`}
                       className="inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
                     >
-                      {archiveActionLabel()}
+                      {archivedSignalActionLabel()}
                     </Link>
                   </div>
                 </article>

--- a/src/lib/dossier-workflow-notifications.ts
+++ b/src/lib/dossier-workflow-notifications.ts
@@ -188,7 +188,7 @@ export function buildCandidateNotifications(
       label: "Possible identity link",
       tone: "warning",
       reason: "Review before confirming aliases or routing future signals.",
-      actionLabel: "Review Match",
+      actionLabel: "Review Identity Links",
       actionHref: candidateHref,
     });
   }
@@ -196,9 +196,9 @@ export function buildCandidateNotifications(
   if (candidate.connectedSourceFileCandidateId) {
     pushUnique(notifications, {
       id: "existing-source-file-match",
-      label: "Existing Source File match",
+      label: "Existing Source File linked",
       tone: "info",
-      actionLabel: "Open Matched Source File",
+      actionLabel: "Open Source File",
       actionHref: `/admin/dossiers/candidates/${candidate.connectedSourceFileCandidateId}`,
     });
   }
@@ -206,40 +206,11 @@ export function buildCandidateNotifications(
   if (hasLiveDossierMatch(candidate, context.publicDossiers)) {
     pushUnique(notifications, {
       id: "existing-live-dossier-match",
-      label: "Existing live dossier match",
+      label: "Live dossier exists",
       tone: "info",
-      actionLabel: "Review as Live Dossier Update",
-      actionHref: candidateHref,
-    });
-  }
-
-  if (
-    candidate.duplicateRisk === "medium" ||
-    candidate.duplicateRisk === "high" ||
-    hasActiveDuplicateGroup(
-      candidate,
-      context.candidates,
-      context.duplicateGroups,
-    )
-  ) {
-    pushUnique(notifications, {
-      id: "possible-duplicate",
-      label: "Possible duplicate",
-      tone: candidate.duplicateRisk === "high" ? "danger" : "warning",
-      actionLabel: "Review Match",
-      actionHref: candidateHref,
-    });
-  }
-
-  if (isReviewOnlySignal(candidate)) {
-    pushUnique(notifications, {
-      id: "low-confidence-review-only",
-      label: "Low confidence / review-only",
-      tone: "muted",
-      reason:
-        "Keep evidence in admin review until public-safe material is selected.",
-      actionLabel: "Review Candidate",
-      actionHref: candidateHref,
+      actionLabel: "Open Live Dossier",
+      actionHref:
+        liveDossierHref(candidate, context.publicDossiers) ?? candidateHref,
     });
   }
 
@@ -249,7 +220,7 @@ export function buildCandidateNotifications(
   ) {
     pushUnique(notifications, {
       id: "bnl-signal-attached",
-      label: "BNL signal attached",
+      label: "New BNL signals attached",
       tone: "info",
       reason:
         "Review-only signal; it does not publish or create drafts by itself.",
@@ -276,7 +247,7 @@ export function buildRecommendationNotifications(
       id: "possible-identity-link",
       label: "Possible identity link",
       tone: "warning",
-      actionLabel: "Review Match",
+      actionLabel: "Review Identity Links",
       actionHref: recommendationHref,
     });
   }
@@ -290,9 +261,9 @@ export function buildRecommendationNotifications(
       recommendation.targetCandidateId;
     pushUnique(notifications, {
       id: "existing-source-file-match",
-      label: "Existing Source File match",
+      label: "Existing Source File linked",
       tone: "info",
-      actionLabel: "Open Matched Source File",
+      actionLabel: "Open Source File",
       actionHref: `/admin/dossiers/candidates/${candidateId}`,
     });
   }
@@ -305,23 +276,9 @@ export function buildRecommendationNotifications(
   ) {
     pushUnique(notifications, {
       id: "existing-live-dossier-match",
-      label: "Existing live dossier match",
+      label: "Live dossier exists",
       tone: "info",
-      actionLabel: "Review as Live Dossier Update",
-      actionHref: recommendationHref,
-    });
-  }
-
-  if (
-    recommendation.confidence === "low" ||
-    (recommendation.publicSafetyNotes ?? []).length > 0
-  ) {
-    pushUnique(notifications, {
-      id: "low-confidence-review-only",
-      label: "Low confidence / review-only",
-      tone: "muted",
-      reason: "BNL recommendations are review-only and do not publish.",
-      actionLabel: "Review Candidate",
+      actionLabel: "Open Live Dossier",
       actionHref: recommendationHref,
     });
   }
@@ -380,9 +337,9 @@ export function buildSourceFileNotifications(
   if (activeDraft && !readyDraft) {
     pushUnique(notifications, {
       id: "draft-in-progress",
-      label: "Draft in progress",
+      label: "Proposed Dossier in progress",
       tone: "info",
-      actionLabel: "Open Draft",
+      actionLabel: "Open Proposed Dossier",
       actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
     });
   }
@@ -390,7 +347,7 @@ export function buildSourceFileNotifications(
   if (readyDraft) {
     pushUnique(notifications, {
       id: "owner-review-ready",
-      label: "Owner Review ready",
+      label: "Proposed Dossier ready for Owner Review",
       tone: "success",
       actionLabel: "Owner Review",
       actionHref: "/admin/dossiers/owner-review",
@@ -400,11 +357,11 @@ export function buildSourceFileNotifications(
   if (hasNewSignal) {
     pushUnique(notifications, {
       id: "new-bnl-signal",
-      label: "New BNL signal",
+      label: "New BNL signals attached",
       tone: "info",
       reason:
         "Review-only signal; it does not publish or create Source Files automatically.",
-      actionLabel: "Review Updates",
+      actionLabel: "Open Source File",
       actionHref: candidateHref,
     });
   }
@@ -412,20 +369,20 @@ export function buildSourceFileNotifications(
   if (hasNewSignal && liveDossierExists) {
     pushUnique(notifications, {
       id: "live-dossier-update",
-      label: "Live dossier update?",
+      label: "Live dossier exists",
       tone: "warning",
       reason:
         "Only use for potential updates to an existing live/public dossier.",
-      actionLabel: "Review Updates",
+      actionLabel: "Open Source File",
       actionHref: candidateHref,
     });
   } else if (hasNewSignal && activeDraft) {
     pushUnique(notifications, {
       id: "draft-revision",
-      label: "Draft revision?",
+      label: "Proposed Dossier in progress",
       tone: "warning",
       reason: "Active Proposed Dossier change; not a live dossier update.",
-      actionLabel: "Open Draft",
+      actionLabel: "Open Proposed Dossier",
       actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
     });
   }
@@ -433,9 +390,9 @@ export function buildSourceFileNotifications(
   if (hasPossibleIdentityLink(candidate) || hasPendingIdentityLink(candidate)) {
     pushUnique(notifications, {
       id: "identity-review-pending",
-      label: "Identity review pending",
+      label: "Possible identity link",
       tone: "warning",
-      actionLabel: "Review Identity",
+      actionLabel: "Review Identity Links",
       actionHref: candidateHref,
     });
   }
@@ -448,7 +405,7 @@ export function buildSourceFileNotifications(
       id: "missing-info",
       label: "Missing info",
       tone: "warning",
-      actionLabel: "Review Missing Info",
+      actionLabel: "Open Source File",
       actionHref: candidateHref,
     });
   }

--- a/src/lib/dossier-workflow-notifications.ts
+++ b/src/lib/dossier-workflow-notifications.ts
@@ -1,0 +1,456 @@
+import type {
+  DossierCandidate,
+  DossierDraft,
+  DossierDuplicateGroup,
+  DossierRecommendation,
+} from "@/lib/dossier-workflow";
+
+export type DossierWorkflowNotificationTone =
+  | "info"
+  | "warning"
+  | "success"
+  | "danger"
+  | "muted";
+
+export type DossierWorkflowNotification = {
+  id: string;
+  label: string;
+  tone: DossierWorkflowNotificationTone;
+  reason?: string;
+  actionLabel?: string;
+  actionHref?: string;
+};
+
+export type DossierWorkflowPublicDossierRef = {
+  id: string;
+  name: string;
+};
+
+type NotificationContext = {
+  candidates?: DossierCandidate[];
+  recommendations?: DossierRecommendation[];
+  drafts?: DossierDraft[];
+  duplicateGroups?: DossierDuplicateGroup[];
+  publicDossiers?: DossierWorkflowPublicDossierRef[];
+};
+
+const activeRecommendationStatuses = new Set<DossierRecommendation["status"]>([
+  "new",
+  "reviewing",
+]);
+
+const activeDraftStatuses = new Set<DossierDraft["status"]>([
+  "draft",
+  "owner_changes_requested",
+  "ready_for_owner_review",
+]);
+
+const systemRecordPatterns = [
+  /\bbnl\b/i,
+  /barcode radio/i,
+  /tiktok/i,
+  /carl-bot logging/i,
+  /bnl-01_member_log/i,
+];
+
+function pushUnique(
+  notifications: DossierWorkflowNotification[],
+  notification: DossierWorkflowNotification,
+) {
+  if (!notifications.some((item) => item.id === notification.id)) {
+    notifications.push(notification);
+  }
+}
+
+function hasPossibleIdentityLink(
+  item: Pick<
+    DossierCandidate | DossierRecommendation,
+    "identityReviewStatus" | "possibleMatchCandidateIds"
+  >,
+) {
+  return (
+    item.identityReviewStatus === "needs_confirmation" ||
+    (item.possibleMatchCandidateIds ?? []).length > 0
+  );
+}
+
+function hasPendingIdentityLink(candidate: DossierCandidate) {
+  return (candidate.identityLinks ?? []).some(
+    (link) => link.status === "proposed",
+  );
+}
+
+function activeRecommendationsForCandidate(
+  candidate: DossierCandidate,
+  recommendations: DossierRecommendation[] = [],
+) {
+  const connectedIds = new Set(candidate.connectedRecommendationIds ?? []);
+  return recommendations.filter(
+    (recommendation) =>
+      activeRecommendationStatuses.has(recommendation.status) &&
+      (connectedIds.has(recommendation.id) ||
+        recommendation.targetCandidateId === candidate.id ||
+        recommendation.connectedCandidateId === candidate.id ||
+        recommendation.connectedSourceFileCandidateId === candidate.id),
+  );
+}
+
+function activeDraftsForCandidate(
+  candidate: DossierCandidate,
+  drafts: DossierDraft[] = [],
+) {
+  return drafts.filter(
+    (draft) =>
+      draft.candidateId === candidate.id &&
+      activeDraftStatuses.has(draft.status),
+  );
+}
+
+function hasLiveDossierMatch(
+  candidate: DossierCandidate,
+  publicDossiers: DossierWorkflowPublicDossierRef[] = [],
+) {
+  if (candidate.existingDossierMatch) return true;
+  const possibleIds = new Set(candidate.possibleMatchDossierIds ?? []);
+  return publicDossiers.some((dossier) => possibleIds.has(dossier.id));
+}
+
+function liveDossierHref(
+  candidate: DossierCandidate,
+  publicDossiers: DossierWorkflowPublicDossierRef[] = [],
+) {
+  const dossierId =
+    candidate.existingDossierMatch?.id ??
+    publicDossiers.find((dossier) =>
+      (candidate.possibleMatchDossierIds ?? []).includes(dossier.id),
+    )?.id;
+  return dossierId ? `/database/${dossierId}` : undefined;
+}
+
+function hasActiveDuplicateGroup(
+  candidate: DossierCandidate,
+  candidates: DossierCandidate[] = [],
+  duplicateGroups: DossierDuplicateGroup[] = [],
+) {
+  return duplicateGroups.some((group) => {
+    if (!group.candidateIds.includes(candidate.id)) return false;
+    return group.candidateIds.some((candidateId) => {
+      if (candidateId === candidate.id) return false;
+      const peer = candidates.find((item) => item.id === candidateId);
+      return peer && peer.status !== "denied" && peer.status !== "merged";
+    });
+  });
+}
+
+function isReviewOnlySignal(candidate: DossierCandidate) {
+  return (
+    candidate.confidence === "low" ||
+    candidate.source === "bnl_source_knowledge_bridge" ||
+    (candidate.publicSafetyNotes ?? []).length > 0 ||
+    (candidate.doNotSay ?? []).length > 0
+  );
+}
+
+function isSystemRecord(candidate: DossierCandidate) {
+  return (
+    candidate.candidateType === "interface" ||
+    candidate.candidateType === "production" ||
+    candidate.source === "bnl_source_file_enrichment" ||
+    systemRecordPatterns.some((pattern) => pattern.test(candidate.name))
+  );
+}
+
+export function buildCandidateNotifications(
+  candidate: DossierCandidate,
+  context: NotificationContext = {},
+): DossierWorkflowNotification[] {
+  const notifications: DossierWorkflowNotification[] = [];
+  const candidateHref = `/admin/dossiers/candidates/${candidate.id}`;
+
+  if (hasPossibleIdentityLink(candidate) || hasPendingIdentityLink(candidate)) {
+    pushUnique(notifications, {
+      id: "possible-identity-link",
+      label: "Possible identity link",
+      tone: "warning",
+      reason: "Review before confirming aliases or routing future signals.",
+      actionLabel: "Review Match",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (candidate.connectedSourceFileCandidateId) {
+    pushUnique(notifications, {
+      id: "existing-source-file-match",
+      label: "Existing Source File match",
+      tone: "info",
+      actionLabel: "Open Matched Source File",
+      actionHref: `/admin/dossiers/candidates/${candidate.connectedSourceFileCandidateId}`,
+    });
+  }
+
+  if (hasLiveDossierMatch(candidate, context.publicDossiers)) {
+    pushUnique(notifications, {
+      id: "existing-live-dossier-match",
+      label: "Existing live dossier match",
+      tone: "info",
+      actionLabel: "Review as Live Dossier Update",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (
+    candidate.duplicateRisk === "medium" ||
+    candidate.duplicateRisk === "high" ||
+    hasActiveDuplicateGroup(
+      candidate,
+      context.candidates,
+      context.duplicateGroups,
+    )
+  ) {
+    pushUnique(notifications, {
+      id: "possible-duplicate",
+      label: "Possible duplicate",
+      tone: candidate.duplicateRisk === "high" ? "danger" : "warning",
+      actionLabel: "Review Match",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (isReviewOnlySignal(candidate)) {
+    pushUnique(notifications, {
+      id: "low-confidence-review-only",
+      label: "Low confidence / review-only",
+      tone: "muted",
+      reason:
+        "Keep evidence in admin review until public-safe material is selected.",
+      actionLabel: "Review Candidate",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (
+    activeRecommendationsForCandidate(candidate, context.recommendations)
+      .length > 0
+  ) {
+    pushUnique(notifications, {
+      id: "bnl-signal-attached",
+      label: "BNL signal attached",
+      tone: "info",
+      reason:
+        "Review-only signal; it does not publish or create drafts by itself.",
+      actionLabel: "Review Candidate",
+      actionHref: candidateHref,
+    });
+  }
+
+  return notifications;
+}
+
+export function buildRecommendationNotifications(
+  recommendation: DossierRecommendation,
+  context: NotificationContext = {},
+): DossierWorkflowNotification[] {
+  const notifications: DossierWorkflowNotification[] = [];
+  const recommendationHref = `/admin/dossiers/recommendations/${recommendation.id}`;
+
+  if (
+    hasPossibleIdentityLink(recommendation) ||
+    recommendation.type === "identity_link"
+  ) {
+    pushUnique(notifications, {
+      id: "possible-identity-link",
+      label: "Possible identity link",
+      tone: "warning",
+      actionLabel: "Review Match",
+      actionHref: recommendationHref,
+    });
+  }
+
+  if (
+    recommendation.connectedSourceFileCandidateId ||
+    recommendation.targetCandidateId
+  ) {
+    const candidateId =
+      recommendation.connectedSourceFileCandidateId ??
+      recommendation.targetCandidateId;
+    pushUnique(notifications, {
+      id: "existing-source-file-match",
+      label: "Existing Source File match",
+      tone: "info",
+      actionLabel: "Open Matched Source File",
+      actionHref: `/admin/dossiers/candidates/${candidateId}`,
+    });
+  }
+
+  const hasPublicTarget =
+    Boolean(recommendation.targetDossierId) ||
+    context.publicDossiers?.some((dossier) =>
+      (recommendation.possibleMatchDossierIds ?? []).includes(dossier.id),
+    );
+  if (hasPublicTarget || recommendation.type === "modify_existing_dossier") {
+    pushUnique(notifications, {
+      id: "existing-live-dossier-match",
+      label: "Existing live dossier match",
+      tone: "info",
+      actionLabel: "Review as Live Dossier Update",
+      actionHref: recommendationHref,
+    });
+  }
+
+  if (
+    recommendation.confidence === "low" ||
+    (recommendation.publicSafetyNotes ?? []).length > 0
+  ) {
+    pushUnique(notifications, {
+      id: "low-confidence-review-only",
+      label: "Low confidence / review-only",
+      tone: "muted",
+      reason: "BNL recommendations are review-only and do not publish.",
+      actionLabel: "Review Candidate",
+      actionHref: recommendationHref,
+    });
+  }
+
+  return notifications;
+}
+
+export function buildSourceFileNotifications(
+  candidate: DossierCandidate,
+  context: NotificationContext = {},
+): DossierWorkflowNotification[] {
+  const notifications: DossierWorkflowNotification[] = [];
+  const candidateHref = `/admin/dossiers/candidates/${candidate.id}`;
+  const liveDossierExists = hasLiveDossierMatch(
+    candidate,
+    context.publicDossiers,
+  );
+  const activeDrafts = activeDraftsForCandidate(candidate, context.drafts);
+  const readyDraft = activeDrafts.find(
+    (draft) => draft.status === "ready_for_owner_review",
+  );
+  const activeDraft = activeDrafts[0];
+  const activeSignals = activeRecommendationsForCandidate(
+    candidate,
+    context.recommendations,
+  );
+  const hasNewSignal =
+    activeSignals.length > 0 ||
+    (candidate.sourceFileNotes ?? []).some(
+      (note) =>
+        note.status === "active" && note.source === "bnl_recommendation",
+    );
+
+  if (isSystemRecord(candidate)) {
+    pushUnique(notifications, {
+      id: "system-record",
+      label: "System record",
+      tone: "muted",
+      reason:
+        "Special/system Source File; do not treat as a normal person/community candidate.",
+      actionLabel: "Open Source File",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (liveDossierExists) {
+    pushUnique(notifications, {
+      id: "live-dossier-exists",
+      label: "Live dossier exists",
+      tone: "success",
+      actionLabel: "Open Live Dossier",
+      actionHref: liveDossierHref(candidate, context.publicDossiers),
+    });
+  }
+
+  if (activeDraft && !readyDraft) {
+    pushUnique(notifications, {
+      id: "draft-in-progress",
+      label: "Draft in progress",
+      tone: "info",
+      actionLabel: "Open Draft",
+      actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
+    });
+  }
+
+  if (readyDraft) {
+    pushUnique(notifications, {
+      id: "owner-review-ready",
+      label: "Owner Review ready",
+      tone: "success",
+      actionLabel: "Owner Review",
+      actionHref: "/admin/dossiers/owner-review",
+    });
+  }
+
+  if (hasNewSignal) {
+    pushUnique(notifications, {
+      id: "new-bnl-signal",
+      label: "New BNL signal",
+      tone: "info",
+      reason:
+        "Review-only signal; it does not publish or create Source Files automatically.",
+      actionLabel: "Review Updates",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (hasNewSignal && liveDossierExists) {
+    pushUnique(notifications, {
+      id: "live-dossier-update",
+      label: "Live dossier update?",
+      tone: "warning",
+      reason:
+        "Only use for potential updates to an existing live/public dossier.",
+      actionLabel: "Review Updates",
+      actionHref: candidateHref,
+    });
+  } else if (hasNewSignal && activeDraft) {
+    pushUnique(notifications, {
+      id: "draft-revision",
+      label: "Draft revision?",
+      tone: "warning",
+      reason: "Active Proposed Dossier change; not a live dossier update.",
+      actionLabel: "Open Draft",
+      actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
+    });
+  }
+
+  if (hasPossibleIdentityLink(candidate) || hasPendingIdentityLink(candidate)) {
+    pushUnique(notifications, {
+      id: "identity-review-pending",
+      label: "Identity review pending",
+      tone: "warning",
+      actionLabel: "Review Identity",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (
+    (candidate.missingInfo ?? []).length > 0 ||
+    candidate.status === "needs_more_evidence"
+  ) {
+    pushUnique(notifications, {
+      id: "missing-info",
+      label: "Missing info",
+      tone: "warning",
+      actionLabel: "Review Missing Info",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (
+    (candidate.sourceFileArchiveIds ?? []).length > 0 ||
+    Boolean(candidate.latestSourceFileArchiveId) ||
+    Boolean(candidate.latestSourceFileArchive)
+  ) {
+    pushUnique(notifications, {
+      id: "bnl-archive-available",
+      label: "BNL archive available",
+      tone: "info",
+      actionLabel: "Open Source File",
+      actionHref: candidateHref,
+    });
+  }
+
+  return notifications;
+}

--- a/src/lib/dossier-workflow-notifications.ts
+++ b/src/lib/dossier-workflow-notifications.ts
@@ -155,9 +155,24 @@ function isSystemRecord(candidate: DossierCandidate) {
   return (
     candidate.candidateType === "interface" ||
     candidate.candidateType === "production" ||
-    candidate.source === "bnl_source_file_enrichment" ||
     systemRecordPatterns.some((pattern) => pattern.test(candidate.name))
   );
+}
+
+export function isLiveDossierUpdateRecommendation(
+  recommendation: DossierRecommendation,
+  context: Pick<NotificationContext, "candidates" | "publicDossiers"> = {},
+) {
+  if (recommendation.type === "modify_existing_dossier") return true;
+  if (recommendation.targetDossierId) return true;
+  if (!recommendation.targetCandidateId) return false;
+
+  const targetCandidate = context.candidates?.find(
+    (candidate) => candidate.id === recommendation.targetCandidateId,
+  );
+  return targetCandidate
+    ? hasLiveDossierMatch(targetCandidate, context.publicDossiers)
+    : false;
 }
 
 export function buildCandidateNotifications(
@@ -282,12 +297,12 @@ export function buildRecommendationNotifications(
     });
   }
 
-  const hasPublicTarget =
-    Boolean(recommendation.targetDossierId) ||
+  if (
+    isLiveDossierUpdateRecommendation(recommendation, context) ||
     context.publicDossiers?.some((dossier) =>
       (recommendation.possibleMatchDossierIds ?? []).includes(dossier.id),
-    );
-  if (hasPublicTarget || recommendation.type === "modify_existing_dossier") {
+    )
+  ) {
     pushUnique(notifications, {
       id: "existing-live-dossier-match",
       label: "Existing live dossier match",

--- a/src/lib/dossier-workflow-notifications.ts
+++ b/src/lib/dossier-workflow-notifications.ts
@@ -1,8 +1,10 @@
-import type {
-  DossierCandidate,
-  DossierDraft,
-  DossierDuplicateGroup,
-  DossierRecommendation,
+import {
+  normalizeDossierSubjectName,
+  type DossierCandidate,
+  type DossierDraft,
+  type DossierDuplicateGroup,
+  type DossierRecommendation,
+  type DossierSourceFileRefreshRequest,
 } from "@/lib/dossier-workflow";
 
 export type DossierWorkflowNotificationTone =
@@ -19,7 +21,59 @@ export type DossierWorkflowNotification = {
   reason?: string;
   actionLabel?: string;
   actionHref?: string;
+  actionDestinationKey?: string;
+  actionGroup?: DossierDashboardAction["group"];
 };
+
+export type DossierSourceFileFocus =
+  | "overview"
+  | "identity"
+  | "missing-info"
+  | "signals"
+  | "archive"
+  | "dossier"
+  | "refresh";
+
+export const dossierSourceFileFocusSectionIds: Record<
+  DossierSourceFileFocus,
+  string
+> = {
+  overview: "source-file-overview",
+  identity: "source-file-identity",
+  "missing-info": "source-file-missing-info",
+  signals: "source-file-signals",
+  archive: "source-file-archive",
+  dossier: "source-file-dossier",
+  refresh: "source-file-refresh",
+};
+
+export type DossierDashboardAction = {
+  label: string;
+  href: string;
+  destinationKey: string;
+  group?: "primary" | "source-file" | "external" | "archive";
+};
+
+export function sourceFileFocusHref(
+  candidateId: string,
+  focus: DossierSourceFileFocus,
+) {
+  return `/admin/dossiers/candidates/${candidateId}?focus=${focus}`;
+}
+
+export function dedupeDossierDashboardActions(
+  actions: DossierDashboardAction[],
+) {
+  const byDestination = new Map<string, DossierDashboardAction>();
+  const exactHrefs = new Set<string>();
+  for (const action of actions) {
+    if (!action.href || exactHrefs.has(action.href)) continue;
+    if (byDestination.has(action.destinationKey)) continue;
+    byDestination.set(action.destinationKey, action);
+    exactHrefs.add(action.href);
+  }
+  return Array.from(byDestination.values());
+}
 
 export type DossierWorkflowPublicDossierRef = {
   id: string;
@@ -32,6 +86,7 @@ type NotificationContext = {
   drafts?: DossierDraft[];
   duplicateGroups?: DossierDuplicateGroup[];
   publicDossiers?: DossierWorkflowPublicDossierRef[];
+  sourceFileRefreshRequests?: DossierSourceFileRefreshRequest[];
 };
 
 const activeRecommendationStatuses = new Set<DossierRecommendation["status"]>([
@@ -52,6 +107,48 @@ const systemRecordPatterns = [
   /carl-bot logging/i,
   /bnl-01_member_log/i,
 ];
+
+
+function focusAction(
+  candidateId: string,
+  focus: DossierSourceFileFocus,
+  label: string,
+): Pick<
+  DossierWorkflowNotification,
+  "actionLabel" | "actionHref" | "actionDestinationKey" | "actionGroup"
+> {
+  return {
+    actionLabel: label,
+    actionHref: sourceFileFocusHref(candidateId, focus),
+    actionDestinationKey: dossierSourceFileFocusSectionIds[focus],
+    actionGroup: "source-file",
+  };
+}
+
+function latestRefreshRequestForCandidate(
+  candidate: DossierCandidate,
+  requests: DossierSourceFileRefreshRequest[] = [],
+) {
+  const normalizedSubjectKey = normalizeDossierSubjectName(candidate.name);
+  return requests
+    .filter(
+      (request) =>
+        request.candidateId === candidate.id ||
+        request.normalizedSubjectKey === normalizedSubjectKey,
+    )
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+}
+
+function hasRefreshStatusForDashboard(
+  candidate: DossierCandidate,
+  requests: DossierSourceFileRefreshRequest[] = [],
+) {
+  const latestRequest = latestRefreshRequestForCandidate(candidate, requests);
+  return Boolean(
+    latestRequest &&
+      (latestRequest.status === "failed" || latestRequest.status === "skipped"),
+  );
+}
 
 function pushUnique(
   notifications: DossierWorkflowNotification[],
@@ -195,7 +292,7 @@ export function buildCandidateNotifications(
   context: NotificationContext = {},
 ): DossierWorkflowNotification[] {
   const notifications: DossierWorkflowNotification[] = [];
-  const candidateHref = `/admin/dossiers/candidates/${candidate.id}`;
+  const candidateHref = sourceFileFocusHref(candidate.id, "overview");
 
   if (hasPossibleIdentityLink(candidate) || hasPendingIdentityLink(candidate)) {
     pushUnique(notifications, {
@@ -203,8 +300,7 @@ export function buildCandidateNotifications(
       label: "Possible identity link",
       tone: "warning",
       reason: "Review before confirming aliases or routing future signals.",
-      actionLabel: "Review Identity Links",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "identity", "Review Identity Links"),
     });
   }
 
@@ -213,8 +309,7 @@ export function buildCandidateNotifications(
       id: "possible-duplicate",
       label: "Possible duplicate",
       tone: "warning",
-      actionLabel: "Review Identity Links",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "identity", "Review Identity Links"),
     });
   }
 
@@ -223,8 +318,13 @@ export function buildCandidateNotifications(
       id: "existing-source-file-match",
       label: "Existing Source File linked",
       tone: "info",
-      actionLabel: "Open Source File",
-      actionHref: `/admin/dossiers/candidates/${candidate.connectedSourceFileCandidateId}`,
+      actionLabel: "Open Matched Source File",
+      actionHref: sourceFileFocusHref(
+        candidate.connectedSourceFileCandidateId,
+        "overview",
+      ),
+      actionDestinationKey: "source-file-overview",
+      actionGroup: "source-file",
     });
   }
 
@@ -236,6 +336,8 @@ export function buildCandidateNotifications(
       actionLabel: "Open Live Dossier",
       actionHref:
         liveDossierHref(candidate, context.publicDossiers) ?? candidateHref,
+      actionDestinationKey: "live-dossier",
+      actionGroup: "external",
     });
   }
 
@@ -249,8 +351,7 @@ export function buildCandidateNotifications(
       tone: "info",
       reason:
         "Review-only signal; it does not publish or create drafts by itself.",
-      actionLabel: "Review Candidate",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "signals", "Review BNL Signals"),
     });
   }
 
@@ -289,7 +390,9 @@ export function buildRecommendationNotifications(
       label: "Existing Source File linked",
       tone: "info",
       actionLabel: "Open Source File",
-      actionHref: `/admin/dossiers/candidates/${candidateId}`,
+      actionHref: sourceFileFocusHref(candidateId ?? "", "overview"),
+      actionDestinationKey: "source-file-overview",
+      actionGroup: "source-file",
     });
   }
 
@@ -304,7 +407,11 @@ export function buildRecommendationNotifications(
       label: "Live dossier exists",
       tone: "info",
       actionLabel: "Open Live Dossier",
-      actionHref: recommendationHref,
+      actionHref: recommendation.targetDossierId
+        ? `/database/${recommendation.targetDossierId}`
+        : recommendationHref,
+      actionDestinationKey: "live-dossier",
+      actionGroup: "external",
     });
   }
 
@@ -316,7 +423,6 @@ export function buildSourceFileNotifications(
   context: NotificationContext = {},
 ): DossierWorkflowNotification[] {
   const notifications: DossierWorkflowNotification[] = [];
-  const candidateHref = `/admin/dossiers/candidates/${candidate.id}`;
   const liveDossierExists = hasLiveDossierMatch(
     candidate,
     context.publicDossiers,
@@ -344,8 +450,7 @@ export function buildSourceFileNotifications(
       tone: "muted",
       reason:
         "Special/system Source File; do not treat as a normal person/community candidate.",
-      actionLabel: "Open Source File",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "overview", "Open Source File"),
     });
   }
 
@@ -356,6 +461,8 @@ export function buildSourceFileNotifications(
       tone: "success",
       actionLabel: "Open Live Dossier",
       actionHref: liveDossierHref(candidate, context.publicDossiers),
+      actionDestinationKey: "live-dossier",
+      actionGroup: "external",
     });
   }
 
@@ -366,6 +473,8 @@ export function buildSourceFileNotifications(
       tone: "info",
       actionLabel: "Open Proposed Dossier",
       actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
+      actionDestinationKey: "proposed-dossier",
+      actionGroup: "external",
     });
   }
 
@@ -376,6 +485,8 @@ export function buildSourceFileNotifications(
       tone: "success",
       actionLabel: "Owner Review",
       actionHref: "/admin/dossiers/owner-review",
+      actionDestinationKey: "owner-review",
+      actionGroup: "external",
     });
   }
 
@@ -386,8 +497,7 @@ export function buildSourceFileNotifications(
       tone: "info",
       reason:
         "Review-only signal; it does not publish or create Source Files automatically.",
-      actionLabel: "Open Source File",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "signals", "Review BNL Signals"),
     });
   }
 
@@ -398,8 +508,6 @@ export function buildSourceFileNotifications(
       tone: "warning",
       reason:
         "Only use for potential updates to an existing live/public dossier.",
-      actionLabel: "Open Source File",
-      actionHref: candidateHref,
     });
   } else if (hasNewSignal && activeDraft) {
     pushUnique(notifications, {
@@ -409,6 +517,8 @@ export function buildSourceFileNotifications(
       reason: "Active Proposed Dossier change; not a live dossier update.",
       actionLabel: "Open Proposed Dossier",
       actionHref: `/admin/dossiers/drafts/${activeDraft.id}`,
+      actionDestinationKey: "proposed-dossier",
+      actionGroup: "external",
     });
   }
 
@@ -417,8 +527,7 @@ export function buildSourceFileNotifications(
       id: "identity-review-pending",
       label: "Possible identity link",
       tone: "warning",
-      actionLabel: "Review Identity Links",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "identity", "Review Identity Links"),
     });
   }
 
@@ -427,8 +536,7 @@ export function buildSourceFileNotifications(
       id: "possible-duplicate",
       label: "Possible duplicate",
       tone: "warning",
-      actionLabel: "Review Identity Links",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "identity", "Review Identity Links"),
     });
   }
 
@@ -440,8 +548,7 @@ export function buildSourceFileNotifications(
       id: "missing-info",
       label: "Missing info",
       tone: "warning",
-      actionLabel: "Open Source File",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "missing-info", "Review Missing Info"),
     });
   }
 
@@ -454,8 +561,19 @@ export function buildSourceFileNotifications(
       id: "bnl-archive-available",
       label: "BNL archive available",
       tone: "info",
-      actionLabel: "Open Source File",
-      actionHref: candidateHref,
+      ...focusAction(candidate.id, "archive", "Open BNL Archive"),
+    });
+  }
+
+
+  if (
+    hasRefreshStatusForDashboard(candidate, context.sourceFileRefreshRequests)
+  ) {
+    pushUnique(notifications, {
+      id: "refresh-status",
+      label: "FILE NOT UPDATED",
+      tone: "warning",
+      ...focusAction(candidate.id, "refresh", "View Refresh Status"),
     });
   }
 

--- a/src/lib/dossier-workflow-notifications.ts
+++ b/src/lib/dossier-workflow-notifications.ts
@@ -142,6 +142,21 @@ function hasActiveDuplicateGroup(
   });
 }
 
+function hasPossibleDuplicate(
+  candidate: DossierCandidate,
+  context: Pick<NotificationContext, "candidates" | "duplicateGroups"> = {},
+) {
+  return (
+    candidate.duplicateRisk === "medium" ||
+    candidate.duplicateRisk === "high" ||
+    hasActiveDuplicateGroup(
+      candidate,
+      context.candidates,
+      context.duplicateGroups,
+    )
+  );
+}
+
 function isReviewOnlySignal(candidate: DossierCandidate) {
   return (
     candidate.confidence === "low" ||
@@ -188,6 +203,16 @@ export function buildCandidateNotifications(
       label: "Possible identity link",
       tone: "warning",
       reason: "Review before confirming aliases or routing future signals.",
+      actionLabel: "Review Identity Links",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (hasPossibleDuplicate(candidate, context)) {
+    pushUnique(notifications, {
+      id: "possible-duplicate",
+      label: "Possible duplicate",
+      tone: "warning",
       actionLabel: "Review Identity Links",
       actionHref: candidateHref,
     });
@@ -391,6 +416,16 @@ export function buildSourceFileNotifications(
     pushUnique(notifications, {
       id: "identity-review-pending",
       label: "Possible identity link",
+      tone: "warning",
+      actionLabel: "Review Identity Links",
+      actionHref: candidateHref,
+    });
+  }
+
+  if (hasPossibleDuplicate(candidate, context)) {
+    pushUnique(notifications, {
+      id: "possible-duplicate",
+      label: "Possible duplicate",
       tone: "warning",
       actionLabel: "Review Identity Links",
       actionHref: candidateHref,

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1101,6 +1101,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Review Candidate",
     "Open Proposed Dossier",
     "Open Source File",
+    "Open Archived Signal",
     "Open Live Dossier",
   ]) {
     assertIncludesCopy(pageCopy, label);
@@ -1113,6 +1114,9 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, />\s*Open\s*</);
   assert.doesNotMatch(page, /Add Missing Info|Review Signal|Review Source Update|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
   assert.doesNotMatch(page, /Open Draft|Review Updates|Review Missing Info|Review Match|Needs Attention/);
+  assert.match(page, /archivedCandidateActionLabel\(\)/);
+  assert.match(page, /archivedSignalActionLabel\(\)/);
+  assert.doesNotMatch(page, /function archiveActionLabel/);
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /eyebrow="Dossier Updates"|title="Dossier Updates"/);
@@ -4197,6 +4201,13 @@ test("ignore, dismiss, and archive recommendations preserve records", async () =
   assert.match(dashboard, /terminalRecommendations/);
   assertIncludesCopy(dashboardCopy, "Archive / Dismissed / Trash");
   assertIncludesCopy(dashboardCopy, "dismissed or archived signals");
+  assertIncludesCopy(dashboardCopy, "Open Source File");
+  assertIncludesCopy(dashboardCopy, "Open Archived Signal");
+  assert.match(dashboard, /function archivedCandidateActionLabel\(\) \{\s*return "Open Source File";/);
+  assert.match(dashboard, /function archivedSignalActionLabel\(\) \{\s*return "Open Archived Signal";/);
+  assert.match(dashboard, /terminalRecommendations[\s\S]*archivedSignalActionLabel\(\)/);
+  assert.doesNotMatch(dashboard, /function archivedSignalActionLabel\(\) \{\s*return "Open Source File";/);
+  assert.doesNotMatch(dashboard, /terminalRecommendations[\s\S]*archiveActionLabel\(\)/);
 });
 
 test("recommendation inbox and source note UI are present and bounded", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1072,36 +1072,36 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Archive / Dismissed / Trash",
     "Manual Signal",
     "Use this only when BNL has not suggested something yet. This creates a BNL Signal, not a direct source file.",
-    "Why BNL noticed",
-    "Strength / confidence",
-    "Identity status",
-    "Suggested next step",
-    "Identity: Clear",
-    "Identity: Possible Match",
-    "Identity: Connected to Existing Subject",
-    "Identity: Needs Confirmation",
-    "Existing Dossier Match",
-    "Possible Duplicate",
-    "Why they matter / engagement summary",
-    "Dossier status",
-    "No Proposed Dossier",
-    "Draft started",
-    "Needs update from Source File",
-    "Ready for Owner Review",
-    "Owner changes requested",
-    "Approved / publish later",
+    "Signal",
+    "Identity / Match",
+    "Dossier / Source Status",
+    "Actions",
+    "No known match",
     "Possible identity link",
-    "Existing Source File match",
-    "Existing live dossier match",
-    "New BNL signal",
+    "Confirmed aliases",
+    "Possible identity link",
+    "Live dossier exists",
+    "Possible identity link",
+    "Source File Status",
+    "Dossier Status",
+    "No Proposed Dossier",
+    "Proposed Dossier in progress",
+    "New BNL signals attached",
+    "Proposed Dossier ready for Owner Review",
+    "Proposed Dossier in progress",
+    "Proposed Dossier in progress",
+    "Possible identity link",
+    "Existing Source File linked",
+    "Live dossier exists",
+    "New BNL signals attached",
     "Missing info",
     "BNL archive available",
-    "Owner Review ready",
+    "Proposed Dossier ready for Owner Review",
     "System record",
     "Review Candidate",
-    "Review Updates",
+    "Open Proposed Dossier",
     "Open Source File",
-    "Review Record",
+    "Open Live Dossier",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -1112,6 +1112,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.doesNotMatch(page, />\s*Open\s*</);
   assert.doesNotMatch(page, /Add Missing Info|Review Signal|Review Source Update|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
+  assert.doesNotMatch(page, /Open Draft|Review Updates|Review Missing Info|Review Match|Needs Attention/);
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /eyebrow="Dossier Updates"|title="Dossier Updates"/);
@@ -1165,10 +1166,10 @@ test("computed dossier workflow notifications cover candidate row contexts", () 
       confidence: "high",
     },
   });
-  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(existingLive)).includes("Existing live dossier match"));
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(existingLive)).includes("Live dossier exists"));
 
   const duplicate = baseNotificationCandidate({ duplicateRisk: "high" });
-  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(duplicate)).includes("Possible duplicate"));
+  assert.ok(!notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(duplicate)).includes("Possible duplicate"));
 });
 
 test("computed dossier workflow notifications cover source file draft, archive, missing info, and update contexts", () => {
@@ -1202,11 +1203,11 @@ test("computed dossier workflow notifications cover source file draft, archive, 
     recommendations: [activeRecommendation],
   }));
 
-  assert.ok(labels.includes("Draft in progress"));
-  assert.ok(labels.includes("Draft revision?"));
+  assert.ok(labels.includes("Proposed Dossier in progress"));
+  assert.ok(labels.includes("Proposed Dossier in progress"));
   assert.ok(labels.includes("BNL archive available"));
   assert.ok(labels.includes("Missing info"));
-  assert.ok(!labels.includes("Live dossier update?"));
+  assert.ok(!labels.includes("Live dossier exists"));
   assert.equal(
     dossierWorkflowNotifications.isLiveDossierUpdateRecommendation(activeRecommendation, { candidates: [candidate] }),
     false,
@@ -1215,7 +1216,7 @@ test("computed dossier workflow notifications cover source file draft, archive, 
   const readyLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(candidate, {
     drafts: [{ ...activeDraft, status: "ready_for_owner_review" }],
   }));
-  assert.ok(readyLabels.includes("Owner Review ready"));
+  assert.ok(readyLabels.includes("Proposed Dossier ready for Owner Review"));
 
   const liveCandidate = baseNotificationCandidate({
     ...candidate,
@@ -1229,8 +1230,8 @@ test("computed dossier workflow notifications cover source file draft, archive, 
     liveCandidate,
     { drafts: [activeDraft], recommendations: [activeRecommendation] },
   ));
-  assert.ok(liveLabels.includes("Live dossier update?"));
-  assert.ok(!liveLabels.includes("Draft revision?"));
+  assert.ok(liveLabels.includes("Live dossier exists"));
+  assert.ok(liveLabels.includes("Proposed Dossier in progress"));
   assert.equal(
     dossierWorkflowNotifications.isLiveDossierUpdateRecommendation(activeRecommendation, { candidates: [liveCandidate] }),
     true,
@@ -1776,9 +1777,8 @@ test("dashboard uses actual workflow ids, source metrics, and simplified overvie
   assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.match(page, /candidateActionLabel/);
   assert.match(page, /recommendationActionLabel/);
-  assert.match(page, /dossierUpdateActionLabel/);
   assert.match(page, /sourceFileActionLabel/);
-  assert.match(page, /Review Record/);
+  assert.match(page, /Open Source File/);
   assert.match(page, /activeCandidateStatuses/);
   assert.match(page, /activeCandidates = candidates\.filter/);
   assert.match(page, /activeDraftStatuses/);
@@ -1786,10 +1786,10 @@ test("dashboard uses actual workflow ids, source metrics, and simplified overvie
   assert.match(page, /getDossierSourceFileMetrics/);
   assert.match(page, /sourceFilesWithUnappliedNotes/);
   assert.match(page, /sourceFilesWithDrafts/);
-  assert.match(page, /metrics\?\.sourceDepth/);
-  assert.match(page, /Dossier status/);
-  assert.match(page, /identityBadgeForCandidate/);
-  assert.match(page, /identityBadgeForRecommendation/);
+  assert.match(page, /Source File Status/);
+  assert.match(page, /Dossier Status/);
+  assert.match(page, /Identity \/ Match/);
+  assert.match(page, /RowStatusList/);
   assert.match(page, /Archive \/ Dismissed \/ Trash/);
   assert.doesNotMatch(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
   assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
@@ -2946,7 +2946,7 @@ test("admin dossiers dashboard does not promote duplicate merge review", () => {
   const mergePage = source(
     "src/app/admin/dossiers/duplicates/[groupId]/page.tsx",
   );
-  assert.match(page, /Identity: Possible Match|Identity: Needs Confirmation|Possible Duplicate/);
+  assert.match(page, /Identity \/ Match|No known match|Confirmed aliases/);
   assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /\/admin\/dossiers\/duplicates\//);
   assert.doesNotMatch(page, /Merge into Master Candidate/);
@@ -3414,11 +3414,11 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
     /Identity link retired\. It is no longer active\./,
   );
 
-  assert.match(dashboard, /Identity: Connected to Existing Subject/);
-  assert.match(dashboard, /Identity: Needs Confirmation/);
+  assert.match(dashboard, /Confirmed aliases/);
+  assert.match(`${dashboard} ${source("src/lib/dossier-workflow-notifications.ts")}`, /Possible identity link/);
   assert.match(dashboard, /link\.status === "confirmed"/);
-  assert.match(dashboard, /link\.status === "proposed"/);
-  assert.doesNotMatch(dashboard, /Review Identity|Identity Link Actions|Create Proposed Identity Link|Confirm<|Reject<|Retire</);
+  assert.match(`${dashboard} ${source("src/lib/dossier-workflow-notifications.ts")}`, /link\.status === "proposed"/);
+  assert.doesNotMatch(dashboard, /Identity Link Actions|Create Proposed Identity Link|Confirm<|Reject<|Retire</);
 
   assert.match(recommendationPage, /Matched by confirmed alias/);
   assert.match(recommendationPage, /Identity Link Actions/);
@@ -3562,8 +3562,8 @@ test("unapplied source notes count after draft creation without mutating draft f
   const draftCopy = normalizedSource(
     "src/app/admin/dossiers/drafts/[draftId]/page.tsx",
   );
-  assertIncludesCopy(dashboardCopy, "Needs update from Source File");
-  assertIncludesCopy(dashboardCopy, "Dossier status");
+  assertIncludesCopy(`${dashboardCopy} ${normalizedSource("src/lib/dossier-workflow-notifications.ts")}`, "New BNL signals attached");
+  assertIncludesCopy(dashboardCopy, "Dossier Status");
   assertIncludesCopy(sourceFileCopy, "This Case File / BNL Source File has new info not yet applied to the Proposed Dossier.");
   assertIncludesCopy(draftCopy, "Case File / BNL Source File has new notes since this Proposed Dossier was last updated.");
   assertIncludesCopy(draftCopy, "Draft fields are not mutated automatically when new source notes arrive.");
@@ -4201,18 +4201,19 @@ test("ignore, dismiss, and archive recommendations preserve records", async () =
 
 test("recommendation inbox and source note UI are present and bounded", () => {
   const dashboard = source("src/app/admin/dossiers/page.tsx");
+  const dashboardWithNotifications = `${dashboard} ${source("src/lib/dossier-workflow-notifications.ts")}`;
   assert.match(dashboard, /Candidates/);
   assert.match(dashboard, /Manual Signal/);
   assert.match(dashboard, /Create Manual Signal/);
-  assert.match(dashboard, /Why BNL noticed/);
-  assert.match(dashboard, /Identity: Possible Match/);
-  assert.match(dashboard, /Identity: Needs Confirmation/);
+  assert.match(dashboard, /Signal/);
+  assert.match(dashboardWithNotifications, /Possible identity link/);
+  assert.match(dashboard, /Identity \/ Match/);
   assert.match(dashboard, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.match(dashboard, /Review Candidate/);
-  assert.match(dashboard, /Review Update/);
+  assert.match(dashboard, /Create Proposed Dossier|Open Proposed Dossier|Owner Review/);
   assert.match(dashboard, /Open Source File/);
-  assert.match(dashboard, /Review Record/);
-  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info|Attach to Existing Source File/);
+  assert.match(dashboard, /Open Source File/);
+  assert.doesNotMatch(dashboard, /Add Missing Info|Attach to Existing Source File/);
 
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
@@ -6104,9 +6105,9 @@ test("recommendation detail case-file view uses the same sanitizer", () => {
 test("admin dashboard keeps public dossier-only source lookup fallback bounded", () => {
   const pageCopy = `${normalizedSource("src/app/admin/dossiers/page.tsx")} ${normalizedSource("src/lib/dossier-workflow-notifications.ts")}`;
   assertIncludesCopy(pageCopy, "Live dossier update signals");
-  assertIncludesCopy(pageCopy, "Live dossier update?");
-  assertIncludesCopy(pageCopy, "Existing live dossier match");
-  assertIncludesCopy(pageCopy, "Identity: Needs Confirmation");
+  assertIncludesCopy(pageCopy, "Live dossier exists");
+  assertIncludesCopy(pageCopy, "Live dossier exists");
+  assertIncludesCopy(pageCopy, "Possible identity link");
   assert.doesNotMatch(pageCopy, /No existing dossier updates are waiting\.|eyebrow="Dossier Updates"|title="Dossier Updates"/);
 });
 

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1078,6 +1078,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Actions",
     "No known match",
     "Possible identity link",
+    "Possible duplicate",
     "Confirmed aliases",
     "Possible identity link",
     "Live dossier exists",
@@ -1114,6 +1115,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, />\s*Open\s*</);
   assert.doesNotMatch(page, /Add Missing Info|Review Signal|Review Source Update|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
   assert.doesNotMatch(page, /Open Draft|Review Updates|Review Missing Info|Review Match|Needs Attention/);
+  assert.match(page, /primaryLabel=\{sourceFileActionLabel\(\)\}/);
   assert.match(page, /archivedCandidateActionLabel\(\)/);
   assert.match(page, /archivedSignalActionLabel\(\)/);
   assert.doesNotMatch(page, /function archiveActionLabel/);
@@ -1173,7 +1175,31 @@ test("computed dossier workflow notifications cover candidate row contexts", () 
   assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(existingLive)).includes("Live dossier exists"));
 
   const duplicate = baseNotificationCandidate({ duplicateRisk: "high" });
-  assert.ok(!notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(duplicate)).includes("Possible duplicate"));
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(duplicate)).includes("Possible duplicate"));
+
+  const duplicateGroupCandidate = baseNotificationCandidate({
+    id: "duplicate-group-candidate",
+    duplicateRisk: "none",
+  });
+  const duplicateGroupPeer = baseNotificationCandidate({
+    id: "duplicate-group-peer",
+    status: "active_source_file",
+  });
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(
+    duplicateGroupCandidate,
+    {
+      candidates: [duplicateGroupCandidate, duplicateGroupPeer],
+      duplicateGroups: [{
+        id: "duplicate-group-fixture",
+        normalizedName: "duplicate fixture",
+        candidateIds: [duplicateGroupCandidate.id, duplicateGroupPeer.id],
+        draftIds: [],
+        names: [duplicateGroupCandidate.name, duplicateGroupPeer.name],
+        risk: "medium",
+        reason: "Fixture duplicate group.",
+      }],
+    },
+  )).includes("Possible duplicate"));
 });
 
 test("computed dossier workflow notifications cover source file draft, archive, missing info, and update contexts", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1115,6 +1115,8 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
   assert.doesNotMatch(page, /eyebrow="Dossier Updates"|title="Dossier Updates"/);
+  assert.match(page, /isLiveDossierUpdateRecommendation\(recommendation/);
+  assert.doesNotMatch(page, /Boolean\(recommendation\.targetCandidateId\)/);
   assert.doesNotMatch(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
   assert.doesNotMatch(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
   assert.doesNotMatch(page, />Delete Permanently</);
@@ -1205,22 +1207,55 @@ test("computed dossier workflow notifications cover source file draft, archive, 
   assert.ok(labels.includes("BNL archive available"));
   assert.ok(labels.includes("Missing info"));
   assert.ok(!labels.includes("Live dossier update?"));
+  assert.equal(
+    dossierWorkflowNotifications.isLiveDossierUpdateRecommendation(activeRecommendation, { candidates: [candidate] }),
+    false,
+  );
 
   const readyLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(candidate, {
     drafts: [{ ...activeDraft, status: "ready_for_owner_review" }],
   }));
   assert.ok(readyLabels.includes("Owner Review ready"));
 
-  const liveLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(baseNotificationCandidate({
+  const liveCandidate = baseNotificationCandidate({
     ...candidate,
     existingDossierMatch: {
       id: "public-live-dossier",
       name: "Public Live Dossier",
       confidence: "high",
     },
-  }), { drafts: [activeDraft], recommendations: [activeRecommendation] }));
+  });
+  const liveLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(
+    liveCandidate,
+    { drafts: [activeDraft], recommendations: [activeRecommendation] },
+  ));
   assert.ok(liveLabels.includes("Live dossier update?"));
   assert.ok(!liveLabels.includes("Draft revision?"));
+  assert.equal(
+    dossierWorkflowNotifications.isLiveDossierUpdateRecommendation(activeRecommendation, { candidates: [liveCandidate] }),
+    true,
+  );
+});
+
+test("computed source file notifications only mark explicit system records", () => {
+  const enrichedArtist = baseNotificationCandidate({
+    source: "bnl_source_file_enrichment",
+    candidateType: "artist",
+    name: "Normal Artist Source File",
+  });
+  assert.ok(!notificationLabels(
+    dossierWorkflowNotifications.buildSourceFileNotifications(enrichedArtist),
+  ).includes("System record"));
+
+  for (const systemCandidate of [
+    baseNotificationCandidate({ name: "BNL-01", candidateType: "entity" }),
+    baseNotificationCandidate({ name: "BARCODE Radio", candidateType: "production" }),
+    baseNotificationCandidate({ name: "Carl-bot Logging", candidateType: "interface" }),
+  ]) {
+    assert.ok(notificationLabels(
+      dossierWorkflowNotifications.buildSourceFileNotifications(systemCandidate),
+    ).includes("System record"));
+  }
 });
 
 test("dossier admin pages keep dashboard simple while detail pages retain workflow controls", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -62,6 +62,7 @@ const sourceSummaryPanelComponent = require("../src/components/DossierSourceFile
 const actionableBrief = require("../src/lib/dossier-source-file-actionable-brief.ts");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
+const dossierWorkflowNotifications = require("../src/lib/dossier-workflow-notifications.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -1057,13 +1058,13 @@ test("admin panel includes Dossier Control Center link", () => {
 
 test("admin dossier dashboard is a simplified subject sorting overview", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
-  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+  const pageCopy = `${normalizedSource("src/app/admin/dossiers/page.tsx")} ${normalizedSource("src/lib/dossier-workflow-notifications.ts")}`;
   for (const label of [
     "Dossier Control Center",
     "Sort noticed subjects, review updates, and open Source Files.",
     "Summary",
     "Candidates",
-    "Dossier Updates",
+    "Live dossier update signals",
     "Source Files",
     "Needs Info",
     "Ready for Dossier",
@@ -1089,8 +1090,16 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Ready for Owner Review",
     "Owner changes requested",
     "Approved / publish later",
+    "Possible identity link",
+    "Existing Source File match",
+    "Existing live dossier match",
+    "New BNL signal",
+    "Missing info",
+    "BNL archive available",
+    "Owner Review ready",
+    "System record",
     "Review Candidate",
-    "Review Update",
+    "Review Updates",
     "Open Source File",
     "Review Record",
   ]) {
@@ -1102,9 +1111,10 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.doesNotMatch(page, />\s*Open\s*</);
-  assert.doesNotMatch(page, /Add Missing Info|Review Identity|Review Signal|Review Source Update|Open Draft|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
+  assert.doesNotMatch(page, /Add Missing Info|Review Signal|Review Source Update|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
   assert.doesNotMatch(page, /PhaseRail|Numbered dossier phases|Workflow map|System Boundaries/);
   assert.doesNotMatch(page, /Duplicate Analysis|Record Compactor|View Warning \/ Open Merge Review/);
+  assert.doesNotMatch(page, /eyebrow="Dossier Updates"|title="Dossier Updates"/);
   assert.doesNotMatch(page, /candidateAction\(candidate\.id, "archiveCandidate"\)/);
   assert.doesNotMatch(page, /candidateAction\(\s*candidate\.id,\s*"permanentlyDeleteCandidate"/);
   assert.doesNotMatch(page, />Delete Permanently</);
@@ -1116,12 +1126,108 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   assert.match(page, /if \(error \|\| !payload\)/);
 });
 
+
+function baseNotificationCandidate(overrides = {}) {
+  return {
+    id: overrides.id ?? "candidate-notification-fixture",
+    name: overrides.name ?? "Notification Fixture",
+    candidateType: overrides.candidateType ?? "artist",
+    source: overrides.source ?? "manual",
+    tier: overrides.tier ?? "review_candidate",
+    score: overrides.score ?? 5,
+    whyNow: overrides.whyNow ?? "Notification test.",
+    reason: overrides.reason ?? "Notification test.",
+    evidenceSummary: overrides.evidenceSummary ?? "Notification evidence.",
+    status: overrides.status ?? "active_source_file",
+    createdAt: overrides.createdAt ?? "2026-06-01T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-06-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function notificationLabels(notifications) {
+  return notifications.map((notification) => notification.label);
+}
+
+test("computed dossier workflow notifications cover candidate row contexts", () => {
+  const possibleIdentity = baseNotificationCandidate({
+    identityReviewStatus: "needs_confirmation",
+    possibleMatchCandidateIds: ["candidate-peer"],
+  });
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(possibleIdentity)).includes("Possible identity link"));
+
+  const existingLive = baseNotificationCandidate({
+    existingDossierMatch: {
+      id: "public-live-dossier",
+      name: "Public Live Dossier",
+      confidence: "high",
+    },
+  });
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(existingLive)).includes("Existing live dossier match"));
+
+  const duplicate = baseNotificationCandidate({ duplicateRisk: "high" });
+  assert.ok(notificationLabels(dossierWorkflowNotifications.buildCandidateNotifications(duplicate)).includes("Possible duplicate"));
+});
+
+test("computed dossier workflow notifications cover source file draft, archive, missing info, and update contexts", () => {
+  const candidate = baseNotificationCandidate({
+    id: "source-file-notification-fixture",
+    missingInfo: ["Confirm public-safe role."],
+    sourceFileArchiveIds: ["archive-1"],
+    latestSourceFileArchiveId: "archive-1",
+  });
+  const activeDraft = {
+    id: "draft-active-notification-fixture",
+    candidateId: candidate.id,
+    status: "draft",
+    fields: { name: candidate.name },
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+  const activeRecommendation = {
+    id: "recommendation-active-notification-fixture",
+    type: "new_subject",
+    subjectName: candidate.name,
+    targetCandidateId: candidate.id,
+    status: "new",
+    reason: "New BNL signal fixture.",
+    sourceLanes: ["rd_context"],
+    createdAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  };
+  const labels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(candidate, {
+    drafts: [activeDraft],
+    recommendations: [activeRecommendation],
+  }));
+
+  assert.ok(labels.includes("Draft in progress"));
+  assert.ok(labels.includes("Draft revision?"));
+  assert.ok(labels.includes("BNL archive available"));
+  assert.ok(labels.includes("Missing info"));
+  assert.ok(!labels.includes("Live dossier update?"));
+
+  const readyLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(candidate, {
+    drafts: [{ ...activeDraft, status: "ready_for_owner_review" }],
+  }));
+  assert.ok(readyLabels.includes("Owner Review ready"));
+
+  const liveLabels = notificationLabels(dossierWorkflowNotifications.buildSourceFileNotifications(baseNotificationCandidate({
+    ...candidate,
+    existingDossierMatch: {
+      id: "public-live-dossier",
+      name: "Public Live Dossier",
+      confidence: "high",
+    },
+  }), { drafts: [activeDraft], recommendations: [activeRecommendation] }));
+  assert.ok(liveLabels.includes("Live dossier update?"));
+  assert.ok(!liveLabels.includes("Draft revision?"));
+});
+
 test("dossier admin pages keep dashboard simple while detail pages retain workflow controls", () => {
   const dashboard = normalizedSource("src/app/admin/dossiers/page.tsx");
   for (const label of [
     "Summary",
     "Candidates",
-    "Dossier Updates",
     "Source Files",
     "Archive / Dismissed / Trash",
     "Owner Review",
@@ -5961,11 +6067,12 @@ test("recommendation detail case-file view uses the same sanitizer", () => {
 });
 
 test("admin dashboard keeps public dossier-only source lookup fallback bounded", () => {
-  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
-  assertIncludesCopy(pageCopy, "Dossier Updates");
-  assertIncludesCopy(pageCopy, "No existing dossier updates are waiting.");
-  assertIncludesCopy(pageCopy, "Review update details before attaching anywhere public.");
+  const pageCopy = `${normalizedSource("src/app/admin/dossiers/page.tsx")} ${normalizedSource("src/lib/dossier-workflow-notifications.ts")}`;
+  assertIncludesCopy(pageCopy, "Live dossier update signals");
+  assertIncludesCopy(pageCopy, "Live dossier update?");
+  assertIncludesCopy(pageCopy, "Existing live dossier match");
   assertIncludesCopy(pageCopy, "Identity: Needs Confirmation");
+  assert.doesNotMatch(pageCopy, /No existing dossier updates are waiting\.|eyebrow="Dossier Updates"|title="Dossier Updates"/);
 });
 
 test("Phase 2 draft workflow keeps PR 155 stacked shared preview order", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1109,13 +1109,15 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
   }
 
   assert.match(page, /href="\/admin\/dossiers\/owner-review"/);
-  assert.match(page, /href=\{`\/admin\/dossiers\/candidates\/\$\{candidate\.id\}`\}/);
+  assert.match(page, /sourceFileFocusHref\(candidate\.id, "overview"\)/);
   assert.match(page, /href=\{`\/admin\/dossiers\/recommendations\/\$\{recommendation\.id\}`\}/);
   assert.doesNotMatch(page, /`\/admin\/dossiers\/drafts\/\$\{openDraftId\}`/);
   assert.doesNotMatch(page, />\s*Open\s*</);
   assert.doesNotMatch(page, /Add Missing Info|Review Signal|Review Source Update|Review Draft|Review Archived|Review Closed Signal|Review Trash/);
-  assert.doesNotMatch(page, /Open Draft|Review Updates|Review Missing Info|Review Match|Needs Attention/);
-  assert.match(page, /primaryLabel=\{sourceFileActionLabel\(\)\}/);
+  assert.doesNotMatch(page, /Open Draft|Review Updates|Review Match|Needs Attention/);
+  assert.match(pageCopy, /Review Missing Info/);
+  assert.match(pageCopy, /missing-info/);
+  assert.match(page, /destinationKey: "source-file-overview"/);
   assert.match(page, /archivedCandidateActionLabel\(\)/);
   assert.match(page, /archivedSignalActionLabel\(\)/);
   assert.doesNotMatch(page, /function archiveActionLabel/);
@@ -1266,6 +1268,135 @@ test("computed dossier workflow notifications cover source file draft, archive, 
     dossierWorkflowNotifications.isLiveDossierUpdateRecommendation(activeRecommendation, { candidates: [liveCandidate] }),
     true,
   );
+});
+
+
+test("dossier dashboard actions use distinct Source File focus destinations", () => {
+  const candidate = baseNotificationCandidate({
+    id: "focus-action-source-file",
+    identityReviewStatus: "needs_confirmation",
+    missingInfo: ["Confirm public-safe details."],
+    sourceFileArchiveIds: ["archive-focus"],
+    latestSourceFileArchiveId: "archive-focus",
+  });
+  const draft = {
+    id: "draft-focus-action",
+    candidateId: candidate.id,
+    status: "draft",
+    fields: { name: candidate.name },
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+  const signal = {
+    id: "signal-focus-action",
+    type: "new_subject",
+    subjectName: candidate.name,
+    targetCandidateId: candidate.id,
+    status: "new",
+    reason: "Attached BNL signal.",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+  const refresh = {
+    id: "refresh-focus-action",
+    candidateId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: workflow.normalizeDossierSubjectName(candidate.name),
+    status: "failed",
+    reason: "Refresh did not complete.",
+    requestedAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    requestSource: "manual_admin",
+    priority: 3,
+  };
+  const liveCandidate = {
+    ...candidate,
+    existingDossierMatch: {
+      id: "live-focus-dossier",
+      name: "Live Focus Dossier",
+      confidence: "high",
+    },
+  };
+  const notifications = dossierWorkflowNotifications.buildSourceFileNotifications(liveCandidate, {
+    drafts: [draft],
+    recommendations: [signal],
+    sourceFileRefreshRequests: [refresh],
+  });
+  const actions = dossierWorkflowNotifications.dedupeDossierDashboardActions([
+    {
+      label: "Open Source File",
+      href: dossierWorkflowNotifications.sourceFileFocusHref(candidate.id, "overview"),
+      destinationKey: "source-file-overview",
+    },
+    ...notifications
+      .filter((notification) => notification.actionLabel && notification.actionHref && notification.actionDestinationKey)
+      .map((notification) => ({
+        label: notification.actionLabel,
+        href: notification.actionHref,
+        destinationKey: notification.actionDestinationKey,
+      })),
+  ]);
+  const hrefs = actions.map((action) => action.href);
+
+  assert.equal(new Set(hrefs).size, hrefs.length);
+  assert.ok(actions.some((action) => action.label === "Open Source File" && action.href.endsWith("?focus=overview")));
+  assert.ok(actions.some((action) => action.label === "Review Identity Links" && action.href.endsWith("?focus=identity")));
+  assert.ok(actions.some((action) => action.label === "Review Missing Info" && action.href.endsWith("?focus=missing-info")));
+  assert.ok(actions.some((action) => action.label === "Review BNL Signals" && action.href.endsWith("?focus=signals")));
+  assert.ok(actions.some((action) => action.label === "Open BNL Archive" && action.href.endsWith("?focus=archive")));
+  assert.ok(actions.some((action) => action.label === "View Refresh Status" && action.href.endsWith("?focus=refresh")));
+  assert.ok(actions.some((action) => action.label === "Open Proposed Dossier" && action.href === `/admin/dossiers/drafts/${draft.id}`));
+  assert.ok(actions.some((action) => action.label === "Open Live Dossier" && action.href === "/database/live-focus-dossier"));
+
+  const readyActions = dossierWorkflowNotifications.buildSourceFileNotifications(candidate, {
+    drafts: [{ ...draft, status: "ready_for_owner_review" }],
+  });
+  assert.ok(readyActions.some((notification) => notification.actionLabel === "Owner Review" && notification.actionHref === "/admin/dossiers/owner-review"));
+});
+
+test("candidate dashboard actions point matching and identity states to focused Source File sections", () => {
+  const candidate = baseNotificationCandidate({
+    id: "candidate-focus-action",
+    identityReviewStatus: "needs_confirmation",
+    connectedSourceFileCandidateId: "matched-source-file-focus",
+  });
+  const notifications = dossierWorkflowNotifications.buildCandidateNotifications(candidate);
+
+  assert.ok(notifications.some((notification) => notification.actionLabel === "Review Identity Links" && notification.actionHref.endsWith("?focus=identity")));
+  assert.ok(notifications.some((notification) => notification.actionLabel === "Open Matched Source File" && notification.actionHref === "/admin/dossiers/candidates/matched-source-file-focus?focus=overview"));
+});
+
+test("source file detail page exposes focus section ids and workspace status map", () => {
+  const page = `${normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx")} ${normalizedSource("src/lib/dossier-workflow-notifications.ts")}`;
+  for (const sectionId of [
+    "source-file-overview",
+    "source-file-identity",
+    "source-file-missing-info",
+    "source-file-signals",
+    "source-file-archive",
+    "source-file-dossier",
+    "source-file-refresh",
+  ]) {
+    assertIncludesCopy(page, sectionId);
+  }
+  for (const label of [
+    "Source File Status Map",
+    "Workspace Map",
+    "Possible identity link",
+    "Possible duplicate",
+    "New BNL signals attached",
+    "Missing info",
+    "BNL archive available",
+    "Proposed Dossier in progress",
+    "Proposed Dossier ready for Owner Review",
+    "Live dossier exists",
+    "FILE UPDATED",
+    "FILE NOT UPDATED",
+  ]) {
+    assertIncludesCopy(page, label);
+  }
+  assert.match(page, /useSearchParams/);
+  assert.match(page, /scrollIntoView/);
 });
 
 test("computed source file notifications only mark explicit system records", () => {


### PR DESCRIPTION
### Motivation
- Surface contextual, render-time notifications/actions on Candidate and Source File rows so admins can see what each record needs without adding top-level panels or persisting notifications. 
- Keep the existing dossier workflow, Source File, identity, and BNL behavior unchanged while making the dashboard rows more actionable and informative.

### Description
- Added a new helper module `src/lib/dossier-workflow-notifications.ts` that exports a compact `DossierWorkflowNotification` shape and builders `buildCandidateNotifications`, `buildRecommendationNotifications`, and `buildSourceFileNotifications` to compute chips from the workflow payload at render time.
- Updated `src/app/admin/dossiers/page.tsx` to render compact notification chips and contextual action buttons inline for Candidate/recommendation/Source File rows, to compute a `notificationContext` from the current payload, and to include existing-dossier-update rows in the Source Files table (keeps dashboard top-level sections simple and replaces the standalone Dossier Updates card with a summary label `Live dossier update signals`).
- Added UI helpers `NotificationChips` and `NotificationActions` (small chips and primary action links) and wired them into existing review links rather than introducing destructive one-click actions.
- Updated `tests/admin-dossiers.test.mjs` to include unit tests for computed notifications and adjusted dashboard expectations to cover the new inline chips and summary wording.

### Testing
- Ran the admin dossier test suite with `node --test tests/admin-dossiers.test.mjs` and all tests passed (`141` passing, `0` failing). 
- Ran the TypeScript check with `npx tsc --noEmit` and the code type-checked successfully. 
- Attempted a headless screenshot for visual verification, but Playwright/Puppeteer is not installed in the environment so no screenshot was captured (no runtime changes required by bots or VPS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a1b959148321832f2b12bccc1175)