### PR TITLE
Move Identity Check to Source File preflight

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1639,7 +1639,7 @@ export default function CandidateReviewPage() {
           </div>
 
           <div className="mt-5 space-y-3 text-xs uppercase tracking-widest">
-            <p className="text-muted">Signal / Seed Actions · Case File Actions · Identity Link Actions · Proposed Dossier Actions · Archive / Danger</p>
+            <p className="text-muted">Signal / Seed Actions · Case File Actions · Identity Check · Proposed Dossier Actions · Archive / Danger</p>
             <div className="flex flex-wrap gap-3">
             <Link
               href="/admin/dossiers"
@@ -1781,6 +1781,81 @@ export default function CandidateReviewPage() {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
+        {identityLinks.length > 0 && (
+          <Section title="Identity Check">
+            <div className="space-y-5">
+              <p className="border border-border/70 bg-background/20 p-3">
+                Identity links are internal routing/context tools. Resolve these before
+                using this Source File for dossier drafting. Confirming a link can
+                help future BNL Signals route to this Source File, but it does not
+                merge Source Files, publish identity, or place the label in a
+                public dossier.
+              </p>
+
+              <div className="space-y-4">
+                {[
+                  {
+                    title: "Proposed Identity Links",
+                    links: proposedIdentityLinks,
+                    quiet: false,
+                  },
+                  {
+                    title: "Confirmed Identity Links",
+                    links: confirmedIdentityLinks,
+                    quiet: false,
+                  },
+                  {
+                    title: "Rejected / Retired Identity History",
+                    links: closedIdentityLinks,
+                    quiet: true,
+                  },
+                ]
+                  .filter((group) => group.links.length > 0)
+                  .map((group) => (
+                    <section
+                      key={group.title}
+                      className={`border border-border/60 bg-background/10 p-3 space-y-3 ${
+                        group.quiet ? "opacity-80" : ""
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <h3 className="text-sm font-bold uppercase tracking-widest text-foreground">
+                          {group.title}
+                        </h3>
+                        <span className="text-xs text-muted">
+                          {group.links.length} link
+                          {group.links.length === 1 ? "" : "s"}
+                        </span>
+                      </div>
+                      <div className="space-y-3">
+                        {group.links.map((identityLink) => (
+                          <IdentityLinkCard
+                            key={identityLink.id}
+                            identityLink={identityLink}
+                            saving={saving}
+                            recommendation={
+                              identityLink.createdFromRecommendationId
+                                ? recommendationById.get(
+                                    identityLink.createdFromRecommendationId,
+                                  )
+                                : undefined
+                            }
+                            onReview={(identityLink, action, options) =>
+                              void reviewIdentityLink(
+                                identityLink,
+                                action,
+                                options,
+                              )
+                            }
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  ))}
+              </div>
+            </div>
+          </Section>
+        )}
         {sourceFileSummary && (
           <>
             <DossierSourceFileSummaryPanel
@@ -1931,100 +2006,24 @@ export default function CandidateReviewPage() {
           )}
         </Section>
 
-        <Section title="Identity Link Actions">
-          <div className="space-y-5">
-            <div className="space-y-2">
+        <details className="border border-border bg-surface p-5 space-y-4">
+          <summary className="cursor-pointer text-2xl font-bold text-foreground">
+            Advanced: Add Identity Link Manually
+          </summary>
+          <div className="space-y-5 pt-4">
+            <div className="space-y-2 text-sm text-muted">
               <p>
-                Aliases help BNL route future BNL Signals to the right
-                source file. Identity Links create proposed review
-                material only, not confirmed identity. Internal aliases are not
-                public dossier text and remain admin-only. Public-safe
-                visibility does not publish anything yet.
+                Aliases help BNL route future BNL Signals to the right source file.
+                Identity Links create proposed review material only, not confirmed
+                identity. Internal aliases are not public dossier text and remain
+                admin-only. Public-safe visibility does not publish anything yet.
               </p>
               <p className="border border-border/70 bg-background/20 p-3">
-                Adding an alias does not make it public and does not affect
-                matching until confirmed. If an alias is created as proposed,
-                matching is not active yet.
+                Adding an alias does not make it public and does not affect matching
+                until confirmed. If an alias is created as proposed, matching is not
+                active yet.
               </p>
             </div>
-
-            {identityLinks.length === 0 ? (
-              <p>No identity links saved yet.</p>
-            ) : (
-              <div className="space-y-4">
-                {[
-                  {
-                    title: "Proposed Identity Links",
-                    empty: "No proposed identity links.",
-                    links: proposedIdentityLinks,
-                    quiet: false,
-                    intro:
-                      "Identity links are internal routing/context tools. Confirming a link can help future BNL Signals route to this Source File, but it does not merge Source Files, publish identity, or place the label in a public dossier.",
-                  },
-                  {
-                    title: "Confirmed Identity Links",
-                    empty: "No confirmed identity links.",
-                    links: confirmedIdentityLinks,
-                    quiet: false,
-                  },
-                  {
-                    title: "Rejected / Retired Identity History",
-                    empty: "No rejected or retired identity history.",
-                    links: closedIdentityLinks,
-                    quiet: true,
-                  },
-                ].map((group) => (
-                  <section
-                    key={group.title}
-                    className={`border border-border/60 bg-background/10 p-3 space-y-3 ${
-                      group.quiet ? "opacity-80" : ""
-                    }`}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <h3 className="text-sm font-bold uppercase tracking-widest text-foreground">
-                        {group.title}
-                      </h3>
-                      <span className="text-xs text-muted">
-                        {group.links.length} link
-                        {group.links.length === 1 ? "" : "s"}
-                      </span>
-                    </div>
-                    {group.intro && (
-                      <p className="border border-border/70 bg-background/20 p-3">
-                        {group.intro}
-                      </p>
-                    )}
-                    {group.links.length === 0 ? (
-                      <p className="text-xs">{group.empty}</p>
-                    ) : (
-                      <div className="space-y-3">
-                        {group.links.map((identityLink) => (
-                          <IdentityLinkCard
-                            key={identityLink.id}
-                            identityLink={identityLink}
-                            saving={saving}
-                            recommendation={
-                              identityLink.createdFromRecommendationId
-                                ? recommendationById.get(
-                                    identityLink.createdFromRecommendationId,
-                                  )
-                                : undefined
-                            }
-                            onReview={(identityLink, action, options) =>
-                              void reviewIdentityLink(
-                                identityLink,
-                                action,
-                                options,
-                              )
-                            }
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </section>
-                ))}
-              </div>
-            )}
             <form
               onSubmit={addIdentityLink}
               className="grid grid-cols-1 md:grid-cols-4 gap-3 text-xs uppercase tracking-widest text-muted"
@@ -2152,7 +2151,7 @@ export default function CandidateReviewPage() {
               </div>
             </form>
           </div>
-        </Section>
+        </details>
 
         <section className="border border-border bg-surface p-5 space-y-4">
           <h2 className="text-2xl font-bold text-foreground">

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -943,7 +943,8 @@ test("admin Source File page uses immediate refresh status/retry UI and preserve
     "What BNL Knows",
     "Evidence receipts",
     "Source Notes / Admin Addendums",
-    "Identity Link Actions",
+    "Identity Check",
+    "Advanced: Add Identity Link Manually",
     "Phase 4 — Owner Review",
     "Diagnostics — collapsed by default",
   ]) {
@@ -1178,7 +1179,8 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Internal-Only Notes",
     "Source Warnings",
     "Conflicts / Needs Review",
-    "Identity Link Actions",
+    "Identity Check",
+    "Advanced: Add Identity Link Manually",
     "Do Not Say",
     "Missing Info",
     "Proposed Dossier Status",
@@ -1350,7 +1352,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Internal-Only Notes",
     "Source Warnings",
     "Conflicts / Needs Review",
-    "Identity Link Actions",
+    "Identity Check",
+    "Advanced: Add Identity Link Manually",
     "Do Not Say",
     "Missing Info",
     "Review-only memory context",
@@ -1372,14 +1375,16 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   assert.doesNotMatch(pageCopy, /Internal Operator Summary/);
   assert.doesNotMatch(pageCopy, /Save Internal Summary/);
   assert.match(pageCopy, /Operator Case File Summary/);
-  const workspace = page.slice(page.indexOf("<DossierSourceFileSummaryPanel"));
+  const workspace = page.slice(page.indexOf('<Section title="Identity Check"'));
+  assert.ok(workspace.indexOf("Identity Check") < workspace.indexOf("DossierSourceFileSummaryPanel"));
+  assert.ok(workspace.indexOf("Identity Check") < workspace.indexOf("Proposed Dossier Status"));
   assert.ok(
     workspace.indexOf("DossierSourceFileSummaryPanel") < workspace.indexOf("Proposed Dossier Status"),
   );
   assert.ok(workspace.indexOf("Proposed Dossier Status") < workspace.indexOf("Add to Case File / BNL Source File"));
   assert.ok(workspace.indexOf("Add to Case File / BNL Source File") < workspace.indexOf("Source Notes / Admin Addendums"));
-  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Identity Link Actions"));
-  assert.ok(workspace.indexOf("Identity Link Actions") < workspace.indexOf("Operator Case File Summary"));
+  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Advanced: Add Identity Link Manually"));
+  assert.ok(workspace.indexOf("Advanced: Add Identity Link Manually") < workspace.indexOf("Operator Case File Summary"));
   assert.ok(workspace.indexOf("Operator Case File Summary") < workspace.indexOf("Diagnostics — collapsed by default"));
   assert.equal((page.match(/>\s*Open Proposed Dossier\s*</g) ?? []).length, 1);
   assert.equal((page.match(/>\s*Create Proposed Dossier\s*</g) ?? []).length, 1);
@@ -3248,6 +3253,22 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   ]) {
     assert.match(sourceFilePage, new RegExp(group));
   }
+  assert.match(sourceFilePage, /<Section title="Identity Check">/);
+  assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
+  assert.match(sourceFilePage, /identityLinks\.length > 0 &&/);
+  assert.doesNotMatch(sourceFilePage, /No identity links saved yet/);
+  assert.match(sourceFilePage, /title: "Proposed Identity Links",[\s\S]*links: proposedIdentityLinks/);
+  assert.match(sourceFilePage, /title: "Confirmed Identity Links",[\s\S]*links: confirmedIdentityLinks/);
+  assert.match(sourceFilePage, /title: "Rejected \/ Retired Identity History",[\s\S]*links: closedIdentityLinks/);
+  assert.match(sourceFilePage, /\.filter\(\(group\) => group\.links\.length > 0\)/);
+  const identityCheckStart = sourceFilePage.indexOf('<Section title="Identity Check">');
+  const identityCheckEnd = sourceFilePage.indexOf('</Section>', identityCheckStart);
+  const identityCheckSection = sourceFilePage.slice(identityCheckStart, identityCheckEnd);
+  assert.ok(identityCheckStart >= 0);
+  assert.ok(identityCheckStart < sourceFilePage.indexOf('Source Notes / Admin Addendums'));
+  assert.ok(identityCheckStart < sourceFilePage.indexOf('Proposed Dossier Status'));
+  assert.match(sourceFilePage, /Advanced: Add Identity Link Manually/);
+  assert.doesNotMatch(identityCheckSection, /Add Identity Link/);
   assert.match(
     sourceFilePage,
     /This alias is waiting for review\. It will not affect matching until confirmed\./,
@@ -3272,7 +3293,7 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   assert.match(sourceFilePage, /Not public dossier text/);
   assert.match(
     sourceFilePage,
-    /Identity links are internal routing\/context tools\. Confirming a link can help future BNL Signals route to this Source File, but it does not merge Source Files, publish identity, or place the label in a public dossier\./,
+    /Identity links are internal routing\/context tools\.[\s\S]*Resolve these before[\s\S]*using this Source File for dossier drafting\.[\s\S]*Confirming a link can[\s\S]*help future BNL Signals route to this Source File, but it does not[\s\S]*merge Source Files, publish identity, or place the label in a[\s\S]*public dossier\./,
   );
   assert.match(sourceFilePage, /Use for future matching after confirmation/);
   assert.match(sourceFilePage, /identityLink\.status === "proposed"/);
@@ -4122,7 +4143,9 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(sourceFilePage, /This source file[\s\S]*remains one subject\/entity/);
   assert.match(sourceFilePage, /create or wait for a separate BNL\s+recommendation/);
   assert.match(sourceFilePage, /Save Info/);
-  assert.match(sourceFilePage, /Identity Link Actions/);
+  assert.match(sourceFilePage, /Identity Check/);
+  assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
+  assert.match(sourceFilePage, /Advanced: Add Identity Link Manually/);
   assert.match(sourceFilePage, /Aliases help BNL route future BNL Signals/);
   assert.match(sourceFilePage, /Internal aliases are not\s+public dossier text/);
   assert.match(sourceFilePage, /Add Identity Link/);


### PR DESCRIPTION
### Motivation
- Identity links are a preflight/admin verification step and must be surfaced early so admins resolve identity context before drafting or public-facing work.
- The existing resolver rendered at the bottom and displayed an empty state and the manual add form inside the elevated resolver, which made the resolver appear even when nothing needed resolving.

### Description
- Renamed the resolver display label from "Identity Link Actions" to "Identity Check" in the Source File action taxonomy. (file: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Moved the elevated resolver block to the top of the Source File workspace (after the header/refresh block and before summary/dossier review) and gated it with `identityLinks.length > 0` so it only renders when links exist. (file: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Changed resolver rendering to only show non-empty groups by filtering for groups where `group.links.length > 0` and preserved all existing review actions/decision flows (confirm for matching, confirm reference only, reject, keep proposed, retire, created-from-BNL signal). (file: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Moved the manual Add Identity Link form out of the elevated resolver into a collapsed `details` section titled "Advanced: Add Identity Link Manually" so manual creation does not cause the Identity Check to appear. (files: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `tests/admin-dossiers.test.mjs`)
- Updated `tests/admin-dossiers.test.mjs` to assert the new heading, gating, group behavior, ordering (Identity Check appears before Source Notes / Admin Addendums and Proposed Dossier Status), absence of the empty "No identity links saved yet" copy in the elevated resolver, and presence of the advanced manual form below. (file: `tests/admin-dossiers.test.mjs`)

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs`, and all tests passed (139 tests run, 0 failures). 
- Ran `npx tsc --noEmit`, and TypeScript checked with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e7d7ccf8832196b6d377c1f955cb)