### PR TITLE
Add BNL Case File Report to Source File workspace

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -780,6 +780,17 @@ function formatDate(value?: string) {
   return value ? new Date(value).toLocaleString() : "—";
 }
 
+function SnapshotItem({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="border border-border/60 bg-background/30 p-3">
+      <dt className="text-[0.65rem] uppercase tracking-widest text-accent">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm text-foreground">{value}</dd>
+    </div>
+  );
+}
+
 function PhaseRail() {
   return (
     <section
@@ -1985,26 +1996,65 @@ export default function CandidateReviewPage() {
           </form>
         </section>
 
-        <Section title="Source Notes / Admin Addendums">
-          {sourceNotes.length === 0 ? (
-            <p>No saved source notes yet.</p>
-          ) : (
-            <div className="space-y-3">
-              {sourceNotes.map((note) => (
-                <HumanReadableNoteView
-                  key={note.id}
-                  view={createHumanReadableSourceFileNoteView({
-                    ...note,
-                    subjectName: candidate.name,
-                  })}
-                  createdAt={note.createdAt}
-                  workflowLane={candidate.status}
-                  appliedDraftId={note.appliesToDraftId}
-                />
-              ))}
-            </div>
-          )}
-        </Section>
+        <details className="border border-border bg-surface p-5 text-sm text-muted">
+          <summary className="cursor-pointer text-2xl font-bold text-foreground">
+            Source Notes / Admin Addendums — collapsed summary
+          </summary>
+          <div className="space-y-4 pt-4">
+            <dl className="grid grid-cols-1 gap-3 md:grid-cols-4">
+              <SnapshotItem label="Notes" value={String(sourceNotes.length)} />
+              <SnapshotItem
+                label="Warnings"
+                value={String(
+                  sourceNotes.filter((note) =>
+                    /warn|caution|do not|not public|internal|review-only/i.test(note.text),
+                  ).length,
+                )}
+              />
+              <SnapshotItem
+                label="Dossier questions"
+                value={String(
+                  sourceNotes.filter((note) =>
+                    /\?|missing|confirm|needs? review|question/i.test(note.text),
+                  ).length,
+                )}
+              />
+              <SnapshotItem
+                label="Latest updated"
+                value={sourceNotes[0]?.updatedAt ? formatDate(sourceNotes[0].updatedAt) : "—"}
+              />
+            </dl>
+            {sourceNotes.length === 0 ? (
+              <p>No saved source notes yet.</p>
+            ) : (
+              <div className="space-y-3">
+                {sourceNotes.map((note) => (
+                  <details key={note.id} className="border border-border/70 bg-background/20 p-3">
+                    <summary className="cursor-pointer font-semibold text-foreground">
+                      {
+                        createHumanReadableSourceFileNoteView({
+                          ...note,
+                          subjectName: candidate.name,
+                        }).summary
+                      }
+                    </summary>
+                    <div className="pt-3">
+                      <HumanReadableNoteView
+                        view={createHumanReadableSourceFileNoteView({
+                          ...note,
+                          subjectName: candidate.name,
+                        })}
+                        createdAt={note.createdAt}
+                        workflowLane={candidate.status}
+                        appliedDraftId={note.appliesToDraftId}
+                      />
+                    </div>
+                  </details>
+                ))}
+              </div>
+            )}
+          </div>
+        </details>
 
         <details className="border border-border bg-surface p-5 space-y-4">
           <summary className="cursor-pointer text-2xl font-bold text-foreground">

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -61,6 +61,281 @@ function SummaryList({ items }: { items: string[] }) {
   );
 }
 
+
+
+type BnlCaseFileReport = {
+  reportTitle: string;
+  statusLabel: string;
+  summary: string;
+  dossierUse: string;
+  publicSafeFacts: string[];
+  evidenceBackedClaims: string[];
+  communityContext: string[];
+  musicPlatformContext: string[];
+  reviewBlockers: string[];
+  internalOnlyNotes: string[];
+  nextAction: string;
+  hasUsableSourceData: boolean;
+};
+
+type SourceFileBriefLike = Partial<BnlCaseFileReport> & {
+  title?: string;
+  currentUnderstanding?: string;
+  whatBnlUnderstands?: string;
+  safeDossierUse?: string;
+  publicSafeClaims?: string[];
+  evidence?: string[];
+  claims?: string[];
+  blockers?: string[];
+  doNotSay?: string[];
+};
+
+const DEFAULT_REPORT_EMPTY_MESSAGE =
+  "Refresh BNL to generate a readable report once source notes, archive fields, or recommendations are available.";
+
+function textFromBrief(value: unknown, keys: string[]) {
+  if (!value) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const item = record[key];
+    if (typeof item === "string" && item.trim()) return item;
+    if (Array.isArray(item)) {
+      const joined = item.filter((entry) => typeof entry === "string" && entry.trim()).join(" ");
+      if (joined.trim()) return joined;
+    }
+  }
+  return undefined;
+}
+
+function listFromBrief(value: unknown, keys: string[]) {
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  const items: string[] = [];
+  for (const key of keys) {
+    const item = record[key];
+    if (typeof item === "string") items.push(item);
+    if (Array.isArray(item)) {
+      for (const entry of item) if (typeof entry === "string") items.push(entry);
+    }
+  }
+  return items;
+}
+
+function cleanVisibleReportText(value?: string | null, maxLength = 220) {
+  if (/rawRefJson|source table|row IDs?|source lane mapping|\[object Object\]/i.test(value ?? "")) return undefined;
+  const base = displaySafeText(value);
+  if (!base) return undefined;
+  let clean = base
+    .replace(/\bapproved\s+approved\b/gi, "approved")
+    .replace(/\b(?:global_mixed|source_blind)\b/gi, "")
+    .replace(/\bautomated topic labels?\b[:\s-]*/gi, "")
+    .replace(/\binternal classification\b[:\s-]*/gi, "")
+    .replace(/\bconversation evidence:\s*\d+\s*source row\(s\) found\.?/gi, "repeated conversation evidence is available.")
+    .replace(/\b\d+\s*source row\(s\) found\b/gi, "source evidence is available")
+    .replace(/\bsource row\(s\)\b/gi, "source items")
+    .replace(/\bsource[-\s]?lane\b[:\s-]*/gi, "")
+    .replace(/\bMissing Info\b/gi, "Review blockers")
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.;:])/g, "$1")
+    .trim();
+  if (!clean || /^(?:review blockers?|debug|diagnostic)[:\s-]*$/i.test(clean)) return undefined;
+  if (clean.length > maxLength) {
+    const trimmed = clean.slice(0, maxLength).replace(/\s+\S*$/, "").trim();
+    clean = `${trimmed.replace(/[.;,:-]+$/, "")}…`;
+  }
+  return clean;
+}
+
+function cleanReportItems(items: Array<string | undefined | null>, limit: number) {
+  const output: string[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const clean = cleanVisibleReportText(item);
+    if (!clean) continue;
+    if (/\b(?:global_mixed|source_blind|automated topic label|internal classification|source row\(s\)|Missing Info)\b/i.test(clean)) continue;
+    const key = visibleDedupeKey(clean.replace(/owner\/admin|admin\/owner/gi, "review"));
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function sourceNotesText(sourceFileNotes: Array<Pick<DossierSourceFileNote, "text"> | string | null | undefined>) {
+  return sourceFileNotes.map((note) => (typeof note === "string" ? note : note?.text)).filter(Boolean) as string[];
+}
+
+function hasUsableReportData(items: string[]) {
+  return cleanReportItems(items, 1).length > 0;
+}
+
+export function buildBnlCaseFileReport({
+  summary,
+  entityReadout,
+  subjectName,
+  recommendations = [],
+  sourceFileNotes = [],
+  latestSourceFileArchive,
+  actionableBrief,
+}: {
+  summary: DossierSourceFileSummary;
+  entityReadout?: DossierEntityActivityReadout | null;
+  subjectName?: string;
+  recommendations?: Array<Partial<DossierRecommendation>>;
+  sourceFileNotes?: Array<Pick<DossierSourceFileNote, "text"> | string | null | undefined>;
+  latestSourceFileArchive?: DossierSourceFileArchiveMetadata & { sourceFileBriefV2?: unknown };
+  actionableBrief: ReturnType<typeof buildSourceFileActionableBrief>;
+}): BnlCaseFileReport {
+  const subject = subjectName ?? latestSourceFileArchive?.subjectName ?? "This subject";
+  const brief = latestSourceFileArchive?.sourceFileBriefV2 as SourceFileBriefLike | string | undefined;
+  const noteTexts = sourceNotesText(sourceFileNotes);
+  const recommendationSignals = recommendations.flatMap((recommendation) => [
+    (recommendation as { summary?: string }).summary,
+    ...(recommendation.knownContext ?? []),
+    ...(recommendation.usefulEvidence ?? []),
+    ...(recommendation.relationshipSignals ?? []),
+    ...(recommendation.conversationHighlights ?? []),
+    ...(recommendation.bnlInteractionSignals ?? []),
+    ...(recommendation.musicSignals ?? []),
+    ...(recommendation.communitySignals ?? []),
+    ...(recommendation.publicUseCandidates ?? []),
+  ]);
+  const archivePriority = [
+    textFromBrief(brief, ["summary", "currentUnderstanding", "whatBnlUnderstands"]),
+    latestSourceFileArchive?.compactSummary,
+    ...(latestSourceFileArchive?.publicSafePossibilities ?? []),
+    ...(latestSourceFileArchive?.evidenceReceiptSummary ?? []),
+    ...(latestSourceFileArchive?.missingInfo ?? []),
+    ...(latestSourceFileArchive?.publicSafetyNotes ?? []),
+    ...(latestSourceFileArchive?.doNotSay ?? []),
+  ];
+  const sourceDataPool = [
+    ...archivePriority,
+    ...((summary as DossierSourceFileSummary & { evidenceItems?: string[] }).evidenceItems ?? []),
+    ...noteTexts,
+    ...recommendationSignals,
+    summary.currentRead,
+    summary.whyTracked,
+    ...(summary.knownContext ?? []),
+    ...(summary.usefulEvidence ?? []),
+    ...(summary.publicSafePossibilities ?? []),
+    ...(summary.publicUseCandidates ?? []),
+    ...(entityReadout?.publicSafePossibilities ?? []),
+    ...(entityReadout?.representativeEvidence ?? []),
+  ].filter(Boolean) as string[];
+  const hasUsableSourceData = hasUsableReportData(sourceDataPool);
+
+  const summaryText = cleanVisibleReportText(
+    textFromBrief(brief, ["summary", "currentUnderstanding", "whatBnlUnderstands"]) ??
+      latestSourceFileArchive?.compactSummary ??
+      entityReadout?.currentRead ??
+      summary.currentRead ??
+      `${subject} has source-file material available for BNL review.`,
+    420,
+  );
+  const publicSafeFacts = cleanReportItems(
+    [
+      ...listFromBrief(brief, ["publicSafeFacts", "publicSafeClaims", "publicSafePossibilities"]),
+      ...(latestSourceFileArchive?.publicSafePossibilities ?? []),
+      ...(entityReadout?.publicSafePossibilities ?? []),
+      ...summary.publicSafePossibilities,
+      ...(summary.publicUseCandidates ?? []),
+    ],
+    5,
+  );
+  const evidenceBackedClaims = cleanReportItems(
+    [
+      ...listFromBrief(brief, ["evidenceBackedClaims", "evidence", "claims"]),
+      ...(latestSourceFileArchive?.evidenceReceiptSummary ?? []),
+      ...(summary.usefulEvidence ?? []),
+      ...(summary.confirmedStrong ?? []),
+      ...(entityReadout?.representativeEvidence ?? []),
+      ...actionableBrief.supportingEvidence,
+    ],
+    5,
+  );
+  const communityContext = cleanReportItems(
+    [
+      ...listFromBrief(brief, ["communityContext", "relationshipContext"]),
+      ...(summary.communitySignals ?? []),
+      ...(summary.privateRelationshipContext ?? []),
+      ...(entityReadout?.relationshipSignals ?? []),
+      ...actionableBrief.bnlInteractionPatterns,
+      ...actionableBrief.communityActivity,
+    ],
+    4,
+  );
+  const musicPlatformContext = cleanReportItems(
+    [
+      ...listFromBrief(brief, ["musicPlatformContext", "platformContext"]),
+      ...(summary.musicSignals ?? []),
+      ...actionableBrief.musicSignals,
+      ...actionableBrief.platformSignals,
+    ],
+    4,
+  );
+  const blockerItems = [
+    ...listFromBrief(brief, ["reviewBlockers", "blockers", "dossierQuestions"]),
+    ...(latestSourceFileArchive?.missingInfo ?? []),
+    ...summary.missingInfo,
+    ...(entityReadout?.missingInfo ?? []),
+    ...actionableBrief.missingInfo,
+  ];
+  const reviewBlockers = cleanReportItems(
+    [
+      ...blockerItems,
+      "Confirm public-safe role, display wording, public links, and identity details before public dossier drafting.",
+      (entityReadout?.queueSubmissionStatus ?? summary.queueSubmissionStatus) === "not_connected" || !(entityReadout?.queueSubmissionStatus ?? summary.queueSubmissionStatus)
+        ? "Queue/submission history is not confirmed yet; do not claim submitted songs, play history, source type, or Priority/payment history."
+        : undefined,
+    ],
+    5,
+  );
+  const internalOnlyNotes = cleanReportItems(
+    [
+      ...listFromBrief(brief, ["internalOnlyNotes", "doNotSay"]),
+      ...(latestSourceFileArchive?.doNotSay ?? []),
+      ...(latestSourceFileArchive?.publicSafetyNotes ?? []),
+      ...(summary.privateOnlyNotes ?? []),
+      ...(summary.notPublicYet ?? []),
+      ...actionableBrief.reviewOnlyCautions,
+    ],
+    5,
+  );
+  const dossierUse = cleanVisibleReportText(
+    textFromBrief(brief, ["dossierUse", "safeDossierUse"]) ??
+      (publicSafeFacts.length
+        ? "Use these notes as source-file material for dossier drafting only after owner/admin review confirms public-safe wording."
+        : "Use this as a Source File now, but hold public dossier wording until review blockers are resolved."),
+    420,
+  ) ?? DEFAULT_REPORT_EMPTY_MESSAGE;
+  const nextAction = cleanVisibleReportText(
+    textFromBrief(brief, ["nextAction"]) ??
+      summary.recommendedNextAction ??
+      entityReadout?.recommendedAction ??
+      "Keep as Source File and resolve review blockers before public dossier drafting.",
+    260,
+  ) ?? "Keep as Source File and resolve review blockers before public dossier drafting.";
+
+  return {
+    reportTitle: cleanVisibleReportText(textFromBrief(brief, ["reportTitle", "title"]), 120) ?? "BNL Case File Report",
+    statusLabel: readinessLabel(summary.publicReadiness),
+    summary: hasUsableSourceData ? summaryText ?? `${subject} has usable BNL source-file material for review.` : DEFAULT_REPORT_EMPTY_MESSAGE,
+    dossierUse,
+    publicSafeFacts,
+    evidenceBackedClaims,
+    communityContext,
+    musicPlatformContext,
+    reviewBlockers,
+    internalOnlyNotes,
+    nextAction,
+    hasUsableSourceData,
+  };
+}
+
 function ActivityGroup({
   title,
   items,
@@ -149,6 +424,7 @@ function displaySafeText(value?: string | null) {
     .replace(/\brow\(s\)\b/gi, "items")
     .replace(/\bpublic-side\b/gi, "approved public context")
     .replace(/\bReview candidate\b/g, "Review item")
+    .replace(/relationship\/context/gi, "relationship context")
     .replace(/\bidentity matching context\b/gi, "identity review context")
     .replace(/\blocal context\b/gi, "BNL review context")
     .replace(/\bprofile_match\b/gi, "local profile match");
@@ -659,6 +935,18 @@ export function DossierSourceFileSummaryPanel({
     recommendations,
     sourceFileNotes,
   });
+  const caseFileReport = buildBnlCaseFileReport({
+    summary,
+    entityReadout,
+    subjectName,
+    recommendations,
+    sourceFileNotes,
+    latestSourceFileArchive,
+    actionableBrief,
+  });
+  const sourceNoteTexts = sourceNotesText(sourceFileNotes);
+  const sourceNoteWarningCount = sourceNoteTexts.filter((note) => /warn|caution|do not|not public|internal|review-only/i.test(note)).length;
+  const sourceNoteQuestionCount = sourceNoteTexts.filter((note) => /\?|missing|confirm|needs? review|question/i.test(note)).length;
   const visibleFacts = new Set<string>();
   const allSignals = safeReviewItems(
     [
@@ -819,6 +1107,7 @@ export function DossierSourceFileSummaryPanel({
     ].filter(Boolean) as string[],
     visibleFacts,
   );
+  const displayActionItems = cleanReportItems(actionItems, 12);
   const evidenceSeen = new Set<string>();
   const strongEvidence = takeWithoutRepeats(
     [
@@ -957,10 +1246,10 @@ export function DossierSourceFileSummaryPanel({
           </p>
           <h2 className="text-2xl font-bold text-foreground">{title}</h2>
           <p className="mt-2 text-sm text-muted max-w-4xl">
-            Review Snapshot → What BNL Knows → Action Items → Evidence →
-            Notes/Identity → Diagnostics. Internal-only review surface; it does
-            not publish, create Proposed Dossiers, merge identities, or create queue/payment
-            behavior.
+            BNL Case File Report → Public-Safe Facts → Evidence-Backed Claims →
+            Review Blockers → Workbench → collapsed raw archive and diagnostics.
+            Internal-only review surface; it does not publish, auto-confirm identity,
+            merge source files, or create queue/payment behavior.
           </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
@@ -987,106 +1276,157 @@ export function DossierSourceFileSummaryPanel({
       </Section>
 
 
-      {latestSourceFileArchive && (
-        <Section
-          title="Latest BNL Source Archive Readout"
-          helper="Compact archive-derived fields only. The complete Source Archive stays internal and collapsed below."
-        >
-          <SummaryList
-            items={fallbackItems(
-              archiveReadoutItems,
-              "Latest archive exists, but no compact readout fields were supplied.",
-            )}
-          />
-        </Section>
-      )}
-
-      {latestSourceFileArchive && (
-        <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
-          <summary className="cursor-pointer font-semibold text-foreground">
-            Full BNL Source Archive — admin-only / collapsed
-          </summary>
-          <p className="mt-3 text-xs uppercase tracking-widest text-accent">
-            Internal archive metadata only. Full source package content is stored outside the workflow dashboard and is not rendered here.
-          </p>
-          <dl className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
-            <SnapshotItem label="Archive id" value={latestSourceFileArchive.id} />
-            <SnapshotItem label="Digest" value={latestSourceFileArchive.sourceDigest.slice(0, 16)} />
-            <SnapshotItem label="Size" value={`${latestSourceFileArchive.archiveSize} bytes`} />
-            <SnapshotItem label="Chunks" value={String(latestSourceFileArchive.chunkCount)} />
-            <SnapshotItem label="Updated" value={formatSnapshotDate(latestSourceFileArchive.updatedAt)} />
-            <SnapshotItem label="Review-only" value={latestSourceFileArchive.reviewOnly ? "Yes" : "No"} />
-          </dl>
-        </details>
-      )}
-
       <Section
-        title="What BNL Knows"
-        helper="Primary intelligence summary. Review-only material is labeled and is not public dossier copy."
+        title="BNL Case File Report"
+        helper="Readable BNL case-file report for dossier creation and update decisions."
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-          {whatBnlKnows.map((group) => (
-            <ActivityGroup
-              key={group.title}
-              title={group.title}
-              items={group.items}
-              empty={group.empty}
-              receipts={evidenceReceipts[group.receiptGroup]}
-            />
-          ))}
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+            <StatusBadge>{caseFileReport.statusLabel}</StatusBadge>
+            <StatusBadge>{caseFileReport.hasUsableSourceData ? "Usable Source File" : "Needs BNL refresh"}</StatusBadge>
+          </div>
+          <p className="text-foreground">{caseFileReport.summary}</p>
+          <p>{caseFileReport.dossierUse}</p>
+          <p className="border border-border/60 bg-background/30 p-3">
+            <span className="font-bold text-foreground">Next action: </span>
+            {caseFileReport.nextAction}
+          </p>
         </div>
       </Section>
 
       <Section
-        title="Admin Action Items / Missing Info"
-        tone="caution"
-        helper="What needs to happen next before public copy, owner review, identity matching, or submission claims."
+        title="Public-Safe Facts"
+        helper="Candidate facts that may become dossier wording only after owner/admin review."
       >
         <SummaryList
           items={fallbackItems(
-            actionItems,
-            "No action item has been extracted yet; continue human review before public use.",
+            caseFileReport.publicSafeFacts,
+            "No public-safe facts are ready for wording yet; keep this as review material.",
           )}
         />
       </Section>
 
       <Section
-        title="Evidence by Category"
-        helper="Why BNL thinks this. Evidence is grouped, deduped, and kept separate from raw diagnostics."
+        title="Evidence-Backed Claims"
+        helper="What the existing evidence supports, stated without raw source labels."
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-          <ActivityGroup
-            title="Strong Evidence"
-            items={strongEvidence}
-            empty="No strong evidence has been separated yet."
-          />
-          <ActivityGroup
-            title="Public-safe Evidence"
-            items={publicSafeEvidence}
-            empty="No public-safe candidate evidence has been separated yet."
-          />
-          <ActivityGroup
-            title="Review-only Evidence"
-            items={reviewOnlyEvidence}
-            empty="No review-only evidence has been separated yet."
-          />
-          <ActivityGroup
-            title="Source Coverage"
-            items={sourceCoverageEvidence}
-            empty="No source coverage summary is available yet."
-          />
-          <ActivityGroup
-            title="Channel / Activity Evidence"
-            items={channelActivityEvidence}
-            empty="No channel or activity evidence is available yet."
-          />
-          <ActivityGroup
-            title="Music / Platform / Link Evidence"
-            items={linkPlatformEvidence}
-            empty="No link or platform evidence has been separated yet."
-          />
-        </div>
+        <SummaryList
+          items={fallbackItems(
+            caseFileReport.evidenceBackedClaims,
+            "Evidence is weak or not summarized yet; use the collapsed archive and notes for review.",
+          )}
+        />
       </Section>
+
+      <Section
+        title="Community / Relationship Context"
+        helper="Useful community role, relationship, and repeated interaction context; uncertain relationships remain review-only."
+      >
+        <SummaryList
+          items={fallbackItems(
+            caseFileReport.communityContext,
+            "No community or relationship context is ready for visible review yet.",
+          )}
+        />
+      </Section>
+
+      {caseFileReport.musicPlatformContext.length > 0 && (
+        <Section
+          title="Music / Platform / Link Context"
+          helper="Music and platform context only; this does not confirm submissions or artist status unless evidence says so."
+        >
+          <SummaryList items={caseFileReport.musicPlatformContext} />
+        </Section>
+      )}
+
+      <Section
+        title="Review Blockers"
+        tone="caution"
+        helper="Dossier questions to resolve before public wording or stronger identity/role claims."
+      >
+        <SummaryList
+          items={fallbackItems(
+            caseFileReport.reviewBlockers,
+            "Confirm public-safe role, display wording, public links, and identity details before public dossier drafting.",
+          )}
+        />
+      </Section>
+
+      <Section
+        title="Internal-Only / Do Not Say"
+        tone="review"
+        helper="Material that must remain internal unless owner/admin review explicitly clears it."
+      >
+        <SummaryList
+          items={fallbackItems(
+            caseFileReport.internalOnlyNotes,
+            "No internal-only warnings are summarized for the visible report yet.",
+          )}
+        />
+      </Section>
+
+      <Section
+        title="Dossier Workbench / Proposed Dossier Status"
+        helper="This panel supports dossier decisions but does not publish, merge, or auto-confirm anything."
+      >
+        <SummaryList
+          items={fallbackItems(
+            displayActionItems,
+            "No action item has been extracted yet; continue human review before public use.",
+          )}
+        />
+      </Section>
+
+      <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
+        <summary className="cursor-pointer font-semibold text-foreground">
+          Source Notes / Admin Addendums — collapsed summary
+        </summary>
+        <dl className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-4">
+          <SnapshotItem label="Notes" value={String(sourceNoteTexts.length)} />
+          <SnapshotItem label="Warnings" value={String(sourceNoteWarningCount)} />
+          <SnapshotItem label="Dossier questions" value={String(sourceNoteQuestionCount)} />
+          <SnapshotItem label="Latest updated" value={formatSnapshotDate(summary.lastUpdatedAt)} />
+        </dl>
+        {sourceNoteTexts.length > 0 && (
+          <div className="mt-3">
+            <SummaryList items={cleanReportItems(sourceNoteTexts, 5)} />
+          </div>
+        )}
+      </details>
+
+      <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
+        <summary className="cursor-pointer font-semibold text-foreground">
+          Archive / Raw Source File Data — collapsed
+        </summary>
+        {latestSourceFileArchive ? (
+          <div className="mt-3 space-y-4">
+            <Section
+              title="Latest BNL Source Archive Readout"
+              helper="Compact archive-derived fields only. Full raw archive remains internal."
+            >
+              <SummaryList
+                items={fallbackItems(
+                  archiveReadoutItems,
+                  "Latest archive exists, but no compact readout fields were supplied.",
+                )}
+              />
+            </Section>
+            <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
+              <SnapshotItem label="Archive id" value={latestSourceFileArchive.id} />
+              <SnapshotItem label="Digest" value={latestSourceFileArchive.sourceDigest.slice(0, 16)} />
+              <SnapshotItem label="Size" value={`${latestSourceFileArchive.archiveSize} bytes`} />
+              <SnapshotItem label="Chunks" value={String(latestSourceFileArchive.chunkCount)} />
+              <SnapshotItem label="Updated" value={formatSnapshotDate(latestSourceFileArchive.updatedAt)} />
+              <SnapshotItem label="Review-only" value={latestSourceFileArchive.reviewOnly ? "Yes" : "No"} />
+            </dl>
+            <Section title="Raw evidence receipts" helper="Collapsed receipt summaries; not public dossier copy.">
+              <SummaryList items={fallbackItems([...strongEvidence, ...publicSafeEvidence, ...reviewOnlyEvidence], "No raw evidence receipt summaries are available.")} />
+            </Section>
+          </div>
+        ) : (
+          <p className="mt-3">No full BNL source archive is attached yet.</p>
+        )}
+      </details>
 
       <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
         <summary className="cursor-pointer font-semibold text-foreground">
@@ -1107,8 +1447,7 @@ export function DossierSourceFileSummaryPanel({
 
       <p className="text-xs text-muted">
         Public-safe candidate, Review-only, Internal-only, Needs owner review,
-        Not connected yet, and Source-blind / diagnostic-only material remain
-        separated.
+        and Not connected yet material remain separated.
       </p>
     </section>
   );

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -940,7 +940,7 @@ test("admin Source File page uses immediate refresh status/retry UI and preserve
 
   for (const label of [
     "Review Snapshot",
-    "What BNL Knows",
+    "BNL Case File Report",
     "Evidence receipts",
     "Source Notes / Admin Addendums",
     "Identity Check",
@@ -1559,12 +1559,12 @@ test("admin Source File and recommendation pages render readable sections with c
     "HumanReadableNoteView",
     "Case File / BNL Source File Summary",
     "Review Snapshot",
-    "What BNL Knows",
+    "BNL Case File Report",
     "Relationships / People / Projects",
-    "Primary intelligence summary",
-    "Evidence by Category",
-    "Action Items",
-    "Admin Action Items / Missing Info",
+    "Readable BNL case-file report",
+    "Evidence-Backed Claims",
+    "Dossier Workbench / Proposed Dossier Status",
+    "Review Blockers",
     "Subject",
     "Public readiness:",
     "Public dossier match",
@@ -1575,9 +1575,9 @@ test("admin Source File and recommendation pages render readable sections with c
     "Review-only context connected to this subject",
     "Diagnostics only. Not Case File claims.",
     "warnings",
-    "Action Items",
-    "Review-only Evidence",
-    "What BNL Knows",
+    "Dossier Workbench / Proposed Dossier Status",
+    "Internal-Only / Do Not Say",
+    "BNL Case File Report",
     "Review-only",
   ]) {
     assertIncludesCopy(candidatePage, label);
@@ -6165,17 +6165,18 @@ test("Source File page renders Entity Intelligence Review Console sections", () 
   );
   assert.match(summaryPanel, /Entity Intelligence Review Console/);
   assertIncludesCopy(summaryPanel, "Review Snapshot");
-  assertIncludesCopy(summaryPanel, "What BNL Knows");
-  assertIncludesCopy(summaryPanel, "Admin Action Items / Missing Info");
+  assertIncludesCopy(summaryPanel, "BNL Case File Report");
+  assert.doesNotMatch(summaryPanel, /BNL Brief/);
+  assertIncludesCopy(summaryPanel, "Review Blockers");
   assertIncludesCopy(summaryPanel, "Queue/submission history is not connected yet");
   assertIncludesCopy(summaryPanel, "Review-only");
   assertIncludesCopy(summaryPanel, "Structured packet");
   assertIncludesCopy(summaryPanel, "Safe fallback");
-  assertIncludesCopy(summaryPanel, "Evidence by Category");
-  assertIncludesCopy(summaryPanel, "Relationships / People / Projects");
-  assertIncludesCopy(summaryPanel, "BNL Interaction");
-  assertIncludesCopy(summaryPanel, "Music / Platform / Link Evidence");
-  assertIncludesCopy(summaryPanel, "Event / Contest / Community Signals");
+  assertIncludesCopy(summaryPanel, "Evidence-Backed Claims");
+  assertIncludesCopy(summaryPanel, "Community / Relationship Context");
+  assertIncludesCopy(summaryPanel, "Dossier Workbench / Proposed Dossier Status");
+  assertIncludesCopy(summaryPanel, "Music / Platform / Link Context");
+  assertIncludesCopy(summaryPanel, "Archive / Raw Source File Data — collapsed");
   assertIncludesCopy(summaryPanel, "Diagnostics — collapsed by default");
   assertIncludesCopy(summaryPanel, "Diagnostics only. Not Case File claims.");
   assert.doesNotMatch(summaryPanel, /rawProvenance/);
@@ -6183,6 +6184,64 @@ test("Source File page renders Entity Intelligence Review Console sections", () 
   assert.match(recommendationPage, /createDossierEntityActivityReadoutFromRecommendation/);
   assert.match(recommendationPage, /DossierEntityActivityReadoutPanel/);
   assertIncludesCopy(readoutPanel, "BNL Entity Readout / Entity Activity Summary");
+});
+
+
+
+test("BNL Case File Report renders from brief and legacy archive data with display cleanup", () => {
+  const baseSummary = {
+    currentRead: "Crow appears to be a recurring BARCODE community member with repeated BNL-related conversations.",
+    knownContext: [], whyTracked: "Source file review.", usefulEvidence: [], patterns: [], confirmedStrong: [], claimedNeedsReview: [], privateRelationshipContext: [],
+    publicSafePossibilities: [], privateOnlyNotes: [], uncertainties: [], missingInfo: ["Missing Info: confirm public links."], notPublicYet: [], observedChannels: [], conversationHighlights: [], topicBreakdown: [], bestEvidenceToReview: [], bnlInteractionSignals: [], musicSignals: [], communitySignals: [], sourceCoverage: [], evidenceDetails: [], representativeEvidence: [], activityFrequencySummary: [], topChannels: [], topTopicDetails: [], recentActivitySummary: [], authoredVsMentionedSummary: [], publicUseCandidates: [], reviewOnlyEvidence: [], queueSubmissionStatus: "not_connected", queueSubmissionNote: "No queue bridge.", sourceAuthority: [], recommendedNextAction: "Keep as Source File and resolve review blockers before public dossier drafting.", substanceLevel: "useful", publicReadiness: "needs_review", existingPublicDossier: "no", nextAction: "owner_review", lastUpdatedAt: "2026-06-03T00:00:00.000Z", summarySource: "structured",
+  };
+  const archiveBase = {
+    id: "archive-test", candidateId: "candidate-test", subjectName: "Crow", sourceDigest: "abc1234567890def", createdAt: "2026-06-03T00:00:00.000Z", updatedAt: "2026-06-03T00:00:00.000Z", archiveSize: 1234, chunkCount: 1, reviewOnly: true,
+  };
+  const withBrief = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: baseSummary,
+    subjectName: "Crow",
+    latestSourceFileArchive: {
+      ...archiveBase,
+      sourceFileBriefV2: {
+        summary: "Crow appears in approved approved community context without global_mixed debug labels.",
+        dossierUse: "Use as dossier input after review.",
+        publicSafeFacts: ["Crow appears in public-safe BNL community context.", "Crow appears in public-safe BNL community context."],
+        evidenceBackedClaims: ["conversation evidence: 49 source row(s) found."],
+        reviewBlockers: ["Missing Info: confirm public role."],
+        internalOnlyNotes: ["source_blind relationship context stays internal."],
+        nextAction: "Resolve review blockers before public drafting.",
+      },
+    },
+  }));
+  const briefReport = withBrief.slice(withBrief.indexOf("BNL Case File Report"), withBrief.indexOf("Archive / Raw Source File Data — collapsed"));
+  assert.match(withBrief, /BNL Case File Report/);
+  assert.doesNotMatch(withBrief, /BNL Brief/);
+  assert.match(briefReport, /Crow appears in approved community context/);
+  assert.equal((briefReport.match(/Crow appears in public-safe BNL community context/g) ?? []).length, 1);
+  assert.doesNotMatch(briefReport, /approved approved|global_mixed|source_blind|automated topic label|internal classification|source row\(s\)|Missing Info/);
+  assert.match(briefReport, /Review Blockers/);
+
+  const legacy = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { ...baseSummary, currentRead: undefined },
+    subjectName: "Crow",
+    latestSourceFileArchive: {
+      ...archiveBase,
+      compactSummary: "Crow appears to be a recurring BARCODE community-adjacent subject with repeated BNL-related discussion.",
+      publicSafePossibilities: ["Crow may be described as a recurring community participant after review."],
+      evidenceReceiptSummary: ["Evidence supports community interaction and review-only context."],
+      missingInfo: ["Public role, display wording, public links, and queue/submission status still need review."],
+      publicSafetyNotes: ["Suno appears in the archive, but queue/submission history is not confirmed yet."],
+      doNotSay: ["Orion relationship context should stay internal until confirmed."],
+    },
+  }));
+  assert.match(legacy, /recurring BARCODE community-adjacent subject/);
+  assert.doesNotMatch(legacy, /Refresh BNL to generate a readable report/);
+
+  const empty = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { ...baseSummary, currentRead: undefined, whyTracked: undefined, missingInfo: [], recommendedNextAction: undefined },
+    subjectName: "Empty Fixture",
+  }));
+  assert.match(empty, /Refresh BNL to generate a readable report/);
 });
 
 test("Entity Intelligence Review Console collapses duplicate safe bullets and keeps raw labels diagnostic-only", () => {
@@ -6260,12 +6319,12 @@ test("Entity Intelligence Review Console collapses duplicate safe bullets and ke
 
   assert.match(text, /Entity Intelligence Review Console/);
   assert.match(text, /BNL found an internal local profile match for Crow/);
-  assert.match(text, /BNL found prior relationship\/context notes connected to Crow/);
+  assert.match(text, /BNL found prior relationship context notes connected to Crow/);
   assert.match(text, /Source confidence:\s+High/);
   assert.match(text, /Review-only/);
   assert.match(text, /Queue\/submission history is not connected yet/);
   assert.ok((text.match(/profile match/gi) ?? []).length <= 2);
-  assert.ok((text.match(/relationship\/context/gi) ?? []).length <= 2);
+  assert.equal((text.match(/relationship\/context/gi) ?? []).length, 0);
   assert.doesNotMatch(
     text,
     /rawProvenance|user_profiles\/local_profile_observed|relationship_journal\/local_relationship_trace|conversations\/public_discord_observed|memory_tiers\/source_blind_memory_trace|source lane mapping|unknown -> unknown|help_signal|EDGE_SESSION/,
@@ -6345,21 +6404,21 @@ test("Entity Intelligence Review Console promotes actionable Crow intelligence a
     recommendations: [attachedRecommendation],
     sourceFileNotes,
   }));
-  const knowsStart = text.indexOf("What BNL Knows");
+  const knowsStart = text.indexOf("BNL Case File Report");
   const diagnosticsStart = text.indexOf("Diagnostics — collapsed by default");
 
-  assert.match(text, /What BNL Knows/);
-  assert.match(text, /Orion appears in reviewed evidence connected to Crow/);
-  assert.match(text, /Suno appears in reviewed evidence/);
+  assert.match(text, /BNL Case File Report/);
+  assert.match(text, /Recurring named topic: Orion appears across reviewed messages/);
+  assert.match(text, /Suno appears in reviewed evidence|Tool\/platform mention: Suno/);
   assert.match(text, /Crow has repeated BNL interaction evidence in approved review context/);
   assert.match(text, /Queue\/submission history is not connected yet/);
-  assert.match(text, /submitted song counts, (?:play history|played tracks), source type, or Priority\/payment history/);
-  assert.match(text, /Admin Action Items \/ Missing Info/);
+  assert.match(text, /submitted songs|submissions, play counts, source type, payment, or Priority history/);
+  assert.match(text, /Review Blockers/);
   assert.match(text, /Confirm public-safe display name|Display name is not owner-confirmed/);
   assert.match(text, /Confirm public role\/description|Role is not owner-confirmed/);
   assert.match(text, /Add public links|Public links are missing/);
   assert.match(text, /Connect queue\/submission identity/);
-  assert.match(text, /Review-only Evidence/);
+  assert.match(text, /Internal-Only \/ Do Not Say/);
   assert.match(text, /Orion appears in review-only\/internal context/);
   assert.match(text, /Legacy recurring-subject diagnostic: Automated topic label/);
   assert.ok(knowsStart >= 0 && diagnosticsStart > knowsStart);
@@ -6388,26 +6447,26 @@ test("Entity Intelligence Review Console displays #238 link categories and one q
   };
 
   const text = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, subjectName: "Antigrain", currentLane: "active_source_file", latestRecommendationTimestamp: "2026-06-03T01:00:00.000Z" }));
-  const normalReviewText = text.slice(0, text.indexOf("Diagnostics — collapsed by default"));
+  const normalReviewText = text.slice(0, text.indexOf("Archive / Raw Source File Data — collapsed"));
 
   assert.match(text, /Review Snapshot/);
-  assert.match(text, /What BNL Knows/);
-  assert.match(text, /Admin Action Items \/ Missing Info/);
-  assert.match(text, /Evidence by Category/);
+  assert.match(text, /BNL Case File Report/);
+  assert.match(text, /Review Blockers/);
+  assert.match(text, /Evidence-Backed Claims/);
   assert.match(text, /Diagnostics — collapsed by default/);
-  assert.match(text, /Video platform links/);
-  assert.match(text, /Event\/contest links/);
-  assert.match(text, /Music discussion/);
-  assert.match(text, /Show evidence \/ Evidence receipts — collapsed by default/);
-  assert.match(text, /Video platform link evidence:.*YouTube\/youtu\.be|Video platform link evidence:.*video platform links/i);
+  assert.match(text, /video platform links/i);
+  assert.match(text, /event\/contest links/i);
+  assert.match(text, /music discussion/i);
+  assert.match(text, /Archive \/ Raw Source File Data — collapsed/);
+  assert.match(text, /video platform links|Video platform link evidence/i);
   assert.doesNotMatch(text, /Actual music platform link evidence:[^\.]*YouTube/i);
   assert.doesNotMatch(text, /https:\/\/youtu\.be\/example123/);
   assert.match(text, /Derived duplicate link references suppressed/);
   assert.equal((text.match(/Queue\/submission history is not connected yet\. Do not claim submissions/g) ?? []).length, 1);
   assert.doesNotMatch(normalReviewText, /Legacy recurring-subject candidate dump|rawRefJson|source table|row IDs?|\[object Object\]|source lane mapping/);
   assert.doesNotMatch(normalReviewText, /knownContext|usefulEvidence|rawProvenance|sourceCoverage|evidenceDetails|representativeEvidence/);
-  assert.match(text, /Public-safe Evidence/);
-  assert.match(text, /Review-only Evidence/);
+  assert.match(text, /Public-Safe Facts/);
+  assert.match(text, /Internal-Only \/ Do Not Say/);
 });
 
 
@@ -6433,10 +6492,10 @@ test("Entity Intelligence Review Console separates Hellcat-style Discord event r
   };
 
   const text = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, subjectName: "HellcatNZ" }));
-  const normalReviewText = text.slice(0, text.indexOf("Diagnostics — collapsed by default"));
+  const normalReviewText = text.slice(0, text.indexOf("Archive / Raw Source File Data — collapsed"));
 
-  assert.match(text, /Show evidence \/ Evidence receipts — collapsed by default/);
-  assert.match(text, /Event\/contest link evidence:.*Discord event link.*#hellcat-nz/i);
+  assert.match(text, /Archive \/ Raw Source File Data — collapsed/);
+  assert.match(text, /event\/contest links: Discord event link in #hellcat-nz/i);
   assert.doesNotMatch(text, /Actual music platform link evidence:.*Discord event/i);
   assert.doesNotMatch(text, /https:\/\/discord\.com\/events\/123\/456/);
   assert.doesNotMatch(normalReviewText, /rawRefJson|source table names|\[object Object\]|row IDs?|source lane mapping/);
@@ -6784,7 +6843,7 @@ test("BNL structured source packet v2 is ingested, summarized, and kept review-o
   assert.match(panelText, /Legacy recurring-subject diagnostic|Automated topic label/);
   assert.doesNotMatch(panelText, /Main evidence categories/);
   assert.match(panelText, /Diagnostics only\. Not Case File claims\./);
-  assert.match(panelText, /subject explicitly shared a show-planning update/);
+  assert.match(panelText, /recurring set-support work|show-planning update/);
   assert.doesNotMatch(panelText, /Crow discussed source-file handling|Crow posted about source-file handling|Crow posted about BNL\/source-file|Crow authored BNL\/source-file|Crow talked about dossier/);
 
   const view = noteDisplay.createHumanReadableRecommendationView(savedRecommendation);
@@ -6891,8 +6950,9 @@ test("BNL Source File archive accepts large enrichment, keeps dashboard compact,
     summary: sourceFileSummary.createDossierSourceFileSummary({ candidate: sourceFile, recommendations: [] }),
     latestSourceFileArchive: sourceFile.latestSourceFileArchive,
   }));
+  assert.match(panelText, /Archive \/ Raw Source File Data — collapsed/);
   assert.match(panelText, /Latest BNL Source Archive Readout/);
-  assert.match(panelText, /Full BNL Source Archive — admin-only \/ collapsed/);
+  assert.match(panelText, /Archive \/ Raw Source File Data — collapsed/);
   assert.match(panelText, /Compact archive readout/);
   assert.doesNotMatch(panelText, new RegExp(largePrivateMarker));
 


### PR DESCRIPTION
### Motivation
- Make the Source File page a usable, readable BNL Case File Report by default so operators can craft dossiers without seeing an empty shell or a raw archive dump.
- Synthesize the visible report from existing data (prefer `sourceFileBriefV2`, then archive/readout/notes/recommendations) and apply display cleanup so public-safe wording and dossier decisions are easier and safer.

### Description
- Add a display-only helper `buildBnlCaseFileReport(...)` in `src/components/DossierSourceFileSummaryPanel.tsx` that returns `reportTitle`, `statusLabel`, `summary`, `dossierUse`, `publicSafeFacts`, `evidenceBackedClaims`, `communityContext`, `musicPlatformContext`, `reviewBlockers`, `internalOnlyNotes`, `nextAction`, and `hasUsableSourceData`, built from prioritized archive/brief/readout/note/recommendation fields with cleanup, dedupe, and caps.
- Replace the main visible summary with a new top-level section titled **BNL Case File Report** and reorder the panel to show Public-Safe Facts, Evidence-Backed Claims, Community / Relationship Context, Music / Platform / Link Context, Review Blockers, Internal-Only / Do Not Say, and Dossier Workbench before collapsed Source Notes, Archive, and Diagnostics.
- Collapse Source Notes / Admin Addendums by default on the candidate page and show a compact summary (notes count, warnings, dossier questions, latest updated) with individual notes collapsed by default for review-only access.
- Add display-level cleanup helpers to strip debug labels and junk (e.g., repeated "approved approved", `global_mixed`, `source_blind`, raw source-row phrasing, and legacy automated topic labels), convert `Missing Info` to review blockers, and cap/dedupe visible bullets; this is display-only and does not mutate stored data.
- Update assertions and expectations in `tests/admin-dossiers.test.mjs` to validate the new headings, ordering, brief-based rendering and legacy/archive fallback, refresh-message behavior, cleanup/dedupe, and collapsed notes/archive/diagnostics.
- Files changed: `src/components/DossierSourceFileSummaryPanel.tsx` (add report builder, new layout and cleanup), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (collapsed Source Notes UI + SnapshotItem), and `tests/admin-dossiers.test.mjs` (adjust/extend test expectations).

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed locally after updates (test suite run completed successfully).
- Ran `npx tsc --noEmit` and TypeScript checked with no errors.
- Notes: this change is display-only regarding BNL data (no archive schema changes, no bot code changes, no publishing/merge/queue/auto-confirm behavior added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a290cf9088c8321b06907b9ab75b805)