### PR TITLE
Make Source File refresh case-report aware

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -244,6 +244,19 @@ function latestBnlSourceFileEnrichment(input: {
   );
 }
 
+
+function candidateLatestArchiveMissingCaseReport(candidate?: DossierCandidate | null) {
+  if (!candidate) return false;
+  const hasLatestSourceData = Boolean(
+    candidate.latestSourceFileArchive ??
+      candidate.latestSourceFileArchiveId ??
+      candidate.latestSourceFileArchiveDigest ??
+      candidate.latestSourceFileArchiveUpdatedAt ??
+      (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
+  );
+  return hasLatestSourceData && !candidate.latestSourceFileArchive?.sourceFileCaseReportV1;
+}
+
 function requestResolvedByNewerEnrichment(input: {
   request?: DossierSourceFileRefreshRequest;
   recommendation?: DossierRecommendation;
@@ -1109,6 +1122,7 @@ export default function CandidateReviewPage() {
       (request) => isOpenRefreshRequest(request) && !isStaleOpenRefreshRequest(request),
     )
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  const caseReportMissingForLatestArchive = candidateLatestArchiveMissingCaseReport(candidate);
   const activeRefreshResolvedByEnrichment = requestResolvedByNewerEnrichment({
     request: nonStaleActiveRefreshRequest,
     recommendation: latestEnrichmentForRefreshStatus,
@@ -1135,25 +1149,36 @@ export default function CandidateReviewPage() {
       ),
   );
   const sourceFileFreshForOpen = Boolean(
-    latestEnrichmentNewerThanOpen ||
-      (sourceFileOpenState.immediateRefresh?.ok && immediateRecommendationVisible),
+    !caseReportMissingForLatestArchive &&
+      (latestEnrichmentNewerThanOpen ||
+        (sourceFileOpenState.immediateRefresh?.ok && immediateRecommendationVisible)),
   );
   const refreshStatusLabel = sourceFileOpenState.running
     ? "UPDATING SOURCE FILE"
-    : sourceFileFreshForOpen
-      ? "FILE UPDATED"
-      : "FILE NOT UPDATED";
+    : caseReportMissingForLatestArchive
+      ? latestRefreshRequest?.status === "pending" || latestRefreshRequest?.status === "claimed"
+        ? "CASE REPORT QUEUED"
+        : latestRefreshRequest?.status === "failed"
+          ? "CASE REPORT FAILED"
+          : "CASE REPORT MISSING"
+      : sourceFileFreshForOpen
+        ? "FILE UPDATED"
+        : "FILE NOT UPDATED";
   const refreshStatusDetail = sourceFileOpenState.running
     ? "BNL is updating this Source File now through the server-side immediate refresh endpoint."
-    : sourceFileFreshForOpen
-      ? "Latest BNL enrichment is fresh for this page open."
-      : "This page is not treating older BNL Source File data as current. Use FILE NOT UPDATED to retry the immediate update.";
+    : caseReportMissingForLatestArchive
+      ? "Latest archive exists, but BNL has not generated the Case File Report yet. Refresh requests ask BNL for case-report backfill."
+      : sourceFileFreshForOpen
+        ? "Latest BNL enrichment is fresh for this page open."
+        : "This page is not treating older BNL Source File data as current. Use FILE NOT UPDATED to retry the immediate update.";
   const refreshFailureReason =
     sourceFileOpenState.immediateRefresh?.failureReason ??
     latestRefreshRequest?.failureReason ??
-    (!sourceFileFreshForOpen && !sourceFileOpenState.running
-      ? "No fresh BNL enrichment is visible for this page open."
-      : undefined);
+    (caseReportMissingForLatestArchive
+      ? "case_report_missing_after_refresh"
+      : !sourceFileFreshForOpen && !sourceFileOpenState.running
+        ? "No fresh BNL enrichment is visible for this page open."
+        : undefined);
   const manualRefreshDisabled = saving || !candidate || sourceFileOpenState.running || sourceFileFreshForOpen;
   const manualRefreshButtonLabel = sourceFileOpenState.running
     ? sourceFileOpenState.immediateRefresh
@@ -1268,7 +1293,9 @@ export default function CandidateReviewPage() {
       const data = await postWorkflow({
         action: "requestSourceFileRefresh",
         candidateId,
-        reason: "Manual admin requested a BNL Source File immediate update retry.",
+        reason: caseReportMissingForLatestArchive
+          ? "case_report_missing"
+          : "Manual admin requested a BNL Source File immediate update retry.",
       });
       const refresh = data.refresh;
       if (refresh?.request && isOpenRefreshRequest(refresh.request)) {

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -48,6 +48,7 @@ import {
   getDossierWorkflowStorageMode,
   ignoreDossierRecommendation,
   recordDossierSourceFileOpen,
+  sourceFileNeedsCaseReportBackfill,
   rejectDossierIdentityLink,
   requestDossierSourceFileRefresh,
   retireDossierIdentityLink,
@@ -314,6 +315,29 @@ function draftFieldsFromBody(
   return draftFields;
 }
 
+
+async function verifySourceFileCaseReportAfterImmediateRefresh(input: {
+  request: DossierSourceFileRefreshRequest;
+  immediateRefresh: Awaited<ReturnType<typeof refreshBnlSourceFileNow>>;
+}): Promise<Awaited<ReturnType<typeof refreshBnlSourceFileNow>>> {
+  if (!input.immediateRefresh.ok || !input.request.candidateId) {
+    return input.immediateRefresh;
+  }
+  const state = await getDossierWorkflowState();
+  const candidate = state.candidates.find(
+    (item) => item.id === input.request.candidateId,
+  );
+  if (!candidate || !sourceFileNeedsCaseReportBackfill(candidate)) {
+    return input.immediateRefresh;
+  }
+  return {
+    ...input.immediateRefresh,
+    ok: false,
+    status: "failed",
+    failureReason: "case_report_missing_after_refresh",
+  };
+}
+
 async function workflowPayload(
   state?: DossierWorkflowState,
 ): Promise<DossierWorkflowResponse> {
@@ -470,7 +494,7 @@ export async function POST(req: Request) {
         candidateId,
         requestedBy: "admin_open_source_file",
       });
-      const immediateRefresh = refresh.request
+      const immediateRefreshRaw = refresh.request
         ? await refreshBnlSourceFileNow({
             request: refresh.request,
             source: "admin_open_source_file",
@@ -480,6 +504,12 @@ export async function POST(req: Request) {
             status: "skipped" as const,
             failureReason: refresh.decision.reason,
           };
+      const immediateRefresh = refresh.request
+        ? await verifySourceFileCaseReportAfterImmediateRefresh({
+            request: refresh.request,
+            immediateRefresh: immediateRefreshRaw,
+          })
+        : immediateRefreshRaw;
       if (refresh.request && immediateRefresh.ok) {
         await updateDossierSourceFileRefreshRequestStatus({
           requestId: refresh.request.id,
@@ -519,9 +549,13 @@ export async function POST(req: Request) {
         requestSource: "manual_admin",
         requestedBy: "admin_manual",
       });
-      const immediateRefresh = await refreshBnlSourceFileNow({
+      const immediateRefreshRaw = await refreshBnlSourceFileNow({
         request: refresh.request,
         source: "admin_manual",
+      });
+      const immediateRefresh = await verifySourceFileCaseReportAfterImmediateRefresh({
+        request: refresh.request,
+        immediateRefresh: immediateRefreshRaw,
       });
       if (immediateRefresh.ok) {
         await updateDossierSourceFileRefreshRequestStatus({

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -363,11 +363,12 @@ export function DossierSourceFileSummaryPanel({
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
+  const latestArchiveMissingReport = Boolean(latestSourceFileArchive && !report);
   const snapshotItems = [
     ["Subject", subjectName ?? latestSourceFileArchive?.subjectName ?? "Unknown subject"],
     ["Current state", humanStatus(currentLane ?? summary.nextAction)],
-    ["Refresh status", formatSnapshotDate(summary.lastUpdatedAt)],
-    ["Latest BNL refresh", formatSnapshotDate(latestRecommendationTimestamp)],
+    ["Refresh status", latestArchiveMissingReport ? "Case report missing" : formatSnapshotDate(summary.lastUpdatedAt)],
+    ["Latest BNL refresh", latestArchiveMissingReport ? "Report backfill required" : formatSnapshotDate(latestRecommendationTimestamp)],
     ["Source file target", humanStatus(sourceFileTargetStatus ?? summary.nextAction)],
     ["Evidence depth", evidenceDepthLabel(summary.substanceLevel)],
     ["Public readiness", readinessLabel(summary.publicReadiness)],

--- a/src/lib/bnl-source-file-refresh-now.ts
+++ b/src/lib/bnl-source-file-refresh-now.ts
@@ -89,6 +89,9 @@ export async function refreshBnlSourceFileNow(
         subjectName: input.request.subjectName,
         normalizedSubjectKey: input.request.normalizedSubjectKey,
         reason: input.request.reason,
+        caseReportMissing: input.request.caseReportMissing === true,
+        requiresCaseReportBackfill:
+          input.request.requiresCaseReportBackfill === true,
         source: input.source ?? input.request.requestSource,
       }),
       cache: "no-store",

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1914,6 +1914,26 @@ const OPEN_REQUEST_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
 const COMPLETABLE_REFRESH_STATUSES =
   new Set<DossierSourceFileRefreshRequestStatus>(["pending", "claimed"]);
 
+
+export function latestArchiveMissingCaseReport(candidate: DossierCandidate): boolean {
+  const latestArchive = candidate.latestSourceFileArchive;
+  const hasLatestSourceData = Boolean(
+    latestArchive ??
+      candidate.latestSourceFileArchiveId ??
+      candidate.latestSourceFileArchiveDigest ??
+      candidate.latestSourceFileArchiveUpdatedAt ??
+      (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
+  );
+  if (!hasLatestSourceData) return false;
+  return !latestArchive?.sourceFileCaseReportV1;
+}
+
+export const candidateMissingCaseReport = latestArchiveMissingCaseReport;
+
+export function sourceFileNeedsCaseReportBackfill(candidate: DossierCandidate): boolean {
+  return latestArchiveMissingCaseReport(candidate);
+}
+
 function latestBnlSourceFileRecommendation(input: {
   candidate: DossierCandidate;
   recommendations: DossierRecommendation[];
@@ -2046,6 +2066,11 @@ function mergeActiveSourceFileRefreshRequests(
           request.lastAttemptAt > existing.lastAttemptAt)
           ? request.lastAttemptAt
           : existing.lastAttemptAt,
+      caseReportMissing:
+        request.caseReportMissing ?? existing.caseReportMissing,
+      requiresCaseReportBackfill:
+        request.requiresCaseReportBackfill ??
+        existing.requiresCaseReportBackfill,
     };
     merged.set(key, mergedRequest);
     const outputIndex = output.findIndex((item) => item.id === existing.id);
@@ -2081,6 +2106,17 @@ export function evaluateDossierSourceFileRefresh(input: {
     ? Date.parse(completed.completedAt)
     : NaN;
   const nowTime = Date.parse(now);
+
+  if (sourceFileNeedsCaseReportBackfill(input.candidate)) {
+    return {
+      needed: true,
+      reason: "case_report_missing",
+      requestSource: "case_report_missing",
+      priority: input.candidate.status === "existing_dossier_update" ? 85 : 80,
+      latestRecommendationTimestamp,
+      latestSourceNoteTimestamp,
+    };
+  }
 
   if (
     completed &&
@@ -2193,6 +2229,8 @@ function upsertSourceFileRefreshRequestInState(input: {
   requestedBy?: string;
   now: string;
   force?: boolean;
+  caseReportMissing?: boolean;
+  requiresCaseReportBackfill?: boolean;
 }): {
   state: DossierWorkflowState;
   request: DossierSourceFileRefreshRequest;
@@ -2229,6 +2267,9 @@ function upsertSourceFileRefreshRequestInState(input: {
       priority: Math.max(existing.priority ?? 0, input.priority),
       requestedBy: input.requestedBy ?? existing.requestedBy,
       updatedAt: input.now,
+      caseReportMissing: input.caseReportMissing ?? existing.caseReportMissing,
+      requiresCaseReportBackfill:
+        input.requiresCaseReportBackfill ?? existing.requiresCaseReportBackfill,
     };
     const requests = [...state.sourceFileRefreshRequests];
     requests[existingIndex] = updated;
@@ -2273,6 +2314,8 @@ function upsertSourceFileRefreshRequestInState(input: {
     updatedAt: input.now,
     requestSource: input.requestSource,
     priority: input.priority,
+    caseReportMissing: input.caseReportMissing,
+    requiresCaseReportBackfill: input.requiresCaseReportBackfill,
   };
   return {
     state: {
@@ -2514,20 +2557,26 @@ export async function recordDossierSourceFileOpen(input: {
       refreshRequests: currentState.sourceFileRefreshRequests,
       now,
     });
+    const missingCaseReport = sourceFileNeedsCaseReportBackfill(candidate);
     const upserted = upsertSourceFileRefreshRequestInState({
       state: currentState,
       candidate,
-      reason: decision.needed
+      reason: missingCaseReport
+        ? "case_report_missing"
+        : decision.needed
         ? decision.reason
         : "Admin opened the Source File and requested an immediate BNL freshness check.",
-      requestSource:
-        decision.requestSource === "opened_source_file"
+      requestSource: missingCaseReport
+        ? "case_report_missing"
+        : decision.requestSource === "opened_source_file"
           ? "opened_source_file"
           : decision.requestSource,
-      priority: Math.max(decision.priority, 60),
+      priority: Math.max(decision.priority, missingCaseReport ? 80 : 60),
       requestedBy: input.requestedBy ?? "admin_open_source_file",
       now,
       force: true,
+      caseReportMissing: missingCaseReport || undefined,
+      requiresCaseReportBackfill: missingCaseReport || undefined,
     });
     result = { request: upserted.request, decision, created: upserted.created };
     return upserted.state;
@@ -2556,17 +2605,23 @@ export async function requestDossierSourceFileRefresh(input: {
         "Source File candidate was not found or cannot be refreshed",
       );
     }
+    const missingCaseReport = sourceFileNeedsCaseReportBackfill(candidate);
     const upserted = upsertSourceFileRefreshRequestInState({
       state: currentState,
       candidate,
-      reason:
-        input.reason?.trim() ||
-        "Manual admin requested a BNL Source File refresh.",
-      requestSource: input.requestSource ?? "manual_admin",
-      priority: input.priority ?? 90,
+      reason: missingCaseReport
+        ? "case_report_missing"
+        : input.reason?.trim() ||
+          "Manual admin requested a BNL Source File refresh.",
+      requestSource: missingCaseReport
+        ? "case_report_missing"
+        : input.requestSource ?? "manual_admin",
+      priority: input.priority ?? (missingCaseReport ? 95 : 90),
       requestedBy: input.requestedBy ?? "admin_manual",
       now,
       force: true,
+      caseReportMissing: missingCaseReport || undefined,
+      requiresCaseReportBackfill: missingCaseReport || undefined,
     });
     result = { request: upserted.request, created: upserted.created };
     return upserted.state;

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -474,7 +474,8 @@ export type DossierSourceFileRefreshRequestSource =
   | "stale_source_file"
   | "missing_bnl_refresh"
   | "source_notes_newer_than_bnl"
-  | "existing_dossier_update_review";
+  | "existing_dossier_update_review"
+  | "case_report_missing";
 
 export type DossierSourceFileRefreshRequest = {
   id: string;
@@ -490,6 +491,8 @@ export type DossierSourceFileRefreshRequest = {
   completedAt?: string;
   completedByRecommendationId?: string;
   failureReason?: string;
+  caseReportMissing?: boolean;
+  requiresCaseReportBackfill?: boolean;
   requestSource: DossierSourceFileRefreshRequestSource;
   priority: number;
   notBeforeAt?: string;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -634,6 +634,118 @@ test("confirmed aliases are safe matches, but proposed/rejected/retired aliases 
   await store.rejectDossierIdentityLink({ candidateId: sourceFile.candidate.id, identityLinkId: proposedOnly.id });
 });
 
+
+test("Source File refresh requests case-report backfill and refuses false completion when latest archive lacks report", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Case Report Missing Fixture",
+      candidateType: "artist",
+      reason: "Operator wants case-report refresh coverage.",
+      whyNow: "The archive exists but the report is missing.",
+      evidenceSummary: "Admin fixture evidence.",
+    },
+  })).json();
+  const candidateId = created.candidate.id;
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+
+  const state = await store.getDossierWorkflowState();
+  const now = "2026-06-10T00:00:00.000Z";
+  const candidate = state.candidates.find((item) => item.id === candidateId);
+  const archive = {
+    id: "archive-missing-case-report",
+    candidateId,
+    subjectName: candidate.name,
+    subjectKey: "case-report-missing-fixture",
+    sourceDigest: "abcdef1234567890",
+    createdAt: now,
+    updatedAt: now,
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    compactSummary: "COMPACT_SUMMARY_SHOULD_NOT_BECOME_REPORT",
+  };
+  await store.saveDossierWorkflowState({
+    ...state,
+    candidates: state.candidates.map((item) =>
+      item.id === candidateId
+        ? {
+            ...item,
+            latestSourceFileArchive: archive,
+            latestSourceFileArchiveId: archive.id,
+            latestSourceFileArchiveDigest: archive.sourceDigest,
+            latestSourceFileArchiveUpdatedAt: archive.updatedAt,
+            sourceFileArchiveIds: [archive.id],
+          }
+        : item,
+    ),
+    updatedAt: now,
+  });
+  const missingCandidate = (await store.getDossierWorkflowState()).candidates.find((item) => item.id === candidateId);
+  assert.equal(store.sourceFileNeedsCaseReportBackfill(missingCandidate), true);
+  assert.equal(store.candidateMissingCaseReport(missingCandidate), true);
+  assert.equal(store.latestArchiveMissingCaseReport(missingCandidate), true);
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), body: JSON.parse(options.body) });
+    return Response.json({ ok: true, status: "success", recommendationId: `case-report-refresh-${calls.length}` });
+  };
+
+  try {
+    const opened = await (await authedPost({ action: "recordSourceFileOpen", candidateId })).json();
+    assert.equal(opened.immediateRefresh.ok, false);
+    assert.equal(opened.immediateRefresh.status, "failed");
+    assert.equal(opened.immediateRefresh.failureReason, "case_report_missing_after_refresh");
+    assert.equal(opened.sourceFileRefreshRequests[0].status, "failed");
+    assert.equal(opened.sourceFileRefreshRequests[0].completedAt, undefined);
+    assert.equal(opened.sourceFileRefreshRequests[0].reason, "case_report_missing");
+    assert.equal(opened.sourceFileRefreshRequests[0].caseReportMissing, true);
+    assert.equal(opened.sourceFileRefreshRequests[0].requiresCaseReportBackfill, true);
+    assert.equal(calls[0].body.reason, "case_report_missing");
+    assert.equal(calls[0].body.caseReportMissing, true);
+    assert.equal(calls[0].body.requiresCaseReportBackfill, true);
+
+    const manual = await (await authedPost({
+      action: "requestSourceFileRefresh",
+      candidateId,
+      reason: "Manual generic refresh should become case report backfill.",
+    })).json();
+    assert.equal(manual.immediateRefresh.ok, false);
+    assert.equal(manual.immediateRefresh.failureReason, "case_report_missing_after_refresh");
+    assert.equal(manual.sourceFileRefreshRequests[0].status, "failed");
+    assert.equal(manual.sourceFileRefreshRequests[0].reason, "case_report_missing");
+    assert.equal(manual.sourceFileRefreshRequests[0].failureReason, "case_report_missing_after_refresh");
+    assert.equal(calls[1].body.reason, "case_report_missing");
+    assert.equal(calls[1].body.caseReportMissing, true);
+    assert.equal(calls[1].body.requiresCaseReportBackfill, true);
+
+    const withReport = {
+      ...missingCandidate,
+      latestSourceFileArchive: {
+        ...missingCandidate.latestSourceFileArchive,
+        sourceFileCaseReportV1: {
+          version: "1",
+          generatedAt: now,
+          caseSummary: "BNL-authored report now exists.",
+        },
+      },
+    };
+    assert.equal(store.sourceFileNeedsCaseReportBackfill(withReport), false);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  }
+});
+
 test("Source File immediate refresh timeout/unavailable and stale open requests do not trap retries or cross-file matching", async () => {
   await resetWorkflowStore();
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";


### PR DESCRIPTION
### Motivation
- The site marked a BNL refresh as completed even when the latest Source File archive lacked a BNL-authored `sourceFileCaseReportV1`, producing misleading “Latest BNL Refresh: updated” / “BNL Report: Not generated yet” states. 
- The refresh flow must explicitly detect a missing case report, request a case-report backfill intent to the bot, and avoid marking the refresh completed until the report actually lands. 
- Keep all behavior read-only/display-only and avoid synthesizing reports or changing bot code.

### Description
- Add archive/report detection helpers and a backfill predicate: `latestArchiveMissingCaseReport`, `candidateMissingCaseReport`, and `sourceFileNeedsCaseReportBackfill`, and wire them into refresh evaluation so missing reports are prioritized before the stale/completed logic. (files: `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-workflow.ts`)
- Propagate explicit case-report backfill intent in refresh requests and state: refresh requests now include `caseReportMissing` / `requiresCaseReportBackfill` flags and use a new `case_report_missing` requestSource when appropriate. (files: `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-workflow.ts`)
- Send the backfill intent to BNL when calling `refreshBnlSourceFileNow(...)` by adding `caseReportMissing` / `requiresCaseReportBackfill` to the outgoing payload. (file: `src/lib/bnl-source-file-refresh-now.ts`)
- Re-check workflow state after immediate refresh and refuse to mark a request completed when the report still isn't present; convert an otherwise-ok immediate response into a failed/pending result with failureReason `case_report_missing_after_refresh`. Implemented server-side verification helper and applied it to both open and manual refresh flows. (file: `src/app/api/admin/dossiers/route.ts`)
- Make UI honest about missing reports: Source File header/summary and candidate page show “Case report missing” / “Report backfill required” / queued/failed case-report statuses and ensure manual refreshes send the case-report backfill reason when needed. (files: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Add tests verifying detection, request shaping, false-completion refusal, failure reason, and that reports are not synthesized from compactSummary/raw archive. (file: `tests/admin-dossiers.test.mjs`)

Files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/lib/bnl-source-file-refresh-now.ts`, `src/app/api/admin/dossiers/route.ts`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/components/DossierSourceFileSummaryPanel.tsx`, `tests/admin-dossiers.test.mjs`.

### Testing
- Ran the full admin dossiers test suite with `node --test tests/admin-dossiers.test.mjs`, all tests passed (141 passed, 0 failed).
- Ran TypeScript check `npx tsc --noEmit`, type-check succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29ab87c3c8832190094bf754eb3c74)