### PR TITLE
Send trusted site callback base to BNL Source File refresh

### DIFF
--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -3,6 +3,7 @@ import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
 import { databasePage } from "@/content";
 import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
 import { refreshBnlSourceFileNow } from "@/lib/bnl-source-file-refresh-now";
+import { trustedRequestingSiteOrigin } from "@/lib/trusted-requesting-site-origin";
 import { buildDossierTagRegistry } from "@/lib/dossier-tags";
 import {
   DOSSIER_CANDIDATE_SCORING_POLICY,
@@ -490,6 +491,7 @@ export async function POST(req: Request) {
         );
       }
       const openedAt = new Date().toISOString();
+      const requestingSiteOrigin = trustedRequestingSiteOrigin(req);
       const refresh = await recordDossierSourceFileOpen({
         candidateId,
         requestedBy: "admin_open_source_file",
@@ -498,11 +500,13 @@ export async function POST(req: Request) {
         ? await refreshBnlSourceFileNow({
             request: refresh.request,
             source: "admin_open_source_file",
+            requestingSiteOrigin,
           })
         : {
             ok: false,
             status: "skipped" as const,
             failureReason: refresh.decision.reason,
+            callbackBaseSent: false,
           };
       const immediateRefresh = refresh.request
         ? await verifySourceFileCaseReportAfterImmediateRefresh({
@@ -543,6 +547,7 @@ export async function POST(req: Request) {
           { status: 400 },
         );
       }
+      const requestingSiteOrigin = trustedRequestingSiteOrigin(req);
       const refresh = await requestDossierSourceFileRefresh({
         candidateId,
         reason: typeof body.reason === "string" ? body.reason : undefined,
@@ -552,6 +557,7 @@ export async function POST(req: Request) {
       const immediateRefreshRaw = await refreshBnlSourceFileNow({
         request: refresh.request,
         source: "admin_manual",
+        requestingSiteOrigin,
       });
       const immediateRefresh = await verifySourceFileCaseReportAfterImmediateRefresh({
         request: refresh.request,

--- a/src/lib/bnl-source-file-refresh-now.ts
+++ b/src/lib/bnl-source-file-refresh-now.ts
@@ -1,4 +1,5 @@
 import type { DossierSourceFileRefreshRequest } from "@/lib/dossier-workflow";
+import { safeOriginHost } from "@/lib/trusted-requesting-site-origin";
 
 export type BnlSourceFileImmediateRefreshStatus =
   | "success"
@@ -12,12 +13,15 @@ export type BnlSourceFileImmediateRefreshResult = {
   status: BnlSourceFileImmediateRefreshStatus;
   recommendationId?: string;
   failureReason?: string;
+  callbackBaseSent?: boolean;
+  callbackBaseHost?: string;
 };
 
 export type BnlSourceFileImmediateRefreshInput = {
   request: DossierSourceFileRefreshRequest;
   source?: string;
   timeoutMs?: number;
+  requestingSiteOrigin?: string;
 };
 
 const DEFAULT_REFRESH_NOW_TIMEOUT_MS = 25_000;
@@ -67,8 +71,17 @@ export async function refreshBnlSourceFileNow(
       ok: false,
       status: "unavailable",
       failureReason: "BNL immediate refresh is not configured.",
+      callbackBaseSent: false,
     };
   }
+
+  const callbackBaseUrl = stringValue(input.requestingSiteOrigin);
+  const callbackDiagnostics = {
+    callbackBaseSent: Boolean(callbackBaseUrl),
+    ...(callbackBaseUrl
+      ? { callbackBaseHost: safeOriginHost(callbackBaseUrl) }
+      : {}),
+  };
 
   const controller = new AbortController();
   const timeout = setTimeout(
@@ -93,6 +106,13 @@ export async function refreshBnlSourceFileNow(
         requiresCaseReportBackfill:
           input.request.requiresCaseReportBackfill === true,
         source: input.source ?? input.request.requestSource,
+        ...(callbackBaseUrl
+          ? {
+              siteCallbackBaseUrl: callbackBaseUrl,
+              requestingSiteOrigin: callbackBaseUrl,
+              sourceFileArchiveCallbackBaseUrl: callbackBaseUrl,
+            }
+          : {}),
       }),
       cache: "no-store",
       signal: controller.signal,
@@ -109,6 +129,7 @@ export async function refreshBnlSourceFileNow(
         recommendationId,
         failureReason:
           failureReason ?? `BNL immediate refresh returned HTTP ${response.status}.`,
+        ...callbackDiagnostics,
       };
     }
 
@@ -117,10 +138,22 @@ export async function refreshBnlSourceFileNow(
         ? stringValue((payload as Record<string, unknown>).status)
         : undefined;
     if (payloadStatus === "skipped") {
-      return { ok: false, status: "skipped", recommendationId, failureReason };
+      return {
+        ok: false,
+        status: "skipped",
+        recommendationId,
+        failureReason,
+        ...callbackDiagnostics,
+      };
     }
     if (payloadStatus === "failed") {
-      return { ok: false, status: "failed", recommendationId, failureReason };
+      return {
+        ok: false,
+        status: "failed",
+        recommendationId,
+        failureReason,
+        ...callbackDiagnostics,
+      };
     }
 
     return {
@@ -128,6 +161,7 @@ export async function refreshBnlSourceFileNow(
       status: "success",
       recommendationId,
       failureReason,
+      ...callbackDiagnostics,
     };
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
@@ -135,6 +169,7 @@ export async function refreshBnlSourceFileNow(
         ok: false,
         status: "timeout",
         failureReason: "BNL immediate refresh timed out.",
+        ...callbackDiagnostics,
       };
     }
     return {
@@ -144,6 +179,7 @@ export async function refreshBnlSourceFileNow(
         error instanceof Error
           ? error.message
           : "BNL immediate refresh could not be reached.",
+      ...callbackDiagnostics,
     };
   } finally {
     clearTimeout(timeout);

--- a/src/lib/trusted-requesting-site-origin.ts
+++ b/src/lib/trusted-requesting-site-origin.ts
@@ -1,0 +1,114 @@
+const PRODUCTION_SITE_ORIGIN = "https://barcode-network.com";
+
+const CONFIGURED_SITE_ORIGIN_ENV_KEYS = [
+  "NEXT_PUBLIC_SITE_URL",
+  "SITE_URL",
+  "PUBLIC_SITE_URL",
+  "BARCODE_SITE_URL",
+];
+
+const CONFIGURED_ALLOWLIST_ENV_KEYS = [
+  "TRUSTED_SITE_ORIGINS",
+  "SITE_CALLBACK_BASE_URL_ALLOWLIST",
+  "SOURCE_FILE_CALLBACK_BASE_URL_ALLOWLIST",
+];
+
+const VERCEL_URL_ENV_KEYS = [
+  "VERCEL_URL",
+  "VERCEL_BRANCH_URL",
+  "VERCEL_PROJECT_PRODUCTION_URL",
+];
+
+function normalizeOrigin(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+  const withProtocol = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  try {
+    const url = new URL(withProtocol);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+    return url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function originHost(origin: string | undefined): string | undefined {
+  if (!origin) return undefined;
+  try {
+    return new URL(origin).host.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function splitEnvList(value: string | undefined): string[] {
+  return value
+    ? value
+        .split(/[\s,]+/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function configuredTrustedOrigins(): Set<string> {
+  const origins = new Set<string>([PRODUCTION_SITE_ORIGIN]);
+  for (const key of CONFIGURED_SITE_ORIGIN_ENV_KEYS) {
+    const origin = normalizeOrigin(process.env[key]);
+    if (origin) origins.add(origin);
+  }
+  for (const key of CONFIGURED_ALLOWLIST_ENV_KEYS) {
+    for (const value of splitEnvList(process.env[key])) {
+      const origin = normalizeOrigin(value);
+      if (origin) origins.add(origin);
+    }
+  }
+  return origins;
+}
+
+function configuredVercelHosts(): Set<string> {
+  const hosts = new Set<string>();
+  for (const key of VERCEL_URL_ENV_KEYS) {
+    const host = originHost(normalizeOrigin(process.env[key]));
+    if (host) hosts.add(host);
+  }
+  return hosts;
+}
+
+function originFromForwardedHeaders(req: Request): string | undefined {
+  const forwardedHost = req.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  if (!forwardedHost) return undefined;
+  const forwardedProto =
+    req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() || "https";
+  return normalizeOrigin(`${forwardedProto}://${forwardedHost}`);
+}
+
+function requestUrlOrigin(req: Request): string | undefined {
+  try {
+    return normalizeOrigin(new URL(req.url).origin);
+  } catch {
+    return undefined;
+  }
+}
+
+function isTrustedOrigin(origin: string): boolean {
+  const trustedOrigins = configuredTrustedOrigins();
+  if (trustedOrigins.has(origin)) return true;
+
+  const host = originHost(origin);
+  if (!host) return false;
+  return configuredVercelHosts().has(host);
+}
+
+export function trustedRequestingSiteOrigin(req: Request): string | undefined {
+  const candidates = [originFromForwardedHeaders(req), requestUrlOrigin(req)];
+  return candidates.find((origin): origin is string =>
+    Boolean(origin && isTrustedOrigin(origin)),
+  );
+}
+
+export function safeOriginHost(origin: string | undefined): string | undefined {
+  return originHost(origin);
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -246,13 +246,14 @@ async function authedGet() {
   );
 }
 
-async function authedPost(body) {
+async function authedPost(body, options = {}) {
   return route.POST(
-    new Request("https://example.test/api/admin/dossiers", {
+    new Request(options.url ?? "https://example.test/api/admin/dossiers", {
       method: "POST",
       headers: {
         "content-type": "application/json",
         cookie: await adminCookie(),
+        ...(options.headers ?? {}),
       },
       body: JSON.stringify(body),
     }),
@@ -492,6 +493,7 @@ test("Source File open and retry call BNL refresh-now server-side with safe stat
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
   process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+  process.env.NEXT_PUBLIC_SITE_URL = "https://example.test";
 
   const originalFetch = global.fetch;
   const calls = [];
@@ -501,6 +503,9 @@ test("Source File open and retry call BNL refresh-now server-side with safe stat
     assert.equal(options.headers["X-BNL-REFRESH-TOKEN"], "test-refresh-token");
     const body = JSON.parse(options.body);
     assert.equal(body.source, calls.length === 1 ? "admin_open_source_file" : "admin_manual");
+    assert.equal(body.siteCallbackBaseUrl, "https://example.test");
+    assert.equal(body.requestingSiteOrigin, "https://example.test");
+    assert.equal(body.sourceFileArchiveCallbackBaseUrl, "https://example.test");
     assert.ok(body.requestId);
     assert.equal(body.candidateId, body.candidateId);
     if (calls.length === 1) {
@@ -527,6 +532,8 @@ test("Source File open and retry call BNL refresh-now server-side with safe stat
     assert.equal(opened.immediateRefresh.ok, true);
     assert.equal(opened.immediateRefresh.status, "success");
     assert.equal(opened.immediateRefresh.recommendationId, "fresh-rec-id");
+    assert.equal(opened.immediateRefresh.callbackBaseSent, true);
+    assert.equal(opened.immediateRefresh.callbackBaseHost, "example.test");
     assert.equal(opened.sourceFileRefreshRequests[0].status, "completed");
     assert.equal(opened.sourceFileRefreshRequests[0].completedByRecommendationId, "fresh-rec-id");
 
@@ -538,7 +545,62 @@ test("Source File open and retry call BNL refresh-now server-side with safe stat
     assert.equal(retry.immediateRefresh.ok, false);
     assert.equal(retry.immediateRefresh.status, "failed");
     assert.equal(retry.immediateRefresh.failureReason, "BNL fixture failure");
+    assert.equal(retry.immediateRefresh.callbackBaseSent, true);
+    assert.equal(retry.immediateRefresh.callbackBaseHost, "example.test");
     assert.equal(calls.length, 2);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  }
+});
+
+
+test("Source File refresh does not forward untrusted callback origins", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+  delete process.env.VERCEL;
+  delete process.env.VERCEL_URL;
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), body: JSON.parse(options.body) });
+    return Response.json({ ok: true, status: "success", recommendationId: "untrusted-refresh" });
+  };
+
+  try {
+    const created = await (await authedPost({
+      action: "createManualCandidate",
+      input: {
+        name: "Untrusted Origin Fixture",
+        candidateType: "artist",
+        reason: "Operator wants callback origin safety coverage.",
+        whyNow: "The source file should not trust hostile hosts.",
+        evidenceSummary: "Admin fixture evidence.",
+      },
+      siteCallbackBaseUrl: "https://evil.example.test",
+    }, { url: "https://evil.example.test/api/admin/dossiers" })).json();
+    const candidateId = created.candidate.id;
+    await authedPost({ action: "promoteCandidateToSourceFile", candidateId }, { url: "https://evil.example.test/api/admin/dossiers" });
+
+    const opened = await (await authedPost({
+      action: "recordSourceFileOpen",
+      candidateId,
+      siteCallbackBaseUrl: "https://evil.example.test",
+    }, { url: "https://evil.example.test/api/admin/dossiers" })).json();
+
+    assert.equal(opened.immediateRefresh.callbackBaseSent, false);
+    assert.equal(opened.immediateRefresh.callbackBaseHost, undefined);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].body.siteCallbackBaseUrl, undefined);
+    assert.equal(calls[0].body.requestingSiteOrigin, undefined);
+    assert.equal(calls[0].body.sourceFileArchiveCallbackBaseUrl, undefined);
   } finally {
     global.fetch = originalFetch;
     delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
@@ -640,6 +702,7 @@ test("Source File refresh requests case-report backfill and refuses false comple
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
   process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+  process.env.NEXT_PUBLIC_SITE_URL = "https://example.test";
 
   const created = await (await authedPost({
     action: "createManualCandidate",
@@ -711,6 +774,11 @@ test("Source File refresh requests case-report backfill and refuses false comple
     assert.equal(calls[0].body.reason, "case_report_missing");
     assert.equal(calls[0].body.caseReportMissing, true);
     assert.equal(calls[0].body.requiresCaseReportBackfill, true);
+    assert.equal(calls[0].body.siteCallbackBaseUrl, "https://example.test");
+    assert.equal(calls[0].body.requestingSiteOrigin, "https://example.test");
+    assert.equal(calls[0].body.sourceFileArchiveCallbackBaseUrl, "https://example.test");
+    assert.equal(opened.immediateRefresh.callbackBaseSent, true);
+    assert.equal(opened.immediateRefresh.callbackBaseHost, "example.test");
 
     const manual = await (await authedPost({
       action: "requestSourceFileRefresh",
@@ -725,6 +793,15 @@ test("Source File refresh requests case-report backfill and refuses false comple
     assert.equal(calls[1].body.reason, "case_report_missing");
     assert.equal(calls[1].body.caseReportMissing, true);
     assert.equal(calls[1].body.requiresCaseReportBackfill, true);
+    assert.equal(calls[1].body.siteCallbackBaseUrl, "https://example.test");
+    assert.equal(calls[1].body.requestingSiteOrigin, "https://example.test");
+    assert.equal(calls[1].body.sourceFileArchiveCallbackBaseUrl, "https://example.test");
+    assert.equal(manual.immediateRefresh.callbackBaseSent, true);
+    assert.equal(manual.immediateRefresh.callbackBaseHost, "example.test");
+    const afterRefreshState = await store.getDossierWorkflowState();
+    const afterRefreshCandidate = afterRefreshState.candidates.find((item) => item.id === candidateId);
+    assert.equal(afterRefreshCandidate.latestSourceFileArchive.sourceFileCaseReportV1, undefined);
+    assert.equal(afterRefreshCandidate.latestSourceFileArchive.compactSummary, "COMPACT_SUMMARY_SHOULD_NOT_BECOME_REPORT");
 
     const withReport = {
       ...missingCandidate,
@@ -743,6 +820,7 @@ test("Source File refresh requests case-report backfill and refuses false comple
     delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
     delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
     delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
   }
 });
 


### PR DESCRIPTION
### Motivation
- Ensure BNL knows the trusted site origin to post generated Source File archives/case-reports back to the same site instance that requested a refresh, preventing cross-deployment delivery and the `case_report_missing_after_refresh` failure.
- Only use server-side request data and configured/trusted origins to avoid forwarding client-controlled or hostile callback URLs.
- Preserve existing backfill semantics and failure handling while adding safe diagnostics.

### Description
- Add a server-side trusted origin helper `trustedRequestingSiteOrigin(req)` and `safeOriginHost(...)` to derive and validate the current site origin from forwarded headers/Request URL against production/configured allowlist and Vercel preview hosts (`src/lib/trusted-requesting-site-origin.ts`).
- Thread the trusted origin from admin actions into `refreshBnlSourceFileNow(...)` for both `recordSourceFileOpen` and manual refresh flows in the admin dossiers route (`src/app/api/admin/dossiers/route.ts`).
- Update `refreshBnlSourceFileNow(...)` to accept `requestingSiteOrigin`, include `siteCallbackBaseUrl`, `requestingSiteOrigin`, and `sourceFileArchiveCallbackBaseUrl` in the payload sent to BNL only when a trusted origin exists, and return safe diagnostics (`callbackBaseSent` and `callbackBaseHost`) in the immediate refresh result (`src/lib/bnl-source-file-refresh-now.ts`).
- Add and extend tests to verify forwarding of trusted callback base, rejection of untrusted origins, preservation of `caseReportMissing`/`requiresCaseReportBackfill` flags, no site-side report synthesis, and `case_report_missing_after_refresh` behavior (`tests/admin-dossiers.test.mjs`).

### Testing
- Ran the full admin dossier tests: `node --test tests/admin-dossiers.test.mjs`, all tests passed (142 passed, 0 failed).
- Type-checked the project: `npx tsc --noEmit`, which completed with no errors.

Files changed and why (end-of-task summary)
- `src/lib/trusted-requesting-site-origin.ts` (new): Add origin derivation and allowlist logic to determine a trusted request-origin from server-side request data.
- `src/lib/bnl-source-file-refresh-now.ts` (modified): Thread `requestingSiteOrigin` into BNL payload when trusted and add callback diagnostics to results; preserve case-report backfill flags and existing failure handling.
- `src/app/api/admin/dossiers/route.ts` (modified): Obtain trusted origin server-side and pass it into `refreshBnlSourceFileNow` for both Source File open and manual refresh actions.
- `tests/admin-dossiers.test.mjs` (modified): Extend tests to cover trusted callback forwarding, rejection of untrusted origins, payload field assertions for `siteCallbackBaseUrl`/`requestingSiteOrigin`/`sourceFileArchiveCallbackBaseUrl`, preserved backfill flags, and that no site-side report synthesis occurs.

Intentionally left untouched
- Bot code and any BNL-side components were not changed.
- No new public routes or publishing/identity-confirmation/dossier-approval behavior were added or altered.

Follow-up risks / manual checks
- Verify production environment variables (e.g., `NEXT_PUBLIC_SITE_URL`, any configured allowlist keys, and Vercel envs) are set correctly in deployments so legitimate preview/prod origins are recognized as trusted.
- Monitor initial deployments for any BNL callback failures from preview hosts to confirm hosts are recognized or added to allowlist if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c95382608321af4252e61ba6f58f)