### PR TITLE
Preserve BNL Case File Reports from Source File archive wrapper payloads

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -245,6 +245,56 @@ function latestBnlSourceFileEnrichment(input: {
 }
 
 
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function hasCaseReportShape(value: unknown) {
+  const report = recordValue(value);
+  if (!report) return false;
+  return [
+    "caseSummary",
+    "dossierUse",
+    "publicSafeClaims",
+    "evidenceSummary",
+    "reviewBlockers",
+    "recommendedNextSteps",
+    "confidenceNotes",
+    "memoryCoverage",
+  ].some((key) => report[key] !== undefined);
+}
+
+function latestArchiveHasCaseReport(candidate: DossierCandidate) {
+  const root = recordValue(candidate.latestSourceFileArchive);
+  if (!root) return false;
+  const candidates: Record<string, unknown>[] = [];
+  const seen = new Set<Record<string, unknown>>();
+  const add = (value: unknown) => {
+    const object = recordValue(value);
+    if (!object || seen.has(object)) return;
+    seen.add(object);
+    candidates.push(object);
+  };
+  add(root);
+  for (const key of ["sourcePackage", "archivePayload", "archive", "payload", "sourceFileArchive"] as const) {
+    const wrapped = root[key];
+    add(wrapped);
+    add(recordValue(wrapped)?.sourcePackage);
+  }
+  return candidates.some((candidateValue) => {
+    const brief = recordValue(candidateValue.sourceFileBriefV2);
+    return [
+      candidateValue.sourceFileCaseReportV1,
+      brief?.sourceFileCaseReportV1,
+      brief?.caseFileReport,
+      candidateValue.caseFileReport,
+    ].some(hasCaseReportShape);
+  });
+}
+
 function candidateLatestArchiveMissingCaseReport(candidate?: DossierCandidate | null) {
   if (!candidate) return false;
   const hasLatestSourceData = Boolean(
@@ -254,7 +304,7 @@ function candidateLatestArchiveMissingCaseReport(candidate?: DossierCandidate | 
       candidate.latestSourceFileArchiveUpdatedAt ??
       (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
   );
-  return hasLatestSourceData && !candidate.latestSourceFileArchive?.sourceFileCaseReportV1;
+  return hasLatestSourceData && !latestArchiveHasCaseReport(candidate);
 }
 
 function requestResolvedByNewerEnrichment(input: {

--- a/src/app/api/bnl/source-file-enrichments/route.ts
+++ b/src/app/api/bnl/source-file-enrichments/route.ts
@@ -86,6 +86,12 @@ function normalizePayload(value: unknown): CreateDossierSourceFileArchiveInput {
       10,
       1000,
     ),
+    sourceFileCaseReportV1: payload.sourceFileCaseReportV1 as CreateDossierSourceFileArchiveInput["sourceFileCaseReportV1"],
+    sourceFileBriefV2: payload.sourceFileBriefV2 as CreateDossierSourceFileArchiveInput["sourceFileBriefV2"],
+    archivePayload: payload.archivePayload,
+    archive: payload.archive,
+    payload: payload.payload,
+    sourceFileArchive: payload.sourceFileArchive,
   };
 }
 

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -106,26 +106,48 @@ function hasReportShape(value: unknown): value is DossierSourceFileCaseReportV1 
   ].some((key) => report[key] !== undefined);
 }
 
+function archivePayloadCandidates(latestSourceFileArchive?: DossierSourceFileArchiveMetadata) {
+  const archive = asRecord(latestSourceFileArchive);
+  if (!archive) return [];
+  const candidates: UnknownRecord[] = [];
+  const seen = new Set<UnknownRecord>();
+  const add = (value: unknown) => {
+    const object = asRecord(value);
+    if (!object || seen.has(object)) return;
+    seen.add(object);
+    candidates.push(object);
+  };
+  add(archive);
+  for (const key of ["sourcePackage", "archivePayload", "archive", "payload", "sourceFileArchive"] as const) {
+    const wrapped = archive[key];
+    add(wrapped);
+    add(asRecord(wrapped)?.sourcePackage);
+  }
+  return candidates;
+}
+
 function normalizeCaseReport(
   latestSourceFileArchive?: DossierSourceFileArchiveMetadata,
 ): DossierSourceFileCaseReportV1 | undefined {
-  const archive = asRecord(latestSourceFileArchive);
-  if (!archive) return undefined;
-  const sourcePackage = asRecord(archive.sourcePackage);
-  const brief = asRecord(archive.sourceFileBriefV2);
-  const candidates = [
-    archive.sourceFileCaseReportV1,
-    sourcePackage?.sourceFileCaseReportV1,
-    brief?.sourceFileCaseReportV1,
-    brief?.caseFileReport,
-  ];
-  return candidates.find(hasReportShape);
+  for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
+    const brief = asRecord(candidate.sourceFileBriefV2);
+    const report = [
+      candidate.sourceFileCaseReportV1,
+      brief?.sourceFileCaseReportV1,
+      brief?.caseFileReport,
+      candidate.caseFileReport,
+    ].find(hasReportShape);
+    if (report) return report;
+  }
+  return undefined;
 }
 
 function normalizeInterimBrief(latestSourceFileArchive?: DossierSourceFileArchiveMetadata) {
-  const archive = asRecord(latestSourceFileArchive);
-  if (!archive) return undefined;
-  return asRecord(archive.sourceFileBriefV2) ?? asRecord(asRecord(archive.sourcePackage)?.sourceFileBriefV2);
+  for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
+    const brief = asRecord(candidate.sourceFileBriefV2);
+    if (brief) return brief;
+  }
+  return undefined;
 }
 
 function firstCompleteSentence(value: string) {
@@ -364,6 +386,9 @@ export function DossierSourceFileSummaryPanel({
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
   const latestArchiveMissingReport = Boolean(latestSourceFileArchive && !report);
+  const hasArchiveDiagnostics =
+    latestSourceFileArchive?.caseReportPresent !== undefined ||
+    latestSourceFileArchive?.caseReportExtractedFrom !== undefined;
   const snapshotItems = [
     ["Subject", subjectName ?? latestSourceFileArchive?.subjectName ?? "Unknown subject"],
     ["Current state", humanStatus(currentLane ?? summary.nextAction)],
@@ -409,6 +434,21 @@ export function DossierSourceFileSummaryPanel({
           Summary badge: {formatDossierSummaryBadge(summary.summarySource)}.
         </p>
       </Section>
+
+      {hasArchiveDiagnostics && (
+        <Section title="Archive ingest diagnostics" helper="Admin-only preservation check. These fields are safe booleans and path labels, not raw archive secrets.">
+          <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <SnapshotItem
+              label="caseReportPresent"
+              value={latestSourceFileArchive?.caseReportPresent ? "true" : "false"}
+            />
+            <SnapshotItem
+              label="caseReportExtractedFrom"
+              value={latestSourceFileArchive?.caseReportExtractedFrom ?? "—"}
+            />
+          </dl>
+        </Section>
+      )}
 
       <CaseReportView report={report} />
       <InterimBriefView brief={interimBrief} hasReport={Boolean(report)} />

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -477,6 +477,35 @@ function sourceArchiveObject(value: unknown): Record<string, unknown> | undefine
     : undefined;
 }
 
+type SourceArchivePayloadCandidate = {
+  value: Record<string, unknown>;
+  path: string;
+};
+
+export function sourceArchivePayloadCandidates(input: unknown): SourceArchivePayloadCandidate[] {
+  const root = sourceArchiveObject(input);
+  if (!root) return [];
+  const candidates: SourceArchivePayloadCandidate[] = [];
+  const seen = new Set<Record<string, unknown>>();
+  const add = (value: unknown, path: string) => {
+    const object = sourceArchiveObject(value);
+    if (!object || seen.has(object)) return;
+    seen.add(object);
+    candidates.push({ value: object, path });
+  };
+
+  add(root, "input");
+  for (const key of ["sourcePackage", "archivePayload", "archive", "payload", "sourceFileArchive"] as const) {
+    const wrapped = root[key];
+    add(wrapped, `input.${key}`);
+    const wrappedObject = sourceArchiveObject(wrapped);
+    if (wrappedObject) {
+      add(wrappedObject.sourcePackage, `input.${key}.sourcePackage`);
+    }
+  }
+  return candidates;
+}
+
 function isSourceFileCaseReportShape(value: unknown) {
   const report = sourceArchiveObject(value);
   if (!report) return false;
@@ -506,26 +535,52 @@ function normalizeSourceArchiveBrief(value: unknown) {
   };
 }
 
+function findSourceFileCaseReportV1(input: unknown) {
+  for (const candidate of sourceArchivePayloadCandidates(input)) {
+    const brief = normalizeSourceArchiveBrief(candidate.value.sourceFileBriefV2);
+    const checks: Array<{ value: unknown; path: string }> = [
+      { value: candidate.value.sourceFileCaseReportV1, path: `${candidate.path}.sourceFileCaseReportV1` },
+      { value: brief?.sourceFileCaseReportV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1` },
+      { value: brief?.caseFileReport, path: `${candidate.path}.sourceFileBriefV2.caseFileReport` },
+      { value: candidate.value.caseFileReport, path: `${candidate.path}.caseFileReport` },
+    ];
+    const match = checks.find((check) => isSourceFileCaseReportShape(check.value));
+    if (match) {
+      return {
+        report: match.value as DossierSourceFileCaseReportV1,
+        path: match.path,
+      };
+    }
+  }
+  return { report: undefined, path: undefined };
+}
+
 function extractSourceFileCaseReportV1(input: CreateDossierSourceFileArchiveInput) {
-  const inputObject = sourceArchiveObject(input);
-  const sourcePackage = sourceArchiveObject(input.sourcePackage);
-  const brief = normalizeSourceArchiveBrief(
-    inputObject?.sourceFileBriefV2 ?? sourcePackage?.sourceFileBriefV2,
-  );
-  const candidates = [
-    inputObject?.sourceFileCaseReportV1,
-    sourcePackage?.sourceFileCaseReportV1,
-    brief?.sourceFileCaseReportV1,
-    brief?.caseFileReport,
-  ];
-  return candidates.find(isSourceFileCaseReportShape) as DossierSourceFileCaseReportV1 | undefined;
+  return findSourceFileCaseReportV1(input).report;
+}
+
+function findSourceFileBriefV2(input: unknown) {
+  for (const candidate of sourceArchivePayloadCandidates(input)) {
+    const brief = normalizeSourceArchiveBrief(candidate.value.sourceFileBriefV2);
+    if (brief) return { brief, path: `${candidate.path}.sourceFileBriefV2` };
+  }
+  return { brief: undefined, path: undefined };
 }
 
 function extractSourceFileBriefV2(input: CreateDossierSourceFileArchiveInput) {
-  const inputObject = sourceArchiveObject(input);
-  const sourcePackage = sourceArchiveObject(input.sourcePackage);
-  return normalizeSourceArchiveBrief(
-    inputObject?.sourceFileBriefV2 ?? sourcePackage?.sourceFileBriefV2,
+  return findSourceFileBriefV2(input).brief;
+}
+
+function sourceArchiveHasSubjectMemoryPacket(input: unknown) {
+  return sourceArchivePayloadCandidates(input).some(({ value }) =>
+    [
+      "subjectMemoryPacket",
+      "subjectMemoryPacketV1",
+      "subjectMemoryPacketV2",
+      "sourceMemoryPacket",
+      "sourceMemoryPacketV1",
+      "sourceMemoryPacketV2",
+    ].some((key) => value[key] !== undefined),
   );
 }
 
@@ -542,10 +597,16 @@ function normalizeSourceFileArchiveInput(
       evidenceReceiptSummary?: string[];
       sourceFileCaseReportV1?: unknown;
       sourceFileBriefV2?: unknown;
+      caseReportPresent: boolean;
+      subjectMemoryPacketPresent: boolean;
+      caseReportExtractedFrom?: string;
+      sourceFileBriefExtractedFrom?: string;
     })
   | null {
   const subjectName = compactArchiveText(input.subjectName, 200);
   if (!subjectName) return null;
+  const caseReport = findSourceFileCaseReportV1(input);
+  const sourceFileBrief = findSourceFileBriefV2(input);
   return {
     ...input,
     candidateId: compactArchiveText(input.candidateId, 200),
@@ -563,8 +624,12 @@ function normalizeSourceFileArchiveInput(
       10,
       1000,
     ),
-    sourceFileCaseReportV1: extractSourceFileCaseReportV1(input),
-    sourceFileBriefV2: extractSourceFileBriefV2(input),
+    sourceFileCaseReportV1: caseReport.report,
+    sourceFileBriefV2: sourceFileBrief.brief,
+    caseReportPresent: Boolean(caseReport.report),
+    subjectMemoryPacketPresent: sourceArchiveHasSubjectMemoryPacket(input),
+    caseReportExtractedFrom: caseReport.path,
+    sourceFileBriefExtractedFrom: sourceFileBrief.path,
   };
 }
 
@@ -1925,7 +1990,7 @@ export function latestArchiveMissingCaseReport(candidate: DossierCandidate): boo
       (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
   );
   if (!hasLatestSourceData) return false;
-  return !latestArchive?.sourceFileCaseReportV1;
+  return !findSourceFileCaseReportV1(latestArchive).report;
 }
 
 export const candidateMissingCaseReport = latestArchiveMissingCaseReport;
@@ -2455,6 +2520,10 @@ export async function ingestDossierSourceFileArchive(
       evidenceReceiptSummary: normalized.evidenceReceiptSummary,
       sourceFileCaseReportV1: normalized.sourceFileCaseReportV1,
       sourceFileBriefV2: normalized.sourceFileBriefV2,
+      caseReportPresent: normalized.caseReportPresent,
+      subjectMemoryPacketPresent: normalized.subjectMemoryPacketPresent,
+      caseReportExtractedFrom: normalized.caseReportExtractedFrom,
+      sourceFileBriefExtractedFrom: normalized.sourceFileBriefExtractedFrom,
       archiveKey,
       chunkKeys,
       reviewOnly: true,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -171,6 +171,10 @@ export type DossierSourceFileArchiveCompactReadout = {
   evidenceReceiptSummary?: string[];
   sourceFileCaseReportV1?: DossierSourceFileCaseReportV1;
   sourceFileBriefV2?: DossierSourceFileBriefV2;
+  archivePayload?: unknown;
+  archive?: unknown;
+  payload?: unknown;
+  sourceFileArchive?: unknown;
 };
 
 export type DossierSourceFileArchiveMetadata =
@@ -189,6 +193,10 @@ export type DossierSourceFileArchiveMetadata =
     archiveKey?: string;
     chunkKeys?: string[];
     reviewOnly: true;
+    caseReportPresent?: boolean;
+    subjectMemoryPacketPresent?: boolean;
+    caseReportExtractedFrom?: string;
+    sourceFileBriefExtractedFrom?: string;
   };
 
 export type DossierSourceFileEnrichmentArchive =

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -824,6 +824,159 @@ test("Source File refresh requests case-report backfill and refuses false comple
   }
 });
 
+
+
+function bnlCaseReportFixture(label) {
+  return {
+    version: "1",
+    generatedAt: "2026-06-10T00:00:00.000Z",
+    reportStatus: "dossier_ready",
+    caseSummary: `BNL-authored case report from ${label}.`,
+    dossierUse: `Use preserved ${label} report for owner review only.`,
+    publicSafeClaims: [`Public-safe claim from ${label}.`],
+  };
+}
+
+test("Source File archive ingest preserves BNL Case File Reports from accepted wrapper shapes", async () => {
+  await resetWorkflowStore();
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Wrapped Case Report Fixture",
+      candidateType: "artist",
+      reason: "Operator wants wrapper archive coverage.",
+      whyNow: "BNL archive callback shape changed.",
+      evidenceSummary: "Admin fixture evidence.",
+    },
+  })).json();
+  const candidateId = created.candidate.id;
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+
+  const cases = [
+    {
+      label: "top-level sourceFileCaseReportV1",
+      expectedPath: "input.sourceFileCaseReportV1",
+      input: (report) => ({ sourceFileCaseReportV1: report }),
+    },
+    {
+      label: "sourcePackage.sourceFileCaseReportV1",
+      expectedPath: "input.sourcePackage.sourceFileCaseReportV1",
+      input: (report) => ({ sourcePackagePatch: { sourceFileCaseReportV1: report } }),
+    },
+    {
+      label: "archivePayload.sourceFileCaseReportV1",
+      expectedPath: "input.archivePayload.sourceFileCaseReportV1",
+      input: (report) => ({ archivePayload: { sourceFileCaseReportV1: report } }),
+    },
+    {
+      label: "archivePayload.sourcePackage.sourceFileCaseReportV1",
+      expectedPath: "input.archivePayload.sourcePackage.sourceFileCaseReportV1",
+      input: (report) => ({ archivePayload: { sourcePackage: { sourceFileCaseReportV1: report } } }),
+    },
+    {
+      label: "payload.sourceFileBriefV2.caseFileReport",
+      expectedPath: "input.payload.sourceFileBriefV2.caseFileReport",
+      input: (report) => ({ payload: { sourceFileBriefV2: { oneLineSummary: "Wrapped interim brief.", caseFileReport: report } } }),
+    },
+  ];
+
+  for (const [index, item] of cases.entries()) {
+    const report = bnlCaseReportFixture(item.label);
+    const shape = item.input(report);
+    const sourcePackage = {
+      archiveOrdinal: index,
+      compactSummary: `COMPACT_SUMMARY_MUST_NOT_SYNTHESIZE_${index}`,
+      ...(shape.sourcePackagePatch ?? {}),
+    };
+    delete shape.sourcePackagePatch;
+
+    const result = await store.ingestDossierSourceFileArchive({
+      candidateId,
+      subjectName: "Wrapped Case Report Fixture",
+      subjectKey: "wrapped-case-report-fixture",
+      ingestKey: `wrapped-case-report-${index}`,
+      sourcePackage,
+      compactSummary: `COMPACT_SUMMARY_MUST_NOT_SYNTHESIZE_${index}`,
+      ...shape,
+    });
+
+    assert.equal(result.archive.sourceFileCaseReportV1.caseSummary, report.caseSummary);
+    assert.equal(result.archive.caseReportPresent, true);
+    assert.equal(result.archive.caseReportExtractedFrom, item.expectedPath);
+    assert.equal(store.latestArchiveMissingCaseReport(result.candidate), false);
+
+    const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+      summary: sourceFileReportTestSummary(),
+      subjectName: "Wrapped Case Report Fixture",
+      latestSourceFileArchive: result.archive,
+    }));
+    assert.match(panelText, /BNL Case File Report/);
+    assert.match(panelText, new RegExp(item.label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(panelText, /caseReportPresent/);
+    assert.match(panelText, new RegExp(item.expectedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(panelText, /COMPACT_SUMMARY_MUST_NOT_SYNTHESIZE/);
+  }
+});
+
+test("Source File case-report missing detection uses normalized archive extraction without compact-summary synthesis", () => {
+  const report = bnlCaseReportFixture("nested preserved archive");
+  const candidateBase = {
+    id: "candidate-wrapper-detection",
+    name: "Wrapper Detection",
+    status: "source_file_open",
+    latestSourceFileArchiveId: "archive-wrapper-detection",
+    latestSourceFileArchiveDigest: "digest-wrapper-detection",
+    latestSourceFileArchiveUpdatedAt: "2026-06-10T00:00:00.000Z",
+    sourceFileArchiveIds: ["archive-wrapper-detection"],
+  };
+
+  for (const latestSourceFileArchive of [
+    { archivePayload: { sourceFileCaseReportV1: report } },
+    { archivePayload: { sourcePackage: { sourceFileCaseReportV1: report } } },
+    { payload: { sourceFileBriefV2: { caseFileReport: report } } },
+    { archive: { sourceFileCaseReportV1: report } },
+    { sourceFileArchive: { sourceFileCaseReportV1: report } },
+  ]) {
+    assert.equal(
+      store.latestArchiveMissingCaseReport({ ...candidateBase, latestSourceFileArchive }),
+      false,
+    );
+  }
+
+  const compactOnlyCandidate = {
+    ...candidateBase,
+    latestSourceFileArchive: {
+      id: "archive-wrapper-detection",
+      candidateId: "candidate-wrapper-detection",
+      subjectName: "Wrapper Detection",
+      subjectKey: "wrapper-detection",
+      sourceDigest: "digest-wrapper-detection",
+      createdAt: "2026-06-10T00:00:00.000Z",
+      updatedAt: "2026-06-10T00:00:00.000Z",
+      archiveSize: 100,
+      chunkCount: 1,
+      reviewOnly: true,
+      compactSummary: "COMPACT_SUMMARY_SHOULD_NOT_BECOME_REPORT",
+      sourceFileBriefV2: { oneLineSummary: "Brief only is not a report." },
+    },
+  };
+  assert.equal(store.latestArchiveMissingCaseReport(compactOnlyCandidate), true);
+
+  const visibleText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: sourceFileReportTestSummary(),
+    latestSourceFileArchive: compactOnlyCandidate.latestSourceFileArchive,
+  }));
+  assert.match(visibleText, /BNL has not generated a dossier-ready Case File Report/);
+  assert.doesNotMatch(visibleText, /COMPACT_SUMMARY_SHOULD_NOT_BECOME_REPORT/);
+
+  const rawArchiveText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileArchiveRawData({
+    latestSourceFileArchive: compactOnlyCandidate.latestSourceFileArchive,
+  }));
+  assert.match(rawArchiveText, /Archive \/ Raw Source File Data/);
+  assert.match(rawArchiveText, /COMPACT_SUMMARY_SHOULD_NOT_BECOME_REPORT/);
+});
+
 test("Source File immediate refresh timeout/unavailable and stale open requests do not trap retries or cross-file matching", async () => {
   await resetWorkflowStore();
   process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";


### PR DESCRIPTION
### Motivation
- BNL callback archives are sometimes wrapped (e.g., `archivePayload`, `payload`, `archive`, `sourceFileArchive`) and the site was only checking a few top-level locations, causing accepted archives that contained a BNL-authored `sourceFileCaseReportV1` to be ignored and the UI to show `case_report_missing_after_refresh`.
- The change normalizes accepted wrapper shapes on ingest and read paths so genuine BNL reports and briefs are preserved and rendered without synthesizing a report from `compactSummary`.

### Description
- Add a normalized payload explorer and extraction helpers: `sourceArchivePayloadCandidates(...)`, `findSourceFileCaseReportV1(...)`, and `findSourceFileBriefV2(...)`, and use them from `extractSourceFileCaseReportV1(...)` and `extractSourceFileBriefV2(...)` so reports/briefs are found inside `input`, `sourcePackage`, `archivePayload`, `archive`, `payload`, `sourceFileArchive`, and nested `sourcePackage` objects.
- Persist safe diagnostics into archive metadata (`caseReportPresent`, `subjectMemoryPacketPresent`, `caseReportExtractedFrom`, `sourceFileBriefExtractedFrom`) and extend types so the UI can surface non-secret diagnostics; do not store raw secrets.
- Update logic that detects missing reports to use the normalized extraction (so `latestArchiveMissingCaseReport` no longer relies only on `latestSourceFileArchive.sourceFileCaseReportV1`).
- Update admin UI rendering to read reports and interim briefs from normalized locations and show a small admin-only diagnostics section when diagnostics exist.
- Accept and forward wrapper fields from the BNL ingest endpoint in `normalizePayload(...)` so the store can find reports preserved in wrappers.
- Files changed and why: `src/lib/dossier-workflow-store.ts` (normalize/unwrap payloads, extractors, diagnostics, store diagnostics at ingest), `src/lib/dossier-workflow.ts` (types extended for wrapper fields and diagnostics), `src/app/api/bnl/source-file-enrichments/route.ts` (accept wrapper fields in payload), `src/components/DossierSourceFileSummaryPanel.tsx` (normalize report/brief lookup and admin diagnostics UI), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (missing-report detection updated to use normalized lookup), and `tests/admin-dossiers.test.mjs` (added regression tests for wrapper-preserved reports and missing-report detection).

### Testing
- Ran the full relevant test file with `node --test tests/admin-dossiers.test.mjs` and the suite passed (new tests included); all tests in that file passed.
- Type-checked with `npx tsc --noEmit` and it succeeded with no type errors.
- Added automated tests verifying ingest/preservation from these wrapper shapes: top-level `sourceFileCaseReportV1`, `sourcePackage.sourceFileCaseReportV1`, `archivePayload.sourceFileCaseReportV1`, `archivePayload.sourcePackage.sourceFileCaseReportV1`, and `payload.sourceFileBriefV2.caseFileReport`, plus tests asserting no synthesis from `compactSummary` and that `latestArchiveMissingCaseReport(...)` returns false when a report exists in any accepted wrapper location.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29d9c454cc8321aa1996fd9dde9557)