### PR TITLE
Site PR #189 — Source File admin workspace layout cleanup; remove top Advanced/Diagnostics noise

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1616,22 +1616,27 @@ export default function CandidateReviewPage() {
             {candidate.name}
           </h1>
           <p className="text-sm text-muted mt-3 max-w-3xl">
-            {workspaceType} ID: {candidate.id}. Internal working case file. This may
-            include unverified, internal, conflicting, source-blind, or
-            private-review material. Do not treat this as public copy. Admins
-            can add information to this workspace, but cannot turn this
-            record into another subject. Notes do not publish, create tags,
-            or mutate public records.
+            {workspaceType} ID: {candidate.id}. Internal working material only; not
+            public copy. Owner review is required before any public use.
           </p>
           {isExistingDossierUpdate && (
             <p className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
               This internal record is a Dossier Update target, not a new dossier proposal.
             </p>
           )}
-          <div className="mt-4">
-            <PhaseRail />
-          </div>
-          <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-6 gap-3 text-xs text-muted">
+          <details className="mt-4 border border-border/60 bg-background/20 p-3 text-xs text-muted">
+            <summary className="cursor-pointer font-semibold uppercase tracking-widest text-foreground">
+              Phase Rail
+            </summary>
+            <div className="mt-3">
+              <PhaseRail />
+            </div>
+          </details>
+          <details className="mt-5 border border-border bg-background/20 p-3 text-xs text-muted">
+            <summary className="cursor-pointer font-semibold uppercase tracking-widest text-foreground">
+              File Status · {sourceMetrics?.sourceDepth ?? "Low"} strength · {sourceMetrics?.sourceNotesCount ?? 0} notes · {nextRecommendedAction}
+            </summary>
+            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-6 gap-3 text-xs text-muted">
             <div className="border border-border bg-background/30 p-3">
               <p className="uppercase tracking-widest text-accent">
                 Source strength
@@ -1678,7 +1683,8 @@ export default function CandidateReviewPage() {
               </p>
               <p>{nextRecommendedAction}</p>
             </div>
-          </div>
+            </div>
+          </details>
           {(sourceMetrics?.unappliedSourceNotesCount ?? 0) > 0 &&
             primaryDraft && (
               <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -1707,13 +1713,6 @@ export default function CandidateReviewPage() {
                     Last-known BNL data is not current for this page open.
                   </p>
                 )}
-                <p className="mt-2 text-xs">
-                  Diagnostics: request {latestRefreshRequest?.id ?? "—"} / status{" "}
-                  {latestRefreshRequest?.status ?? "—"} / latest enrichment{" "}
-                  {latestEnrichmentTimestamp ?? "—"} / immediate{" "}
-                  {sourceFileOpenState.immediateRefresh?.status ??
-                    (sourceFileOpenState.running ? "running" : "—")}
-                </p>
               </div>
               <button
                 type="button"
@@ -1726,139 +1725,151 @@ export default function CandidateReviewPage() {
             </div>
           </div>
 
-          <div className="mt-5 space-y-3 text-xs uppercase tracking-widest">
-            <p className="text-muted">Signal / Seed Actions · Case File Actions · Identity Check · Proposed Dossier Actions · Archive / Danger</p>
-            <div className="flex flex-wrap gap-3">
-            <Link
-              href="/admin/dossiers"
-              className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent"
-            >
-              Back to Dossier Control Center
-            </Link>
-            <a
-              href="#add-info"
-              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
-            >
-              Add to Case File / BNL Source File
-            </a>
-            {canCreateDraft && (
-              <button
-                type="button"
-                onClick={() => void createDraft()}
-                disabled={saving}
-                className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Create Proposed Dossier
-              </button>
-            )}
-            {primaryDraft && isDraftActive(primaryDraft) && (
-              <Link
-                href={`/admin/dossiers/drafts/${primaryDraft.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
-              >
-                Open Proposed Dossier
-              </Link>
-            )}
-            <button
-              type="button"
-              disabled
-              className="border border-border px-4 py-2 text-muted opacity-50"
-              title="Owner action required for final dismissal; add dismissal context as an info/correction note for now."
-            >
-              Recommend Dismissal (owner later)
-            </button>
-            <button
-              type="button"
-              disabled={
-                saving ||
-                !canUpdateCandidate ||
-                candidate.status === "needs_more_evidence"
-              }
-              onClick={() => void update("markNeedsMoreEvidence")}
-              className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-            >
-              Mark Needs Info
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                void candidateLifecycleAction(
-                  "markCandidateAsExistingDossierUpdate",
-                )
-              }
-              disabled={
-                saving || !canUpdateCandidate || !existingDossierSelection
-              }
-              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              title="Reclassify this record as update/enrichment material for the attached public dossier. Does not publish or edit public content."
-            >
-              Move to Dossier Update
-            </button>
-            {isExistingDossierUpdate && (
-              <button
-                type="button"
-                onClick={() =>
-                  void candidateLifecycleAction("promoteCandidateToSourceFile")
-                }
-                disabled={saving}
-                className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-              >
-                Move Back to Case File
-              </button>
-            )}
-            {canPromoteCandidate && (
-              <button
-                type="button"
-                onClick={() =>
-                  void candidateLifecycleAction("promoteCandidateToSourceFile")
-                }
-                disabled={saving}
-                className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-              >
-                Promote to Case File
-              </button>
-            )}
-            {canArchiveCandidate && (
-              <button
-                type="button"
-                onClick={() =>
-                  void candidateLifecycleAction("archiveCandidate")
-                }
-                disabled={saving}
-                className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-                title="Safe cleanup: removes this Case File from active dashboard lanes without deleting public dossiers or published data."
-              >
-                Archive
-              </button>
-            )}
-            {canRestoreCandidate && (
-              <button
-                type="button"
-                onClick={() =>
-                  void candidateLifecycleAction("restoreCandidate")
-                }
-                disabled={saving}
-                className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-              >
-                Restore
-              </button>
-            )}
-            {canPermanentlyDeleteCandidate && (
-              <button
-                type="button"
-                onClick={() =>
-                  void candidateLifecycleAction("permanentlyDeleteCandidate")
-                }
-                disabled={saving}
-                className="border border-red-500/70 px-4 py-2 text-red-300 hover:bg-red-500/10 disabled:opacity-50"
-                title='Requires typing "DELETE SOURCE FILE". Does not delete public dossiers or published data.'
-              >
-                Delete Permanently
-              </button>
-            )}
+          <div className="mt-5 grid grid-cols-1 gap-3 text-xs uppercase tracking-widest lg:grid-cols-3">
+            <div className="border border-border bg-background/20 p-3">
+              <p className="mb-3 text-accent">Main actions</p>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href="/admin/dossiers"
+                  className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent"
+                >
+                  Back to Dossier Control Center
+                </Link>
+                <a
+                  href="#add-info"
+                  className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
+                >
+                  Add to Source File
+                </a>
+                {canCreateDraft && (
+                  <button
+                    type="button"
+                    onClick={() => void createDraft()}
+                    disabled={saving}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Create Proposed Dossier
+                  </button>
+                )}
+                {primaryDraft && isDraftActive(primaryDraft) && (
+                  <Link
+                    href={`/admin/dossiers/drafts/${primaryDraft.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
+                  >
+                    Open Proposed Dossier
+                  </Link>
+                )}
+              </div>
             </div>
+            <div className="border border-border bg-background/20 p-3">
+              <p className="mb-3 text-accent">Review state</p>
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  disabled
+                  className="border border-border px-4 py-2 text-muted opacity-50"
+                  title="Owner action required for final dismissal; add dismissal context as an info/correction note for now."
+                >
+                  Recommend Dismissal (owner later)
+                </button>
+                <button
+                  type="button"
+                  disabled={
+                    saving ||
+                    !canUpdateCandidate ||
+                    candidate.status === "needs_more_evidence"
+                  }
+                  onClick={() => void update("markNeedsMoreEvidence")}
+                  className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+                >
+                  Mark Needs Info
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void candidateLifecycleAction(
+                      "markCandidateAsExistingDossierUpdate",
+                    )
+                  }
+                  disabled={
+                    saving || !canUpdateCandidate || !existingDossierSelection
+                  }
+                  className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  title="Reclassify this record as update/enrichment material for the attached public dossier. Does not publish or edit public content."
+                >
+                  Move to Dossier Update
+                </button>
+                {isExistingDossierUpdate && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void candidateLifecycleAction("promoteCandidateToSourceFile")
+                    }
+                    disabled={saving}
+                    className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+                  >
+                    Move Back to Case File
+                  </button>
+                )}
+                {canPromoteCandidate && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void candidateLifecycleAction("promoteCandidateToSourceFile")
+                    }
+                    disabled={saving}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Promote to Case File
+                  </button>
+                )}
+              </div>
+            </div>
+            <details className="border border-border bg-background/20 p-3">
+              <summary className="cursor-pointer text-accent">Archive / danger</summary>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {canArchiveCandidate && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void candidateLifecycleAction("archiveCandidate")
+                    }
+                    disabled={saving}
+                    className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+                    title="Safe cleanup: removes this Case File from active dashboard lanes without deleting public dossiers or published data."
+                  >
+                    Archive
+                  </button>
+                )}
+                {canRestoreCandidate && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void candidateLifecycleAction("restoreCandidate")
+                    }
+                    disabled={saving}
+                    className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+                  >
+                    Restore
+                  </button>
+                )}
+                {canPermanentlyDeleteCandidate && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void candidateLifecycleAction("permanentlyDeleteCandidate")
+                    }
+                    disabled={saving}
+                    className="border border-red-500/70 px-4 py-2 text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+                    title='Requires typing "DELETE SOURCE FILE". Does not delete public dossiers or published data.'
+                  >
+                    Delete Permanently
+                  </button>
+                )}
+              </div>
+            </details>
           </div>
           {notice && (
             <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
@@ -1869,8 +1880,24 @@ export default function CandidateReviewPage() {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">
-        {identityLinks.length > 0 && (
-          <Section title="Identity Check">
+        <section className="border border-border bg-surface p-4 space-y-3">
+          <h2 className="text-lg font-bold text-foreground">
+            Review Boundaries
+          </h2>
+          <p className="text-sm text-muted">
+            Internal working material only: not public copy, owner review required,
+            and no public use until review clears the claim.
+          </p>
+          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+            {sourceWarningLabels({
+              candidate,
+              recommendations: attachedRecommendations,
+            }).map((label) => (
+              <StatusBadge key={label}>{label}</StatusBadge>
+            ))}
+          </div>
+        </section>
+        <Section title="Identity Check">
             <div className="space-y-5">
               <p className="border border-border/70 bg-background/20 p-3">
                 Identity links are internal routing/context tools. Resolve these before
@@ -1942,8 +1969,12 @@ export default function CandidateReviewPage() {
                   ))}
               </div>
             </div>
-          </Section>
-        )}
+          {identityLinks.length === 0 && (
+            <p className="mt-3 border border-border/70 bg-background/20 p-3 text-sm text-muted">
+              No identity links pending. Manual identity-link tools are available in the lower admin tools area.
+            </p>
+          )}
+        </Section>
         {sourceFileSummary && (
           <>
             <DossierSourceFileSummaryPanel
@@ -1990,6 +2021,81 @@ export default function CandidateReviewPage() {
             </div>
           )}
         </Section>
+
+        <details
+          open={Boolean(candidate.existingDossierMatch)}
+          className="border border-border bg-surface p-5 space-y-4"
+        >
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Dossier Update Actions
+          </summary>
+          <div className="mt-4 space-y-4">
+          {candidate.existingDossierMatch ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
+              <p>
+                Matched public dossier name:{" "}
+                {candidate.existingDossierMatch.name}
+              </p>
+              <p>
+                Match confidence: {candidate.existingDossierMatch.confidence}
+              </p>
+              <p>Public dossier id/slug: {candidate.existingDossierMatch.id}</p>
+              <p>Current workflow state: {candidate.status}</p>
+            </div>
+          ) : (
+            <p className="text-sm text-muted">
+              No existing public dossier match currently attached.
+            </p>
+          )}
+          <label className="block space-y-2 text-xs uppercase tracking-widest text-muted">
+            Attach to Existing Public Dossier
+            <select
+              value={existingDossierSelection}
+              onChange={(event) =>
+                setSelectedExistingDossierId(event.target.value)
+              }
+              className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
+            >
+              <option value="">Choose public dossier…</option>
+              {publicDossiers.map((dossier) => (
+                <option key={dossier.id} value={dossier.id}>
+                  {dossier.name} ({dossier.id})
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction(
+                  "attachCandidateToExistingDossier",
+                )
+              }
+              disabled={saving || !existingDossierSelection}
+              className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              Attach to Existing Public Dossier
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void candidateLifecycleAction(
+                  "markCandidateAsExistingDossierUpdate",
+                )
+              }
+              disabled={
+                saving || !canUpdateCandidate || !existingDossierSelection
+              }
+              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+            >
+              {isExistingDossierUpdate
+                ? "Keep as Dossier Update"
+                : "Move to Dossier Update"}
+            </button>
+          </div>
+          </div>
+        </details>
 
         <section
           id="add-info"
@@ -2109,29 +2215,91 @@ export default function CandidateReviewPage() {
 
         <DossierSourceFileArchiveRawData latestSourceFileArchive={candidate.latestSourceFileArchive} />
 
+
+
+
+
+        <details
+          open={hasSavedOperatorSourceSummary}
+          className="border border-border bg-surface p-5 text-sm text-muted"
+        >
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Operator Case File Summary
+          </summary>
+          <p className="mt-3 text-sm text-muted max-w-4xl">
+            Optional internal override for the top Source File summary. Use only
+            when BNL&apos;s current read needs owner/admin correction. This is
+            not a draft, not public copy, and not the normal add-info workflow.
+          </p>
+          <form
+            onSubmit={saveSourceFileSummary}
+            className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm"
+          >
+            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
+              Summary text
+              <textarea
+                name="summaryText"
+                defaultValue={candidate.sourceFileSummary?.summaryText ?? ""}
+                rows={3}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="Plain-English internal correction to BNL's current read…"
+              />
+            </label>
+            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
+              Known context
+              <textarea
+                name="knownContext"
+                defaultValue={(
+                  candidate.sourceFileSummary?.knownContext ?? []
+                ).join("\n")}
+                rows={4}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="One owner/admin-corrected context line per row"
+              />
+            </label>
+            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
+              Open questions
+              <textarea
+                name="openQuestions"
+                defaultValue={(
+                  candidate.sourceFileSummary?.openQuestions ?? []
+                ).join("\n")}
+                rows={4}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="One review question per row"
+              />
+            </label>
+            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
+              Recommended next step
+              <input
+                name="nextAction"
+                defaultValue={candidate.sourceFileSummary?.nextAction ?? ""}
+                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                placeholder="What should an operator do next?"
+              />
+            </label>
+            <div className="md:col-span-2 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
+              <button
+                type="submit"
+                disabled={saving}
+                className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+              >
+                Save Operator Case File Summary
+              </button>
+              <span className="text-muted self-center">
+                Optional override only; use Add to Case File / BNL Source File for normal
+                source updates.
+              </span>
+            </div>
+          </form>
+        </details>
+
         <details className="border border-border bg-surface p-5 space-y-4">
           <summary className="cursor-pointer text-2xl font-bold text-foreground">
             Advanced Tools
           </summary>
-          <div className="pt-4 text-sm text-muted">
-            Advanced controls stay collapsed by default and do not generate reports.
-          </div>
-        </details>
-
-        <details className="border border-border bg-surface p-5 space-y-4">
-          <summary className="cursor-pointer text-2xl font-bold text-foreground">
-            Diagnostics
-          </summary>
-          <div className="pt-4 text-sm text-muted">
-            Diagnostics only. Not Case File claims.
-          </div>
-        </details>
-
-        <details className="border border-border bg-surface p-5 space-y-4">
-          <summary className="cursor-pointer text-2xl font-bold text-foreground">
-            Advanced Tools: Add Identity Link Manually
-          </summary>
           <div className="space-y-5 pt-4">
+            <p className="text-sm text-muted">Advanced controls stay collapsed by default and do not generate reports. Manual identity links live here so they do not interrupt normal review.</p>
             <div className="space-y-2 text-sm text-muted">
               <p>
                 Aliases help BNL route future BNL Signals to the right source file.
@@ -2274,170 +2442,6 @@ export default function CandidateReviewPage() {
           </div>
         </details>
 
-        <section className="border border-border bg-surface p-5 space-y-4">
-          <h2 className="text-2xl font-bold text-foreground">
-            Review Boundaries
-          </h2>
-          <p className="text-sm text-muted">
-            This is an internal working case file. It can hold confirmed facts,
-            claims that need review, possible connections, public-safety notes,
-            and private context. It is not public copy and should not be treated
-            as proof on its own.
-          </p>
-          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
-            {sourceWarningLabels({
-              candidate,
-              recommendations: attachedRecommendations,
-            }).map((label) => (
-              <StatusBadge key={label}>{label}</StatusBadge>
-            ))}
-          </div>
-        </section>
-
-        <section className="border border-border bg-surface p-5 space-y-4">
-          <h2 className="text-2xl font-bold text-foreground">
-            Dossier Update Actions
-          </h2>
-          {candidate.existingDossierMatch ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted">
-              <p>
-                Matched public dossier name:{" "}
-                {candidate.existingDossierMatch.name}
-              </p>
-              <p>
-                Match confidence: {candidate.existingDossierMatch.confidence}
-              </p>
-              <p>Public dossier id/slug: {candidate.existingDossierMatch.id}</p>
-              <p>Current workflow state: {candidate.status}</p>
-            </div>
-          ) : (
-            <p className="text-sm text-muted">
-              No existing public dossier match currently attached.
-            </p>
-          )}
-          <label className="block space-y-2 text-xs uppercase tracking-widest text-muted">
-            Attach to Existing Public Dossier
-            <select
-              value={existingDossierSelection}
-              onChange={(event) =>
-                setSelectedExistingDossierId(event.target.value)
-              }
-              className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
-            >
-              <option value="">Choose public dossier…</option>
-              {publicDossiers.map((dossier) => (
-                <option key={dossier.id} value={dossier.id}>
-                  {dossier.name} ({dossier.id})
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-widest">
-            <button
-              type="button"
-              onClick={() =>
-                void candidateLifecycleAction(
-                  "attachCandidateToExistingDossier",
-                )
-              }
-              disabled={saving || !existingDossierSelection}
-              className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
-            >
-              Attach to Existing Public Dossier
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                void candidateLifecycleAction(
-                  "markCandidateAsExistingDossierUpdate",
-                )
-              }
-              disabled={
-                saving || !canUpdateCandidate || !existingDossierSelection
-              }
-              className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
-            >
-              {isExistingDossierUpdate
-                ? "Keep as Dossier Update"
-                : "Move to Dossier Update"}
-            </button>
-          </div>
-        </section>
-
-        <details
-          open={hasSavedOperatorSourceSummary}
-          className="border border-border bg-surface p-5 text-sm text-muted"
-        >
-          <summary className="cursor-pointer text-xl font-bold text-foreground">
-            Operator Case File Summary
-          </summary>
-          <p className="mt-3 text-sm text-muted max-w-4xl">
-            Optional internal override for the top Source File summary. Use only
-            when BNL&apos;s current read needs owner/admin correction. This is
-            not a draft, not public copy, and not the normal add-info workflow.
-          </p>
-          <form
-            onSubmit={saveSourceFileSummary}
-            className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm"
-          >
-            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
-              Summary text
-              <textarea
-                name="summaryText"
-                defaultValue={candidate.sourceFileSummary?.summaryText ?? ""}
-                rows={3}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="Plain-English internal correction to BNL's current read…"
-              />
-            </label>
-            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
-              Known context
-              <textarea
-                name="knownContext"
-                defaultValue={(
-                  candidate.sourceFileSummary?.knownContext ?? []
-                ).join("\n")}
-                rows={4}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="One owner/admin-corrected context line per row"
-              />
-            </label>
-            <label className="space-y-2 text-xs uppercase tracking-widest text-muted">
-              Open questions
-              <textarea
-                name="openQuestions"
-                defaultValue={(
-                  candidate.sourceFileSummary?.openQuestions ?? []
-                ).join("\n")}
-                rows={4}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="One review question per row"
-              />
-            </label>
-            <label className="md:col-span-2 space-y-2 text-xs uppercase tracking-widest text-muted">
-              Recommended next step
-              <input
-                name="nextAction"
-                defaultValue={candidate.sourceFileSummary?.nextAction ?? ""}
-                className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="What should an operator do next?"
-              />
-            </label>
-            <div className="md:col-span-2 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
-              <button
-                type="submit"
-                disabled={saving}
-                className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-              >
-                Save Operator Case File Summary
-              </button>
-              <span className="text-muted self-center">
-                Optional override only; use Add to Case File / BNL Source File for normal
-                source updates.
-              </span>
-            </div>
-          </form>
-        </details>
 
         <details className="border border-border bg-surface p-5 text-sm text-muted">
           <summary className="cursor-pointer text-2xl font-bold text-foreground">

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -290,16 +290,10 @@ function SubjectIntelligenceBriefView({
   return (
     <Section title="BNL Subject Intelligence Brief" tone="review" helper="Primary review-only BNL readout. Use this as admin context, not public copy.">
       <div className="space-y-4">
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <div className="border border-border/50 bg-background/20 p-3">
-            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Subject read</h4>
-            <BriefParagraphs value={brief.subjectRead} />
-          </div>
-          <div className="border border-border/50 bg-background/20 p-3">
-            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">BNL take</h4>
-            <BriefParagraphs value={brief.bnlTake} />
-          </div>
-        </div>
+        <section className="border border-accent/60 bg-background/30 p-4">
+          <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Subject Read</h4>
+          <BriefParagraphs value={brief.subjectRead} />
+        </section>
 
         <section className="border border-border/50 bg-background/20 p-3">
           <h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">Activity Snapshot</h4>
@@ -350,7 +344,7 @@ function SubjectIntelligenceBriefView({
         </section>
 
         <section className="border border-border/50 bg-background/20 p-3">
-          <h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">BNL’s Current Take</h4>
+          <h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">Current Take / Admin Guidance</h4>
           <dl className="space-y-2">
             <div><dt className="text-xs uppercase tracking-widest text-accent">Confirmed fact</dt><dd className="text-foreground">{scalarLabel(valueByKeys(bnlTake, ["confirmedFact", "confirmedFacts", "confirmed"]))}</dd></div>
             <div><dt className="text-xs uppercase tracking-widest text-accent">BNL interpretation</dt><dd className="text-foreground">{scalarLabel(valueByKeys(bnlTake, ["bnlInterpretation", "interpretation", "take"]) ?? brief.bnlTake)}</dd></div>
@@ -664,7 +658,7 @@ export function DossierSourceFileSummaryPanel({
           </p>
           <h2 className="text-2xl font-bold text-foreground">{title}</h2>
           <p className="mt-2 text-sm text-muted max-w-4xl">
-            Source File header / refresh status → BNL Case File Report → Dossier Workbench / Proposed Dossier Status → Source Notes / Admin Addendums → Archive / Raw Source File Data → Advanced Tools → Diagnostics. BNL thinks; the site displays; admins decide.
+            Primary BNL readout for this internal Source File. BNL thinks; the site displays; admins decide.
           </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1277,7 +1277,7 @@ test("admin Source File page uses immediate refresh status/retry UI and preserve
   assert.match(page, /FILE NOT UPDATED/);
   assert.match(page, /RETRYING UPDATE/);
   assert.match(page, /Last-known BNL data is not current for this page open/);
-  assert.match(page, /Diagnostics: request/);
+  assert.doesNotMatch(page, /Diagnostics: request/);
   assert.doesNotMatch(page, /Refresh Requested/);
   assert.doesNotMatch(page, /Waiting for BNL/);
 
@@ -1513,8 +1513,8 @@ test("dossier admin pages keep dashboard simple while detail pages retain workfl
 test("dossier workflow boundary copy separates case files, drafts, owner review, and recommendations", () => {
   const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
   for (const label of [
-    "Internal working case file",
-    "Do not treat this as public copy",
+    "Internal working material only",
+    "not public copy",
     "BNL Case File Report",
         "Source Notes / Admin Addendums",
     "Diagnostics",
@@ -1524,7 +1524,7 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Source Warnings",
     "Conflicts / Needs Review",
     "Identity Check",
-    "Advanced Tools: Add Identity Link Manually",
+    "Advanced Tools",
     "Do Not Say",
     "dossier question",
     "Dossier Workbench / Proposed Dossier Status",
@@ -1676,8 +1676,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Recommended next step",
     "BNL Case File Report",
     "Review Boundaries",
-    "claims that need review",
-    "public-safety notes",
+    "owner review required",
+    "no public use until review",
     "Add to Case File / BNL Source File",
     "This adds information to this subject&apos;s Case File / BNL Source File. It does not directly edit the proposed dossier.",
     "DossierSourceFileSummaryPanel",
@@ -1687,8 +1687,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Open Proposed Dossier",
     "Save Info",
     "Mark Needs Info",
-    "Internal working case file",
-    "Do not treat this as public copy",
+    "Internal working material only",
+    "not public copy",
         "Source Notes / Admin Addendums",
     "Diagnostics",
     "Review Context / Possible Supporting Evidence",
@@ -1697,7 +1697,7 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
     "Source Warnings",
     "Conflicts / Needs Review",
     "Identity Check",
-    "Advanced Tools: Add Identity Link Manually",
+    "Advanced Tools",
     "Do Not Say",
     "dossier question",
     "Review-only memory context",
@@ -1727,8 +1727,8 @@ test("dedicated candidate review route is the BNL Source File subject hub", () =
   );
   assert.ok(workspace.indexOf("Dossier Workbench / Proposed Dossier Status") < workspace.indexOf("Add to Case File / BNL Source File"));
   assert.ok(workspace.indexOf("Add to Case File / BNL Source File") < workspace.indexOf("Source Notes / Admin Addendums"));
-  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Advanced Tools: Add Identity Link Manually"));
-  assert.ok(workspace.indexOf("Advanced Tools: Add Identity Link Manually") < workspace.indexOf("Operator Case File Summary"));
+  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Operator Case File Summary"));
+  assert.ok(workspace.indexOf("Operator Case File Summary") < workspace.indexOf("Advanced Tools"));
   assert.ok(workspace.indexOf("Archive / Raw Source File Data") < workspace.indexOf("Diagnostics"));
   assert.equal((page.match(/>\s*Open Proposed Dossier\s*</g) ?? []).length, 1);
   assert.equal((page.match(/>\s*Create Proposed Dossier\s*</g) ?? []).length, 1);
@@ -3599,7 +3599,8 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   }
   assert.match(sourceFilePage, /<Section title="Identity Check">/);
   assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
-  assert.match(sourceFilePage, /identityLinks\.length > 0 &&/);
+  assert.doesNotMatch(sourceFilePage, /identityLinks\.length > 0 &&/);
+  assert.match(sourceFilePage, /No identity links pending/);
   assert.doesNotMatch(sourceFilePage, /No identity links saved yet/);
   assert.match(sourceFilePage, /title: "Proposed Identity Links",[\s\S]*links: proposedIdentityLinks/);
   assert.match(sourceFilePage, /title: "Confirmed Identity Links",[\s\S]*links: confirmedIdentityLinks/);
@@ -3611,7 +3612,8 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   assert.ok(identityCheckStart >= 0);
   assert.ok(identityCheckStart < sourceFilePage.indexOf('Source Notes / Admin Addendums'));
   assert.ok(identityCheckStart < sourceFilePage.indexOf('Proposed Dossier Status'));
-  assert.match(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
+  assert.doesNotMatch(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
+  assert.match(sourceFilePage, /Advanced Tools/);
   assert.doesNotMatch(identityCheckSection, /Add Identity Link/);
   assert.match(
     sourceFilePage,
@@ -4489,7 +4491,8 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(sourceFilePage, /Save Info/);
   assert.match(sourceFilePage, /Identity Check/);
   assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
-  assert.match(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
+  assert.doesNotMatch(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
+  assert.match(sourceFilePage, /Advanced Tools/);
   assert.match(sourceFilePage, /Aliases help BNL route future BNL Signals/);
   assert.match(sourceFilePage, /Internal aliases are not\s+public dossier text/);
   assert.match(sourceFilePage, /Add Identity Link/);
@@ -6660,7 +6663,7 @@ test("Source File page renders subjectIntelligenceBriefV1 as the primary report 
   assert.match(visibleText, /Activity Snapshot/);
   assert.match(visibleText, /What They Talk About/);
   assert.match(visibleText, /Named Anchors \/ Connections/);
-  assert.match(visibleText, /BNL’s Current Take/);
+  assert.match(visibleText, /Current Take \/ Admin Guidance/);
   assert.match(visibleText, /Music \/ Link Signals/);
   assert.match(visibleText, /Relationship \/ Context Signals/);
   assert.match(visibleText, /Queue \/ Submission Read/);
@@ -6950,7 +6953,7 @@ test("Entity Intelligence Review Console promotes actionable Crow intelligence a
   assert.doesNotMatch(text, /Orion appears in review-only\/internal context/);
   assert.doesNotMatch(text, /Legacy recurring-subject diagnostic: Automated topic label/);
   assert.ok(knowsStart >= 0);
-  assert.ok(diagnosticsStart > knowsStart);
+  assert.ok(diagnosticsStart === -1 || diagnosticsStart > knowsStart);
   assert.doesNotMatch(text, /What BNL Found|rawProvenance|Priority\/payment status confirmed|submitted song counts confirmed/);
 });
 
@@ -7563,4 +7566,102 @@ test("Source File archive foundation does not add queue, payment, tags, identity
   assert.doesNotMatch(archiveRoute, /createDossierRecommendation|createDraftFromCandidate|mergeDossierCandidates/);
   assert.match(workflowSource, /latestSourceFileArchiveId/);
   assert.match(storeSource, /DOSSIER_SOURCE_FILE_ARCHIVE_KEY_PREFIX/);
+});
+
+test("Source File workspace layout keeps advanced diagnostics below the normal review flow", () => {
+  const page = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const normalizedPage = page.replace(/\s+/g, " ");
+  const workspaceStart = page.indexOf('<section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">');
+  const reviewStart = page.indexOf("Review Boundaries", workspaceStart);
+  const identityStart = page.indexOf('<Section title="Identity Check">', workspaceStart);
+  const readoutStart = page.indexOf("<DossierSourceFileSummaryPanel", workspaceStart);
+  const workbenchStart = page.indexOf("Dossier Workbench / Proposed Dossier Status");
+  const addInfoStart = page.indexOf("Add to Case File / BNL Source File");
+  const notesStart = page.indexOf("Source Notes / Admin Addendums");
+  const rawStart = page.indexOf("<DossierSourceFileArchiveRawData", workspaceStart);
+  const advancedStart = page.indexOf("Advanced Tools", rawStart);
+  const diagnosticsStart = page.indexOf("Diagnostics — collapsed by default", advancedStart);
+
+  for (const [label, index] of Object.entries({
+    reviewStart,
+    identityStart,
+    readoutStart,
+    workbenchStart,
+    addInfoStart,
+    notesStart,
+    rawStart,
+    advancedStart,
+    diagnosticsStart,
+  })) {
+    assert.ok(index >= 0, `Expected ${label} to be present`);
+  }
+
+  assert.ok(reviewStart < identityStart);
+  assert.ok(identityStart < readoutStart);
+  assert.ok(readoutStart < workbenchStart);
+  assert.ok(workbenchStart < addInfoStart);
+  assert.ok(addInfoStart < notesStart);
+  assert.ok(notesStart < rawStart);
+  assert.ok(rawStart < advancedStart);
+  assert.ok(advancedStart < diagnosticsStart);
+  assert.doesNotMatch(page.slice(0, readoutStart), /<summary[^>]*>\s*Advanced Tools|Diagnostics — collapsed by default|Advanced Tools: Add Identity Link Manually/);
+  assert.equal((page.match(/Advanced Tools: Add Identity Link Manually/g) ?? []).length, 0);
+  assert.equal((page.match(/Diagnostics — collapsed by default/g) ?? []).length, 1);
+  assert.match(normalizedPage, /<details open=\{Boolean\(candidate\.existingDossierMatch\)\} className="border border-border bg-surface p-5 space-y-4" > <summary className="cursor-pointer text-xl font-bold text-foreground"> Dossier Update Actions/);
+  assert.match(page, /No identity links pending/);
+  assert.match(page, /SourceNotesSummary|sourceNotesSummary/);
+});
+
+test("Source File brief leads with Subject Read and renders Current Take once", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "layout-archive-report-v1",
+    candidateId: "layout-candidate-report-v1",
+    subjectName: "Layout Subject",
+    subjectKey: "layout-subject",
+    sourceDigest: "abcdefabcdef1234",
+    createdAt: "2026-06-10T00:00:00.000Z",
+    updatedAt: "2026-06-10T00:00:00.000Z",
+    archiveSize: 100,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileCaseReportV1: {
+      version: "1",
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      reportStatus: "dossier_ready",
+      subjectIntelligenceBriefV1: {
+        subjectRead: "Subject Read should lead this brief.",
+        bnlTake: {
+          confirmedFact: "Confirmed fact for layout test.",
+          bnlInterpretation: "BNL Take should appear only as admin guidance.",
+          uncertainty: "Still needs owner review.",
+        },
+        activitySnapshot: { totalEvidenceScanned: 3, activityLevel: "active" },
+        topicBuckets: [],
+        namedAnchors: [],
+        musicAndLinkSignals: [],
+        relationshipSignals: [],
+        queueSubmissionRead: "No queue bridge is confirmed.",
+        sourceFileGaps: [],
+        recommendedAdminActions: [],
+        doNotSayPubliclyYet: [],
+      },
+    },
+  };
+
+  const element = sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    subjectName: "Layout Subject",
+    latestSourceFileArchive: archive,
+  });
+  const visibleText = collectDefaultVisibleText(element);
+  assert.match(visibleText, /BNL Subject Intelligence Brief/);
+  assert.ok(visibleText.indexOf("Subject Read") < visibleText.indexOf("Activity Snapshot"));
+  assert.ok(visibleText.indexOf("Activity Snapshot") < visibleText.indexOf("Current Take / Admin Guidance"));
+  assert.equal((visibleText.match(/Current Take \/ Admin Guidance/g) ?? []).length, 1);
+  assert.equal((visibleText.match(/BNL Take/g) ?? []).length, 1);
+  assert.doesNotMatch(visibleText, /Subject read[\s\S]{0,240}BNL take/i);
+
+  const panelSource = source("src/components/DossierSourceFileSummaryPanel.tsx");
+  assert.doesNotMatch(panelSource, /lg:grid-cols-2[\s\S]{0,260}BNL take/i);
 });


### PR DESCRIPTION
### Motivation

- The Source File admin page had too many controls and diagnostic blocks competing with the primary BNL readout, creating visual noise and confusing workflow priority. 
- Top-level collapsed sections such as `Advanced Tools`, `Diagnostics`, and the manual identity-link form were appearing above core review steps and needed to be moved lower and collapsed by default. 
- The BNL brief needed a clearer read order where `Subject Read` leads and the BNL take appears once as admin guidance rather than competing side-by-side with the subject read.

### Description

- Simplified the page header by shortening the internal-disclaimer copy and collapsing `PhaseRail` into a collapsible `Phase Rail` block and secondary metrics into a collapsed `File Status` detail (keeps refresh controls visible). 
- Reorganized the top action area into grouped panels (`Main actions`, `Review state`, and a collapsed `Archive / danger`) so destructive/archive actions no longer visually compete with the main readout. 
- Moved and reordered the workspace flow to: `Review Boundaries` → `Identity Check` (with a compact empty-state when no links) → `DossierSourceFileSummaryPanel` (BNL readout) → `Dossier Workbench` → `Dossier Update Actions` (collapsed when no match) → `Add to Case File` → `Source Notes` → `Raw archive / debug` → `Advanced Tools` → `Diagnostics`. 
- In `DossierSourceFileSummaryPanel.tsx` made `Subject Read` the leading card, removed the two-column Subject Read / BNL Take competition, and render the BNL take once as `Current Take / Admin Guidance`; preserved activity snapshot, topic buckets, anchors, music/link signals, and collapsed raw/debug archive behavior. 
- Consolidated manual identity-link form into a single `Advanced Tools` block lower on the page and removed duplicated top-level manual identity-link headings. 
- Collapsed `Dossier Update Actions` by default unless `candidate.existingDossierMatch` is present while keeping attach/move controls available. 
- Updated tests in `tests/admin-dossiers.test.mjs` to assert the new layout, visibility rules, ordering, and that advanced/debug content remains collapsed and available only at the bottom. 
- Files changed: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/components/DossierSourceFileSummaryPanel.tsx`, and `tests/admin-dossiers.test.mjs`.

### Testing

- Ran `node --test tests/admin-dossiers.test.mjs`, which completed successfully with the full test suite passing after the layout and test updates. 
- Ran `npx tsc --noEmit`, which completed with no type errors. 
- The changes are purely site/admin workspace layout and test updates; no bot code, ingest shapes, publishing rules, or queue logic were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aee9ca0f88321b0d03958246de2a9)