### PR TITLE
Add Dossier Control Center population audit (admin-only, non-destructive)

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
+  createDossierPopulationAudit,
   getDossierSourceFileMetrics,
   matchDossierRecommendationSubject,
   type DossierCandidate,
@@ -439,6 +440,15 @@ export default function DossierControlCenterPage() {
     closedCandidates.length +
     closedDrafts.length +
     terminalRecommendations.length;
+  const populationAudit = useMemo(
+    () =>
+      createDossierPopulationAudit({
+        candidates,
+        recommendations,
+        publicDossiers,
+      }),
+    [candidates, recommendations, publicDossiers],
+  );
 
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
@@ -793,6 +803,249 @@ export default function DossierControlCenterPage() {
             ))}
           </div>
         </DashboardCard>
+
+        <details className="border border-accent/40 bg-surface/70 p-5">
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Source File Population Audit
+          </summary>
+          <div className="mt-4 space-y-5">
+            <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+              The site can only audit records and recommendations already
+              present in the workflow store. Active Discord members who have not
+              been ingested by BNL will not appear here yet. This panel is
+              review-only: it does not merge, delete, publish, or mutate records
+              automatically.
+            </p>
+
+            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-3 text-xs text-muted">
+              {[
+                [
+                  "Active Source Files / Case Files",
+                  populationAudit.counts.activeSourceFiles,
+                ],
+                [
+                  "Candidate Intake / Dossier Seeds",
+                  populationAudit.counts.candidateIntake,
+                ],
+                [
+                  "Existing Dossier Updates",
+                  populationAudit.counts.existingDossierUpdates,
+                ],
+                ["Public Dossiers", populationAudit.counts.publicDossiers],
+                [
+                  "Archived / closed records",
+                  populationAudit.counts.archivedClosedRecords,
+                ],
+                [
+                  "Records with proposed identity links",
+                  populationAudit.counts.proposedIdentityLinks,
+                ],
+                [
+                  "Records with confirmed identity links",
+                  populationAudit.counts.confirmedIdentityLinks,
+                ],
+                [
+                  "Records with attached BNL recommendations",
+                  populationAudit.counts.recordsWithAttachedBnlRecommendations,
+                ],
+                [
+                  "BNL recommendations not clearly attached to an active Source File",
+                  populationAudit.counts.unattachedBnlRecommendations,
+                ],
+                [
+                  "Records missing latest BNL case report or source enrichment",
+                  populationAudit.counts
+                    .recordsMissingLatestCaseReportOrEnrichment,
+                ],
+              ].map(([label, value]) => (
+                <div
+                  key={label}
+                  className="border border-border/70 bg-background/30 p-3"
+                >
+                  <p className="uppercase tracking-[0.25em] text-accent mb-2">
+                    {label}
+                  </p>
+                  <p className="text-2xl font-bold text-foreground">{value}</p>
+                </div>
+              ))}
+            </div>
+
+            <section className="space-y-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-muted">
+                  Possible Duplicate / Same Subject Review
+                </p>
+                <h3 className="text-lg font-bold text-foreground">
+                  Possible same-subject review
+                </h3>
+              </div>
+              {populationAudit.possibleDuplicateGroups.length === 0 ? (
+                <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+                  No conservative possible duplicate groups were detected.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {populationAudit.possibleDuplicateGroups
+                    .slice(0, 10)
+                    .map((group) => (
+                      <article
+                        key={group.id}
+                        className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
+                      >
+                        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <p className="font-semibold text-foreground">
+                              Needs admin review — {group.reason}
+                            </p>
+                            <p>
+                              Suggested safe action: {group.suggestedAction}
+                            </p>
+                            {group.publicDossierMatch && (
+                              <p>
+                                Public dossier match:{" "}
+                                {group.publicDossierMatch.name ??
+                                  group.publicDossierMatch.id}
+                              </p>
+                            )}
+                          </div>
+                          <StatusPill>{group.matchKind}</StatusPill>
+                        </div>
+                        <div className="mt-3 grid gap-2 md:grid-cols-2">
+                          {group.records.map((record) => (
+                            <div
+                              key={`${group.id}-${record.type}-${record.id}`}
+                              className="border border-border/60 bg-background/30 p-3"
+                            >
+                              <p className="font-semibold text-foreground">
+                                {record.name}
+                              </p>
+                              <p>
+                                Type/status: {record.type} / {record.status}
+                              </p>
+                              <p>
+                                Candidate/source file ID:{" "}
+                                {record.candidateId ?? "—"}
+                              </p>
+                              <p>
+                                Recommendation ID:{" "}
+                                {record.recommendationId ?? "—"}
+                              </p>
+                              <p>
+                                Confirmed aliases: {record.confirmedAliasCount}
+                              </p>
+                              <p>
+                                Proposed aliases: {record.proposedAliasCount}
+                              </p>
+                              <p>
+                                Recommendation count:{" "}
+                                {record.attachedRecommendationCount}
+                              </p>
+                              {record.publicDossierId && (
+                                <p>
+                                  Public dossier target:{" "}
+                                  {record.publicDossierName ??
+                                    record.publicDossierId}
+                                </p>
+                              )}
+                              {record.href && (
+                                <Link
+                                  href={record.href}
+                                  className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
+                                >
+                                  {record.type === "recommendation"
+                                    ? "Open recommendation"
+                                    : "Open Source File"}
+                                </Link>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      </article>
+                    ))}
+                </div>
+              )}
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-muted">
+                  Unattached BNL Signals / Recommendations
+                </p>
+                <h3 className="text-lg font-bold text-foreground">
+                  BNL recommendations that need placement review
+                </h3>
+              </div>
+              {populationAudit.unattachedBnlRecommendations.length === 0 ? (
+                <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+                  No unattached BNL recommendations were detected.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[900px] text-left text-sm text-muted">
+                    <thead className="text-xs uppercase tracking-widest text-foreground">
+                      <tr>
+                        <th className="py-2 pr-3">Subject</th>
+                        <th className="py-2 pr-3">subjectKey</th>
+                        <th className="py-2 pr-3">
+                          ingestSource / sourceLanes
+                        </th>
+                        <th className="py-2 pr-3">Confidence</th>
+                        <th className="py-2 pr-3">Created / updated</th>
+                        <th className="py-2 pr-3">Matching Source File?</th>
+                        <th className="py-2 pr-3">Safe next action</th>
+                        <th className="py-2 pr-3">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {populationAudit.unattachedBnlRecommendations.map(
+                        (recommendation) => (
+                          <tr
+                            key={recommendation.id}
+                            className="border-t border-border/70 align-top"
+                          >
+                            <td className="py-3 pr-3 font-semibold text-foreground">
+                              {recommendation.subjectName}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.subjectKey ?? "—"}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.ingestSource ?? "unknown"} /{" "}
+                              {recommendation.sourceLanes.join(", ")}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.confidence ?? "unset"}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {formatDate(recommendation.createdAt)} /{" "}
+                              {formatDate(recommendation.updatedAt)}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.matchingSourceFileName
+                                ? `${recommendation.matchingSourceFileName} (${recommendation.matchBasis})`
+                                : "No clear active Source File match"}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.safeNextAction}
+                            </td>
+                            <td className="py-3 pr-3">
+                              <Link
+                                href={recommendation.href}
+                                className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                              >
+                                Open recommendation
+                              </Link>
+                            </td>
+                          </tr>
+                        ),
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+          </div>
+        </details>
 
         <DashboardCard
           eyebrow="Candidates"

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -131,7 +131,6 @@ export type DossierSourceFileOperatorSummary = {
   updatedBy?: string;
 };
 
-
 export type DossierSubjectIntelligenceBriefV1 = {
   subjectRead?: unknown;
   bnlTake?: unknown;
@@ -741,6 +740,518 @@ export function getDossierSourceFileMetrics(input: {
     sourceDepthScore: score,
     unappliedSourceNotesCount: unappliedSourceNotes.length,
     unappliedSourceNotes,
+  };
+}
+
+export type DossierPopulationAuditRecordType =
+  | "source_file"
+  | "candidate_intake"
+  | "dossier_update"
+  | "recommendation"
+  | "archived_or_closed";
+
+export type DossierPopulationAuditRecord = {
+  id: string;
+  type: DossierPopulationAuditRecordType;
+  name: string;
+  status: string;
+  href?: string;
+  candidateId?: string;
+  recommendationId?: string;
+  publicDossierId?: string;
+  publicDossierName?: string;
+  confirmedAliasCount: number;
+  proposedAliasCount: number;
+  attachedRecommendationCount: number;
+  missingLatestCaseReport: boolean;
+};
+
+export type DossierPopulationAuditDuplicateGroup = {
+  id: string;
+  reason: string;
+  matchKind:
+    | "normalized_name"
+    | "confirmed_alias"
+    | "public_dossier"
+    | "recommendation_subject_key"
+    | "bnl_recommendation_subject_name";
+  publicDossierMatch?: { id: string; name?: string };
+  records: DossierPopulationAuditRecord[];
+  suggestedAction: string;
+};
+
+export type DossierPopulationAuditUnattachedRecommendation = {
+  id: string;
+  subjectName: string;
+  subjectKey?: string;
+  ingestSource?: DossierRecommendationIngestSource;
+  sourceLanes: DossierRecommendationSourceLane[];
+  confidence?: DossierRecommendation["confidence"];
+  createdAt: string;
+  updatedAt: string;
+  matchingSourceFileId?: string;
+  matchingSourceFileName?: string;
+  matchBasis?: string;
+  href: string;
+  safeNextAction: string;
+};
+
+export type DossierPopulationAudit = {
+  counts: {
+    activeSourceFiles: number;
+    candidateIntake: number;
+    existingDossierUpdates: number;
+    publicDossiers: number;
+    archivedClosedRecords: number;
+    proposedIdentityLinks: number;
+    confirmedIdentityLinks: number;
+    recordsWithAttachedBnlRecommendations: number;
+    unattachedBnlRecommendations: number;
+    recordsMissingLatestCaseReportOrEnrichment: number;
+  };
+  records: DossierPopulationAuditRecord[];
+  possibleDuplicateGroups: DossierPopulationAuditDuplicateGroup[];
+  unattachedBnlRecommendations: DossierPopulationAuditUnattachedRecommendation[];
+};
+
+function isBnlRecommendation(
+  recommendation: Pick<DossierRecommendation, "ingestSource" | "createdBy">,
+): boolean {
+  return (
+    recommendation.createdBy === "bnl" ||
+    recommendation.ingestSource === "bnl" ||
+    recommendation.ingestSource === "bnl_dynamic_candidate_discovery" ||
+    recommendation.ingestSource === "bnl_source_knowledge_bridge" ||
+    recommendation.ingestSource === "bnl_source_file_enrichment"
+  );
+}
+
+function isClosedPopulationCandidate(
+  candidate: Pick<DossierCandidate, "status">,
+): boolean {
+  return (
+    candidate.status === "archived" ||
+    candidate.status === "denied" ||
+    candidate.status === "merged"
+  );
+}
+
+function candidatePopulationType(
+  candidate: DossierCandidate,
+): DossierPopulationAuditRecordType {
+  if (isClosedPopulationCandidate(candidate)) return "archived_or_closed";
+  if (candidate.status === "candidate_intake") return "candidate_intake";
+  if (candidate.status === "existing_dossier_update") return "dossier_update";
+  return "source_file";
+}
+
+function candidateMissingLatestCaseReportOrEnrichment(
+  candidate: DossierCandidate,
+): boolean {
+  if (!isActiveSourceFileCandidate(candidate)) return false;
+  const archive = candidate.latestSourceFileArchive;
+  if (archive?.caseReportPresent === false) return true;
+  return !Boolean(
+    candidate.latestSourceFileArchiveUpdatedAt ||
+    candidate.latestSourceFileArchiveId ||
+    archive?.updatedAt ||
+    candidate.sourceFileSummary?.updatedAt,
+  );
+}
+
+function recordKey(
+  record: Pick<DossierPopulationAuditRecord, "type" | "id">,
+): string {
+  return `${record.type}:${record.id}`;
+}
+
+function uniqueAuditRecords(
+  records: DossierPopulationAuditRecord[],
+): DossierPopulationAuditRecord[] {
+  const seen = new Set<string>();
+  return records.filter((record) => {
+    const key = recordKey(record);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function duplicateGroupAction(
+  matchKind: DossierPopulationAuditDuplicateGroup["matchKind"],
+  records: DossierPopulationAuditRecord[],
+): string {
+  if (matchKind === "confirmed_alias")
+    return "Review manually; confirmed aliases may justify moving stale records out of the active lane.";
+  if (matchKind === "public_dossier")
+    return "Review manually; consider moving one record to Dossier Updates if it targets an existing public dossier.";
+  if (records.some((record) => record.proposedAliasCount > 0)) {
+    return "Review manually; proposed aliases need confirmation before they are used as duplicate evidence.";
+  }
+  return "Review manually before drafting; confirm alias or archive stale duplicate only after owner/admin decision.";
+}
+
+export function createDossierPopulationAudit(input: {
+  candidates: DossierCandidate[];
+  recommendations?: DossierRecommendation[];
+  publicDossiers?: Array<{ id: string; name: string }>;
+}): DossierPopulationAudit {
+  const recommendations = input.recommendations ?? [];
+  const bnlRecommendations = recommendations.filter(isBnlRecommendation);
+  const candidatesById = new Map(
+    input.candidates.map((candidate) => [candidate.id, candidate]),
+  );
+  const publicDossiersById = new Map(
+    (input.publicDossiers ?? []).map((dossier) => [dossier.id, dossier]),
+  );
+
+  const bnlRecommendationIdsByCandidate = new Map<string, Set<string>>();
+  for (const recommendation of bnlRecommendations) {
+    for (const candidateId of [
+      recommendation.targetCandidateId,
+      recommendation.connectedCandidateId,
+      recommendation.connectedSourceFileCandidateId,
+    ]) {
+      if (!candidateId) continue;
+      const current =
+        bnlRecommendationIdsByCandidate.get(candidateId) ?? new Set<string>();
+      current.add(recommendation.id);
+      bnlRecommendationIdsByCandidate.set(candidateId, current);
+    }
+  }
+  for (const candidate of input.candidates) {
+    for (const recommendationId of [
+      ...(candidate.sourceRecommendationIds ?? []),
+      ...(candidate.connectedRecommendationIds ?? []),
+      candidate.createdFromRecommendationId,
+      candidate.routedFromRecommendationId,
+    ]) {
+      if (!recommendationId) continue;
+      const recommendation = bnlRecommendations.find(
+        (item) => item.id === recommendationId,
+      );
+      if (!recommendation) continue;
+      const current =
+        bnlRecommendationIdsByCandidate.get(candidate.id) ?? new Set<string>();
+      current.add(recommendation.id);
+      bnlRecommendationIdsByCandidate.set(candidate.id, current);
+    }
+  }
+
+  const records = input.candidates.map((candidate) => {
+    const confirmedAliasCount = (candidate.identityLinks ?? []).filter(
+      (link) => link.status === "confirmed",
+    ).length;
+    const proposedAliasCount = (candidate.identityLinks ?? []).filter(
+      (link) => link.status === "proposed",
+    ).length;
+    return {
+      id: candidate.id,
+      type: candidatePopulationType(candidate),
+      name: candidate.name,
+      status: candidate.status,
+      href: `/admin/dossiers/candidates/${candidate.id}`,
+      candidateId: candidate.id,
+      publicDossierId: candidate.existingDossierMatch?.id,
+      publicDossierName: candidate.existingDossierMatch?.name,
+      confirmedAliasCount,
+      proposedAliasCount,
+      attachedRecommendationCount:
+        bnlRecommendationIdsByCandidate.get(candidate.id)?.size ?? 0,
+      missingLatestCaseReport:
+        candidateMissingLatestCaseReportOrEnrichment(candidate),
+    } satisfies DossierPopulationAuditRecord;
+  });
+  const recordByCandidateId = new Map(
+    records.map((record) => [record.id, record]),
+  );
+
+  const clearlyAttachedRecommendationIds = new Set<string>();
+  for (const recommendation of bnlRecommendations) {
+    const targetCandidate = recommendation.targetCandidateId
+      ? candidatesById.get(recommendation.targetCandidateId)
+      : undefined;
+    const connectedCandidate = recommendation.connectedCandidateId
+      ? candidatesById.get(recommendation.connectedCandidateId)
+      : undefined;
+    const connectedSourceFile = recommendation.connectedSourceFileCandidateId
+      ? candidatesById.get(recommendation.connectedSourceFileCandidateId)
+      : undefined;
+    if (
+      [targetCandidate, connectedCandidate, connectedSourceFile].some(
+        (candidate) =>
+          candidate &&
+          (candidate.status === "active_source_file" ||
+            candidate.status === "existing_dossier_update" ||
+            isActiveSourceFileCandidate(candidate)),
+      ) ||
+      recommendation.status === "attached_to_source_file" ||
+      recommendation.status === "attached_to_existing_dossier_update" ||
+      recommendation.status === "converted_to_source_file"
+    ) {
+      clearlyAttachedRecommendationIds.add(recommendation.id);
+    }
+  }
+
+  const activeSourceFiles = input.candidates.filter(
+    (candidate) =>
+      !isClosedPopulationCandidate(candidate) &&
+      isActiveSourceFileCandidate(candidate),
+  );
+  const activeSourceFilesByNormalizedName = new Map(
+    activeSourceFiles.map((candidate) => [
+      normalizeDossierSubjectName(candidate.name),
+      candidate,
+    ]),
+  );
+  const activeSourceFilesByConfirmedAlias = new Map<string, DossierCandidate>();
+  for (const candidate of activeSourceFiles) {
+    for (const link of candidate.identityLinks ?? []) {
+      if (link.status !== "confirmed" || link.useForMatching !== true) continue;
+      activeSourceFilesByConfirmedAlias.set(
+        link.normalizedLabel || normalizeDossierSubjectName(link.label),
+        candidate,
+      );
+    }
+  }
+
+  const unattachedBnlRecommendations = bnlRecommendations
+    .filter(
+      (recommendation) =>
+        !clearlyAttachedRecommendationIds.has(recommendation.id),
+    )
+    .map((recommendation) => {
+      const normalizedSubject = normalizeDossierSubjectName(
+        recommendation.subjectName,
+      );
+      const normalizedSubjectKey = recommendation.subjectKey
+        ? normalizeDossierSubjectName(recommendation.subjectKey)
+        : "";
+      const matchingSourceFile =
+        activeSourceFilesByNormalizedName.get(normalizedSubject) ??
+        (normalizedSubjectKey
+          ? activeSourceFilesByNormalizedName.get(normalizedSubjectKey)
+          : undefined) ??
+        activeSourceFilesByConfirmedAlias.get(normalizedSubject) ??
+        (normalizedSubjectKey
+          ? activeSourceFilesByConfirmedAlias.get(normalizedSubjectKey)
+          : undefined);
+      const matchBasis = matchingSourceFile
+        ? activeSourceFilesByConfirmedAlias.get(normalizedSubject) ===
+            matchingSourceFile ||
+          (normalizedSubjectKey &&
+            activeSourceFilesByConfirmedAlias.get(normalizedSubjectKey) ===
+              matchingSourceFile)
+          ? "confirmed alias"
+          : "normalized name"
+        : undefined;
+      return {
+        id: recommendation.id,
+        subjectName: recommendation.subjectName,
+        subjectKey: recommendation.subjectKey,
+        ingestSource: recommendation.ingestSource,
+        sourceLanes: recommendation.sourceLanes,
+        confidence: recommendation.confidence,
+        createdAt: recommendation.createdAt,
+        updatedAt: recommendation.updatedAt,
+        matchingSourceFileId: matchingSourceFile?.id,
+        matchingSourceFileName: matchingSourceFile?.name,
+        matchBasis,
+        href: `/admin/dossiers/recommendations/${recommendation.id}`,
+        safeNextAction: matchingSourceFile
+          ? "Review manually; attach to the matching Source File only after admin confirmation."
+          : "Review manually; decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
+      } satisfies DossierPopulationAuditUnattachedRecommendation;
+    })
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+
+  const duplicateBuckets = new Map<
+    string,
+    {
+      matchKind: DossierPopulationAuditDuplicateGroup["matchKind"];
+      reason: string;
+      publicDossierMatch?: { id: string; name?: string };
+      records: DossierPopulationAuditRecord[];
+    }
+  >();
+
+  function addBucketRecord(
+    matchKind: DossierPopulationAuditDuplicateGroup["matchKind"],
+    key: string,
+    reason: string,
+    record: DossierPopulationAuditRecord,
+    publicDossierMatch?: { id: string; name?: string },
+  ) {
+    if (!key) return;
+    const bucketKey = `${matchKind}:${key}`;
+    const bucket = duplicateBuckets.get(bucketKey) ?? {
+      matchKind,
+      reason,
+      publicDossierMatch,
+      records: [],
+    };
+    bucket.records.push(record);
+    duplicateBuckets.set(bucketKey, bucket);
+  }
+
+  for (const candidate of input.candidates) {
+    const record = recordByCandidateId.get(candidate.id);
+    if (!record || record.type === "archived_or_closed") continue;
+    addBucketRecord(
+      "normalized_name",
+      normalizeDossierSubjectName(candidate.name),
+      "Normalized exact name match.",
+      record,
+    );
+    if (candidate.existingDossierMatch?.id) {
+      addBucketRecord(
+        "public_dossier",
+        candidate.existingDossierMatch.id,
+        "Shared public dossier target.",
+        record,
+        {
+          id: candidate.existingDossierMatch.id,
+          name: candidate.existingDossierMatch.name,
+        },
+      );
+    }
+    for (const link of candidate.identityLinks ?? []) {
+      if (link.status !== "confirmed" || link.useForMatching !== true) continue;
+      const aliasKey =
+        link.normalizedLabel || normalizeDossierSubjectName(link.label);
+      addBucketRecord(
+        "confirmed_alias",
+        aliasKey,
+        "Confirmed alias match.",
+        record,
+      );
+      for (const possibleAliasTarget of input.candidates) {
+        if (possibleAliasTarget.id === candidate.id) continue;
+        if (isClosedPopulationCandidate(possibleAliasTarget)) continue;
+        if (
+          normalizeDossierSubjectName(possibleAliasTarget.name) !== aliasKey
+        ) {
+          continue;
+        }
+        const possibleAliasTargetRecord = recordByCandidateId.get(
+          possibleAliasTarget.id,
+        );
+        if (possibleAliasTargetRecord) {
+          addBucketRecord(
+            "confirmed_alias",
+            aliasKey,
+            "Confirmed alias match.",
+            possibleAliasTargetRecord,
+          );
+        }
+      }
+    }
+  }
+
+  for (const recommendation of bnlRecommendations) {
+    const record: DossierPopulationAuditRecord = {
+      id: recommendation.id,
+      type: "recommendation",
+      name: recommendation.subjectName,
+      status: recommendation.status,
+      href: `/admin/dossiers/recommendations/${recommendation.id}`,
+      recommendationId: recommendation.id,
+      publicDossierId: recommendation.targetDossierId,
+      publicDossierName: recommendation.targetDossierId
+        ? publicDossiersById.get(recommendation.targetDossierId)?.name
+        : undefined,
+      confirmedAliasCount: 0,
+      proposedAliasCount: 0,
+      attachedRecommendationCount: 1,
+      missingLatestCaseReport: false,
+    };
+    addBucketRecord(
+      "bnl_recommendation_subject_name",
+      normalizeDossierSubjectName(recommendation.subjectName),
+      "Same normalized subjectName from BNL recommendations.",
+      record,
+    );
+    if (recommendation.subjectKey) {
+      addBucketRecord(
+        "recommendation_subject_key",
+        normalizeDossierSubjectName(recommendation.subjectKey),
+        "Same recommendation subjectKey.",
+        record,
+      );
+    }
+    if (recommendation.targetDossierId) {
+      addBucketRecord(
+        "public_dossier",
+        recommendation.targetDossierId,
+        "Shared public dossier target.",
+        record,
+        {
+          id: recommendation.targetDossierId,
+          name: publicDossiersById.get(recommendation.targetDossierId)?.name,
+        },
+      );
+    }
+  }
+
+  const possibleDuplicateGroups = Array.from(duplicateBuckets.entries())
+    .map(([bucketKey, bucket]) => ({
+      id: bucketKey
+        .replace(/[^a-z0-9]+/gi, "-")
+        .replace(/^-|-$/g, "")
+        .toLowerCase(),
+      reason: bucket.reason,
+      matchKind: bucket.matchKind,
+      publicDossierMatch: bucket.publicDossierMatch,
+      records: uniqueAuditRecords(bucket.records),
+      suggestedAction: duplicateGroupAction(bucket.matchKind, bucket.records),
+    }))
+    .filter((group) => group.records.length >= 2)
+    .sort(
+      (left, right) =>
+        right.records.length - left.records.length ||
+        left.id.localeCompare(right.id),
+    );
+
+  return {
+    counts: {
+      activeSourceFiles: activeSourceFiles.length,
+      candidateIntake: input.candidates.filter(
+        (candidate) => candidate.status === "candidate_intake",
+      ).length,
+      existingDossierUpdates: input.candidates.filter(
+        (candidate) => candidate.status === "existing_dossier_update",
+      ).length,
+      publicDossiers: input.publicDossiers?.length ?? 0,
+      archivedClosedRecords: input.candidates.filter(
+        isClosedPopulationCandidate,
+      ).length,
+      proposedIdentityLinks: input.candidates.reduce(
+        (total, candidate) =>
+          total +
+          (candidate.identityLinks ?? []).filter(
+            (link) => link.status === "proposed",
+          ).length,
+        0,
+      ),
+      confirmedIdentityLinks: input.candidates.reduce(
+        (total, candidate) =>
+          total +
+          (candidate.identityLinks ?? []).filter(
+            (link) => link.status === "confirmed",
+          ).length,
+        0,
+      ),
+      recordsWithAttachedBnlRecommendations: Array.from(
+        bnlRecommendationIdsByCandidate.values(),
+      ).filter((recommendationIds) => recommendationIds.size > 0).length,
+      unattachedBnlRecommendations: unattachedBnlRecommendations.length,
+      recordsMissingLatestCaseReportOrEnrichment: records.filter(
+        (record) => record.missingLatestCaseReport,
+      ).length,
+    },
+    records,
+    possibleDuplicateGroups,
+    unattachedBnlRecommendations,
   };
 }
 

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2022,6 +2022,159 @@ test("dashboard frames manual recommendation seed as collapsed fallback", () => 
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
 });
 
+
+
+test("Dossier Control Center population audit maps counts, duplicate review, unattached BNL signals, and safe copy", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+
+  for (const label of [
+    "Source File Population Audit",
+    "Active Source Files / Case Files",
+    "Candidate Intake / Dossier Seeds",
+    "Existing Dossier Updates",
+    "Public Dossiers",
+    "Archived / closed records",
+    "Records with proposed identity links",
+    "Records with confirmed identity links",
+    "Records with attached BNL recommendations",
+    "BNL recommendations not clearly attached to an active Source File",
+    "Records missing latest BNL case report or source enrichment",
+    "Possible Duplicate / Same Subject Review",
+    "Possible same-subject review",
+    "Needs admin review",
+    "Confirmed aliases:",
+    "Proposed aliases:",
+    "Recommendation count:",
+    "Public dossier match:",
+    "Unattached BNL Signals / Recommendations",
+    "BNL recommendations that need placement review",
+    "No clear active Source File match",
+    "The site can only audit records and recommendations already present in the workflow store. Active Discord members who have not been ingested by BNL will not appear here yet.",
+    "it does not merge, delete, publish, or mutate records automatically",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  assert.match(page, /<details className="border border-accent\/40 bg-surface\/70 p-5">/);
+  assert.match(page, /createDossierPopulationAudit/);
+  assert.doesNotMatch(page, /Auto Merge|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
+});
+
+test("population audit helper uses conservative duplicate signals and leaves proposed aliases out of confirmed matching", () => {
+  const now = "2026-06-11T00:00:00.000Z";
+  const baseCandidate = (overrides) => ({
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 5,
+    whyNow: "Fixture",
+    reason: "Fixture",
+    evidenceSummary: "Fixture",
+    status: overrides.status ?? "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  const baseRecommendation = (overrides) => ({
+    id: overrides.id,
+    type: overrides.type ?? "new_subject",
+    subjectName: overrides.subjectName,
+    subjectKey: overrides.subjectKey,
+    targetDossierId: overrides.targetDossierId,
+    targetCandidateId: overrides.targetCandidateId,
+    status: overrides.status ?? "new",
+    reason: "BNL fixture",
+    confidence: overrides.confidence ?? "medium",
+    sourceLanes: overrides.sourceLanes ?? ["public_discord"],
+    createdAt: now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: "bnl",
+    ingestSource: overrides.ingestSource ?? "bnl_dynamic_candidate_discovery",
+    ...overrides,
+  });
+
+  const audit = workflow.createDossierPopulationAudit({
+    publicDossiers: [{ id: "mac-modem", name: "Mac Modem" }],
+    candidates: [
+      baseCandidate({
+        id: "candidate-active",
+        name: "Echo Trace",
+        sourceRecommendationIds: ["rec-attached"],
+        latestSourceFileArchiveUpdatedAt: now,
+        identityLinks: [
+          {
+            id: "alias-confirmed",
+            candidateId: "candidate-active",
+            label: "Trace Echo",
+            normalizedLabel: "trace echo",
+            type: "alias",
+            visibility: "internal_only",
+            status: "confirmed",
+            source: "admin_manual",
+            useForMatching: true,
+            useInPublicDossier: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: "alias-proposed",
+            candidateId: "candidate-active",
+            label: "Proposed Only",
+            normalizedLabel: "proposed only",
+            type: "alias",
+            visibility: "internal_only",
+            status: "proposed",
+            source: "bnl_recommendation",
+            useForMatching: true,
+            useInPublicDossier: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      }),
+      baseCandidate({ id: "candidate-name-dupe", name: "Echo Trace" }),
+      baseCandidate({ id: "candidate-alias-dupe", name: "Trace Echo" }),
+      baseCandidate({
+        id: "candidate-public-target",
+        name: "Mac Update A",
+        status: "existing_dossier_update",
+        existingDossierMatch: { id: "mac-modem", name: "Mac Modem", confidence: "high" },
+      }),
+      baseCandidate({ id: "candidate-intake", name: "Seed Person", status: "candidate_intake" }),
+      baseCandidate({ id: "candidate-archived", name: "Old Person", status: "archived" }),
+      baseCandidate({ id: "candidate-missing-report", name: "Missing Report" }),
+    ],
+    recommendations: [
+      baseRecommendation({ id: "rec-attached", subjectName: "Echo Trace", targetCandidateId: "candidate-active", status: "attached_to_source_file" }),
+      baseRecommendation({ id: "rec-unattached", subjectName: "Loose Signal", subjectKey: "loose-signal" }),
+      baseRecommendation({ id: "rec-shared-key-a", subjectName: "Key Alpha", subjectKey: "shared-key" }),
+      baseRecommendation({ id: "rec-shared-key-b", subjectName: "Key Beta", subjectKey: "shared-key" }),
+      baseRecommendation({ id: "rec-public-target", subjectName: "Mac Update B", targetDossierId: "mac-modem", type: "modify_existing_dossier" }),
+    ],
+  });
+
+  assert.equal(audit.counts.activeSourceFiles, 4);
+  assert.equal(audit.counts.candidateIntake, 1);
+  assert.equal(audit.counts.existingDossierUpdates, 1);
+  assert.equal(audit.counts.publicDossiers, 1);
+  assert.equal(audit.counts.archivedClosedRecords, 1);
+  assert.equal(audit.counts.proposedIdentityLinks, 1);
+  assert.equal(audit.counts.confirmedIdentityLinks, 1);
+  assert.equal(audit.counts.recordsWithAttachedBnlRecommendations, 1);
+  assert.equal(audit.counts.unattachedBnlRecommendations, 4);
+  assert.equal(audit.counts.recordsMissingLatestCaseReportOrEnrichment, 3);
+
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "normalized_name" && group.records.some((record) => record.id === "candidate-active") && group.records.some((record) => record.id === "candidate-name-dupe")));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "confirmed_alias" && group.records.some((record) => record.id === "candidate-active") && group.records.some((record) => record.id === "candidate-alias-dupe")));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "public_dossier" && group.publicDossierMatch?.id === "mac-modem"));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "recommendation_subject_key" && group.records.length === 2));
+  assert.ok(!audit.possibleDuplicateGroups.some((group) => group.matchKind === "confirmed_alias" && group.records.some((record) => record.name === "Proposed Only")));
+  assert.ok(audit.unattachedBnlRecommendations.some((recommendation) => recommendation.id === "rec-unattached" && recommendation.subjectName === "Loose Signal"));
+});
+
 test("owner review page is a placeholder lane without publishing", () => {
   const routePath = "src/app/admin/dossiers/owner-review/page.tsx";
   assert.equal(fs.existsSync(path.join(projectRoot, routePath)), true);


### PR DESCRIPTION
### Motivation
- Operators need a safe, review-only way to audit Source File / Candidate population, spot conservative possible duplicates, and find BNL recommendations that lack clear Source File attachments without mutating data automatically. 
- The change must be admin-only, non-destructive, and clarify that the site can only surface records already present in the workflow store (Discord-active people not ingested by BNL will not appear). 

### Description
- Adds a new population-audit helper `createDossierPopulationAudit` in `src/lib/dossier-workflow.ts` that computes review-only counts, detects conservative duplicate groups (by normalized name, confirmed alias, shared public dossier, recommendation subject key, and BNL recommendation subject name), and returns a list of unattached BNL recommendations with match context and safe next-action text. 
- Adds an admin-only, collapsed `Source File Population Audit` panel to the Dossier Control Center at `src/app/admin/dossiers/page.tsx` that renders: high-level counts, a conservative “Possible Duplicate / Same Subject Review” section, and an “Unattached BNL Signals / Recommendations” table with links to recommendations and safe next-action guidance. 
- Ensures no automatic merge/delete/publish behavior is added, and the UI copy explicitly states the audit is review-only and limited to workflow-store records. 
- Adds tests in `tests/admin-dossiers.test.mjs` to verify the audit panel renders copy, counts, conservative duplicate grouping behavior (proposed aliases do not act as confirmed matches), unattached recommendation detection, and non-destructive audit wording. 

### Testing
- Ran the full admin dossier test suite with `node --test tests/admin-dossiers.test.mjs`; all tests passed (149 passing). 
- Ran TypeScript check with `npx tsc --noEmit`; the type check succeeded. 
- Ran linting (`npm run lint`) to observe pre-existing unrelated lint errors in archived/legacy files and other components; those errors pre-existed and were not addressed by this PR (lint reported unrelated failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af2a50dbc8321b0e9de0770f1899b)