### PR TITLE
Add automated Source File consolidation engine (population audit → automation)

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -444,10 +444,11 @@ export default function DossierControlCenterPage() {
     () =>
       createDossierPopulationAudit({
         candidates,
+        drafts,
         recommendations,
         publicDossiers,
       }),
-    [candidates, recommendations, publicDossiers],
+    [candidates, drafts, recommendations, publicDossiers],
   );
 
   async function postWorkflow(body: Record<string, unknown>) {
@@ -479,6 +480,36 @@ export default function DossierControlCenterPage() {
       return data;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function runPopulationAutomation(input: {
+    automationAction:
+      | "auto_clean_group"
+      | "auto_merge_group"
+      | "auto_attach_recommendation"
+      | "clean_duplicate_recommendations"
+      | "bulk_safe_cleanup"
+      | "suppress_duplicate_group";
+    groupId?: string;
+    recommendationId?: string;
+    reason?: string;
+  }) {
+    try {
+      const data = await postWorkflow({
+        action: "runDossierPopulationAutomation",
+        ...input,
+      });
+      setNotice(
+        data.message ??
+          "Source File consolidation automation revalidated server-side and completed without publishing or changing public dossier copy.",
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error
+          ? err.message
+          : "Source File consolidation automation could not run safely.",
+      );
     }
   }
 
@@ -812,9 +843,10 @@ export default function DossierControlCenterPage() {
             <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
               The site can only audit records and recommendations already
               present in the workflow store. Active Discord members who have not
-              been ingested by BNL will not appear here yet. This panel is
-              review-only: it does not merge, delete, publish, or mutate records
-              automatically.
+              been ingested by BNL will not appear here yet. This panel now
+              classifies every item for safe automation: public dossier text is
+              never changed, internal aliases stay internal, and nothing is
+              published automatically.
             </p>
 
             <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-3 text-xs text-muted">
@@ -870,6 +902,59 @@ export default function DossierControlCenterPage() {
               ))}
             </div>
 
+            <section className="border border-accent/40 bg-background/30 p-4 text-sm text-muted">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.35em] text-accent">
+                    Bulk Safe Automation
+                  </p>
+                  <h3 className="mt-1 text-lg font-bold text-foreground">
+                    Run Safe Cleanup
+                  </h3>
+                  <ul className="mt-3 list-disc space-y-1 pl-5">
+                    <li>
+                      {populationAudit.safeAutomationSummary.emptyDuplicates}{" "}
+                      empty duplicates will be archived/marked merged.
+                    </li>
+                    <li>
+                      {
+                        populationAudit.safeAutomationSummary
+                          .recommendationsToAttach
+                      }{" "}
+                      recommendations will attach to exact/confirmed matches.
+                    </li>
+                    <li>
+                      {
+                        populationAudit.safeAutomationSummary
+                          .duplicateRecommendationsToArchive
+                      }{" "}
+                      duplicate recommendations will be archived.
+                    </li>
+                    <li>0 public dossiers will be changed.</li>
+                    <li>0 public pages will be published.</li>
+                    <li>
+                      {populationAudit.safeAutomationSummary.reviewRequired}{" "}
+                      items still require review;{" "}
+                      {populationAudit.safeAutomationSummary.blocked} are
+                      blocked.
+                    </li>
+                  </ul>
+                </div>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() =>
+                    runPopulationAutomation({
+                      automationAction: "bulk_safe_cleanup",
+                    })
+                  }
+                  className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                >
+                  Run Safe Cleanup
+                </button>
+              </div>
+            </section>
+
             <section className="space-y-3">
               <div>
                 <p className="text-xs uppercase tracking-[0.35em] text-muted">
@@ -895,11 +980,18 @@ export default function DossierControlCenterPage() {
                         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                           <div>
                             <p className="font-semibold text-foreground">
-                              Needs admin review — {group.reason}
+                              {group.automation.safeActionLabel} —{" "}
+                              {group.reason}
                             </p>
                             <p>
-                              Suggested safe action: {group.suggestedAction}
+                              Automation level:{" "}
+                              {group.automation.automationLevel}
                             </p>
+                            <p>
+                              Suggested safe action:{" "}
+                              {group.automation.recommendedAction}
+                            </p>
+                            <p>Confidence: {group.automation.confidence}</p>
                             {group.publicDossierMatch && (
                               <p>
                                 Public dossier match:{" "}
@@ -908,7 +1000,100 @@ export default function DossierControlCenterPage() {
                               </p>
                             )}
                           </div>
-                          <StatusPill>{group.matchKind}</StatusPill>
+                          <div className="flex flex-wrap gap-2">
+                            <StatusPill>{group.matchKind}</StatusPill>
+                            <StatusPill>
+                              {group.automation.dangerLevel}
+                            </StatusPill>
+                          </div>
+                        </div>
+                        {group.automation.blockedReasons.length > 0 && (
+                          <div className="mt-3 border border-red-500/40 bg-red-500/10 p-3 text-red-200">
+                            <p className="font-semibold">
+                              Blocked/manual resolution required:
+                            </p>
+                            <ul className="list-disc pl-5">
+                              {group.automation.blockedReasons.map((reason) => (
+                                <li key={reason}>{reason}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        {group.automation.proposedChanges.length > 0 && (
+                          <div className="mt-3 grid gap-2 md:grid-cols-2">
+                            {group.automation.proposedChanges.map((change) => (
+                              <div
+                                key={`${group.id}-${change.label}`}
+                                className="border border-border/60 bg-background/30 p-3"
+                              >
+                                <p className="font-semibold text-foreground">
+                                  {change.label}
+                                </p>
+                                <p>{change.detail}</p>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {group.automation.automationLevel ===
+                            "auto_clean_now" && (
+                            <button
+                              type="button"
+                              disabled={saving}
+                              onClick={() =>
+                                runPopulationAutomation({
+                                  automationAction: "auto_clean_group",
+                                  groupId: group.id,
+                                })
+                              }
+                              className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                            >
+                              Remove Empty Duplicate
+                            </button>
+                          )}
+                          {group.automation.automationLevel ===
+                            "auto_merge_now" && (
+                            <button
+                              type="button"
+                              disabled={saving}
+                              onClick={() =>
+                                runPopulationAutomation({
+                                  automationAction: "auto_merge_group",
+                                  groupId: group.id,
+                                })
+                              }
+                              className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                            >
+                              Auto-Merge Safe Duplicate
+                            </button>
+                          )}
+                          {group.automation.automationLevel ===
+                            "review_recommended" && (
+                            <>
+                              <Link
+                                href={`/admin/dossiers/duplicates/${group.id}`}
+                                className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
+                              >
+                                Review Merge
+                              </Link>
+                              <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() =>
+                                  runPopulationAutomation({
+                                    automationAction:
+                                      "suppress_duplicate_group",
+                                    groupId: group.id,
+                                    reason:
+                                      "Not the same subject / keep separate.",
+                                  })
+                                }
+                                className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
+                              >
+                                Keep Separate
+                              </button>
+                            </>
+                          )}
                         </div>
                         <div className="mt-3 grid gap-2 md:grid-cols-2">
                           {group.records.map((record) => (
@@ -1026,9 +1211,30 @@ export default function DossierControlCenterPage() {
                                 : "No clear active Source File match"}
                             </td>
                             <td className="py-3 pr-3">
-                              {recommendation.safeNextAction}
+                              <p>{recommendation.safeNextAction}</p>
+                              <p className="mt-1 text-xs uppercase tracking-widest text-accent">
+                                {recommendation.automation.automationLevel} /{" "}
+                                {recommendation.automation.confidence}
+                              </p>
                             </td>
-                            <td className="py-3 pr-3">
+                            <td className="py-3 pr-3 space-y-2">
+                              {recommendation.automation.automationLevel ===
+                                "auto_attach_now" && (
+                                <button
+                                  type="button"
+                                  disabled={saving}
+                                  onClick={() =>
+                                    runPopulationAutomation({
+                                      automationAction:
+                                        "auto_attach_recommendation",
+                                      recommendationId: recommendation.id,
+                                    })
+                                  }
+                                  className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                                >
+                                  Attach Automatically
+                                </button>
+                              )}
                               <Link
                                 href={recommendation.href}
                                 className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
@@ -1043,6 +1249,56 @@ export default function DossierControlCenterPage() {
                   </table>
                 </div>
               )}
+              <section className="space-y-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.35em] text-muted">
+                    Duplicate BNL Recommendation Cleanup
+                  </p>
+                  <h3 className="text-lg font-bold text-foreground">
+                    Duplicate recommendations with no unique evidence
+                  </h3>
+                </div>
+                {populationAudit.duplicateRecommendationGroups.length === 0 ? (
+                  <p className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+                    No duplicate BNL recommendation groups were detected.
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {populationAudit.duplicateRecommendationGroups.map(
+                      (group) => (
+                        <article
+                          key={group.id}
+                          className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
+                        >
+                          <p className="font-semibold text-foreground">
+                            {group.automation.safeActionLabel}
+                          </p>
+                          <p>{group.automation.recommendedAction}</p>
+                          <p>Canonical: {group.canonicalRecommendationId}</p>
+                          <p>
+                            Duplicates:{" "}
+                            {group.duplicateRecommendationIds.join(", ")}
+                          </p>
+                          <button
+                            type="button"
+                            disabled={saving}
+                            onClick={() =>
+                              runPopulationAutomation({
+                                automationAction:
+                                  "clean_duplicate_recommendations",
+                                groupId: group.id,
+                              })
+                            }
+                            className="mt-3 border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                          >
+                            Clean Duplicate Recommendations
+                          </button>
+                        </article>
+                      ),
+                    )}
+                  </div>
+                )}
+              </section>
             </section>
           </div>
         </details>

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -55,6 +55,7 @@ import {
   retireDossierIdentityLink,
   mergeDossierCandidates,
   markCandidateAsExistingDossierUpdate,
+  runDossierPopulationAutomation,
   permanentlyDeleteDossierCandidate,
   promoteCandidateToSourceFile,
   restoreDossierCandidate,
@@ -147,6 +148,7 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "archiveDossierRecommendation",
   "attachCandidateToExistingDossier",
   "markCandidateAsExistingDossierUpdate",
+  "runDossierPopulationAutomation",
 ]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
@@ -315,7 +317,6 @@ function draftFieldsFromBody(
   if (typeof draftFields.name !== "string") return null;
   return draftFields;
 }
-
 
 async function verifySourceFileCaseReportAfterImmediateRefresh(input: {
   request: DossierSourceFileRefreshRequest;
@@ -523,8 +524,7 @@ export async function POST(req: Request) {
       } else if (refresh.request && immediateRefresh.status !== "unavailable") {
         await updateDossierSourceFileRefreshRequestStatus({
           requestId: refresh.request.id,
-          status:
-            immediateRefresh.status === "skipped" ? "skipped" : "failed",
+          status: immediateRefresh.status === "skipped" ? "skipped" : "failed",
           failureReason: immediateRefresh.failureReason,
         });
       }
@@ -559,10 +559,11 @@ export async function POST(req: Request) {
         source: "admin_manual",
         requestingSiteOrigin,
       });
-      const immediateRefresh = await verifySourceFileCaseReportAfterImmediateRefresh({
-        request: refresh.request,
-        immediateRefresh: immediateRefreshRaw,
-      });
+      const immediateRefresh =
+        await verifySourceFileCaseReportAfterImmediateRefresh({
+          request: refresh.request,
+          immediateRefresh: immediateRefreshRaw,
+        });
       if (immediateRefresh.ok) {
         await updateDossierSourceFileRefreshRequestStatus({
           requestId: refresh.request.id,
@@ -572,8 +573,7 @@ export async function POST(req: Request) {
       } else if (immediateRefresh.status !== "unavailable") {
         await updateDossierSourceFileRefreshRequestStatus({
           requestId: refresh.request.id,
-          status:
-            immediateRefresh.status === "skipped" ? "skipped" : "failed",
+          status: immediateRefresh.status === "skipped" ? "skipped" : "failed",
           failureReason: immediateRefresh.failureReason,
         });
       }
@@ -782,6 +782,57 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true, action, candidate, ...payload });
     }
 
+    if (action === "runDossierPopulationAutomation") {
+      const automationAction =
+        typeof body.automationAction === "string"
+          ? body.automationAction
+          : typeof (body.input as Record<string, unknown> | undefined)
+                ?.automationAction === "string"
+            ? String((body.input as Record<string, unknown>).automationAction)
+            : "";
+      const groupId =
+        typeof body.groupId === "string"
+          ? body.groupId
+          : typeof (body.input as Record<string, unknown> | undefined)
+                ?.groupId === "string"
+            ? String((body.input as Record<string, unknown>).groupId)
+            : undefined;
+      const recommendationId =
+        typeof body.recommendationId === "string"
+          ? body.recommendationId
+          : typeof (body.input as Record<string, unknown> | undefined)
+                ?.recommendationId === "string"
+            ? String((body.input as Record<string, unknown>).recommendationId)
+            : undefined;
+      const reason =
+        typeof body.reason === "string"
+          ? body.reason
+          : typeof (body.input as Record<string, unknown> | undefined)
+                ?.reason === "string"
+            ? String((body.input as Record<string, unknown>).reason)
+            : undefined;
+      if (
+        automationAction !== "auto_clean_group" &&
+        automationAction !== "auto_merge_group" &&
+        automationAction !== "auto_attach_recommendation" &&
+        automationAction !== "clean_duplicate_recommendations" &&
+        automationAction !== "bulk_safe_cleanup" &&
+        automationAction !== "suppress_duplicate_group"
+      ) {
+        return NextResponse.json(
+          { error: "Valid dossier population automation action is required" },
+          { status: 400 },
+        );
+      }
+      const automation = await runDossierPopulationAutomation({
+        action: automationAction,
+        groupId,
+        recommendationId,
+        reason,
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, automation, ...payload });
+    }
     if (
       action === "promoteCandidateToSourceFile" ||
       action === "archiveCandidate" ||

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -25,6 +25,10 @@ import {
   type DossierIdentityLinkVisibility,
   type DossierDraft,
   type DossierDuplicateGroup,
+  type DossierPopulationAudit,
+  type DossierPopulationAuditSuppression,
+  createDossierPopulationAudit,
+  normalizeDossierSubjectName,
   type DossierRecommendation,
   type DossierSourceFileArchiveAttachStatus,
   type DossierSourceFileArchiveMetadata,
@@ -55,6 +59,7 @@ export type DossierWorkflowState = {
   drafts: DossierDraft[];
   recommendations: DossierRecommendation[];
   sourceFileRefreshRequests: DossierSourceFileRefreshRequest[];
+  populationAuditSuppressions: DossierPopulationAuditSuppression[];
   updatedAt: string;
 };
 
@@ -90,6 +95,7 @@ function emptyWorkflowState(): DossierWorkflowState {
     drafts: [],
     recommendations: [],
     sourceFileRefreshRequests: [],
+    populationAuditSuppressions: [],
     updatedAt: new Date(0).toISOString(),
   };
 }
@@ -379,6 +385,20 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
         ? candidateState.sourceFileRefreshRequests
         : [],
     ),
+    populationAuditSuppressions: Array.isArray(
+      candidateState.populationAuditSuppressions,
+    )
+      ? candidateState.populationAuditSuppressions.filter(
+          (suppression): suppression is DossierPopulationAuditSuppression =>
+            Boolean(
+              suppression &&
+              typeof suppression === "object" &&
+              typeof suppression.id === "string" &&
+              typeof suppression.groupId === "string" &&
+              Array.isArray(suppression.recordIds),
+            ),
+        )
+      : [],
     updatedAt:
       typeof candidateState.updatedAt === "string"
         ? candidateState.updatedAt
@@ -470,8 +490,9 @@ function compactArchiveList(
   return output.length ? output : undefined;
 }
 
-
-function sourceArchiveObject(value: unknown): Record<string, unknown> | undefined {
+function sourceArchiveObject(
+  value: unknown,
+): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
@@ -482,7 +503,9 @@ type SourceArchivePayloadCandidate = {
   path: string;
 };
 
-export function sourceArchivePayloadCandidates(input: unknown): SourceArchivePayloadCandidate[] {
+export function sourceArchivePayloadCandidates(
+  input: unknown,
+): SourceArchivePayloadCandidate[] {
   const root = sourceArchiveObject(input);
   if (!root) return [];
   const candidates: SourceArchivePayloadCandidate[] = [];
@@ -495,7 +518,13 @@ export function sourceArchivePayloadCandidates(input: unknown): SourceArchivePay
   };
 
   add(root, "input");
-  for (const key of ["sourcePackage", "archivePayload", "archive", "payload", "sourceFileArchive"] as const) {
+  for (const key of [
+    "sourcePackage",
+    "archivePayload",
+    "archive",
+    "payload",
+    "sourceFileArchive",
+  ] as const) {
     const wrapped = root[key];
     add(wrapped, `input.${key}`);
     const wrappedObject = sourceArchiveObject(wrapped);
@@ -527,7 +556,9 @@ function normalizeSourceArchiveBrief(value: unknown) {
   if (!brief) return undefined;
   return {
     ...brief,
-    sourceFileCaseReportV1: isSourceFileCaseReportShape(brief.sourceFileCaseReportV1)
+    sourceFileCaseReportV1: isSourceFileCaseReportShape(
+      brief.sourceFileCaseReportV1,
+    )
       ? (brief.sourceFileCaseReportV1 as DossierSourceFileCaseReportV1)
       : undefined,
     caseFileReport: isSourceFileCaseReportShape(brief.caseFileReport)
@@ -538,14 +569,30 @@ function normalizeSourceArchiveBrief(value: unknown) {
 
 function findSourceFileCaseReportV1(input: unknown) {
   for (const candidate of sourceArchivePayloadCandidates(input)) {
-    const brief = normalizeSourceArchiveBrief(candidate.value.sourceFileBriefV2);
+    const brief = normalizeSourceArchiveBrief(
+      candidate.value.sourceFileBriefV2,
+    );
     const checks: Array<{ value: unknown; path: string }> = [
-      { value: candidate.value.sourceFileCaseReportV1, path: `${candidate.path}.sourceFileCaseReportV1` },
-      { value: brief?.sourceFileCaseReportV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1` },
-      { value: brief?.caseFileReport, path: `${candidate.path}.sourceFileBriefV2.caseFileReport` },
-      { value: candidate.value.caseFileReport, path: `${candidate.path}.caseFileReport` },
+      {
+        value: candidate.value.sourceFileCaseReportV1,
+        path: `${candidate.path}.sourceFileCaseReportV1`,
+      },
+      {
+        value: brief?.sourceFileCaseReportV1,
+        path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1`,
+      },
+      {
+        value: brief?.caseFileReport,
+        path: `${candidate.path}.sourceFileBriefV2.caseFileReport`,
+      },
+      {
+        value: candidate.value.caseFileReport,
+        path: `${candidate.path}.caseFileReport`,
+      },
     ];
-    const match = checks.find((check) => isSourceFileCaseReportShape(check.value));
+    const match = checks.find((check) =>
+      isSourceFileCaseReportShape(check.value),
+    );
     if (match) {
       return {
         report: match.value as DossierSourceFileCaseReportV1,
@@ -556,13 +603,17 @@ function findSourceFileCaseReportV1(input: unknown) {
   return { report: undefined, path: undefined };
 }
 
-function extractSourceFileCaseReportV1(input: CreateDossierSourceFileArchiveInput) {
+function extractSourceFileCaseReportV1(
+  input: CreateDossierSourceFileArchiveInput,
+) {
   return findSourceFileCaseReportV1(input).report;
 }
 
 function findSourceFileBriefV2(input: unknown) {
   for (const candidate of sourceArchivePayloadCandidates(input)) {
-    const brief = normalizeSourceArchiveBrief(candidate.value.sourceFileBriefV2);
+    const brief = normalizeSourceArchiveBrief(
+      candidate.value.sourceFileBriefV2,
+    );
     if (brief) return { brief, path: `${candidate.path}.sourceFileBriefV2` };
   }
   return { brief: undefined, path: undefined };
@@ -1980,15 +2031,16 @@ const OPEN_REQUEST_STATUSES = new Set<DossierSourceFileRefreshRequestStatus>([
 const COMPLETABLE_REFRESH_STATUSES =
   new Set<DossierSourceFileRefreshRequestStatus>(["pending", "claimed"]);
 
-
-export function latestArchiveMissingCaseReport(candidate: DossierCandidate): boolean {
+export function latestArchiveMissingCaseReport(
+  candidate: DossierCandidate,
+): boolean {
   const latestArchive = candidate.latestSourceFileArchive;
   const hasLatestSourceData = Boolean(
     latestArchive ??
-      candidate.latestSourceFileArchiveId ??
-      candidate.latestSourceFileArchiveDigest ??
-      candidate.latestSourceFileArchiveUpdatedAt ??
-      (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
+    candidate.latestSourceFileArchiveId ??
+    candidate.latestSourceFileArchiveDigest ??
+    candidate.latestSourceFileArchiveUpdatedAt ??
+    (candidate.sourceFileArchiveIds?.length ?? 0) > 0,
   );
   if (!hasLatestSourceData) return false;
   return !findSourceFileCaseReportV1(latestArchive).report;
@@ -1996,7 +2048,9 @@ export function latestArchiveMissingCaseReport(candidate: DossierCandidate): boo
 
 export const candidateMissingCaseReport = latestArchiveMissingCaseReport;
 
-export function sourceFileNeedsCaseReportBackfill(candidate: DossierCandidate): boolean {
+export function sourceFileNeedsCaseReportBackfill(
+  candidate: DossierCandidate,
+): boolean {
   return latestArchiveMissingCaseReport(candidate);
 }
 
@@ -2634,8 +2688,8 @@ export async function recordDossierSourceFileOpen(input: {
       reason: missingCaseReport
         ? "case_report_missing"
         : decision.needed
-        ? decision.reason
-        : "Admin opened the Source File and requested an immediate BNL freshness check.",
+          ? decision.reason
+          : "Admin opened the Source File and requested an immediate BNL freshness check.",
       requestSource: missingCaseReport
         ? "case_report_missing"
         : decision.requestSource === "opened_source_file"
@@ -2685,7 +2739,7 @@ export async function requestDossierSourceFileRefresh(input: {
           "Manual admin requested a BNL Source File refresh.",
       requestSource: missingCaseReport
         ? "case_report_missing"
-        : input.requestSource ?? "manual_admin",
+        : (input.requestSource ?? "manual_admin"),
       priority: input.priority ?? (missingCaseReport ? 95 : 90),
       requestedBy: input.requestedBy ?? "admin_manual",
       now,
@@ -5699,6 +5753,635 @@ export async function mergeDossierCandidates(
   });
 
   return result;
+}
+
+export type DossierPopulationAutomationAction =
+  | "auto_clean_group"
+  | "auto_merge_group"
+  | "auto_attach_recommendation"
+  | "clean_duplicate_recommendations"
+  | "bulk_safe_cleanup"
+  | "suppress_duplicate_group";
+
+function publicDossiersForAudit(): Array<{ id: string; name: string }> {
+  return databasePage.entries.map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+  }));
+}
+
+function auditForState(state: DossierWorkflowState): DossierPopulationAudit {
+  return createDossierPopulationAudit({
+    candidates: state.candidates,
+    drafts: state.drafts,
+    recommendations: state.recommendations,
+    publicDossiers: publicDossiersForAudit(),
+    suppressions: state.populationAuditSuppressions,
+  });
+}
+
+function sameConfirmedSubject(
+  candidate: DossierCandidate,
+  recordName: string,
+): boolean {
+  const recordKey = normalizeDossierSubjectName(recordName);
+  if (normalizeDossierSubjectName(candidate.name) === recordKey) return true;
+  return (candidate.identityLinks ?? []).some(
+    (link) =>
+      link.status === "confirmed" &&
+      link.useForMatching === true &&
+      (link.normalizedLabel || normalizeDossierSubjectName(link.label)) ===
+        recordKey,
+  );
+}
+
+function hasActiveDraft(
+  state: DossierWorkflowState,
+  candidateId: string,
+): boolean {
+  return state.drafts.some(
+    (draft) =>
+      draft.candidateId === candidateId &&
+      draft.status !== "denied" &&
+      draft.status !== "published" &&
+      draft.status !== "superseded",
+  );
+}
+
+function addAutomationNote(
+  candidate: DossierCandidate,
+  text: string,
+  now: string,
+): DossierCandidate {
+  const note: DossierSourceFileNote = {
+    id: createSourceFileNoteId(),
+    candidateId: candidate.id,
+    type: "general_note",
+    text,
+    source: "admin_manual",
+    status: "active",
+    publicSafe: false,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: "source_file_consolidation_engine",
+  };
+  return {
+    ...candidate,
+    sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+  };
+}
+
+function mergeCandidateArrays<T extends { id?: string }>(
+  target: T[] | undefined,
+  incoming: T[] | undefined,
+  mapItem?: (item: T) => T,
+): T[] {
+  const output = [...(target ?? [])];
+  const seen = new Set(output.map((item) => item.id ?? JSON.stringify(item)));
+  for (const raw of incoming ?? []) {
+    const item = mapItem ? mapItem(raw) : raw;
+    const key = item.id ?? JSON.stringify(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(item);
+  }
+  return output;
+}
+
+function performSafeCandidateMerge(input: {
+  state: DossierWorkflowState;
+  targetCandidateId: string;
+  sourceCandidateIds: string[];
+  now: string;
+  reason: string;
+}): DossierWorkflowState {
+  const target = input.state.candidates.find(
+    (candidate) => candidate.id === input.targetCandidateId,
+  );
+  if (!target)
+    throw new DossierWorkflowInputError(
+      "Automation target Source File not found",
+      409,
+      "automation_target_missing",
+    );
+  const sources = input.sourceCandidateIds.map((id) =>
+    input.state.candidates.find((candidate) => candidate.id === id),
+  );
+  if (sources.some((candidate) => !candidate))
+    throw new DossierWorkflowInputError(
+      "Automation source Source File not found",
+      409,
+      "automation_source_missing",
+    );
+  const sourceCandidates = sources.filter(
+    (candidate): candidate is DossierCandidate => Boolean(candidate),
+  );
+  const publicDossierIds = uniqueStrings(
+    target.existingDossierMatch?.id ? [target.existingDossierMatch.id] : [],
+    ...sourceCandidates.map((candidate) =>
+      candidate.existingDossierMatch?.id
+        ? [candidate.existingDossierMatch.id]
+        : [],
+    ),
+  );
+  if (publicDossierIds.length > 1) {
+    throw new DossierWorkflowInputError(
+      "Automation blocked: records point to different public dossiers",
+      409,
+      "automation_public_dossier_conflict",
+    );
+  }
+  if (
+    [target, ...sourceCandidates].filter((candidate) =>
+      hasActiveDraft(input.state, candidate.id),
+    ).length > 1
+  ) {
+    throw new DossierWorkflowInputError(
+      "Automation blocked: both records have active proposed dossiers",
+      409,
+      "automation_active_draft_conflict",
+    );
+  }
+  if (
+    sourceCandidates.some(
+      (candidate) =>
+        candidate.status === "merged" || candidate.status === "denied",
+    )
+  ) {
+    throw new DossierWorkflowInputError(
+      "Automation blocked: a source record is already closed",
+      409,
+      "automation_source_closed",
+    );
+  }
+  for (const source of sourceCandidates) {
+    if (
+      !sameConfirmedSubject(target, source.name) &&
+      !sameConfirmedSubject(source, target.name) &&
+      target.existingDossierMatch?.id !== source.existingDossierMatch?.id
+    ) {
+      throw new DossierWorkflowInputError(
+        "Automation blocked: same-subject proof no longer validates server-side",
+        409,
+        "automation_subject_proof_changed",
+      );
+    }
+  }
+
+  const mergedArchiveIds = uniqueStrings(
+    target.sourceFileArchiveIds,
+    ...sourceCandidates.map((candidate) => candidate.sourceFileArchiveIds),
+    ...sourceCandidates.map((candidate) =>
+      candidate.latestSourceFileArchiveId
+        ? [candidate.latestSourceFileArchiveId]
+        : [],
+    ),
+  );
+  const mergedTarget = addAutomationNote(
+    {
+      ...target,
+      sourceFileNotes: mergeCandidateArrays(
+        target.sourceFileNotes,
+        sourceCandidates.flatMap((candidate) =>
+          (candidate.sourceFileNotes ?? []).map((note) => ({
+            ...note,
+            candidateId: target.id,
+          })),
+        ),
+      ),
+      identityLinks: mergeCandidateArrays(
+        target.identityLinks,
+        sourceCandidates.flatMap((candidate) =>
+          (candidate.identityLinks ?? []).map((link) => ({
+            ...link,
+            candidateId: target.id,
+            useInPublicDossier:
+              link.useInPublicDossier === true &&
+              link.visibility === "public_safe",
+          })),
+        ),
+      ),
+      sourceRecommendationIds: uniqueStrings(
+        target.sourceRecommendationIds,
+        target.connectedRecommendationIds,
+        ...sourceCandidates.map(
+          (candidate) => candidate.sourceRecommendationIds,
+        ),
+        ...sourceCandidates.map(
+          (candidate) => candidate.connectedRecommendationIds,
+        ),
+        ...sourceCandidates.map((candidate) =>
+          candidate.createdFromRecommendationId
+            ? [candidate.createdFromRecommendationId]
+            : [],
+        ),
+      ),
+      sourceFileArchiveIds: mergedArchiveIds,
+      latestSourceFileArchiveId:
+        target.latestSourceFileArchiveId ??
+        sourceCandidates.find(
+          (candidate) => candidate.latestSourceFileArchiveId,
+        )?.latestSourceFileArchiveId,
+      latestSourceFileArchiveDigest:
+        target.latestSourceFileArchiveDigest ??
+        sourceCandidates.find(
+          (candidate) => candidate.latestSourceFileArchiveDigest,
+        )?.latestSourceFileArchiveDigest,
+      latestSourceFileArchiveUpdatedAt:
+        target.latestSourceFileArchiveUpdatedAt ??
+        sourceCandidates.find(
+          (candidate) => candidate.latestSourceFileArchiveUpdatedAt,
+        )?.latestSourceFileArchiveUpdatedAt,
+      latestSourceFileArchive:
+        target.latestSourceFileArchive ??
+        sourceCandidates.find((candidate) => candidate.latestSourceFileArchive)
+          ?.latestSourceFileArchive,
+      missingInfo: uniqueStrings(
+        target.missingInfo,
+        ...sourceCandidates.map((candidate) => candidate.missingInfo),
+      ),
+      doNotSay: uniqueStrings(
+        target.doNotSay,
+        ...sourceCandidates.map((candidate) => candidate.doNotSay),
+      ),
+      publicSafetyNotes: uniqueStrings(
+        target.publicSafetyNotes,
+        ...sourceCandidates.map((candidate) => candidate.publicSafetyNotes),
+      ),
+      sourceLanes: uniqueStrings(
+        target.sourceLanes,
+        ...sourceCandidates.map((candidate) => candidate.sourceLanes),
+      ) as DossierRecommendationSourceLane[],
+      mergeSourceCandidateIds: uniqueStrings(
+        target.mergeSourceCandidateIds,
+        sourceCandidates.map((candidate) => candidate.id),
+      ),
+      mergeNote: input.reason,
+      updatedAt: input.now,
+    },
+    `Automated Source File consolidation: ${input.reason}. Moved review-only notes/recommendations/aliases where safe. Public dossier copy was not changed and no publishing occurred.`,
+    input.now,
+  );
+
+  return {
+    ...input.state,
+    candidates: input.state.candidates.map((candidate) => {
+      if (candidate.id === target.id) return mergedTarget;
+      if (input.sourceCandidateIds.includes(candidate.id)) {
+        return {
+          ...candidate,
+          status: "merged" as const,
+          mergedIntoCandidateId: target.id,
+          mergedAt: input.now,
+          mergeNote: input.reason,
+          mergeSourceCandidateIds: uniqueStrings(
+            [target.id],
+            input.sourceCandidateIds,
+          ),
+          updatedAt: input.now,
+        };
+      }
+      return candidate;
+    }),
+    recommendations: input.state.recommendations.map((recommendation) =>
+      input.sourceCandidateIds.some(
+        (sourceId) =>
+          recommendation.targetCandidateId === sourceId ||
+          recommendation.connectedCandidateId === sourceId ||
+          recommendation.connectedSourceFileCandidateId === sourceId,
+      )
+        ? {
+            ...recommendation,
+            targetCandidateId: target.id,
+            connectedCandidateId:
+              recommendation.connectedCandidateId &&
+              input.sourceCandidateIds.includes(
+                recommendation.connectedCandidateId,
+              )
+                ? target.id
+                : recommendation.connectedCandidateId,
+            connectedSourceFileCandidateId:
+              recommendation.connectedSourceFileCandidateId &&
+              input.sourceCandidateIds.includes(
+                recommendation.connectedSourceFileCandidateId,
+              )
+                ? target.id
+                : recommendation.connectedSourceFileCandidateId,
+            status:
+              recommendation.status === "archived" ||
+              recommendation.status === "dismissed" ||
+              recommendation.status === "ignored"
+                ? recommendation.status
+                : "attached_to_source_file",
+            updatedAt: input.now,
+          }
+        : recommendation,
+    ),
+    updatedAt: input.now,
+  };
+}
+
+export async function runDossierPopulationAutomation(input: {
+  action: DossierPopulationAutomationAction;
+  groupId?: string;
+  recommendationId?: string;
+  reason?: string;
+}): Promise<{
+  action: DossierPopulationAutomationAction;
+  audit: DossierPopulationAudit;
+  changed: string[];
+}> {
+  const now = new Date().toISOString();
+  let changed: string[] = [];
+  let finalAudit: DossierPopulationAudit | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const audit = auditForState(currentState);
+    let nextState = currentState;
+
+    const runGroup = (groupId: string, allowMerge: boolean) => {
+      const group = audit.possibleDuplicateGroups.find(
+        (item) => item.id === groupId,
+      );
+      if (!group)
+        throw new DossierWorkflowInputError(
+          "Automation group not found or no longer active",
+          409,
+          "automation_group_not_found",
+        );
+      const targetId = group.automation.targetRecord?.candidateId;
+      const sourceIds = group.automation.sourceRecords
+        .map((record) => record.candidateId)
+        .filter((id): id is string => Boolean(id));
+      if (!targetId || sourceIds.length === 0)
+        throw new DossierWorkflowInputError(
+          "Automation group no longer has a resolvable source and target",
+          409,
+          "automation_unresolved_group",
+        );
+      if (
+        group.automation.automationLevel === "auto_clean_now" ||
+        (allowMerge && group.automation.automationLevel === "auto_merge_now")
+      ) {
+        nextState = performSafeCandidateMerge({
+          state: nextState,
+          targetCandidateId: targetId,
+          sourceCandidateIds: sourceIds,
+          now,
+          reason: group.automation.reason,
+        });
+        changed.push(`${group.automation.automationLevel}:${group.id}`);
+        return;
+      }
+      throw new DossierWorkflowInputError(
+        "Automation revalidation refused this group",
+        409,
+        "automation_revalidation_refused",
+      );
+    };
+
+    if (input.action === "auto_clean_group") {
+      if (!input.groupId)
+        throw new DossierWorkflowInputError(
+          "groupId is required",
+          400,
+          "missing_group_id",
+        );
+      runGroup(input.groupId, false);
+    } else if (input.action === "auto_merge_group") {
+      if (!input.groupId)
+        throw new DossierWorkflowInputError(
+          "groupId is required",
+          400,
+          "missing_group_id",
+        );
+      runGroup(input.groupId, true);
+    } else if (input.action === "auto_attach_recommendation") {
+      if (!input.recommendationId)
+        throw new DossierWorkflowInputError(
+          "recommendationId is required",
+          400,
+          "missing_recommendation_id",
+        );
+      const item = audit.unattachedBnlRecommendations.find(
+        (recommendation) => recommendation.id === input.recommendationId,
+      );
+      if (
+        !item ||
+        item.automation.automationLevel !== "auto_attach_now" ||
+        !item.matchingSourceFileId
+      ) {
+        throw new DossierWorkflowInputError(
+          "Recommendation can no longer be safely auto-attached",
+          409,
+          "automation_attach_not_safe",
+        );
+      }
+      const recommendation = nextState.recommendations.find(
+        (rec) => rec.id === item.id,
+      );
+      const candidate = nextState.candidates.find(
+        (cand) => cand.id === item.matchingSourceFileId,
+      );
+      if (!recommendation || !candidate)
+        throw new DossierWorkflowInputError(
+          "Recommendation or Source File disappeared before attach",
+          409,
+          "automation_attach_missing_record",
+        );
+      if (
+        !sameConfirmedSubject(candidate, recommendation.subjectName) &&
+        (!recommendation.subjectKey ||
+          !sameConfirmedSubject(candidate, recommendation.subjectKey))
+      ) {
+        throw new DossierWorkflowInputError(
+          "Recommendation subject proof changed before attach",
+          409,
+          "automation_attach_proof_changed",
+        );
+      }
+      const note: DossierSourceFileNote = {
+        id: createSourceFileNoteId(),
+        candidateId: candidate.id,
+        type: "general_note",
+        text: recommendation.ingestSource?.startsWith("bnl")
+          ? bnlAutoCandidateNoteText(recommendation)
+          : recommendationSourceNoteText(recommendation),
+        source: "bnl_recommendation",
+        status: "active",
+        publicSafe: false,
+        createdAt: now,
+        updatedAt: now,
+        createdBy: recommendation.createdBy,
+        ingestKey: recommendation.ingestKey,
+        ingestedAt: recommendation.ingestedAt,
+        ingestSource: recommendation.ingestSource,
+      };
+      nextState = {
+        ...nextState,
+        recommendations: nextState.recommendations.map((rec) =>
+          rec.id === recommendation.id
+            ? {
+                ...rec,
+                status: "attached_to_source_file",
+                targetCandidateId: candidate.id,
+                updatedAt: now,
+              }
+            : rec,
+        ),
+        candidates: nextState.candidates.map((cand) =>
+          cand.id === candidate.id
+            ? {
+                ...cand,
+                sourceFileNotes: [note, ...(cand.sourceFileNotes ?? [])],
+                updatedAt: now,
+              }
+            : cand,
+        ),
+        updatedAt: now,
+      };
+      changed.push(`auto_attach_now:${recommendation.id}`);
+    } else if (input.action === "clean_duplicate_recommendations") {
+      const group = audit.duplicateRecommendationGroups.find(
+        (item) => item.id === input.groupId,
+      );
+      if (!group)
+        throw new DossierWorkflowInputError(
+          "Duplicate recommendation group not found",
+          409,
+          "automation_duplicate_recommendation_group_not_found",
+        );
+      nextState = {
+        ...nextState,
+        recommendations: nextState.recommendations.map((recommendation) =>
+          group.duplicateRecommendationIds.includes(recommendation.id)
+            ? { ...recommendation, status: "archived", updatedAt: now }
+            : recommendation,
+        ),
+        updatedAt: now,
+      };
+      changed.push(`duplicate_recommendations:${group.id}`);
+    } else if (input.action === "suppress_duplicate_group") {
+      if (!input.groupId)
+        throw new DossierWorkflowInputError(
+          "groupId is required",
+          400,
+          "missing_group_id",
+        );
+      const group = audit.possibleDuplicateGroups.find(
+        (item) => item.id === input.groupId,
+      );
+      if (!group)
+        throw new DossierWorkflowInputError(
+          "Suppression group not found",
+          409,
+          "automation_group_not_found",
+        );
+      const suppression: DossierPopulationAuditSuppression = {
+        id: `audit-suppression-${now.replace(/[^0-9]/g, "")}-${Math.random().toString(36).slice(2, 8)}`,
+        groupId: group.id,
+        recordIds: group.records.map((record) => record.id).sort(),
+        reason: input.reason?.trim() || "Not the same subject / keep separate.",
+        createdAt: now,
+        createdBy: "admin",
+      };
+      nextState = {
+        ...nextState,
+        populationAuditSuppressions: [
+          suppression,
+          ...nextState.populationAuditSuppressions,
+        ],
+        updatedAt: now,
+      };
+      changed.push(`suppressed:${group.id}`);
+    } else if (input.action === "bulk_safe_cleanup") {
+      for (const group of audit.possibleDuplicateGroups) {
+        if (group.automation.automationLevel === "auto_clean_now")
+          runGroup(group.id, false);
+      }
+      for (const item of audit.unattachedBnlRecommendations) {
+        if (
+          item.automation.automationLevel !== "auto_attach_now" ||
+          !item.matchingSourceFileId
+        )
+          continue;
+        // Re-run as a focused mutation on the current nextState by recursion would deadlock; attach minimally here.
+        const recommendation = nextState.recommendations.find(
+          (rec) => rec.id === item.id,
+        );
+        const candidate = nextState.candidates.find(
+          (cand) => cand.id === item.matchingSourceFileId,
+        );
+        if (!recommendation || !candidate) continue;
+        if (
+          !sameConfirmedSubject(candidate, recommendation.subjectName) &&
+          (!recommendation.subjectKey ||
+            !sameConfirmedSubject(candidate, recommendation.subjectKey))
+        )
+          continue;
+        const note: DossierSourceFileNote = {
+          id: createSourceFileNoteId(),
+          candidateId: candidate.id,
+          type: "general_note",
+          text: recommendation.ingestSource?.startsWith("bnl")
+            ? bnlAutoCandidateNoteText(recommendation)
+            : recommendationSourceNoteText(recommendation),
+          source: "bnl_recommendation",
+          status: "active",
+          publicSafe: false,
+          createdAt: now,
+          updatedAt: now,
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        };
+        nextState = {
+          ...nextState,
+          recommendations: nextState.recommendations.map((rec) =>
+            rec.id === recommendation.id
+              ? {
+                  ...rec,
+                  status: "attached_to_source_file",
+                  targetCandidateId: candidate.id,
+                  updatedAt: now,
+                }
+              : rec,
+          ),
+          candidates: nextState.candidates.map((cand) =>
+            cand.id === candidate.id
+              ? {
+                  ...cand,
+                  sourceFileNotes: [note, ...(cand.sourceFileNotes ?? [])],
+                  updatedAt: now,
+                }
+              : cand,
+          ),
+        };
+        changed.push(`auto_attach_now:${recommendation.id}`);
+      }
+      for (const group of audit.duplicateRecommendationGroups) {
+        nextState = {
+          ...nextState,
+          recommendations: nextState.recommendations.map((recommendation) =>
+            group.duplicateRecommendationIds.includes(recommendation.id)
+              ? { ...recommendation, status: "archived", updatedAt: now }
+              : recommendation,
+          ),
+        };
+        if (group.duplicateRecommendationIds.length > 0)
+          changed.push(`duplicate_recommendations:${group.id}`);
+      }
+      nextState = { ...nextState, updatedAt: now };
+    }
+
+    finalAudit = auditForState(nextState);
+    return nextState;
+  });
+  return {
+    action: input.action,
+    audit: finalAudit ?? auditForState(await getDossierWorkflowState()),
+    changed,
+  };
 }
 
 export function getDossierWorkflowStorageMode(): "redis" | "memory_fallback" {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -750,6 +750,41 @@ export type DossierPopulationAuditRecordType =
   | "recommendation"
   | "archived_or_closed";
 
+export type DossierPopulationAutomationLevel =
+  | "auto_clean_now"
+  | "auto_merge_now"
+  | "auto_attach_now"
+  | "review_recommended"
+  | "blocked_manual_resolution_required"
+  | "keep_separate_not_same_subject";
+
+export type DossierPopulationAutomationDangerLevel =
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "blocked";
+
+export type DossierPopulationAutomationChange = {
+  label: string;
+  detail: string;
+};
+
+export type DossierPopulationAutomationClassification = {
+  automationLevel: DossierPopulationAutomationLevel;
+  recommendedAction: string;
+  confidence: "low" | "medium" | "high";
+  reason: string;
+  targetRecord?: DossierPopulationAuditRecord;
+  sourceRecords: DossierPopulationAuditRecord[];
+  proposedChanges: DossierPopulationAutomationChange[];
+  blockedReasons: string[];
+  canRunAutomatically: boolean;
+  requiresReview: boolean;
+  safeActionLabel: string;
+  dangerLevel: DossierPopulationAutomationDangerLevel;
+};
+
 export type DossierPopulationAuditRecord = {
   id: string;
   type: DossierPopulationAuditRecordType;
@@ -763,6 +798,14 @@ export type DossierPopulationAuditRecord = {
   confirmedAliasCount: number;
   proposedAliasCount: number;
   attachedRecommendationCount: number;
+  sourceNoteCount: number;
+  identityLinkCount: number;
+  archiveCount: number;
+  activeDraftCount: number;
+  sourceLaneCount: number;
+  hasPublicDossierLink: boolean;
+  hasActiveDraft: boolean;
+  hasUsefulUniqueData: boolean;
   missingLatestCaseReport: boolean;
 };
 
@@ -778,6 +821,24 @@ export type DossierPopulationAuditDuplicateGroup = {
   publicDossierMatch?: { id: string; name?: string };
   records: DossierPopulationAuditRecord[];
   suggestedAction: string;
+  automation: DossierPopulationAutomationClassification;
+};
+
+export type DossierPopulationAuditDuplicateRecommendationGroup = {
+  id: string;
+  canonicalRecommendationId: string;
+  duplicateRecommendationIds: string[];
+  recommendations: DossierPopulationAuditUnattachedRecommendation[];
+  automation: DossierPopulationAutomationClassification;
+};
+
+export type DossierPopulationAuditSuppression = {
+  id: string;
+  groupId: string;
+  recordIds: string[];
+  reason?: string;
+  createdAt: string;
+  createdBy?: string;
 };
 
 export type DossierPopulationAuditUnattachedRecommendation = {
@@ -794,6 +855,7 @@ export type DossierPopulationAuditUnattachedRecommendation = {
   matchBasis?: string;
   href: string;
   safeNextAction: string;
+  automation: DossierPopulationAutomationClassification;
 };
 
 export type DossierPopulationAudit = {
@@ -812,7 +874,434 @@ export type DossierPopulationAudit = {
   records: DossierPopulationAuditRecord[];
   possibleDuplicateGroups: DossierPopulationAuditDuplicateGroup[];
   unattachedBnlRecommendations: DossierPopulationAuditUnattachedRecommendation[];
+  duplicateRecommendationGroups: DossierPopulationAuditDuplicateRecommendationGroup[];
+  safeAutomationSummary: {
+    emptyDuplicates: number;
+    safeMerges: number;
+    recommendationsToAttach: number;
+    duplicateRecommendationsToArchive: number;
+    publicDossiersChanged: 0;
+    publicPagesPublished: 0;
+    reviewRequired: number;
+    blocked: number;
+  };
 };
+
+function uniqueStrings(
+  ...groups: Array<Array<string | undefined> | undefined>
+): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const group of groups) {
+    for (const item of group ?? []) {
+      if (!item) continue;
+      const trimmed = item.trim();
+      const key = trimmed.toLowerCase();
+      if (!trimmed || seen.has(key)) continue;
+      seen.add(key);
+      output.push(trimmed);
+    }
+  }
+  return output;
+}
+
+function activeAuditDraftForCandidate(
+  drafts: DossierDraft[],
+  candidateId: string,
+): DossierDraft | undefined {
+  return drafts.find(
+    (draft) =>
+      draft.candidateId === candidateId &&
+      draft.status !== "denied" &&
+      draft.status !== "published" &&
+      draft.status !== "superseded",
+  );
+}
+
+function candidateAuditSubstance(input: {
+  candidate: DossierCandidate;
+  attachedRecommendationCount: number;
+  activeDraftCount: number;
+}): {
+  sourceNoteCount: number;
+  identityLinkCount: number;
+  archiveCount: number;
+  sourceLaneCount: number;
+  hasPublicDossierLink: boolean;
+  hasUsefulUniqueData: boolean;
+} {
+  const sourceNoteCount = (input.candidate.sourceFileNotes ?? []).filter(
+    (note) => note.status === "active" && note.text.trim(),
+  ).length;
+  const identityLinkCount = (input.candidate.identityLinks ?? []).filter(
+    (link) => link.status !== "rejected" && link.status !== "retired",
+  ).length;
+  const archiveCount = uniqueStrings(
+    input.candidate.sourceFileArchiveIds,
+    input.candidate.latestSourceFileArchiveId
+      ? [input.candidate.latestSourceFileArchiveId]
+      : [],
+  ).length;
+  const sourceLaneCount = (input.candidate.sourceLanes ?? []).length;
+  const hasPublicDossierLink = Boolean(
+    input.candidate.existingDossierMatch?.id,
+  );
+  const hasMeaningfulSummary = Boolean(
+    input.candidate.sourceFileSummary?.summaryText?.trim() ||
+    input.candidate.sourceFileSummary?.knownContext?.length ||
+    input.candidate.sourceFileSummary?.openQuestions?.length ||
+    input.candidate.latestSourceFileArchiveId ||
+    input.candidate.latestSourceFileArchiveUpdatedAt,
+  );
+  const hasUsefulUniqueData = Boolean(
+    sourceNoteCount > 0 ||
+    input.attachedRecommendationCount > 0 ||
+    identityLinkCount > 0 ||
+    archiveCount > 0 ||
+    input.activeDraftCount > 0 ||
+    hasPublicDossierLink ||
+    sourceLaneCount > 0 ||
+    (input.candidate.evidenceItems ?? []).length > 0 ||
+    (input.candidate.knownFacts ?? []).length > 0 ||
+    (input.candidate.missingInfo ?? []).length > 0 ||
+    (input.candidate.doNotSay ?? []).length > 0 ||
+    (input.candidate.publicSafetyNotes ?? []).length > 0 ||
+    hasMeaningfulSummary,
+  );
+  return {
+    sourceNoteCount,
+    identityLinkCount,
+    archiveCount,
+    sourceLaneCount,
+    hasPublicDossierLink,
+    hasUsefulUniqueData,
+  };
+}
+
+function automationClassification(input: {
+  automationLevel: DossierPopulationAutomationLevel;
+  recommendedAction: string;
+  confidence: "low" | "medium" | "high";
+  reason: string;
+  targetRecord?: DossierPopulationAuditRecord;
+  sourceRecords?: DossierPopulationAuditRecord[];
+  proposedChanges?: DossierPopulationAutomationChange[];
+  blockedReasons?: string[];
+  safeActionLabel: string;
+  dangerLevel: DossierPopulationAutomationDangerLevel;
+}): DossierPopulationAutomationClassification {
+  const blockedReasons = input.blockedReasons ?? [];
+  return {
+    automationLevel: input.automationLevel,
+    recommendedAction: input.recommendedAction,
+    confidence: input.confidence,
+    reason: input.reason,
+    targetRecord: input.targetRecord,
+    sourceRecords: input.sourceRecords ?? [],
+    proposedChanges: input.proposedChanges ?? [],
+    blockedReasons,
+    canRunAutomatically:
+      blockedReasons.length === 0 &&
+      (input.automationLevel === "auto_clean_now" ||
+        input.automationLevel === "auto_attach_now"),
+    requiresReview: input.automationLevel === "review_recommended",
+    safeActionLabel: input.safeActionLabel,
+    dangerLevel: input.dangerLevel,
+  };
+}
+
+function classifyDuplicateGroup(input: {
+  groupId: string;
+  matchKind: DossierPopulationAuditDuplicateGroup["matchKind"];
+  reason: string;
+  records: DossierPopulationAuditRecord[];
+  suppressions: DossierPopulationAuditSuppression[];
+}): DossierPopulationAutomationClassification {
+  const records = uniqueAuditRecords(input.records);
+  const candidateRecords = records.filter((record) => record.candidateId);
+  const sortedCandidates = [...candidateRecords].sort((left, right) => {
+    const rightScore =
+      (right.hasPublicDossierLink ? 10 : 0) +
+      (right.hasActiveDraft ? 5 : 0) +
+      right.sourceNoteCount +
+      right.attachedRecommendationCount +
+      right.identityLinkCount +
+      right.archiveCount;
+    const leftScore =
+      (left.hasPublicDossierLink ? 10 : 0) +
+      (left.hasActiveDraft ? 5 : 0) +
+      left.sourceNoteCount +
+      left.attachedRecommendationCount +
+      left.identityLinkCount +
+      left.archiveCount;
+    return rightScore - leftScore || left.id.localeCompare(right.id);
+  });
+  const targetRecord = sortedCandidates[0];
+  const sourceRecords = targetRecord
+    ? candidateRecords.filter((record) => record.id !== targetRecord.id)
+    : records.slice(1);
+  const recordIds = candidateRecords.map((record) => record.id).sort();
+  const suppressed = input.suppressions.some((suppression) => {
+    const suppressionIds = [...suppression.recordIds].sort();
+    return (
+      suppression.groupId === input.groupId ||
+      (suppressionIds.length === recordIds.length &&
+        suppressionIds.every((id, index) => id === recordIds[index]))
+    );
+  });
+  if (suppressed) {
+    return automationClassification({
+      automationLevel: "keep_separate_not_same_subject",
+      recommendedAction:
+        "Keep separate; this false-positive pair was suppressed by an admin.",
+      confidence: "high",
+      reason: "Admin suppression says these records are not the same subject.",
+      targetRecord,
+      sourceRecords,
+      safeActionLabel: "Kept Separate",
+      dangerLevel: "none",
+    });
+  }
+
+  const publicDossierIds = uniqueStrings(
+    candidateRecords
+      .map((record) => record.publicDossierId)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const blockedReasons: string[] = [];
+  if (!targetRecord || candidateRecords.length < 2) {
+    blockedReasons.push(
+      "Source and target Source File records could not be resolved.",
+    );
+  }
+  if (publicDossierIds.length > 1) {
+    blockedReasons.push("Records point to different public dossiers.");
+  }
+  if (candidateRecords.filter((record) => record.hasActiveDraft).length > 1) {
+    blockedReasons.push("Both records have active proposed dossiers.");
+  }
+  if (candidateRecords.some((record) => record.status === "merged")) {
+    blockedReasons.push("A source record is already merged.");
+  }
+  if (blockedReasons.length > 0) {
+    return automationClassification({
+      automationLevel: "blocked_manual_resolution_required",
+      recommendedAction:
+        "Resolve the conflict manually before any merge or cleanup.",
+      confidence: "high",
+      reason: input.reason,
+      targetRecord,
+      sourceRecords,
+      blockedReasons,
+      safeActionLabel: "Manual Resolution Required",
+      dangerLevel: "blocked",
+    });
+  }
+
+  const proofIsStrong =
+    input.matchKind === "normalized_name" ||
+    input.matchKind === "confirmed_alias" ||
+    input.matchKind === "public_dossier" ||
+    input.matchKind === "recommendation_subject_key";
+  const hasProposedAlias = candidateRecords.some(
+    (record) => record.proposedAliasCount > 0,
+  );
+  if (!proofIsStrong || hasProposedAlias) {
+    return automationClassification({
+      automationLevel: "review_recommended",
+      recommendedAction:
+        "Review Merge field-by-field or mark Keep Separate before consolidation.",
+      confidence: hasProposedAlias ? "medium" : "low",
+      reason: hasProposedAlias
+        ? "A proposed alias is present and cannot be used as confirmed duplicate evidence."
+        : input.reason,
+      targetRecord,
+      sourceRecords,
+      proposedChanges: [
+        {
+          label: "Review Merge",
+          detail:
+            "Compare target and incoming records before accepting changes.",
+        },
+        {
+          label: "Keep Separate",
+          detail: "Suppress this suggestion if it is not the same subject.",
+        },
+      ],
+      safeActionLabel: "Review Merge",
+      dangerLevel: "medium",
+    });
+  }
+
+  const emptySources = sourceRecords.filter(
+    (record) => !record.hasUsefulUniqueData,
+  );
+  if (emptySources.length === sourceRecords.length && emptySources.length > 0) {
+    return automationClassification({
+      automationLevel: "auto_clean_now",
+      recommendedAction:
+        "No unique info found. This record can be safely removed from the active workflow.",
+      confidence: "high",
+      reason: `${input.reason} The duplicate has no notes, recommendations, identity links, archive, active draft, public dossier link, unique lanes, or meaningful status history.`,
+      targetRecord,
+      sourceRecords: emptySources,
+      proposedChanges: [
+        {
+          label: "Retire duplicate Source File",
+          detail: "Mark empty duplicate records as merged into the target.",
+        },
+        {
+          label: "Audit trail",
+          detail:
+            "Add internal merge metadata without changing public dossier copy.",
+        },
+      ],
+      safeActionLabel: "Remove Empty Duplicate",
+      dangerLevel: "low",
+    });
+  }
+
+  return automationClassification({
+    automationLevel: "auto_merge_now",
+    recommendedAction:
+      "Exact/confirmed duplicate records can be merged automatically after explicit admin action; useful non-conflicting internal data will be moved additively.",
+    confidence: "high",
+    reason: input.reason,
+    targetRecord,
+    sourceRecords,
+    proposedChanges: [
+      {
+        label: "Will add aliases",
+        detail:
+          "Identity links move with original visibility, status, and matching flags.",
+      },
+      {
+        label: "Will move notes",
+        detail:
+          "Source notes move with original timestamps, source, and createdBy metadata.",
+      },
+      {
+        label: "Will attach BNL recommendations",
+        detail:
+          "Recommendation IDs and source lanes are preserved while retargeting to the merged Source File.",
+      },
+      {
+        label: "Will preserve archive history",
+        detail:
+          "Archive IDs and latest enrichment are added only where the target lacks them.",
+      },
+      {
+        label: "Will retire duplicate Source File",
+        detail: "The incoming record is marked merged into the target.",
+      },
+      {
+        label: "Will not change public dossier copy",
+        detail: "No public dossier fields are edited or published.",
+      },
+      {
+        label: "Will not publish identity",
+        detail:
+          "Internal aliases remain internal and useInPublicDossier is not escalated.",
+      },
+    ],
+    safeActionLabel: "Auto-Merge Safe Duplicate",
+    dangerLevel: "medium",
+  });
+}
+
+function classifyUnattachedRecommendation(input: {
+  recommendation: DossierRecommendation;
+  matchingSourceFile?: DossierCandidate;
+  matchBasis?: string;
+}): DossierPopulationAutomationClassification {
+  const recommendationRecord: DossierPopulationAuditRecord = {
+    id: input.recommendation.id,
+    type: "recommendation",
+    name: input.recommendation.subjectName,
+    status: input.recommendation.status,
+    href: `/admin/dossiers/recommendations/${input.recommendation.id}`,
+    recommendationId: input.recommendation.id,
+    publicDossierId: input.recommendation.targetDossierId,
+    confirmedAliasCount: 0,
+    proposedAliasCount: 0,
+    attachedRecommendationCount: 1,
+    sourceNoteCount: 0,
+    identityLinkCount: 0,
+    archiveCount: 0,
+    activeDraftCount: 0,
+    sourceLaneCount: input.recommendation.sourceLanes.length,
+    hasPublicDossierLink: Boolean(input.recommendation.targetDossierId),
+    hasActiveDraft: false,
+    hasUsefulUniqueData: true,
+    missingLatestCaseReport: false,
+  };
+  if (!input.matchingSourceFile) {
+    return automationClassification({
+      automationLevel: "review_recommended",
+      recommendedAction:
+        "Review manually; decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
+      confidence: "low",
+      reason: "No exact Source File or confirmed alias match was found.",
+      sourceRecords: [recommendationRecord],
+      safeActionLabel: "Review Placement",
+      dangerLevel: "medium",
+    });
+  }
+  const targetRecord: DossierPopulationAuditRecord = {
+    id: input.matchingSourceFile.id,
+    type: "source_file",
+    name: input.matchingSourceFile.name,
+    status: input.matchingSourceFile.status,
+    href: `/admin/dossiers/candidates/${input.matchingSourceFile.id}`,
+    candidateId: input.matchingSourceFile.id,
+    publicDossierId: input.matchingSourceFile.existingDossierMatch?.id,
+    publicDossierName: input.matchingSourceFile.existingDossierMatch?.name,
+    confirmedAliasCount: (input.matchingSourceFile.identityLinks ?? []).filter(
+      (link) => link.status === "confirmed",
+    ).length,
+    proposedAliasCount: (input.matchingSourceFile.identityLinks ?? []).filter(
+      (link) => link.status === "proposed",
+    ).length,
+    attachedRecommendationCount: 0,
+    sourceNoteCount: (input.matchingSourceFile.sourceFileNotes ?? []).length,
+    identityLinkCount: (input.matchingSourceFile.identityLinks ?? []).length,
+    archiveCount: (input.matchingSourceFile.sourceFileArchiveIds ?? []).length,
+    activeDraftCount: 0,
+    sourceLaneCount: (input.matchingSourceFile.sourceLanes ?? []).length,
+    hasPublicDossierLink: Boolean(
+      input.matchingSourceFile.existingDossierMatch?.id,
+    ),
+    hasActiveDraft: false,
+    hasUsefulUniqueData: true,
+    missingLatestCaseReport: false,
+  };
+  return automationClassification({
+    automationLevel: "auto_attach_now",
+    recommendedAction:
+      "This BNL Signal matches an existing Source File by confirmed alias/exact subject key. It will be attached for review.",
+    confidence: "high",
+    reason: `Matched by ${input.matchBasis ?? "exact subject"}; attachment remains review-only and does not publish.`,
+    targetRecord,
+    sourceRecords: [recommendationRecord],
+    proposedChanges: [
+      {
+        label: "Attach to Existing Source File",
+        detail:
+          "Set the recommendation targetCandidateId to the matched Source File.",
+      },
+      {
+        label: "Review-only source note",
+        detail: "Add a non-public BNL source note for reviewer context.",
+      },
+      {
+        label: "No public change",
+        detail: "Public dossier text and publishing status stay untouched.",
+      },
+    ],
+    safeActionLabel: "Attach Automatically",
+    dangerLevel: "low",
+  });
+}
 
 function isBnlRecommendation(
   recommendation: Pick<DossierRecommendation, "ingestSource" | "createdBy">,
@@ -893,10 +1382,14 @@ function duplicateGroupAction(
 
 export function createDossierPopulationAudit(input: {
   candidates: DossierCandidate[];
+  drafts?: DossierDraft[];
   recommendations?: DossierRecommendation[];
   publicDossiers?: Array<{ id: string; name: string }>;
+  suppressions?: DossierPopulationAuditSuppression[];
 }): DossierPopulationAudit {
   const recommendations = input.recommendations ?? [];
+  const drafts = input.drafts ?? [];
+  const suppressions = input.suppressions ?? [];
   const bnlRecommendations = recommendations.filter(isBnlRecommendation);
   const candidatesById = new Map(
     input.candidates.map((candidate) => [candidate.id, candidate]),
@@ -945,6 +1438,16 @@ export function createDossierPopulationAudit(input: {
     const proposedAliasCount = (candidate.identityLinks ?? []).filter(
       (link) => link.status === "proposed",
     ).length;
+    const attachedRecommendationCount =
+      bnlRecommendationIdsByCandidate.get(candidate.id)?.size ?? 0;
+    const activeDraftCount = drafts.filter((draft) =>
+      activeAuditDraftForCandidate([draft], candidate.id),
+    ).length;
+    const substance = candidateAuditSubstance({
+      candidate,
+      attachedRecommendationCount,
+      activeDraftCount,
+    });
     return {
       id: candidate.id,
       type: candidatePopulationType(candidate),
@@ -956,8 +1459,15 @@ export function createDossierPopulationAudit(input: {
       publicDossierName: candidate.existingDossierMatch?.name,
       confirmedAliasCount,
       proposedAliasCount,
-      attachedRecommendationCount:
-        bnlRecommendationIdsByCandidate.get(candidate.id)?.size ?? 0,
+      attachedRecommendationCount,
+      sourceNoteCount: substance.sourceNoteCount,
+      identityLinkCount: substance.identityLinkCount,
+      archiveCount: substance.archiveCount,
+      activeDraftCount,
+      sourceLaneCount: substance.sourceLaneCount,
+      hasPublicDossierLink: substance.hasPublicDossierLink,
+      hasActiveDraft: activeDraftCount > 0,
+      hasUsefulUniqueData: substance.hasUsefulUniqueData,
       missingLatestCaseReport:
         candidateMissingLatestCaseReportOrEnrichment(candidate),
     } satisfies DossierPopulationAuditRecord;
@@ -1059,8 +1569,13 @@ export function createDossierPopulationAudit(input: {
         matchBasis,
         href: `/admin/dossiers/recommendations/${recommendation.id}`,
         safeNextAction: matchingSourceFile
-          ? "Review manually; attach to the matching Source File only after admin confirmation."
+          ? "Attach to the matching Source File for review; do not publish or create a new Source File."
           : "Review manually; decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
+        automation: classifyUnattachedRecommendation({
+          recommendation,
+          matchingSourceFile,
+          matchBasis,
+        }),
       } satisfies DossierPopulationAuditUnattachedRecommendation;
     })
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
@@ -1163,6 +1678,14 @@ export function createDossierPopulationAudit(input: {
       confirmedAliasCount: 0,
       proposedAliasCount: 0,
       attachedRecommendationCount: 1,
+      sourceNoteCount: 0,
+      identityLinkCount: 0,
+      archiveCount: 0,
+      activeDraftCount: 0,
+      sourceLaneCount: recommendation.sourceLanes.length,
+      hasPublicDossierLink: Boolean(recommendation.targetDossierId),
+      hasActiveDraft: false,
+      hasUsefulUniqueData: true,
       missingLatestCaseReport: false,
     };
     addBucketRecord(
@@ -1194,23 +1717,144 @@ export function createDossierPopulationAudit(input: {
   }
 
   const possibleDuplicateGroups = Array.from(duplicateBuckets.entries())
-    .map(([bucketKey, bucket]) => ({
-      id: bucketKey
+    .map(([bucketKey, bucket]) => {
+      const id = bucketKey
         .replace(/[^a-z0-9]+/gi, "-")
         .replace(/^-|-$/g, "")
-        .toLowerCase(),
-      reason: bucket.reason,
-      matchKind: bucket.matchKind,
-      publicDossierMatch: bucket.publicDossierMatch,
-      records: uniqueAuditRecords(bucket.records),
-      suggestedAction: duplicateGroupAction(bucket.matchKind, bucket.records),
-    }))
-    .filter((group) => group.records.length >= 2)
+        .toLowerCase();
+      const records = uniqueAuditRecords(bucket.records);
+      const automation = classifyDuplicateGroup({
+        groupId: id,
+        matchKind: bucket.matchKind,
+        reason: bucket.reason,
+        records,
+        suppressions,
+      });
+      return {
+        id,
+        reason: bucket.reason,
+        matchKind: bucket.matchKind,
+        publicDossierMatch: bucket.publicDossierMatch,
+        records,
+        suggestedAction:
+          automation.recommendedAction ||
+          duplicateGroupAction(bucket.matchKind, bucket.records),
+        automation,
+      };
+    })
+    .filter(
+      (group) =>
+        group.records.length >= 2 &&
+        group.automation.automationLevel !== "keep_separate_not_same_subject",
+    )
     .sort(
       (left, right) =>
         right.records.length - left.records.length ||
         left.id.localeCompare(right.id),
     );
+
+  const duplicateRecommendationGroups = Array.from(
+    bnlRecommendations.reduce((map, recommendation) => {
+      const evidenceDigest = normalizeDossierSubjectName(
+        [
+          recommendation.ingestKey,
+          recommendation.subjectKey,
+          recommendation.subjectName,
+          recommendation.sourceLanes.join(","),
+          recommendation.reason,
+          recommendation.evidenceSummary,
+        ]
+          .filter(Boolean)
+          .join("|"),
+      );
+      if (!evidenceDigest) return map;
+      const current = map.get(evidenceDigest) ?? [];
+      current.push(recommendation);
+      map.set(evidenceDigest, current);
+      return map;
+    }, new Map<string, DossierRecommendation[]>()),
+  )
+    .filter(([, group]) => group.length > 1)
+    .map(([key, group]) => {
+      const sorted = [...group].sort(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) ||
+          left.id.localeCompare(right.id),
+      );
+      const canonical = sorted[0];
+      const duplicates = sorted.slice(1);
+      const recommendationRecords = sorted.map(
+        (recommendation) =>
+          ({
+            id: recommendation.id,
+            subjectName: recommendation.subjectName,
+            subjectKey: recommendation.subjectKey,
+            ingestSource: recommendation.ingestSource,
+            sourceLanes: recommendation.sourceLanes,
+            confidence: recommendation.confidence,
+            createdAt: recommendation.createdAt,
+            updatedAt: recommendation.updatedAt,
+            href: `/admin/dossiers/recommendations/${recommendation.id}`,
+            safeNextAction:
+              recommendation.id === canonical.id
+                ? "Keep as canonical duplicate recommendation."
+                : "Archive duplicate recommendation after preserving the canonical item.",
+            automation: automationClassification({
+              automationLevel:
+                recommendation.id === canonical.id
+                  ? "review_recommended"
+                  : "auto_clean_now",
+              recommendedAction:
+                recommendation.id === canonical.id
+                  ? "Keep canonical recommendation."
+                  : "Archive duplicate recommendation; no unique evidence was detected.",
+              confidence: "high",
+              reason: "Same ingest key/subject/evidence digest.",
+              sourceRecords: [],
+              safeActionLabel:
+                recommendation.id === canonical.id
+                  ? "Canonical"
+                  : "Archive Duplicate Recommendation",
+              dangerLevel: recommendation.id === canonical.id ? "none" : "low",
+            }),
+          }) satisfies DossierPopulationAuditUnattachedRecommendation,
+      );
+      return {
+        id: `duplicate-recommendations-${key}`
+          .replace(/[^a-z0-9]+/gi, "-")
+          .replace(/^-|-$/g, "")
+          .toLowerCase(),
+        canonicalRecommendationId: canonical.id,
+        duplicateRecommendationIds: duplicates.map(
+          (recommendation) => recommendation.id,
+        ),
+        recommendations: recommendationRecords,
+        automation: automationClassification({
+          automationLevel: "auto_clean_now",
+          recommendedAction:
+            "Keep one canonical recommendation and archive duplicate recommendations with no unique evidence.",
+          confidence: "high",
+          reason: "Same ingest key/subject/evidence digest.",
+          sourceRecords: [],
+          proposedChanges: [
+            { label: "Keep canonical recommendation", detail: canonical.id },
+            {
+              label: "Archive duplicate recommendations",
+              detail: duplicates
+                .map((recommendation) => recommendation.id)
+                .join(", "),
+            },
+            {
+              label: "Preserve unique evidence",
+              detail:
+                "Cleanup is only suggested when the digest proves no unique evidence.",
+            },
+          ],
+          safeActionLabel: "Clean Duplicate Recommendations",
+          dangerLevel: "low",
+        }),
+      } satisfies DossierPopulationAuditDuplicateRecommendationGroup;
+    });
 
   return {
     counts: {
@@ -1252,6 +1896,37 @@ export function createDossierPopulationAudit(input: {
     records,
     possibleDuplicateGroups,
     unattachedBnlRecommendations,
+    duplicateRecommendationGroups,
+    safeAutomationSummary: {
+      emptyDuplicates: possibleDuplicateGroups.filter(
+        (group) => group.automation.automationLevel === "auto_clean_now",
+      ).length,
+      safeMerges: possibleDuplicateGroups.filter(
+        (group) => group.automation.automationLevel === "auto_merge_now",
+      ).length,
+      recommendationsToAttach: unattachedBnlRecommendations.filter(
+        (recommendation) =>
+          recommendation.automation.automationLevel === "auto_attach_now",
+      ).length,
+      duplicateRecommendationsToArchive: duplicateRecommendationGroups.reduce(
+        (total, group) => total + group.duplicateRecommendationIds.length,
+        0,
+      ),
+      publicDossiersChanged: 0,
+      publicPagesPublished: 0,
+      reviewRequired:
+        possibleDuplicateGroups.filter(
+          (group) => group.automation.requiresReview,
+        ).length +
+        unattachedBnlRecommendations.filter(
+          (recommendation) => recommendation.automation.requiresReview,
+        ).length,
+      blocked: possibleDuplicateGroups.filter(
+        (group) =>
+          group.automation.automationLevel ===
+          "blocked_manual_resolution_required",
+      ).length,
+    },
   };
 }
 
@@ -1609,6 +2284,7 @@ export type DossierWorkflowAction =
   | "markCandidateAsExistingDossierUpdate"
   | "detectDuplicateCandidates"
   | "mergeCandidates"
+  | "runDossierPopulationAutomation"
   | "createMasterDraftFromMerge";
 
 export type DossierSourceBoundary = {
@@ -1658,6 +2334,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "markCandidateAsExistingDossierUpdate",
   "detectDuplicateCandidates",
   "mergeCandidates",
+  "runDossierPopulationAutomation",
   "createMasterDraftFromMerge",
 ];
 

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1999,8 +1999,8 @@ test("dashboard uses actual workflow ids, source metrics, and simplified overvie
   assert.match(page, /identityBadgeForCandidate/);
   assert.match(page, /identityBadgeForRecommendation/);
   assert.match(page, /Archive \/ Dismissed \/ Trash/);
-  assert.doesNotMatch(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
-  assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
+  assert.match(page, /href=\{`\/admin\/dossiers\/duplicates\/\$\{group\.id\}`\}/);
+  assert.match(page, /Review Merge/);
   assert.doesNotMatch(page, />Deny<|>Deny<\/button>/);
 });
 
@@ -2042,7 +2042,9 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Records missing latest BNL case report or source enrichment",
     "Possible Duplicate / Same Subject Review",
     "Possible same-subject review",
-    "Needs admin review",
+    "Automation level:",
+    "Auto-Merge Safe Duplicate",
+    "Remove Empty Duplicate",
     "Confirmed aliases:",
     "Proposed aliases:",
     "Recommendation count:",
@@ -2050,15 +2052,22 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Unattached BNL Signals / Recommendations",
     "BNL recommendations that need placement review",
     "No clear active Source File match",
+    "Run Safe Cleanup",
+    "Duplicate BNL Recommendation Cleanup",
+    "Attach Automatically",
+    "Keep Separate",
+    "0 public dossiers will be changed.",
+    "0 public pages will be published.",
     "The site can only audit records and recommendations already present in the workflow store. Active Discord members who have not been ingested by BNL will not appear here yet.",
-    "it does not merge, delete, publish, or mutate records automatically",
+    "public dossier text is never changed, internal aliases stay internal, and nothing is published automatically",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
 
   assert.match(page, /<details className="border border-accent\/40 bg-surface\/70 p-5">/);
   assert.match(page, /createDossierPopulationAudit/);
-  assert.doesNotMatch(page, /Auto Merge|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
+  assert.match(page, /runDossierPopulationAutomation/);
+  assert.doesNotMatch(page, /auto-create|autoCreate/);
 });
 
 test("population audit helper uses conservative duplicate signals and leaves proposed aliases out of confirmed matching", () => {
@@ -2173,6 +2182,166 @@ test("population audit helper uses conservative duplicate signals and leaves pro
   assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "recommendation_subject_key" && group.records.length === 2));
   assert.ok(!audit.possibleDuplicateGroups.some((group) => group.matchKind === "confirmed_alias" && group.records.some((record) => record.name === "Proposed Only")));
   assert.ok(audit.unattachedBnlRecommendations.some((recommendation) => recommendation.id === "rec-unattached" && recommendation.subjectName === "Loose Signal"));
+});
+
+test("population audit automation classifies and runs safe consolidation without public side effects", async () => {
+  const now = "2026-06-11T00:00:00.000Z";
+  const publicIdsBefore = databasePage.entries.map((entry) => entry.id);
+  const candidate = (overrides) => ({
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 50,
+    whyNow: "Fixture",
+    reason: "Fixture",
+    evidenceSummary: "Fixture",
+    status: overrides.status ?? "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  const note = (overrides) => ({
+    id: overrides.id,
+    candidateId: overrides.candidateId,
+    type: "general_note",
+    text: overrides.text ?? "Incoming source note",
+    source: "admin_manual",
+    status: "active",
+    publicSafe: false,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "fixture-admin",
+    ...overrides,
+  });
+  const alias = (overrides) => ({
+    id: overrides.id,
+    candidateId: overrides.candidateId,
+    label: overrides.label,
+    normalizedLabel: workflow.normalizeDossierSubjectName(overrides.label),
+    type: "alias",
+    visibility: overrides.visibility ?? "internal_only",
+    status: overrides.status ?? "confirmed",
+    source: "admin_manual",
+    confidence: "confirmed",
+    useForMatching: overrides.useForMatching ?? true,
+    useInPublicDossier: overrides.useInPublicDossier ?? false,
+    createdAt: now,
+    updatedAt: now,
+    confirmedBy: "fixture-admin",
+    confirmedAt: now,
+    ...overrides,
+  });
+  const recommendation = (overrides) => ({
+    id: overrides.id,
+    type: overrides.type ?? "new_subject",
+    subjectName: overrides.subjectName,
+    subjectKey: overrides.subjectKey,
+    targetCandidateId: overrides.targetCandidateId,
+    targetDossierId: overrides.targetDossierId,
+    status: overrides.status ?? "new",
+    reason: overrides.reason ?? "Same evidence",
+    evidenceSummary: overrides.evidenceSummary ?? "Same evidence",
+    confidence: "high",
+    sourceLanes: overrides.sourceLanes ?? ["public_discord"],
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: "bnl",
+    ingestSource: overrides.ingestSource ?? "bnl_dynamic_candidate_discovery",
+    ingestKey: overrides.ingestKey,
+    ...overrides,
+  });
+  const baseState = {
+    version: 1,
+    revision: 0,
+    candidates: [
+      candidate({ id: "empty-target", name: "Empty Dupe" }),
+      candidate({ id: "empty-source", name: "Empty Dupe" }),
+      candidate({ id: "merge-target", name: "Merge Subject", sourceFileNotes: [note({ id: "target-note", candidateId: "merge-target", text: "Target note", createdBy: "target-admin" })] }),
+      candidate({ id: "merge-source", name: "Merge Subject", sourceFileNotes: [note({ id: "source-note", candidateId: "merge-source", text: "Source note", createdBy: "source-admin" })], identityLinks: [alias({ id: "internal-alias", candidateId: "merge-source", label: "Secret Alias", visibility: "internal_only", useInPublicDossier: false })], sourceRecommendationIds: ["source-rec"] }),
+      candidate({ id: "attach-target", name: "Attach Subject" }),
+      candidate({ id: "draft-a", name: "Blocked Draft" }),
+      candidate({ id: "draft-b", name: "Blocked Draft" }),
+      candidate({ id: "public-a", name: "Public Clash", existingDossierMatch: { id: "dossier-a", name: "Dossier A", confidence: "high" } }),
+      candidate({ id: "public-b", name: "Public Clash", existingDossierMatch: { id: "dossier-b", name: "Dossier B", confidence: "high" } }),
+      candidate({ id: "route-update", name: "Route Update", status: "existing_dossier_update", existingDossierMatch: { id: "mac-modem", name: "Mac Modem", confidence: "high" } }),
+    ],
+    drafts: [
+      { id: "draft-a-1", candidateId: "draft-a", status: "draft", fields: { name: "Blocked Draft" }, createdAt: now, updatedAt: now },
+      { id: "draft-b-1", candidateId: "draft-b", status: "draft", fields: { name: "Blocked Draft" }, createdAt: now, updatedAt: now },
+    ],
+    recommendations: [
+      recommendation({ id: "source-rec", subjectName: "Merge Subject", subjectKey: "merge-subject", targetCandidateId: "merge-source", status: "attached_to_source_file", sourceLanes: ["broadcast_memory"] }),
+      recommendation({ id: "attach-rec", subjectName: "Attach Subject", subjectKey: "attach-subject" }),
+      recommendation({ id: "dupe-rec-a", subjectName: "Duplicate Rec", subjectKey: "duplicate-rec", ingestKey: "same-ingest", reason: "Same evidence", evidenceSummary: "Same evidence" }),
+      recommendation({ id: "dupe-rec-b", subjectName: "Duplicate Rec", subjectKey: "duplicate-rec", ingestKey: "same-ingest", reason: "Same evidence", evidenceSummary: "Same evidence" }),
+      recommendation({ id: "route-rec", subjectName: "Mac Modem", subjectKey: "mac-modem", targetDossierId: "mac-modem", type: "modify_existing_dossier" }),
+    ],
+    sourceFileRefreshRequests: [],
+    populationAuditSuppressions: [],
+    updatedAt: now,
+  };
+  await store.saveDossierWorkflowState(baseState);
+  const audit = workflow.createDossierPopulationAudit({ candidates: baseState.candidates, drafts: baseState.drafts, recommendations: baseState.recommendations, publicDossiers: [{ id: "mac-modem", name: "Mac Modem" }] });
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.automation.automationLevel === "auto_clean_now"));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.automation.automationLevel === "auto_merge_now"));
+  assert.ok(audit.unattachedBnlRecommendations.some((item) => item.id === "attach-rec" && item.automation.automationLevel === "auto_attach_now"));
+  assert.ok(audit.duplicateRecommendationGroups.some((group) => group.duplicateRecommendationIds.includes("dupe-rec-b")));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "draft-a") && group.automation.automationLevel === "blocked_manual_resolution_required"));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "public-a") && group.automation.blockedReasons.includes("Records point to different public dossiers.")));
+  assert.equal(audit.safeAutomationSummary.publicDossiersChanged, 0);
+  assert.equal(audit.safeAutomationSummary.publicPagesPublished, 0);
+  const cleanGroup = audit.possibleDuplicateGroups.find((group) => group.automation.automationLevel === "auto_clean_now" && group.records.some((record) => record.id === "empty-source"));
+  assert.ok(cleanGroup);
+  await store.runDossierPopulationAutomation({ action: "auto_clean_group", groupId: cleanGroup.id });
+  let state = await store.getDossierWorkflowState();
+  const expectedCleanSourceId = cleanGroup.automation.sourceRecords[0].candidateId;
+  const expectedCleanTargetId = cleanGroup.automation.targetRecord.candidateId;
+  assert.equal(state.candidates.find((item) => item.id === expectedCleanSourceId).status, "merged");
+  assert.equal(state.candidates.find((item) => item.id === expectedCleanSourceId).mergedIntoCandidateId, expectedCleanTargetId);
+  await assert.rejects(() => store.runDossierPopulationAutomation({ action: "auto_clean_group", groupId: cleanGroup.id }), /not found|no longer|refused/i);
+  const mergeAudit = workflow.createDossierPopulationAudit({ candidates: state.candidates, drafts: state.drafts, recommendations: state.recommendations, publicDossiers: [{ id: "mac-modem", name: "Mac Modem" }] });
+  const mergeGroup = mergeAudit.possibleDuplicateGroups.find((group) => group.automation.automationLevel === "auto_merge_now" && group.records.some((record) => record.id === "merge-source"));
+  assert.ok(mergeGroup);
+  const expectedMergeTargetId = mergeGroup.automation.targetRecord.candidateId;
+  const expectedMergeSourceId = mergeGroup.automation.sourceRecords[0].candidateId;
+  await store.runDossierPopulationAutomation({ action: "auto_merge_group", groupId: mergeGroup.id });
+  state = await store.getDossierWorkflowState();
+  const mergedTarget = state.candidates.find((item) => item.id === expectedMergeTargetId);
+  assert.ok(mergedTarget.sourceFileNotes.some((item) => item.id === "source-note" && item.createdBy === "source-admin" && item.candidateId === expectedMergeTargetId));
+  assert.ok(mergedTarget.identityLinks.some((item) => item.id === "internal-alias" && item.visibility === "internal_only" && item.useForMatching === true && item.useInPublicDossier === false));
+  assert.ok(mergedTarget.sourceRecommendationIds.includes("source-rec"));
+  assert.equal(state.recommendations.find((item) => item.id === "source-rec").targetCandidateId, expectedMergeTargetId);
+  assert.equal(state.candidates.find((item) => item.id === expectedMergeSourceId).status, "merged");
+  const attachAudit = workflow.createDossierPopulationAudit({ candidates: state.candidates, drafts: state.drafts, recommendations: state.recommendations });
+  assert.ok(attachAudit.unattachedBnlRecommendations.some((item) => item.id === "attach-rec" && item.automation.canRunAutomatically));
+  await store.runDossierPopulationAutomation({ action: "auto_attach_recommendation", recommendationId: "attach-rec" });
+  state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.find((item) => item.id === "attach-rec").targetCandidateId, "attach-target");
+  assert.ok(state.candidates.find((item) => item.id === "attach-target").sourceFileNotes.some((item) => item.source === "bnl_recommendation" && item.publicSafe === false));
+  await store.runDossierPopulationAutomation({ action: "clean_duplicate_recommendations", groupId: audit.duplicateRecommendationGroups[0].id });
+  state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.find((item) => item.id === "dupe-rec-b").status, "archived");
+  assert.equal(state.recommendations.find((item) => item.id === "dupe-rec-a").status, "new");
+  await store.saveDossierWorkflowState(baseState);
+  await store.runDossierPopulationAutomation({ action: "bulk_safe_cleanup" });
+  state = await store.getDossierWorkflowState();
+  assert.ok(["empty-source", "empty-target"].some((id) => state.candidates.find((item) => item.id === id).status === "merged"));
+  assert.equal(state.candidates.find((item) => item.id === "merge-source").status, "active_source_file");
+  assert.equal(state.candidates.find((item) => item.id === "draft-a").status, "active_source_file");
+  assert.equal(state.recommendations.find((item) => item.id === "attach-rec").targetCandidateId, "attach-target");
+  assert.equal(state.recommendations.find((item) => item.id === "dupe-rec-b").status, "archived");
+  await store.saveDossierWorkflowState({ ...baseState, candidates: [candidate({ id: "review-a", name: "Review Person", identityLinks: [alias({ id: "proposed", candidateId: "review-a", label: "Review Alt", status: "proposed" })] }), candidate({ id: "review-b", name: "Review Person" })], recommendations: [] });
+  state = await store.getDossierWorkflowState();
+  const reviewAudit = workflow.createDossierPopulationAudit({ candidates: state.candidates, drafts: state.drafts, recommendations: state.recommendations });
+  const reviewGroup = reviewAudit.possibleDuplicateGroups[0];
+  assert.equal(reviewGroup.automation.automationLevel, "review_recommended");
+  await store.runDossierPopulationAutomation({ action: "suppress_duplicate_group", groupId: reviewGroup.id, reason: "Not same subject" });
+  state = await store.getDossierWorkflowState();
+  const suppressedAudit = workflow.createDossierPopulationAudit({ candidates: state.candidates, drafts: state.drafts, recommendations: state.recommendations, suppressions: state.populationAuditSuppressions });
+  assert.equal(suppressedAudit.possibleDuplicateGroups.length, 0);
+  assert.deepEqual(databasePage.entries.map((entry) => entry.id), publicIdsBefore);
 });
 
 test("owner review page is a placeholder lane without publishing", () => {
@@ -3302,14 +3471,14 @@ test("mergeCandidates does not mutate public database, public read model, tag re
   );
 });
 
-test("admin dossiers dashboard does not promote duplicate merge review", () => {
+test("admin dossiers dashboard exposes automation review routing without old warning copy", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const mergePage = source(
     "src/app/admin/dossiers/duplicates/[groupId]/page.tsx",
   );
   assert.match(page, /Identity: Possible Match|Identity: Needs Confirmation|Possible Duplicate/);
   assert.doesNotMatch(page, /View Warning \/ Open Merge Review/);
-  assert.doesNotMatch(page, /\/admin\/dossiers\/duplicates\//);
+  assert.match(page, /\/admin\/dossiers\/duplicates\//);
   assert.doesNotMatch(page, /Merge into Master Candidate/);
   assert.doesNotMatch(page, /Create Master Draft from Merge/);
   assert.match(mergePage, /Merge is owner\/lead cleanup/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2186,7 +2186,7 @@ test("population audit helper uses conservative duplicate signals and leaves pro
 
 test("population audit automation classifies and runs safe consolidation without public side effects", async () => {
   const now = "2026-06-11T00:00:00.000Z";
-  const publicIdsBefore = databasePage.entries.map((entry) => entry.id);
+  const publicDatabaseBefore = JSON.stringify(databasePage.entries);
   const candidate = (overrides) => ({
     id: overrides.id,
     name: overrides.name,
@@ -2288,8 +2288,8 @@ test("population audit automation classifies and runs safe consolidation without
   assert.ok(audit.possibleDuplicateGroups.some((group) => group.automation.automationLevel === "auto_merge_now"));
   assert.ok(audit.unattachedBnlRecommendations.some((item) => item.id === "attach-rec" && item.automation.automationLevel === "auto_attach_now"));
   assert.ok(audit.duplicateRecommendationGroups.some((group) => group.duplicateRecommendationIds.includes("dupe-rec-b")));
-  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "draft-a") && group.automation.automationLevel === "blocked_manual_resolution_required"));
-  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "public-a") && group.automation.blockedReasons.includes("Records point to different public dossiers.")));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "draft-a") && group.automation.automationLevel === "blocked_manual_resolution_required" && group.automation.blockedReasons.includes("Both records have active proposed dossiers.")));
+  assert.ok(audit.possibleDuplicateGroups.some((group) => group.records.some((record) => record.id === "public-a") && group.automation.automationLevel === "blocked_manual_resolution_required" && group.automation.blockedReasons.includes("Records point to different public dossiers.")));
   assert.equal(audit.safeAutomationSummary.publicDossiersChanged, 0);
   assert.equal(audit.safeAutomationSummary.publicPagesPublished, 0);
   const cleanGroup = audit.possibleDuplicateGroups.find((group) => group.automation.automationLevel === "auto_clean_now" && group.records.some((record) => record.id === "empty-source"));
@@ -2341,7 +2341,7 @@ test("population audit automation classifies and runs safe consolidation without
   state = await store.getDossierWorkflowState();
   const suppressedAudit = workflow.createDossierPopulationAudit({ candidates: state.candidates, drafts: state.drafts, recommendations: state.recommendations, suppressions: state.populationAuditSuppressions });
   assert.equal(suppressedAudit.possibleDuplicateGroups.length, 0);
-  assert.deepEqual(databasePage.entries.map((entry) => entry.id), publicIdsBefore);
+  assert.equal(JSON.stringify(databasePage.entries), publicDatabaseBefore);
 });
 
 test("owner review page is a placeholder lane without publishing", () => {


### PR DESCRIPTION
### Motivation

- Turn the passive Source File Population Audit into a safe automation engine that can classify and perform non-destructive consolidation actions (auto-clean, auto-merge, auto-attach) while routing uncertain or conflicted items to review. 
- Preserve existing safety rules: do not change public dossier copy, do not expose internal aliases, and require server-side revalidation before any mutation.

### Description

- Add automation classification types and fields to the population audit model and attach per-item automation recommendations and confidence metadata by enhancing `createDossierPopulationAudit` in `src/lib/dossier-workflow.ts`. 
- Implement classification helpers and decision logic for duplicate groups and unattached recommendations (`classifyDuplicateGroup`, `classifyUnattachedRecommendation`, candidate substance helpers) and surface `automation` metadata (automationLevel, recommendedAction, confidence, reason, proposedChanges, blockedReasons, canRunAutomatically, requiresReview, safeActionLabel, dangerLevel). 
- Add a server-side automation runner and safe merge/attach implementations to the workflow store in `src/lib/dossier-workflow-store.ts` (`runDossierPopulationAutomation`, `performSafeCandidateMerge`, helpers for revalidation and audit-preserving merges), plus state support for audit suppressions. 
- Expose the automation runner through the admin API (`src/app/api/admin/dossiers/route.ts`) and add UI controls to the Dossier Control Center (`src/app/admin/dossiers/page.tsx`) including per-group action buttons (Remove Empty Duplicate, Auto-Merge Safe Duplicate, Review Merge / Keep Separate) and a cautious `Run Safe Cleanup` bulk action summary. 
- Add duplicate-recommendation grouping and an automation plan for deduping/archiving duplicate recommendations; add suppression support so admins can mark false-positive groups to be kept separate. 
- Files changed (key edits): `src/lib/dossier-workflow.ts` (audit types, classification logic, duplicate-recommendation grouping), `src/lib/dossier-workflow-store.ts` (state field for suppressions, automation runner, safe merge/attach implementations, helper utilities), `src/app/api/admin/dossiers/route.ts` (new `runDossierPopulationAutomation` action wiring and payload handling), `src/app/admin/dossiers/page.tsx` (UI for automation summary, group-level actions, bulk safe cleanup button). 

### Testing

- No automated tests were executed as part of this rollout. I updated the audit and automation behavior and added server-side runner code; automated tests still need to be run in CI. 
- Suggested commands to run locally: `node --test tests/admin-dossiers.test.mjs` and `npx tsc --noEmit` to exercise the dossier workflow tests and type-check the repo; these will validate that population audit still renders and that automation classifications are present (tests listed in the task describe expected coverage).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2afee1ea348321bc3b3818cc80bb68)