### PR TITLE
Source File Consolidation Planning Audit + Two‑Column Merge Plan UI

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -446,8 +446,9 @@ export default function DossierControlCenterPage() {
         candidates,
         recommendations,
         publicDossiers,
+        drafts,
       }),
-    [candidates, recommendations, publicDossiers],
+    [candidates, recommendations, publicDossiers, drafts],
   );
 
   async function postWorkflow(body: Record<string, unknown>) {
@@ -887,7 +888,9 @@ export default function DossierControlCenterPage() {
                 <div className="space-y-3">
                   {populationAudit.possibleDuplicateGroups
                     .slice(0, 10)
-                    .map((group) => (
+                    .map((group) => {
+                      const plan = group.consolidationPlan;
+                      return (
                       <article
                         key={group.id}
                         className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
@@ -895,73 +898,108 @@ export default function DossierControlCenterPage() {
                         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                           <div>
                             <p className="font-semibold text-foreground">
-                              Needs admin review — {group.reason}
+                              Consolidation plan — Automation tier: {plan.automationTier}
                             </p>
-                            <p>
-                              Suggested safe action: {group.suggestedAction}
-                            </p>
+                            <p>Match reason: {plan.reason}</p>
+                            <p>Target selection: {plan.targetSelectionReason}</p>
+                            <p>Recommended next step: {plan.recommendedNextStep}</p>
+                            {plan.blockedReasons.length > 0 && (
+                              <p>Blocked because: {plan.blockedReasons.join(" ")}</p>
+                            )}
                             {group.publicDossierMatch && (
                               <p>
-                                Public dossier match:{" "}
+                                Public dossier match: {" "}
                                 {group.publicDossierMatch.name ??
                                   group.publicDossierMatch.id}
                               </p>
                             )}
                           </div>
-                          <StatusPill>{group.matchKind}</StatusPill>
+                          <StatusPill>{plan.confidence} confidence</StatusPill>
                         </div>
-                        <div className="mt-3 grid gap-2 md:grid-cols-2">
-                          {group.records.map((record) => (
-                            <div
-                              key={`${group.id}-${record.type}-${record.id}`}
-                              className="border border-border/60 bg-background/30 p-3"
-                            >
-                              <p className="font-semibold text-foreground">
-                                {record.name}
-                              </p>
-                              <p>
-                                Type/status: {record.type} / {record.status}
-                              </p>
-                              <p>
-                                Candidate/source file ID:{" "}
-                                {record.candidateId ?? "—"}
-                              </p>
-                              <p>
-                                Recommendation ID:{" "}
-                                {record.recommendationId ?? "—"}
-                              </p>
-                              <p>
-                                Confirmed aliases: {record.confirmedAliasCount}
-                              </p>
-                              <p>
-                                Proposed aliases: {record.proposedAliasCount}
-                              </p>
-                              <p>
-                                Recommendation count:{" "}
-                                {record.attachedRecommendationCount}
-                              </p>
-                              {record.publicDossierId && (
-                                <p>
-                                  Public dossier target:{" "}
-                                  {record.publicDossierName ??
-                                    record.publicDossierId}
-                                </p>
-                              )}
-                              {record.href && (
-                                <Link
-                                  href={record.href}
-                                  className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent"
-                                >
-                                  {record.type === "recommendation"
-                                    ? "Open recommendation"
-                                    : "Open Source File"}
-                                </Link>
-                              )}
-                            </div>
-                          ))}
+                        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                          <div className="border border-border/60 bg-background/30 p-3">
+                            <p className="text-xs uppercase tracking-[0.3em] text-accent">
+                              Merging / Source
+                            </p>
+                            {plan.sourceRecords.length === 0 ? (
+                              <p className="mt-2">No source record selected yet.</p>
+                            ) : (
+                              <div className="mt-2 space-y-3">
+                                {plan.sourceRecords.map((record) => (
+                                  <div key={`${group.id}-source-${record.type}-${record.id}`}>
+                                    <p className="font-semibold text-foreground">{record.name}</p>
+                                    <p>Record type/status: {record.type} / {record.status}</p>
+                                    <p>Candidate/source file ID: {record.candidateId ?? "—"}</p>
+                                    <p>Recommendation ID: {record.recommendationId ?? "—"}</p>
+                                    <p>Public dossier match: {record.publicDossierName ?? record.publicDossierId ?? "none"}</p>
+                                    <p>Active draft status: {record.activeDraftStatus ?? "no active draft"}</p>
+                                    <p>Confirmed aliases count: {record.confirmedAliasCount}</p>
+                                    <p>Proposed aliases count: {record.proposedAliasCount}</p>
+                                    <p>Source notes count: {record.sourceNotesCount}</p>
+                                    <p>Recommendations count: {record.attachedRecommendationCount}</p>
+                                    <p>Archive/report status: {record.hasLatestArchiveOrReport ? "archive/report present" : "no archive/report detected"}</p>
+                                    <p>Unique info: {record.uniqueInfo.join("; ")}</p>
+                                    {record.href && (
+                                      <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">
+                                        {record.type === "recommendation" ? "Open recommendation" : "Open source Source File"}
+                                      </Link>
+                                    )}
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                          <div className="border border-accent/50 bg-accent/5 p-3">
+                            <p className="text-xs uppercase tracking-[0.3em] text-accent">
+                              Merge Target / Keep
+                            </p>
+                            {plan.targetRecord ? (
+                              <div className="mt-2">
+                                <p className="font-semibold text-foreground">{plan.targetRecord.name}</p>
+                                <p>Record type/status: {plan.targetRecord.type} / {plan.targetRecord.status}</p>
+                                <p>Candidate/source file ID: {plan.targetRecord.candidateId ?? "—"}</p>
+                                <p>Recommendation ID: {plan.targetRecord.recommendationId ?? "—"}</p>
+                                <p>Public dossier match: {plan.targetRecord.publicDossierName ?? plan.targetRecord.publicDossierId ?? "none"}</p>
+                                <p>Active draft status: {plan.targetRecord.activeDraftStatus ?? "no active draft"}</p>
+                                <p>Confirmed aliases count: {plan.targetRecord.confirmedAliasCount}</p>
+                                <p>Proposed aliases count: {plan.targetRecord.proposedAliasCount}</p>
+                                <p>Source notes count: {plan.targetRecord.sourceNotesCount}</p>
+                                <p>Recommendations count: {plan.targetRecord.attachedRecommendationCount}</p>
+                                <p>Archive/report status: {plan.targetRecord.hasLatestArchiveOrReport ? "archive/report present" : "no archive/report detected"}</p>
+                                <p>Unique info: {plan.targetRecord.uniqueInfo.join("; ")}</p>
+                                <p className="mt-2 text-foreground">Why this target: {plan.targetSelectionReason}</p>
+                                {plan.targetRecord.href && (
+                                  <Link href={plan.targetRecord.href} className="mt-2 inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
+                                    Open target Source File
+                                  </Link>
+                                )}
+                              </div>
+                            ) : (
+                              <p className="mt-2">Needs Source File target before any future action.</p>
+                            )}
+                          </div>
+                        </div>
+                        <div className="mt-4 space-y-2">
+                          <p className="text-xs uppercase tracking-[0.3em] text-accent">Field-level merge plan</p>
+                          <p className="sr-only">Identity / aliases Recommendations / BNL Signals Source notes Archives / BNL reports Drafts / public dossiers Safety</p>
+                          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                            {plan.mergePlanSections.map((section) => (
+                              <div key={`${group.id}-${section.title}`} className="border border-border/60 bg-background/30 p-3">
+                                <p className="font-semibold text-foreground">{section.title}</p>
+                                <p>Will add later: {section.willAddLater.join("; ") || "—"}</p>
+                                <p>Already present: {section.alreadyPresent.join("; ") || "—"}</p>
+                                <p>Needs review: {section.needsReview.join("; ") || "—"}</p>
+                                <p>Will not publish: {section.willNotPublish.join("; ") || "—"}</p>
+                              </div>
+                            ))}
+                          </div>
+                          <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
+                            {plan.automationTier === "Auto-clean candidate" ? "Clean Later" : "Auto-Merge Later"}
+                          </button>
                         </div>
                       </article>
-                    ))}
+                      );
+                    })}
                 </div>
               )}
             </section>
@@ -991,9 +1029,11 @@ export default function DossierControlCenterPage() {
                         </th>
                         <th className="py-2 pr-3">Confidence</th>
                         <th className="py-2 pr-3">Created / updated</th>
-                        <th className="py-2 pr-3">Matching Source File?</th>
-                        <th className="py-2 pr-3">Safe next action</th>
-                        <th className="py-2 pr-3">Action</th>
+                        <th className="py-2 pr-3">Likely target</th>
+                        <th className="py-2 pr-3">Match reason</th>
+                        <th className="py-2 pr-3">Classification</th>
+                        <th className="py-2 pr-3">What would happen later</th>
+                        <th className="py-2 pr-3">Review link</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -1021,12 +1061,18 @@ export default function DossierControlCenterPage() {
                               {formatDate(recommendation.updatedAt)}
                             </td>
                             <td className="py-3 pr-3">
-                              {recommendation.matchingSourceFileName
-                                ? `${recommendation.matchingSourceFileName} (${recommendation.matchBasis})`
-                                : "No clear active Source File match"}
+                              {recommendation.likelyTargetName
+                                ? `${recommendation.likelyTargetName} (${recommendation.matchBasis})`
+                                : "Needs Source File target"}
                             </td>
                             <td className="py-3 pr-3">
-                              {recommendation.safeNextAction}
+                              {recommendation.matchReason}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.planClassification}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {recommendation.wouldHappenLater}
                             </td>
                             <td className="py-3 pr-3">
                               <Link

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -991,7 +991,17 @@ export default function DossierControlCenterPage() {
                               </div>
                             ) : (
                               <div className="mt-2">
-                                <p className="font-semibold text-foreground">No Source File target resolved</p>
+                                <p className="font-semibold text-foreground">Suggested workspace to create</p>
+                                {plan.existingPublicDossier && (
+                                  <p>Existing public dossier: {plan.existingPublicDossier.name ?? plan.existingPublicDossier.id}</p>
+                                )}
+                                {plan.suggestedWorkspace && (
+                                  <p>Recommended workspace: {plan.suggestedWorkspace}</p>
+                                )}
+                                {plan.possibleTargetRecords.length > 0 && (
+                                  <p>Possible targets: {plan.possibleTargetRecords.map((record) => record.displayName ?? record.name).join("; ")}</p>
+                                )}
+                                <p>No Source File target resolved</p>
                                 <p>{plan.recommendedNextStep}</p>
                               </div>
                             )}
@@ -1014,15 +1024,19 @@ export default function DossierControlCenterPage() {
                             ))}
                           </div>
                           <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
-                            {plan.automationTier === "Dossier update candidate"
-                              ? "Dossier Update Later"
-                              : plan.automationTier === "Recommendation attach candidate"
-                                ? "Attach Later"
-                                : plan.automationTier === "Source File merge candidate"
-                                  ? "Merge Later"
-                                  : plan.automationTier === "Empty duplicate cleanup candidate"
-                                    ? "Clean Later"
-                                    : "Needs Source File Target"}
+                            {plan.automationTier === "Create Dossier Update workspace candidate"
+                              ? "Create Dossier Update Later"
+                              : plan.automationTier === "Create Source File candidate"
+                                ? "Create Source File Later"
+                                : plan.automationTier === "Attach to Existing Source File candidate"
+                                  ? "Attach Later"
+                                  : plan.automationTier === "Select Target Manually"
+                                    ? "Select Target Later"
+                                    : plan.automationTier === "Source File merge candidate"
+                                      ? "Merge Later"
+                                      : plan.automationTier === "Empty duplicate cleanup candidate"
+                                        ? "Clean Later"
+                                        : "Needs Source File Target"}
                           </button>
                         </div>
                       </article>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -919,29 +919,38 @@ export default function DossierControlCenterPage() {
                         <div className="mt-3 grid gap-3 lg:grid-cols-2">
                           <div className="border border-border/60 bg-background/30 p-3">
                             <p className="text-xs uppercase tracking-[0.3em] text-accent">
-                              Merging / Source
+                              Merging / Incoming Info
                             </p>
                             {plan.sourceRecords.length === 0 ? (
-                              <p className="mt-2">No source record selected yet.</p>
+                              <p className="mt-2">No incoming information selected yet.</p>
                             ) : (
                               <div className="mt-2 space-y-3">
                                 {plan.sourceRecords.map((record) => (
                                   <div key={`${group.id}-source-${record.type}-${record.id}`}>
-                                    <p className="font-semibold text-foreground">{record.name}</p>
-                                    <p>Record type/status: {record.type} / {record.status}</p>
-                                    <p>Candidate/source file ID: {record.candidateId ?? "—"}</p>
-                                    <p>Recommendation ID: {record.recommendationId ?? "—"}</p>
-                                    <p>Public dossier match: {record.publicDossierName ?? record.publicDossierId ?? "none"}</p>
-                                    <p>Active draft status: {record.activeDraftStatus ?? "no active draft"}</p>
-                                    <p>Confirmed aliases count: {record.confirmedAliasCount}</p>
-                                    <p>Proposed aliases count: {record.proposedAliasCount}</p>
-                                    <p>Source notes count: {record.sourceNotesCount}</p>
-                                    <p>Recommendations count: {record.attachedRecommendationCount}</p>
-                                    <p>Archive/report status: {record.hasLatestArchiveOrReport ? "archive/report present" : "no archive/report detected"}</p>
-                                    <p>Unique info: {record.uniqueInfo.join("; ")}</p>
+                                    <p className="font-semibold text-foreground">{record.displayName ?? record.name}</p>
+                                    {record.type === "recommendation" ? (
+                                      <p>Incoming recommendation subject: {record.name}</p>
+                                    ) : (
+                                      <p>Incoming record: {record.type} / {record.status}</p>
+                                    )}
+                                    {record.sourceLanes && record.sourceLanes.length > 0 && (
+                                      <p>Source lanes: {record.sourceLanes.join(", ")}</p>
+                                    )}
+                                    {(record.publicDossierName || record.publicDossierId) && (
+                                      <p>Public dossier match: {record.publicDossierName ?? record.publicDossierId}</p>
+                                    )}
+                                    {record.incomingInfo.length > 0 && (
+                                      <p>What this would add: {record.incomingInfo.join("; ")}</p>
+                                    )}
+                                    {record.duplicateInfo.length > 0 && (
+                                      <p>Already represented / duplicate: {record.duplicateInfo.join("; ")}</p>
+                                    )}
+                                    {!plan.targetRecord && (
+                                      <p>Needs Source File target before any future action.</p>
+                                    )}
                                     {record.href && (
                                       <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">
-                                        {record.type === "recommendation" ? "Open recommendation" : "Open source Source File"}
+                                        {record.type === "recommendation" ? "Open incoming recommendation" : "Open source Source File"}
                                       </Link>
                                     )}
                                   </div>
@@ -949,25 +958,31 @@ export default function DossierControlCenterPage() {
                               </div>
                             )}
                           </div>
-                          <div className="border border-accent/50 bg-accent/5 p-3">
+                          <div className={plan.targetRecord ? "border border-accent/50 bg-accent/5 p-3" : "border border-border/60 bg-background/30 p-3"}>
                             <p className="text-xs uppercase tracking-[0.3em] text-accent">
-                              Merge Target / Keep
+                              Target / Keep
                             </p>
                             {plan.targetRecord ? (
                               <div className="mt-2">
-                                <p className="font-semibold text-foreground">{plan.targetRecord.name}</p>
-                                <p>Record type/status: {plan.targetRecord.type} / {plan.targetRecord.status}</p>
-                                <p>Candidate/source file ID: {plan.targetRecord.candidateId ?? "—"}</p>
-                                <p>Recommendation ID: {plan.targetRecord.recommendationId ?? "—"}</p>
-                                <p>Public dossier match: {plan.targetRecord.publicDossierName ?? plan.targetRecord.publicDossierId ?? "none"}</p>
-                                <p>Active draft status: {plan.targetRecord.activeDraftStatus ?? "no active draft"}</p>
-                                <p>Confirmed aliases count: {plan.targetRecord.confirmedAliasCount}</p>
-                                <p>Proposed aliases count: {plan.targetRecord.proposedAliasCount}</p>
-                                <p>Source notes count: {plan.targetRecord.sourceNotesCount}</p>
-                                <p>Recommendations count: {plan.targetRecord.attachedRecommendationCount}</p>
-                                <p>Archive/report status: {plan.targetRecord.hasLatestArchiveOrReport ? "archive/report present" : "no archive/report detected"}</p>
-                                <p>Unique info: {plan.targetRecord.uniqueInfo.join("; ")}</p>
-                                <p className="mt-2 text-foreground">Why this target: {plan.targetSelectionReason}</p>
+                                <p className="font-semibold text-foreground">{plan.targetDisplayName ?? plan.targetRecord.displayName ?? plan.targetRecord.name}</p>
+                                {plan.targetDisplayReason && (
+                                  <p>{plan.targetDisplayReason}</p>
+                                )}
+                                {plan.targetSourceFileLabel && plan.targetDisplayName !== plan.targetSourceFileLabel && (
+                                  <p>Source File label: {plan.targetSourceFileLabel}</p>
+                                )}
+                                <p>Target type/status: {plan.targetRecord.type} / {plan.targetRecord.status}</p>
+                                <p>Why selected: {plan.targetSelectionReason}</p>
+                                {(plan.targetRecord.publicDossierName || plan.targetRecord.publicDossierId) && (
+                                  <p>Dossier status: public dossier match {plan.targetRecord.publicDossierName ?? plan.targetRecord.publicDossierId}</p>
+                                )}
+                                {plan.targetRecord.activeDraftStatus && (
+                                  <p>Draft status: {plan.targetRecord.activeDraftStatus}</p>
+                                )}
+                                {plan.targetRecord.uniqueInfo.length > 0 && (
+                                  <p>Target already has: {plan.targetRecord.uniqueInfo.join("; ")}</p>
+                                )}
+                                <p>What would be updated later: {plan.automationTier}</p>
                                 {plan.targetRecord.href && (
                                   <Link href={plan.targetRecord.href} className="mt-2 inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
                                     Open target Source File
@@ -975,26 +990,39 @@ export default function DossierControlCenterPage() {
                                 )}
                               </div>
                             ) : (
-                              <p className="mt-2">Needs Source File target before any future action.</p>
+                              <div className="mt-2">
+                                <p className="font-semibold text-foreground">No Source File target resolved</p>
+                                <p>{plan.recommendedNextStep}</p>
+                              </div>
                             )}
                           </div>
                         </div>
                         <div className="mt-4 space-y-2">
-                          <p className="text-xs uppercase tracking-[0.3em] text-accent">Field-level merge plan</p>
-                          <p className="sr-only">Identity / aliases Recommendations / BNL Signals Source notes Archives / BNL reports Drafts / public dossiers Safety</p>
+                          <p className="text-xs uppercase tracking-[0.3em] text-accent">Field-level plan</p>
+                          <p className="sr-only">New info to add Already represented / duplicate info Irrelevant to kept entry Needs review Blocked reason No action needed</p>
                           <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                             {plan.mergePlanSections.map((section) => (
                               <div key={`${group.id}-${section.title}`} className="border border-border/60 bg-background/30 p-3">
                                 <p className="font-semibold text-foreground">{section.title}</p>
-                                <p>Will add later: {section.willAddLater.join("; ") || "—"}</p>
-                                <p>Already present: {section.alreadyPresent.join("; ") || "—"}</p>
+                                <p>New info to add: {section.newInfoToAdd.join("; ") || "—"}</p>
+                                <p>Already represented / duplicate info: {section.alreadyRepresented.join("; ") || "—"}</p>
+                                <p>Irrelevant to kept entry: {section.irrelevantToKeptEntry.join("; ") || "—"}</p>
                                 <p>Needs review: {section.needsReview.join("; ") || "—"}</p>
-                                <p>Will not publish: {section.willNotPublish.join("; ") || "—"}</p>
+                                <p>Blocked reason: {section.blockedReason.join("; ") || "—"}</p>
+                                <p>No action needed: {section.noActionNeeded.join("; ") || "—"}</p>
                               </div>
                             ))}
                           </div>
                           <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
-                            {plan.automationTier === "Auto-clean candidate" ? "Clean Later" : "Auto-Merge Later"}
+                            {plan.automationTier === "Dossier update candidate"
+                              ? "Dossier Update Later"
+                              : plan.automationTier === "Recommendation attach candidate"
+                                ? "Attach Later"
+                                : plan.automationTier === "Source File merge candidate"
+                                  ? "Merge Later"
+                                  : plan.automationTier === "Empty duplicate cleanup candidate"
+                                    ? "Clean Later"
+                                    : "Needs Source File Target"}
                           </button>
                         </div>
                       </article>
@@ -1079,7 +1107,7 @@ export default function DossierControlCenterPage() {
                                 href={recommendation.href}
                                 className="inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background"
                               >
-                                Open recommendation
+                                Open incoming recommendation
                               </Link>
                             </td>
                           </tr>

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -764,6 +764,44 @@ export type DossierPopulationAuditRecord = {
   proposedAliasCount: number;
   attachedRecommendationCount: number;
   missingLatestCaseReport: boolean;
+  activeDraftStatus?: DossierDraftStatus;
+  sourceNotesCount: number;
+  hasLatestArchiveOrReport: boolean;
+  uniqueInfo: string[];
+};
+
+export type DossierPopulationAutomationTier =
+  | "Auto-clean candidate"
+  | "Auto-merge candidate"
+  | "Auto-attach candidate"
+  | "Review required"
+  | "Blocked"
+  | "Keep separate / false positive"
+  | "Needs Source File target"
+  | "Recommendation-only duplicate group";
+
+export type DossierPopulationMergePlanSection = {
+  title: string;
+  willAddLater: string[];
+  alreadyPresent: string[];
+  needsReview: string[];
+  willNotPublish: string[];
+};
+
+export type DossierPopulationConsolidationPlan = {
+  groupId: string;
+  groupType: DossierPopulationAuditDuplicateGroup["matchKind"];
+  confidence: "high" | "medium" | "low";
+  reason: string;
+  targetRecord?: DossierPopulationAuditRecord;
+  sourceRecords: DossierPopulationAuditRecord[];
+  targetSelectionReason: string;
+  automationTier: DossierPopulationAutomationTier;
+  recommendedNextStep: string;
+  canBeAutomatedLater: boolean;
+  requiresReview: boolean;
+  blockedReasons: string[];
+  mergePlanSections: DossierPopulationMergePlanSection[];
 };
 
 export type DossierPopulationAuditDuplicateGroup = {
@@ -778,6 +816,7 @@ export type DossierPopulationAuditDuplicateGroup = {
   publicDossierMatch?: { id: string; name?: string };
   records: DossierPopulationAuditRecord[];
   suggestedAction: string;
+  consolidationPlan: DossierPopulationConsolidationPlan;
 };
 
 export type DossierPopulationAuditUnattachedRecommendation = {
@@ -794,6 +833,11 @@ export type DossierPopulationAuditUnattachedRecommendation = {
   matchBasis?: string;
   href: string;
   safeNextAction: string;
+  likelyTargetId?: string;
+  likelyTargetName?: string;
+  planClassification: DossierPopulationAutomationTier;
+  matchReason: string;
+  wouldHappenLater: string;
 };
 
 export type DossierPopulationAudit = {
@@ -891,10 +935,238 @@ function duplicateGroupAction(
   return "Review manually before drafting; confirm alias or archive stale duplicate only after owner/admin decision.";
 }
 
+
+function auditRecordUniqueInfo(input: {
+  confirmedAliasCount: number;
+  proposedAliasCount: number;
+  sourceNotesCount: number;
+  attachedRecommendationCount: number;
+  hasLatestArchiveOrReport: boolean;
+  activeDraftStatus?: DossierDraftStatus;
+  publicDossierId?: string;
+}): string[] {
+  const info: string[] = [];
+  if (input.confirmedAliasCount > 0)
+    info.push(`${input.confirmedAliasCount} confirmed alias${input.confirmedAliasCount === 1 ? "" : "es"}`);
+  if (input.proposedAliasCount > 0)
+    info.push(`${input.proposedAliasCount} proposed alias${input.proposedAliasCount === 1 ? "" : "es"}`);
+  if (input.sourceNotesCount > 0)
+    info.push(`${input.sourceNotesCount} active source note${input.sourceNotesCount === 1 ? "" : "s"}`);
+  if (input.attachedRecommendationCount > 0)
+    info.push(`${input.attachedRecommendationCount} BNL recommendation${input.attachedRecommendationCount === 1 ? "" : "s"}`);
+  if (input.hasLatestArchiveOrReport) info.push("latest BNL archive or case report");
+  if (input.activeDraftStatus) info.push(`active proposed dossier (${input.activeDraftStatus})`);
+  if (input.publicDossierId) info.push("public dossier match");
+  return info.length > 0 ? info : ["No unique useful data detected by audit."];
+}
+
+function recordHasUsefulData(record: DossierPopulationAuditRecord): boolean {
+  return (
+    record.confirmedAliasCount > 0 ||
+    record.proposedAliasCount > 0 ||
+    record.sourceNotesCount > 0 ||
+    record.attachedRecommendationCount > 0 ||
+    record.hasLatestArchiveOrReport ||
+    Boolean(record.activeDraftStatus) ||
+    Boolean(record.publicDossierId)
+  );
+}
+
+function targetScore(record: DossierPopulationAuditRecord): number {
+  let score = 0;
+  if (record.publicDossierId) score += 100;
+  if (record.activeDraftStatus) score += 80;
+  if (record.type === "source_file" || record.type === "dossier_update") score += 60;
+  if (record.type === "candidate_intake") score += 30;
+  if (record.type === "recommendation") score += 5;
+  score += record.confirmedAliasCount * 8;
+  if (record.hasLatestArchiveOrReport) score += 7;
+  score += record.sourceNotesCount * 3;
+  score += record.attachedRecommendationCount * 2;
+  return score;
+}
+
+function targetSelectionReason(record?: DossierPopulationAuditRecord): string {
+  if (!record) return "No Source File or candidate target could be resolved.";
+  if (record.publicDossierId)
+    return "Selected because it already has an existing public dossier match.";
+  if (record.activeDraftStatus)
+    return "Selected because it has an active proposed dossier draft.";
+  if (record.type === "source_file" || record.type === "dossier_update")
+    return "Selected because an active Source File / Case File is safer than candidate intake or a loose recommendation.";
+  if (record.confirmedAliasCount > 0)
+    return "Selected because it has confirmed aliases that can safely support matching.";
+  if (record.hasLatestArchiveOrReport)
+    return "Selected because it has the latest BNL Source File archive or case report evidence.";
+  if (record.sourceNotesCount > 0 || record.attachedRecommendationCount > 0)
+    return "Selected because it has more source notes, recommendations, or evidence.";
+  return "Selected as the older stable record after higher-priority target signals tied.";
+}
+
+function planSection(
+  title: string,
+  willAddLater: string[],
+  alreadyPresent: string[],
+  needsReview: string[],
+  willNotPublish: string[],
+): DossierPopulationMergePlanSection {
+  return { title, willAddLater, alreadyPresent, needsReview, willNotPublish };
+}
+
+function createConsolidationPlan(input: {
+  id: string;
+  matchKind: DossierPopulationAuditDuplicateGroup["matchKind"];
+  reason: string;
+  records: DossierPopulationAuditRecord[];
+}): DossierPopulationConsolidationPlan {
+  const records = uniqueAuditRecords(input.records);
+  const candidateRecords = records.filter((record) => record.type !== "recommendation");
+  const recommendationRecords = records.filter((record) => record.type === "recommendation");
+  const sortedCandidates = [...candidateRecords].sort(
+    (left, right) =>
+      targetScore(right) - targetScore(left) ||
+      left.status.localeCompare(right.status) ||
+      left.id.localeCompare(right.id),
+  );
+  const targetRecord = sortedCandidates[0];
+  const sourceRecords = targetRecord
+    ? records.filter((record) => recordKey(record) !== recordKey(targetRecord))
+    : records;
+  const publicTargets = new Set(records.map((record) => record.publicDossierId).filter(Boolean));
+  const activeDraftCount = records.filter((record) => record.activeDraftStatus).length;
+  const blockedReasons: string[] = [];
+  if (publicTargets.size > 1) blockedReasons.push("Different public dossier matches are present.");
+  if (activeDraftCount > 1) blockedReasons.push("Multiple records have active proposed dossiers.");
+  if (!targetRecord) blockedReasons.push("Needs Source File target: no active Source File or candidate record exists in this group.");
+  if (records.some((record) => record.status === "merged" || record.status === "deleted")) {
+    blockedReasons.push("Already merged/deleted record involved.");
+  }
+
+  let automationTier: DossierPopulationAutomationTier = "Review required";
+  if (blockedReasons.length > 0) automationTier = targetRecord ? "Blocked" : "Recommendation-only duplicate group";
+  else if (
+    sourceRecords.length > 0 &&
+    sourceRecords.every((record) => !recordHasUsefulData(record))
+  ) automationTier = "Auto-clean candidate";
+  else if (
+    recommendationRecords.length > 0 &&
+    sourceRecords.every((record) => record.type === "recommendation") &&
+    (input.matchKind === "normalized_name" || input.matchKind === "confirmed_alias" || input.matchKind === "recommendation_subject_key" || input.matchKind === "bnl_recommendation_subject_name")
+  ) automationTier = "Auto-attach candidate";
+  else if (
+    input.matchKind === "normalized_name" ||
+    input.matchKind === "confirmed_alias" ||
+    input.matchKind === "public_dossier"
+  ) automationTier = "Auto-merge candidate";
+  if (records.some((record) => record.proposedAliasCount > 0) && input.matchKind !== "confirmed_alias") {
+    automationTier = automationTier === "Blocked" ? automationTier : "Review required";
+  }
+
+  const canBeAutomatedLater = [
+    "Auto-clean candidate",
+    "Auto-merge candidate",
+    "Auto-attach candidate",
+  ].includes(automationTier);
+  const requiresReview = !canBeAutomatedLater || records.some((record) => record.proposedAliasCount > 0);
+
+  return {
+    groupId: input.id,
+    groupType: input.matchKind,
+    confidence:
+      input.matchKind === "confirmed_alias" || input.matchKind === "public_dossier"
+        ? "high"
+        : input.matchKind === "normalized_name"
+          ? "medium"
+          : "low",
+    reason: input.reason,
+    targetRecord,
+    sourceRecords,
+    targetSelectionReason: targetSelectionReason(targetRecord),
+    automationTier,
+    recommendedNextStep: canBeAutomatedLater
+      ? `${automationTier} only: verify the plan before enabling real cleanup actions in a future PR.`
+      : automationTier === "Recommendation-only duplicate group"
+        ? "Needs Source File target before any attach or merge action can be automated."
+        : "Admin review required before any future automation.",
+    canBeAutomatedLater,
+    requiresReview,
+    blockedReasons,
+    mergePlanSections: [
+      planSection(
+        "Identity / aliases",
+        sourceRecords.some((record) => record.confirmedAliasCount > 0)
+          ? ["Confirmed internal aliases could be moved later."]
+          : [],
+        targetRecord?.confirmedAliasCount ? ["Target already has confirmed aliases."] : [],
+        sourceRecords.some((record) => record.proposedAliasCount > 0)
+          ? ["Proposed aliases require human confirmation before use."]
+          : [],
+        ["Internal aliases stay internal and will not publish automatically."],
+      ),
+      planSection(
+        "Recommendations / BNL Signals",
+        sourceRecords.some((record) => record.attachedRecommendationCount > 0)
+          ? ["Would attach or preserve BNL recommendations later."]
+          : [],
+        targetRecord?.attachedRecommendationCount ? ["Target already has BNL recommendations."] : [],
+        recommendationRecords.length > 0 && !targetRecord
+          ? ["Recommendation-only duplicate group needs a Source File target."]
+          : [],
+        ["Duplicate signals will not change public dossier copy."],
+      ),
+      planSection(
+        "Source notes",
+        sourceRecords.some((record) => record.sourceNotesCount > 0)
+          ? ["Would move active source notes later."]
+          : [],
+        targetRecord?.sourceNotesCount ? ["Target already has source notes."] : [],
+        sourceRecords.some((record) => record.sourceNotesCount > 0) ? ["Review note ownership before moving."] : [],
+        ["Source notes remain internal until reviewed."],
+      ),
+      planSection(
+        "Archives / BNL reports",
+        sourceRecords.some((record) => record.hasLatestArchiveOrReport)
+          ? ["Source archive available to preserve later."]
+          : [],
+        targetRecord?.hasLatestArchiveOrReport ? ["Preserve target latest archive."] : [],
+        sourceRecords.some((record) => record.missingLatestCaseReport)
+          ? ["Source is missing latest archive/case report."]
+          : [],
+        sourceRecords.every((record) => !record.hasLatestArchiveOrReport)
+          ? ["No archive to move from source records."]
+          : [],
+      ),
+      planSection(
+        "Drafts / public dossiers",
+        [],
+        [
+          targetRecord?.activeDraftStatus ? `Target has draft (${targetRecord.activeDraftStatus}).` : "Target has no active draft.",
+          targetRecord?.publicDossierId ? "Public dossier match present on target." : "Public dossier match none on target.",
+        ],
+        [
+          ...sourceRecords.map((record) =>
+            `${record.name}: ${record.activeDraftStatus ? `source has draft (${record.activeDraftStatus})` : "source has no draft"}; ${record.publicDossierId ? "public dossier match present" : "public dossier match none"}.`,
+          ),
+          ...blockedReasons,
+        ],
+        [],
+      ),
+      planSection(
+        "Safety",
+        [],
+        ["Public dossier copy will not change.", "Nothing publishes automatically."],
+        requiresReview ? ["Human review gate remains required for unsafe or unclear data."] : [],
+        ["Internal aliases stay internal.", "No merge/delete/archive/attach action is live in this PR."],
+      ),
+    ],
+  };
+}
+
 export function createDossierPopulationAudit(input: {
   candidates: DossierCandidate[];
   recommendations?: DossierRecommendation[];
   publicDossiers?: Array<{ id: string; name: string }>;
+  drafts?: DossierDraft[];
 }): DossierPopulationAudit {
   const recommendations = input.recommendations ?? [];
   const bnlRecommendations = recommendations.filter(isBnlRecommendation);
@@ -904,6 +1176,16 @@ export function createDossierPopulationAudit(input: {
   const publicDossiersById = new Map(
     (input.publicDossiers ?? []).map((dossier) => [dossier.id, dossier]),
   );
+  const activeDraftByCandidateId = new Map<string, DossierDraft>();
+  for (const draft of input.drafts ?? []) {
+    if (
+      draft.status === "draft" ||
+      draft.status === "owner_changes_requested" ||
+      draft.status === "ready_for_owner_review"
+    ) {
+      activeDraftByCandidateId.set(draft.candidateId, draft);
+    }
+  }
 
   const bnlRecommendationIdsByCandidate = new Map<string, Set<string>>();
   for (const recommendation of bnlRecommendations) {
@@ -960,6 +1242,31 @@ export function createDossierPopulationAudit(input: {
         bnlRecommendationIdsByCandidate.get(candidate.id)?.size ?? 0,
       missingLatestCaseReport:
         candidateMissingLatestCaseReportOrEnrichment(candidate),
+      activeDraftStatus: activeDraftByCandidateId.get(candidate.id)?.status,
+      sourceNotesCount: (candidate.sourceFileNotes ?? []).filter(
+        (note) => note.status === "active",
+      ).length,
+      hasLatestArchiveOrReport: Boolean(
+        candidate.latestSourceFileArchiveUpdatedAt ||
+          candidate.latestSourceFileArchiveId ||
+          candidate.latestSourceFileArchive?.caseReportPresent,
+      ),
+      uniqueInfo: auditRecordUniqueInfo({
+        confirmedAliasCount,
+        proposedAliasCount,
+        sourceNotesCount: (candidate.sourceFileNotes ?? []).filter(
+          (note) => note.status === "active",
+        ).length,
+        attachedRecommendationCount:
+          bnlRecommendationIdsByCandidate.get(candidate.id)?.size ?? 0,
+        hasLatestArchiveOrReport: Boolean(
+          candidate.latestSourceFileArchiveUpdatedAt ||
+            candidate.latestSourceFileArchiveId ||
+            candidate.latestSourceFileArchive?.caseReportPresent,
+        ),
+        activeDraftStatus: activeDraftByCandidateId.get(candidate.id)?.status,
+        publicDossierId: candidate.existingDossierMatch?.id,
+      }),
     } satisfies DossierPopulationAuditRecord;
   });
   const recordByCandidateId = new Map(
@@ -1059,8 +1366,19 @@ export function createDossierPopulationAudit(input: {
         matchBasis,
         href: `/admin/dossiers/recommendations/${recommendation.id}`,
         safeNextAction: matchingSourceFile
-          ? "Review manually; attach to the matching Source File only after admin confirmation."
-          : "Review manually; decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
+          ? "Classification only: eligible to attach later after the classifier is approved."
+          : "Needs Source File target: decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
+        likelyTargetId: matchingSourceFile?.id,
+        likelyTargetName: matchingSourceFile?.name,
+        planClassification: matchingSourceFile
+          ? "Auto-attach candidate"
+          : "Needs Source File target",
+        matchReason: matchingSourceFile
+          ? `Exact/confirmed ${matchBasis ?? "subject"} match to active Source File.`
+          : "No exact normalized-name, subjectKey, or confirmed-alias active Source File target exists yet.",
+        wouldHappenLater: matchingSourceFile
+          ? "Later automation could attach this recommendation to the matching Source File without changing public dossier copy."
+          : "Later automation must wait until an admin selects or creates a Source File target.",
       } satisfies DossierPopulationAuditUnattachedRecommendation;
     })
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
@@ -1164,20 +1482,69 @@ export function createDossierPopulationAudit(input: {
       proposedAliasCount: 0,
       attachedRecommendationCount: 1,
       missingLatestCaseReport: false,
+      sourceNotesCount: 0,
+      hasLatestArchiveOrReport: false,
+      uniqueInfo: auditRecordUniqueInfo({
+        confirmedAliasCount: 0,
+        proposedAliasCount: 0,
+        sourceNotesCount: 0,
+        attachedRecommendationCount: 1,
+        hasLatestArchiveOrReport: false,
+        activeDraftStatus: undefined,
+        publicDossierId: recommendation.targetDossierId,
+      }),
     };
+    const recommendationSubjectKey = normalizeDossierSubjectName(
+      recommendation.subjectName,
+    );
+    const subjectKeyRecord = recommendation.subjectKey
+      ? normalizeDossierSubjectName(recommendation.subjectKey)
+      : "";
+    const matchingRecommendationSourceFile =
+      activeSourceFilesByNormalizedName.get(recommendationSubjectKey) ??
+      (subjectKeyRecord
+        ? activeSourceFilesByNormalizedName.get(subjectKeyRecord)
+        : undefined) ??
+      activeSourceFilesByConfirmedAlias.get(recommendationSubjectKey) ??
+      (subjectKeyRecord
+        ? activeSourceFilesByConfirmedAlias.get(subjectKeyRecord)
+        : undefined);
     addBucketRecord(
       "bnl_recommendation_subject_name",
-      normalizeDossierSubjectName(recommendation.subjectName),
-      "Same normalized subjectName from BNL recommendations.",
+      recommendationSubjectKey,
+      matchingRecommendationSourceFile
+        ? "BNL recommendation subject matches an active Source File target."
+        : "Same normalized subjectName from BNL recommendations.",
       record,
     );
+    const matchingRecommendationSourceFileRecord = matchingRecommendationSourceFile
+      ? recordByCandidateId.get(matchingRecommendationSourceFile.id)
+      : undefined;
+    if (matchingRecommendationSourceFileRecord) {
+      addBucketRecord(
+        "bnl_recommendation_subject_name",
+        recommendationSubjectKey,
+        "BNL recommendation subject matches an active Source File target.",
+        matchingRecommendationSourceFileRecord,
+      );
+    }
     if (recommendation.subjectKey) {
       addBucketRecord(
         "recommendation_subject_key",
-        normalizeDossierSubjectName(recommendation.subjectKey),
-        "Same recommendation subjectKey.",
+        subjectKeyRecord,
+        matchingRecommendationSourceFile
+          ? "Recommendation subjectKey matches an active Source File target."
+          : "Same recommendation subjectKey.",
         record,
       );
+      if (matchingRecommendationSourceFileRecord) {
+        addBucketRecord(
+          "recommendation_subject_key",
+          subjectKeyRecord,
+          "Recommendation subjectKey matches an active Source File target.",
+          matchingRecommendationSourceFileRecord,
+        );
+      }
     }
     if (recommendation.targetDossierId) {
       addBucketRecord(
@@ -1204,6 +1571,15 @@ export function createDossierPopulationAudit(input: {
       publicDossierMatch: bucket.publicDossierMatch,
       records: uniqueAuditRecords(bucket.records),
       suggestedAction: duplicateGroupAction(bucket.matchKind, bucket.records),
+      consolidationPlan: createConsolidationPlan({
+        id: bucketKey
+          .replace(/[^a-z0-9]+/gi, "-")
+          .replace(/^-|-$/g, "")
+          .toLowerCase(),
+        matchKind: bucket.matchKind,
+        reason: bucket.reason,
+        records: uniqueAuditRecords(bucket.records),
+      }),
     }))
     .filter((group) => group.records.length >= 2)
     .sort(

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -775,8 +775,10 @@ export type DossierPopulationAuditRecord = {
 };
 
 export type DossierPopulationAutomationTier =
-  | "Dossier update candidate"
-  | "Recommendation attach candidate"
+  | "Create Source File candidate"
+  | "Create Dossier Update workspace candidate"
+  | "Attach to Existing Source File candidate"
+  | "Select Target Manually"
   | "Source File merge candidate"
   | "Empty duplicate cleanup candidate"
   | "Recommendation-only duplicate group"
@@ -804,6 +806,9 @@ export type DossierPopulationConsolidationPlan = {
   targetDisplayName?: string;
   targetSourceFileLabel?: string;
   targetDisplayReason?: string;
+  suggestedWorkspace?: "Dossier Update" | "New Source File / Candidate" | "Existing Source File";
+  existingPublicDossier?: { id: string; name?: string };
+  possibleTargetRecords: DossierPopulationAuditRecord[];
   targetSelectionReason: string;
   automationTier: DossierPopulationAutomationTier;
   recommendedNextStep: string;
@@ -1054,15 +1059,28 @@ function createConsolidationPlan(input: {
       left.status.localeCompare(right.status) ||
       left.id.localeCompare(right.id),
   );
-  const targetRecord = sortedTargets[0];
-  const sourceRecords = targetRecord
-    ? records.filter((record) => recordKey(record) !== recordKey(targetRecord))
+  const publicDossierRecords = records.filter((record) => record.publicDossierId);
+  const publicTargets = new Map<string, string | undefined>();
+  for (const record of publicDossierRecords) {
+    if (record.publicDossierId) {
+      publicTargets.set(record.publicDossierId, record.publicDossierName);
+    }
+  }
+  const possibleTargetRecords = sortedTargets;
+  const topTargetScore = sortedTargets[0]
+    ? realTargetPriority(sortedTargets[0])
+    : undefined;
+  const ambiguousTargetRecords =
+    sortedTargets.length > 1 &&
+    topTargetScore !== undefined &&
+    realTargetPriority(sortedTargets[1]) === topTargetScore;
+  const hasOnlyRecommendations = realRecords.length === 0;
+  const selectedTargetRecord = ambiguousTargetRecords ? undefined : sortedTargets[0];
+  const sourceRecords = selectedTargetRecord
+    ? records.filter((record) => recordKey(record) !== recordKey(selectedTargetRecord))
     : records;
   const realSourceRecords = sourceRecords.filter(
     (record) => record.type !== "recommendation",
-  );
-  const publicTargets = new Set(
-    records.map((record) => record.publicDossierId).filter(Boolean),
   );
   const activeDraftCount = realRecords.filter(
     (record) => record.activeDraftStatus,
@@ -1076,22 +1094,39 @@ function createConsolidationPlan(input: {
     blockedReasons.push("Already merged/deleted record involved.");
   }
 
-  const hasOnlyRecommendations = realRecords.length === 0;
   const hasRecommendationSources = recommendationRecords.length > 0;
   const hasRealDuplicateSources = realSourceRecords.length > 0;
   const allRealSourcesEmpty =
     hasRealDuplicateSources && realSourceRecords.every((record) => !recordHasUsefulData(record));
-  const sharedPublicTarget = publicTargets.size === 1 && Boolean(targetRecord?.publicDossierId);
+  const sharedPublicTarget = publicTargets.size === 1;
+  const existingPublicDossier = sharedPublicTarget
+    ? {
+        id: Array.from(publicTargets.keys())[0],
+        name: Array.from(publicTargets.values())[0],
+      }
+    : undefined;
+  const targetRecord = selectedTargetRecord;
+  const existingWorkspaceTarget = Boolean(targetRecord);
+  const suggestedWorkspace: DossierPopulationConsolidationPlan["suggestedWorkspace"] =
+    targetRecord
+      ? "Existing Source File"
+      : sharedPublicTarget
+        ? "Dossier Update"
+        : hasOnlyRecommendations
+          ? "New Source File / Candidate"
+          : undefined;
 
   let automationTier: DossierPopulationAutomationTier = "Review required";
-  if (hasOnlyRecommendations) {
-    automationTier = "Recommendation-only duplicate group";
-  } else if (blockedReasons.length > 0) {
+  if (blockedReasons.length > 0) {
     automationTier = "Blocked";
-  } else if (sharedPublicTarget && hasRecommendationSources && !hasRealDuplicateSources) {
-    automationTier = "Dossier update candidate";
-  } else if (hasRecommendationSources && !hasRealDuplicateSources) {
-    automationTier = "Recommendation attach candidate";
+  } else if (ambiguousTargetRecords) {
+    automationTier = "Select Target Manually";
+  } else if (hasOnlyRecommendations && sharedPublicTarget) {
+    automationTier = "Create Dossier Update workspace candidate";
+  } else if (hasOnlyRecommendations) {
+    automationTier = "Create Source File candidate";
+  } else if (hasRecommendationSources && existingWorkspaceTarget && !hasRealDuplicateSources) {
+    automationTier = "Attach to Existing Source File candidate";
   } else if (allRealSourcesEmpty) {
     automationTier = "Empty duplicate cleanup candidate";
   } else if (
@@ -1102,7 +1137,6 @@ function createConsolidationPlan(input: {
   }
   if (
     automationTier !== "Blocked" &&
-    automationTier !== "Recommendation-only duplicate group" &&
     records.some((record) => record.proposedAliasCount > 0) &&
     input.matchKind !== "confirmed_alias"
   ) {
@@ -1110,18 +1144,24 @@ function createConsolidationPlan(input: {
   }
 
   const canBeAutomatedLater = [
-    "Dossier update candidate",
-    "Recommendation attach candidate",
+    "Create Source File candidate",
+    "Create Dossier Update workspace candidate",
+    "Attach to Existing Source File candidate",
     "Source File merge candidate",
     "Empty duplicate cleanup candidate",
   ].includes(automationTier);
   const requiresReview = !canBeAutomatedLater || records.some((record) => record.proposedAliasCount > 0);
-  const noTargetExplanation =
-    "These are duplicate or related BNL recommendations, but no Source File target exists in this group yet. The next action is to attach them to an existing Source File if one matches, or create/select a Source File target later.";
+  const noTargetExplanation = sharedPublicTarget
+    ? `These are duplicate or related BNL recommendations for an existing public dossier, but no Dossier Update workspace exists in this group yet. The next action is to create/select a Dossier Update workspace later.`
+    : "These are duplicate or related BNL recommendations, but no Source File target exists in this group yet. The next action is to attach them to an existing Source File if one matches, or create/select a Source File target later.";
   const publicDossierUpdateExplanation =
-    targetRecord?.publicDossierId && hasRecommendationSources
-      ? `Existing public dossier match found. This should be reviewed as an update/attachment to the canonical ${targetDisplayName(targetRecord)} record, not merged into a separate duplicate Source File.`
+    (targetRecord?.publicDossierId || (hasOnlyRecommendations && sharedPublicTarget)) &&
+    hasRecommendationSources
+      ? `Existing public dossier match found. This should be reviewed as an update/attachment to the canonical ${targetDisplayName(targetRecord) ?? existingPublicDossier?.name ?? existingPublicDossier?.id} record, not merged into a separate duplicate Source File.`
       : undefined;
+  const manualTargetExplanation = ambiguousTargetRecords
+    ? "Several possible Source File targets have equal priority. Select the correct target manually before any future action."
+    : undefined;
 
   return {
     groupId: input.id,
@@ -1132,22 +1172,29 @@ function createConsolidationPlan(input: {
         : input.matchKind === "normalized_name"
           ? "medium"
           : "low",
-    reason: publicDossierUpdateExplanation ?? input.reason,
+    reason: publicDossierUpdateExplanation ?? manualTargetExplanation ?? input.reason,
     targetRecord,
     sourceRecords,
     targetDisplayName: targetDisplayName(targetRecord),
     targetSourceFileLabel: targetRecord?.name,
     targetDisplayReason: targetDisplayReason(targetRecord),
-    targetSelectionReason: targetSelectionReason(targetRecord),
+    suggestedWorkspace,
+    existingPublicDossier,
+    possibleTargetRecords,
+    targetSelectionReason: ambiguousTargetRecords
+      ? "No single Source File target was selected because multiple possible targets have the same priority."
+      : targetSelectionReason(targetRecord),
     automationTier,
-    recommendedNextStep: hasOnlyRecommendations
-      ? noTargetExplanation
-      : canBeAutomatedLater
-        ? `${automationTier}: review the deltas below before enabling any real action in a future PR.`
-        : "Admin review required before any future automation.",
+    recommendedNextStep: ambiguousTargetRecords
+      ? manualTargetExplanation ?? "Select the target manually before any future automation."
+      : hasOnlyRecommendations
+        ? noTargetExplanation
+        : canBeAutomatedLater
+          ? `${automationTier}: review the deltas below before enabling any real action in a future PR.`
+          : "Admin review required before any future automation.",
     canBeAutomatedLater,
     requiresReview,
-    blockedReasons: hasOnlyRecommendations
+    blockedReasons: hasOnlyRecommendations && !sharedPublicTarget
       ? ["No Source File target resolved."]
       : blockedReasons,
     mergePlanSections: [
@@ -1171,7 +1218,11 @@ function createConsolidationPlan(input: {
       planSection("Irrelevant to kept entry", {
         irrelevantToKeptEntry: sourceRecords
           .filter((record) => record.type === "recommendation" && !targetRecord)
-          .map((record) => `${record.name} cannot be merged until a Source File target exists.`),
+          .map((record) =>
+            suggestedWorkspace
+              ? `${record.name} is incoming recommendation material for a ${suggestedWorkspace} workspace, not a Source File merge target.`
+              : `${record.name} cannot be merged until a Source File target exists.`,
+          ),
       }),
       planSection("Needs review", {
         needsReview: [
@@ -1180,13 +1231,14 @@ function createConsolidationPlan(input: {
             : []),
           ...(publicDossierUpdateExplanation ? [publicDossierUpdateExplanation] : []),
           ...(hasOnlyRecommendations ? [noTargetExplanation] : []),
+          ...(manualTargetExplanation ? [manualTargetExplanation] : []),
         ],
       }),
       planSection("Blocked reason", {
-        blockedReason: hasOnlyRecommendations
+        blockedReason: hasOnlyRecommendations && !sharedPublicTarget
           ? ["No Source File target resolved."]
           : blockedReasons,
-        noActionNeeded: blockedReasons.length === 0 && !hasOnlyRecommendations
+        noActionNeeded: blockedReasons.length === 0 && !(hasOnlyRecommendations && !sharedPublicTarget)
           ? ["No blocker detected by this planning pass."]
           : [],
       }),
@@ -1195,7 +1247,7 @@ function createConsolidationPlan(input: {
           "Public dossier copy will not change.",
           "Internal aliases stay internal.",
           "Nothing publishes automatically.",
-          "No merge/delete/archive/attach action is live in this PR.",
+          "No merge/delete/archive/attach/create action is live in this PR.",
         ],
       }),
     ],
@@ -1423,18 +1475,22 @@ export function createDossierPopulationAudit(input: {
         likelyTargetId: matchingSourceFile?.id,
         likelyTargetName: matchingSourceFile?.existingDossierMatch?.name ?? matchingSourceFile?.name,
         planClassification: matchingSourceFile
-          ? matchingSourceFile.existingDossierMatch?.id || recommendation.targetDossierId
-            ? "Dossier update candidate"
-            : "Recommendation attach candidate"
-          : "Needs Source File target",
+          ? "Attach to Existing Source File candidate"
+          : recommendation.targetDossierId
+            ? "Create Dossier Update workspace candidate"
+            : "Create Source File candidate",
         matchReason: matchingSourceFile
           ? matchingSourceFile.existingDossierMatch?.name
             ? `Existing public dossier match found for ${matchingSourceFile.existingDossierMatch.name}; route as update/attachment, not a Source File merge.`
             : `Exact/confirmed ${matchBasis ?? "subject"} match to active Source File.`
-          : "No exact normalized-name, subjectKey, or confirmed-alias active Source File target exists yet.",
+          : recommendation.targetDossierId
+            ? "Existing public dossier match found, but no Source File/Dossier Update workspace target exists yet."
+            : "No exact normalized-name, subjectKey, or confirmed-alias active Source File target exists yet.",
         wouldHappenLater: matchingSourceFile
-          ? "Later automation could attach this recommendation or route it as a dossier update without changing public dossier copy."
-          : "Later automation must wait until an admin selects or creates a Source File target.",
+          ? "Later automation could attach this recommendation to the existing Source File without changing public dossier copy."
+          : recommendation.targetDossierId
+            ? "Later automation could create a Dossier Update workspace for the existing public dossier without changing public copy."
+            : "Later automation could create a new Source File / Candidate workspace after review.",
       } satisfies DossierPopulationAuditUnattachedRecommendation;
     })
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -758,6 +758,7 @@ export type DossierPopulationAuditRecord = {
   href?: string;
   candidateId?: string;
   recommendationId?: string;
+  displayName?: string;
   publicDossierId?: string;
   publicDossierName?: string;
   confirmedAliasCount: number;
@@ -768,24 +769,29 @@ export type DossierPopulationAuditRecord = {
   sourceNotesCount: number;
   hasLatestArchiveOrReport: boolean;
   uniqueInfo: string[];
+  incomingInfo: string[];
+  duplicateInfo: string[];
+  sourceLanes?: DossierRecommendationSourceLane[];
 };
 
 export type DossierPopulationAutomationTier =
-  | "Auto-clean candidate"
-  | "Auto-merge candidate"
-  | "Auto-attach candidate"
+  | "Dossier update candidate"
+  | "Recommendation attach candidate"
+  | "Source File merge candidate"
+  | "Empty duplicate cleanup candidate"
+  | "Recommendation-only duplicate group"
   | "Review required"
   | "Blocked"
-  | "Keep separate / false positive"
-  | "Needs Source File target"
-  | "Recommendation-only duplicate group";
+  | "Needs Source File target";
 
 export type DossierPopulationMergePlanSection = {
   title: string;
-  willAddLater: string[];
-  alreadyPresent: string[];
+  newInfoToAdd: string[];
+  alreadyRepresented: string[];
+  irrelevantToKeptEntry: string[];
   needsReview: string[];
-  willNotPublish: string[];
+  blockedReason: string[];
+  noActionNeeded: string[];
 };
 
 export type DossierPopulationConsolidationPlan = {
@@ -795,6 +801,9 @@ export type DossierPopulationConsolidationPlan = {
   reason: string;
   targetRecord?: DossierPopulationAuditRecord;
   sourceRecords: DossierPopulationAuditRecord[];
+  targetDisplayName?: string;
+  targetSourceFileLabel?: string;
+  targetDisplayReason?: string;
   targetSelectionReason: string;
   automationTier: DossierPopulationAutomationTier;
   recommendedNextStep: string;
@@ -968,49 +977,66 @@ function recordHasUsefulData(record: DossierPopulationAuditRecord): boolean {
     record.attachedRecommendationCount > 0 ||
     record.hasLatestArchiveOrReport ||
     Boolean(record.activeDraftStatus) ||
-    Boolean(record.publicDossierId)
+    Boolean(record.publicDossierId) ||
+    record.incomingInfo.length > 0
   );
 }
 
-function targetScore(record: DossierPopulationAuditRecord): number {
+function realTargetPriority(record: DossierPopulationAuditRecord): number {
+  if (record.type === "recommendation") return -1;
   let score = 0;
-  if (record.publicDossierId) score += 100;
-  if (record.activeDraftStatus) score += 80;
-  if (record.type === "source_file" || record.type === "dossier_update") score += 60;
-  if (record.type === "candidate_intake") score += 30;
-  if (record.type === "recommendation") score += 5;
-  score += record.confirmedAliasCount * 8;
-  if (record.hasLatestArchiveOrReport) score += 7;
-  score += record.sourceNotesCount * 3;
-  score += record.attachedRecommendationCount * 2;
+  if (record.publicDossierId) score += 1000;
+  if (record.type === "source_file" || record.type === "dossier_update") score += 800;
+  if (record.activeDraftStatus) score += 300;
+  if (record.hasLatestArchiveOrReport) score += 150;
+  if (record.confirmedAliasCount > 0) score += 100;
+  if (record.type === "candidate_intake") score += 50;
+  score += Math.min(record.sourceNotesCount, 20);
+  score += Math.min(record.attachedRecommendationCount, 20);
   return score;
 }
 
 function targetSelectionReason(record?: DossierPopulationAuditRecord): string {
-  if (!record) return "No Source File or candidate target could be resolved.";
+  if (!record)
+    return "No Source File target resolved. A real Source File/candidate target is missing from this group.";
   if (record.publicDossierId)
-    return "Selected because it already has an existing public dossier match.";
+    return "Selected because it is backed by an existing public dossier match.";
+  if (record.type === "source_file" || record.type === "dossier_update")
+    return "Selected because an active Source File / Case File is safer than candidate intake or loose recommendations.";
   if (record.activeDraftStatus)
     return "Selected because it has an active proposed dossier draft.";
-  if (record.type === "source_file" || record.type === "dossier_update")
-    return "Selected because an active Source File / Case File is safer than candidate intake or a loose recommendation.";
-  if (record.confirmedAliasCount > 0)
-    return "Selected because it has confirmed aliases that can safely support matching.";
   if (record.hasLatestArchiveOrReport)
     return "Selected because it has the latest BNL Source File archive or case report evidence.";
-  if (record.sourceNotesCount > 0 || record.attachedRecommendationCount > 0)
-    return "Selected because it has more source notes, recommendations, or evidence.";
-  return "Selected as the older stable record after higher-priority target signals tied.";
+  if (record.confirmedAliasCount > 0)
+    return "Selected because it has confirmed aliases that can safely support matching.";
+  return "Selected because it is the real candidate record available for this group; recommendations cannot be merge targets.";
 }
 
 function planSection(
   title: string,
-  willAddLater: string[],
-  alreadyPresent: string[],
-  needsReview: string[],
-  willNotPublish: string[],
+  input: Partial<DossierPopulationMergePlanSection>,
 ): DossierPopulationMergePlanSection {
-  return { title, willAddLater, alreadyPresent, needsReview, willNotPublish };
+  return {
+    title,
+    newInfoToAdd: input.newInfoToAdd ?? [],
+    alreadyRepresented: input.alreadyRepresented ?? [],
+    irrelevantToKeptEntry: input.irrelevantToKeptEntry ?? [],
+    needsReview: input.needsReview ?? [],
+    blockedReason: input.blockedReason ?? [],
+    noActionNeeded: input.noActionNeeded ?? [],
+  };
+}
+
+function targetDisplayName(record?: DossierPopulationAuditRecord): string | undefined {
+  return record?.publicDossierName || record?.publicDossierId || record?.name;
+}
+
+function targetDisplayReason(record?: DossierPopulationAuditRecord): string | undefined {
+  if (!record) return undefined;
+  if (record.publicDossierName && record.publicDossierName !== record.name) {
+    return "Target display is using the public dossier match.";
+  }
+  return undefined;
 }
 
 function createConsolidationPlan(input: {
@@ -1020,54 +1046,82 @@ function createConsolidationPlan(input: {
   records: DossierPopulationAuditRecord[];
 }): DossierPopulationConsolidationPlan {
   const records = uniqueAuditRecords(input.records);
-  const candidateRecords = records.filter((record) => record.type !== "recommendation");
+  const realRecords = records.filter((record) => record.type !== "recommendation");
   const recommendationRecords = records.filter((record) => record.type === "recommendation");
-  const sortedCandidates = [...candidateRecords].sort(
+  const sortedTargets = [...realRecords].sort(
     (left, right) =>
-      targetScore(right) - targetScore(left) ||
+      realTargetPriority(right) - realTargetPriority(left) ||
       left.status.localeCompare(right.status) ||
       left.id.localeCompare(right.id),
   );
-  const targetRecord = sortedCandidates[0];
+  const targetRecord = sortedTargets[0];
   const sourceRecords = targetRecord
     ? records.filter((record) => recordKey(record) !== recordKey(targetRecord))
     : records;
-  const publicTargets = new Set(records.map((record) => record.publicDossierId).filter(Boolean));
-  const activeDraftCount = records.filter((record) => record.activeDraftStatus).length;
+  const realSourceRecords = sourceRecords.filter(
+    (record) => record.type !== "recommendation",
+  );
+  const publicTargets = new Set(
+    records.map((record) => record.publicDossierId).filter(Boolean),
+  );
+  const activeDraftCount = realRecords.filter(
+    (record) => record.activeDraftStatus,
+  ).length;
   const blockedReasons: string[] = [];
-  if (publicTargets.size > 1) blockedReasons.push("Different public dossier matches are present.");
-  if (activeDraftCount > 1) blockedReasons.push("Multiple records have active proposed dossiers.");
-  if (!targetRecord) blockedReasons.push("Needs Source File target: no active Source File or candidate record exists in this group.");
+  if (publicTargets.size > 1)
+    blockedReasons.push("Different public dossier matches are present.");
+  if (activeDraftCount > 1)
+    blockedReasons.push("Multiple real records have active proposed dossiers.");
   if (records.some((record) => record.status === "merged" || record.status === "deleted")) {
     blockedReasons.push("Already merged/deleted record involved.");
   }
 
+  const hasOnlyRecommendations = realRecords.length === 0;
+  const hasRecommendationSources = recommendationRecords.length > 0;
+  const hasRealDuplicateSources = realSourceRecords.length > 0;
+  const allRealSourcesEmpty =
+    hasRealDuplicateSources && realSourceRecords.every((record) => !recordHasUsefulData(record));
+  const sharedPublicTarget = publicTargets.size === 1 && Boolean(targetRecord?.publicDossierId);
+
   let automationTier: DossierPopulationAutomationTier = "Review required";
-  if (blockedReasons.length > 0) automationTier = targetRecord ? "Blocked" : "Recommendation-only duplicate group";
-  else if (
-    sourceRecords.length > 0 &&
-    sourceRecords.every((record) => !recordHasUsefulData(record))
-  ) automationTier = "Auto-clean candidate";
-  else if (
-    recommendationRecords.length > 0 &&
-    sourceRecords.every((record) => record.type === "recommendation") &&
-    (input.matchKind === "normalized_name" || input.matchKind === "confirmed_alias" || input.matchKind === "recommendation_subject_key" || input.matchKind === "bnl_recommendation_subject_name")
-  ) automationTier = "Auto-attach candidate";
-  else if (
-    input.matchKind === "normalized_name" ||
-    input.matchKind === "confirmed_alias" ||
-    input.matchKind === "public_dossier"
-  ) automationTier = "Auto-merge candidate";
-  if (records.some((record) => record.proposedAliasCount > 0) && input.matchKind !== "confirmed_alias") {
-    automationTier = automationTier === "Blocked" ? automationTier : "Review required";
+  if (hasOnlyRecommendations) {
+    automationTier = "Recommendation-only duplicate group";
+  } else if (blockedReasons.length > 0) {
+    automationTier = "Blocked";
+  } else if (sharedPublicTarget && hasRecommendationSources && !hasRealDuplicateSources) {
+    automationTier = "Dossier update candidate";
+  } else if (hasRecommendationSources && !hasRealDuplicateSources) {
+    automationTier = "Recommendation attach candidate";
+  } else if (allRealSourcesEmpty) {
+    automationTier = "Empty duplicate cleanup candidate";
+  } else if (
+    hasRealDuplicateSources &&
+    (input.matchKind === "normalized_name" || input.matchKind === "confirmed_alias")
+  ) {
+    automationTier = "Source File merge candidate";
+  }
+  if (
+    automationTier !== "Blocked" &&
+    automationTier !== "Recommendation-only duplicate group" &&
+    records.some((record) => record.proposedAliasCount > 0) &&
+    input.matchKind !== "confirmed_alias"
+  ) {
+    automationTier = "Review required";
   }
 
   const canBeAutomatedLater = [
-    "Auto-clean candidate",
-    "Auto-merge candidate",
-    "Auto-attach candidate",
+    "Dossier update candidate",
+    "Recommendation attach candidate",
+    "Source File merge candidate",
+    "Empty duplicate cleanup candidate",
   ].includes(automationTier);
   const requiresReview = !canBeAutomatedLater || records.some((record) => record.proposedAliasCount > 0);
+  const noTargetExplanation =
+    "These are duplicate or related BNL recommendations, but no Source File target exists in this group yet. The next action is to attach them to an existing Source File if one matches, or create/select a Source File target later.";
+  const publicDossierUpdateExplanation =
+    targetRecord?.publicDossierId && hasRecommendationSources
+      ? `Existing public dossier match found. This should be reviewed as an update/attachment to the canonical ${targetDisplayName(targetRecord)} record, not merged into a separate duplicate Source File.`
+      : undefined;
 
   return {
     groupId: input.id,
@@ -1078,86 +1132,72 @@ function createConsolidationPlan(input: {
         : input.matchKind === "normalized_name"
           ? "medium"
           : "low",
-    reason: input.reason,
+    reason: publicDossierUpdateExplanation ?? input.reason,
     targetRecord,
     sourceRecords,
+    targetDisplayName: targetDisplayName(targetRecord),
+    targetSourceFileLabel: targetRecord?.name,
+    targetDisplayReason: targetDisplayReason(targetRecord),
     targetSelectionReason: targetSelectionReason(targetRecord),
     automationTier,
-    recommendedNextStep: canBeAutomatedLater
-      ? `${automationTier} only: verify the plan before enabling real cleanup actions in a future PR.`
-      : automationTier === "Recommendation-only duplicate group"
-        ? "Needs Source File target before any attach or merge action can be automated."
+    recommendedNextStep: hasOnlyRecommendations
+      ? noTargetExplanation
+      : canBeAutomatedLater
+        ? `${automationTier}: review the deltas below before enabling any real action in a future PR.`
         : "Admin review required before any future automation.",
     canBeAutomatedLater,
     requiresReview,
-    blockedReasons,
+    blockedReasons: hasOnlyRecommendations
+      ? ["No Source File target resolved."]
+      : blockedReasons,
     mergePlanSections: [
-      planSection(
-        "Identity / aliases",
-        sourceRecords.some((record) => record.confirmedAliasCount > 0)
-          ? ["Confirmed internal aliases could be moved later."]
-          : [],
-        targetRecord?.confirmedAliasCount ? ["Target already has confirmed aliases."] : [],
-        sourceRecords.some((record) => record.proposedAliasCount > 0)
-          ? ["Proposed aliases require human confirmation before use."]
-          : [],
-        ["Internal aliases stay internal and will not publish automatically."],
-      ),
-      planSection(
-        "Recommendations / BNL Signals",
-        sourceRecords.some((record) => record.attachedRecommendationCount > 0)
-          ? ["Would attach or preserve BNL recommendations later."]
-          : [],
-        targetRecord?.attachedRecommendationCount ? ["Target already has BNL recommendations."] : [],
-        recommendationRecords.length > 0 && !targetRecord
-          ? ["Recommendation-only duplicate group needs a Source File target."]
-          : [],
-        ["Duplicate signals will not change public dossier copy."],
-      ),
-      planSection(
-        "Source notes",
-        sourceRecords.some((record) => record.sourceNotesCount > 0)
-          ? ["Would move active source notes later."]
-          : [],
-        targetRecord?.sourceNotesCount ? ["Target already has source notes."] : [],
-        sourceRecords.some((record) => record.sourceNotesCount > 0) ? ["Review note ownership before moving."] : [],
-        ["Source notes remain internal until reviewed."],
-      ),
-      planSection(
-        "Archives / BNL reports",
-        sourceRecords.some((record) => record.hasLatestArchiveOrReport)
-          ? ["Source archive available to preserve later."]
-          : [],
-        targetRecord?.hasLatestArchiveOrReport ? ["Preserve target latest archive."] : [],
-        sourceRecords.some((record) => record.missingLatestCaseReport)
-          ? ["Source is missing latest archive/case report."]
-          : [],
-        sourceRecords.every((record) => !record.hasLatestArchiveOrReport)
-          ? ["No archive to move from source records."]
-          : [],
-      ),
-      planSection(
-        "Drafts / public dossiers",
-        [],
-        [
-          targetRecord?.activeDraftStatus ? `Target has draft (${targetRecord.activeDraftStatus}).` : "Target has no active draft.",
-          targetRecord?.publicDossierId ? "Public dossier match present on target." : "Public dossier match none on target.",
+      planSection("New info to add", {
+        newInfoToAdd: sourceRecords.flatMap((record) => record.incomingInfo),
+        noActionNeeded: sourceRecords.flatMap((record) => record.incomingInfo).length
+          ? []
+          : ["No new incoming information detected."],
+      }),
+      planSection("Already represented / duplicate info", {
+        alreadyRepresented: [
+          ...sourceRecords.flatMap((record) => record.duplicateInfo),
+          ...(targetRecord?.publicDossierId && hasRecommendationSources
+            ? ["Incoming recommendation already points at the same public dossier target."]
+            : []),
         ],
-        [
-          ...sourceRecords.map((record) =>
-            `${record.name}: ${record.activeDraftStatus ? `source has draft (${record.activeDraftStatus})` : "source has no draft"}; ${record.publicDossierId ? "public dossier match present" : "public dossier match none"}.`,
-          ),
-          ...blockedReasons,
+        noActionNeeded: sourceRecords.every((record) => record.duplicateInfo.length === 0)
+          ? ["No duplicate facts were identified by this audit."]
+          : [],
+      }),
+      planSection("Irrelevant to kept entry", {
+        irrelevantToKeptEntry: sourceRecords
+          .filter((record) => record.type === "recommendation" && !targetRecord)
+          .map((record) => `${record.name} cannot be merged until a Source File target exists.`),
+      }),
+      planSection("Needs review", {
+        needsReview: [
+          ...(sourceRecords.some((record) => record.proposedAliasCount > 0)
+            ? ["Proposed aliases require human confirmation before matching."]
+            : []),
+          ...(publicDossierUpdateExplanation ? [publicDossierUpdateExplanation] : []),
+          ...(hasOnlyRecommendations ? [noTargetExplanation] : []),
         ],
-        [],
-      ),
-      planSection(
-        "Safety",
-        [],
-        ["Public dossier copy will not change.", "Nothing publishes automatically."],
-        requiresReview ? ["Human review gate remains required for unsafe or unclear data."] : [],
-        ["Internal aliases stay internal.", "No merge/delete/archive/attach action is live in this PR."],
-      ),
+      }),
+      planSection("Blocked reason", {
+        blockedReason: hasOnlyRecommendations
+          ? ["No Source File target resolved."]
+          : blockedReasons,
+        noActionNeeded: blockedReasons.length === 0 && !hasOnlyRecommendations
+          ? ["No blocker detected by this planning pass."]
+          : [],
+      }),
+      planSection("No action needed", {
+        noActionNeeded: [
+          "Public dossier copy will not change.",
+          "Internal aliases stay internal.",
+          "Nothing publishes automatically.",
+          "No merge/delete/archive/attach action is live in this PR.",
+        ],
+      }),
     ],
   };
 }
@@ -1234,6 +1274,7 @@ export function createDossierPopulationAudit(input: {
       status: candidate.status,
       href: `/admin/dossiers/candidates/${candidate.id}`,
       candidateId: candidate.id,
+      displayName: candidate.existingDossierMatch?.name ?? candidate.name,
       publicDossierId: candidate.existingDossierMatch?.id,
       publicDossierName: candidate.existingDossierMatch?.name,
       confirmedAliasCount,
@@ -1251,6 +1292,17 @@ export function createDossierPopulationAudit(input: {
           candidate.latestSourceFileArchiveId ||
           candidate.latestSourceFileArchive?.caseReportPresent,
       ),
+      incomingInfo: [
+        ...(candidate.evidenceSummary ? [`Source evidence: ${candidate.evidenceSummary}`] : []),
+        ...((candidate.sourceFileNotes ?? [])
+          .filter((note) => note.status === "active" && note.text)
+          .slice(0, 2)
+          .map((note) => `Source note: ${note.text}`)),
+      ],
+      duplicateInfo: candidate.existingDossierMatch?.name
+        ? [`Already connected to public dossier ${candidate.existingDossierMatch.name}.`]
+        : [],
+      sourceLanes: candidate.sourceLanes,
       uniqueInfo: auditRecordUniqueInfo({
         confirmedAliasCount,
         proposedAliasCount,
@@ -1369,15 +1421,19 @@ export function createDossierPopulationAudit(input: {
           ? "Classification only: eligible to attach later after the classifier is approved."
           : "Needs Source File target: decide whether this becomes a Dossier Seed, Dossier Update, or archive item.",
         likelyTargetId: matchingSourceFile?.id,
-        likelyTargetName: matchingSourceFile?.name,
+        likelyTargetName: matchingSourceFile?.existingDossierMatch?.name ?? matchingSourceFile?.name,
         planClassification: matchingSourceFile
-          ? "Auto-attach candidate"
+          ? matchingSourceFile.existingDossierMatch?.id || recommendation.targetDossierId
+            ? "Dossier update candidate"
+            : "Recommendation attach candidate"
           : "Needs Source File target",
         matchReason: matchingSourceFile
-          ? `Exact/confirmed ${matchBasis ?? "subject"} match to active Source File.`
+          ? matchingSourceFile.existingDossierMatch?.name
+            ? `Existing public dossier match found for ${matchingSourceFile.existingDossierMatch.name}; route as update/attachment, not a Source File merge.`
+            : `Exact/confirmed ${matchBasis ?? "subject"} match to active Source File.`
           : "No exact normalized-name, subjectKey, or confirmed-alias active Source File target exists yet.",
         wouldHappenLater: matchingSourceFile
-          ? "Later automation could attach this recommendation to the matching Source File without changing public dossier copy."
+          ? "Later automation could attach this recommendation or route it as a dossier update without changing public dossier copy."
           : "Later automation must wait until an admin selects or creates a Source File target.",
       } satisfies DossierPopulationAuditUnattachedRecommendation;
     })
@@ -1474,6 +1530,10 @@ export function createDossierPopulationAudit(input: {
       status: recommendation.status,
       href: `/admin/dossiers/recommendations/${recommendation.id}`,
       recommendationId: recommendation.id,
+      displayName: recommendation.targetDossierId
+        ? publicDossiersById.get(recommendation.targetDossierId)?.name ??
+          recommendation.subjectName
+        : recommendation.subjectName,
       publicDossierId: recommendation.targetDossierId,
       publicDossierName: recommendation.targetDossierId
         ? publicDossiersById.get(recommendation.targetDossierId)?.name
@@ -1484,6 +1544,31 @@ export function createDossierPopulationAudit(input: {
       missingLatestCaseReport: false,
       sourceNotesCount: 0,
       hasLatestArchiveOrReport: false,
+      incomingInfo: [
+        `Incoming recommendation subject: ${recommendation.subjectName}`,
+        ...(recommendation.reason ? [`Recommendation reason: ${recommendation.reason}`] : []),
+        ...(recommendation.evidenceSummary ? [`Recommendation summary: ${recommendation.evidenceSummary}`] : []),
+        ...(recommendation.sourceLanes.length > 0
+          ? [`Source lanes: ${recommendation.sourceLanes.join(", ")}`]
+          : []),
+        ...(recommendation.targetDossierId
+          ? [
+              `Public dossier match: ${
+                publicDossiersById.get(recommendation.targetDossierId)?.name ??
+                recommendation.targetDossierId
+              }`,
+            ]
+          : []),
+      ],
+      duplicateInfo: recommendation.targetDossierId
+        ? [
+            `Recommendation already points at public dossier ${
+              publicDossiersById.get(recommendation.targetDossierId)?.name ??
+              recommendation.targetDossierId
+            }.`,
+          ]
+        : [],
+      sourceLanes: recommendation.sourceLanes,
       uniqueInfo: auditRecordUniqueInfo({
         confirmedAliasCount: 0,
         proposedAliasCount: 0,

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2042,14 +2042,27 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Records missing latest BNL case report or source enrichment",
     "Possible Duplicate / Same Subject Review",
     "Possible same-subject review",
-    "Needs admin review",
-    "Confirmed aliases:",
-    "Proposed aliases:",
-    "Recommendation count:",
+    "Consolidation plan",
+    "Merging / Source",
+    "Merge Target / Keep",
+    "Target selection:",
+    "Automation tier",
+    "Confirmed aliases count:",
+    "Proposed aliases count:",
+    "Source notes count:",
+    "Recommendations count:",
     "Public dossier match:",
+    "Field-level merge plan",
+    "Identity / aliases",
+    "Recommendations / BNL Signals",
+    "Source notes",
+    "Archives / BNL reports",
+    "Drafts / public dossiers",
+    "Safety",
     "Unattached BNL Signals / Recommendations",
     "BNL recommendations that need placement review",
-    "No clear active Source File match",
+    "Needs Source File target",
+    "What would happen later",
     "The site can only audit records and recommendations already present in the workflow store. Active Discord members who have not been ingested by BNL will not appear here yet.",
     "it does not merge, delete, publish, or mutate records automatically",
   ]) {
@@ -2058,7 +2071,7 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
 
   assert.match(page, /<details className="border border-accent\/40 bg-surface\/70 p-5">/);
   assert.match(page, /createDossierPopulationAudit/);
-  assert.doesNotMatch(page, /Auto Merge|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
+  assert.doesNotMatch(page, /Run Safe Cleanup|Remove Empty Duplicate|Attach Automatically|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
 });
 
 test("population audit helper uses conservative duplicate signals and leaves proposed aliases out of confirmed matching", () => {
@@ -2173,6 +2186,151 @@ test("population audit helper uses conservative duplicate signals and leaves pro
   assert.ok(audit.possibleDuplicateGroups.some((group) => group.matchKind === "recommendation_subject_key" && group.records.length === 2));
   assert.ok(!audit.possibleDuplicateGroups.some((group) => group.matchKind === "confirmed_alias" && group.records.some((record) => record.name === "Proposed Only")));
   assert.ok(audit.unattachedBnlRecommendations.some((recommendation) => recommendation.id === "rec-unattached" && recommendation.subjectName === "Loose Signal"));
+});
+
+
+test("population audit consolidation plans classify target/source records without mutation actions", () => {
+  const now = "2026-06-11T00:00:00.000Z";
+  const candidate = (overrides) => ({
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 5,
+    whyNow: "Fixture",
+    reason: "Fixture",
+    evidenceSummary: "Fixture",
+    status: overrides.status ?? "active_source_file",
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    ...overrides,
+  });
+  const recommendation = (overrides) => ({
+    id: overrides.id,
+    type: overrides.type ?? "new_subject",
+    subjectName: overrides.subjectName,
+    subjectKey: overrides.subjectKey,
+    targetDossierId: overrides.targetDossierId,
+    targetCandidateId: overrides.targetCandidateId,
+    status: overrides.status ?? "new",
+    reason: "BNL fixture",
+    confidence: overrides.confidence ?? "medium",
+    sourceLanes: overrides.sourceLanes ?? ["public_discord"],
+    createdAt: now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: "bnl",
+    ingestSource: overrides.ingestSource ?? "bnl_dynamic_candidate_discovery",
+    ...overrides,
+  });
+  const alias = (candidateId, label, status = "confirmed") => ({
+    id: `${candidateId}-${label}-${status}`,
+    candidateId,
+    label,
+    normalizedLabel: workflow.normalizeDossierSubjectName(label),
+    type: "alias",
+    visibility: "internal_only",
+    status,
+    source: "admin_manual",
+    useForMatching: true,
+    useInPublicDossier: false,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const audit = workflow.createDossierPopulationAudit({
+    publicDossiers: [
+      { id: "public-keep", name: "Public Keep" },
+      { id: "public-other", name: "Public Other" },
+    ],
+    drafts: [
+      {
+        id: "draft-target",
+        candidateId: "active-with-draft",
+        status: "draft",
+        fields: { name: "Draft Target", files: [] },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    candidates: [
+      candidate({
+        id: "public-target",
+        name: "Public Keep",
+        status: "existing_dossier_update",
+        existingDossierMatch: { id: "public-keep", name: "Public Keep", confidence: "high" },
+      }),
+      candidate({ id: "public-loose", name: "Public Keep", status: "candidate_intake" }),
+      candidate({
+        id: "active-with-draft",
+        name: "Active Source",
+        identityLinks: [alias("active-with-draft", "Active Alias")],
+        sourceFileNotes: [{ id: "note-1", candidateId: "active-with-draft", type: "fact", text: "Useful note", source: "admin_manual", status: "active", createdAt: now, updatedAt: now }],
+        latestSourceFileArchiveUpdatedAt: now,
+      }),
+      candidate({ id: "active-empty-duplicate", name: "Active Source", status: "candidate_intake", reason: "", whyNow: "", evidenceSummary: "" }),
+      candidate({ id: "clean-target", name: "Empty Clean", latestSourceFileArchiveUpdatedAt: now }),
+      candidate({ id: "clean-duplicate", name: "Empty Clean", status: "candidate_intake", reason: "", whyNow: "", evidenceSummary: "" }),
+      candidate({ id: "confirmed-target", name: "Confirmed Primary", identityLinks: [alias("confirmed-target", "Confirmed Secondary")] }),
+      candidate({ id: "confirmed-secondary", name: "Confirmed Secondary", sourceFileNotes: [{ id: "note-2", candidateId: "confirmed-secondary", type: "fact", text: "Additive note", source: "admin_manual", status: "active", createdAt: now, updatedAt: now }] }),
+      candidate({ id: "proposed-a", name: "Proposed Review", identityLinks: [alias("proposed-a", "Proposed Maybe", "proposed")] }),
+      candidate({ id: "proposed-b", name: "Proposed Review" }),
+      candidate({ id: "blocked-a", name: "Blocked Same", existingDossierMatch: { id: "public-keep", name: "Public Keep", confidence: "high" } }),
+      candidate({ id: "blocked-b", name: "Blocked Same", existingDossierMatch: { id: "public-other", name: "Public Other", confidence: "high" } }),
+      candidate({ id: "attach-target", name: "Attach Me", identityLinks: [alias("attach-target", "Attach Alias")] }),
+    ],
+    recommendations: [
+      recommendation({ id: "rec-public-loose", subjectName: "Public Keep", targetDossierId: "public-keep" }),
+      recommendation({ id: "rec-active", subjectName: "Active Source" }),
+      recommendation({ id: "rec-attach", subjectName: "Attach Alias" }),
+      recommendation({ id: "rec-only-a", subjectName: "Only Signal A", subjectKey: "only-signal" }),
+      recommendation({ id: "rec-only-b", subjectName: "Only Signal B", subjectKey: "only-signal" }),
+    ],
+  });
+
+  const plans = audit.possibleDuplicateGroups.map((group) => group.consolidationPlan);
+  assert.ok(plans.every((plan) => plan.groupId && plan.groupType && plan.confidence && plan.reason && plan.automationTier && plan.recommendedNextStep));
+
+  const publicPlan = plans.find((plan) => plan.groupId.includes("public-dossier-public-keep"));
+  assert.equal(publicPlan?.targetRecord?.type !== "recommendation", true);
+  assert.equal(publicPlan?.targetRecord?.publicDossierId, "public-keep");
+  assert.match(publicPlan.targetSelectionReason, /public dossier match/);
+
+  const activePlan = plans.find((plan) => plan.groupType === "bnl_recommendation_subject_name" && plan.targetRecord?.id === "active-with-draft");
+  assert.equal(activePlan?.targetRecord?.type, "source_file");
+  assert.ok(activePlan.sourceRecords.some((record) => record.type === "recommendation"));
+
+  const cleanPlan = plans.find((plan) => plan.groupType === "normalized_name" && plan.targetRecord?.id === "clean-target");
+  assert.equal(cleanPlan?.automationTier, "Auto-clean candidate");
+
+  const mergePlan = plans.find((plan) => plan.groupType === "confirmed_alias" && plan.targetRecord?.id === "confirmed-target");
+  assert.equal(mergePlan?.automationTier, "Auto-merge candidate");
+
+  const attachPlan = audit.unattachedBnlRecommendations.find((item) => item.id === "rec-attach");
+  assert.equal(attachPlan?.planClassification, "Auto-attach candidate");
+  assert.equal(attachPlan?.likelyTargetId, "attach-target");
+
+  const reviewPlan = plans.find((plan) => plan.targetRecord?.id === "proposed-a" || plan.sourceRecords.some((record) => record.id === "proposed-a"));
+  assert.equal(reviewPlan?.automationTier, "Review required");
+
+  const blockedPlan = plans.find((plan) => plan.groupType === "normalized_name" && plan.targetRecord?.name === "Blocked Same");
+  assert.equal(blockedPlan?.automationTier, "Blocked");
+  assert.match(blockedPlan?.blockedReasons.join(" ") ?? "", /Different public dossier matches/);
+
+  const recommendationOnlyPlan = plans.find((plan) => plan.automationTier === "Recommendation-only duplicate group");
+  assert.ok(recommendationOnlyPlan);
+  assert.match(recommendationOnlyPlan.recommendedNextStep, /Needs Source File target/);
+  assert.doesNotMatch(recommendationOnlyPlan.targetSelectionReason, /source and target records could not be resolved/i);
+
+  const sectionNames = activePlan?.mergePlanSections.map((section) => section.title) ?? [];
+  assert.deepEqual(sectionNames, [
+    "Identity / aliases",
+    "Recommendations / BNL Signals",
+    "Source notes",
+    "Archives / BNL reports",
+    "Drafts / public dossiers",
+    "Safety",
+  ]);
 });
 
 test("owner review page is a placeholder lane without publishing", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2243,7 +2243,9 @@ test("population audit consolidation plans classify target/source records withou
     publicDossiers: [
       { id: "public-keep", name: "Public Keep" },
       { id: "public-other", name: "Public Other" },
+      { id: "blocked-public-a", name: "Blocked Public A" },
       { id: "six-bit", name: "6 Bit" },
+      { id: "public-only", name: "Public Only" },
     ],
     drafts: [
       {
@@ -2277,10 +2279,12 @@ test("population audit consolidation plans classify target/source records withou
       candidate({ id: "confirmed-secondary", name: "Confirmed Secondary", sourceFileNotes: [{ id: "note-2", candidateId: "confirmed-secondary", type: "fact", text: "Additive note", source: "admin_manual", status: "active", createdAt: now, updatedAt: now }] }),
       candidate({ id: "proposed-a", name: "Proposed Review", identityLinks: [alias("proposed-a", "Proposed Maybe", "proposed")] }),
       candidate({ id: "proposed-b", name: "Proposed Review" }),
-      candidate({ id: "blocked-a", name: "Blocked Same", existingDossierMatch: { id: "public-keep", name: "Public Keep", confidence: "high" } }),
+      candidate({ id: "blocked-a", name: "Blocked Same", existingDossierMatch: { id: "blocked-public-a", name: "Blocked Public A", confidence: "high" } }),
       candidate({ id: "blocked-b", name: "Blocked Same", existingDossierMatch: { id: "public-other", name: "Public Other", confidence: "high" } }),
       candidate({ id: "attach-target", name: "Attach Me", identityLinks: [alias("attach-target", "Attach Alias")] }),
       candidate({ id: "six-bit-source", name: "6 Bit’s", existingDossierMatch: { id: "six-bit", name: "6 Bit", confidence: "high" } }),
+      candidate({ id: "ambiguous-a", name: "Ambiguous Target" }),
+      candidate({ id: "ambiguous-b", name: "Ambiguous Target" }),
     ],
     recommendations: [
       recommendation({ id: "rec-public-loose", subjectName: "Public Keep", targetDossierId: "public-keep" }),
@@ -2289,6 +2293,8 @@ test("population audit consolidation plans classify target/source records withou
       recommendation({ id: "rec-only-a", subjectName: "Only Signal A", subjectKey: "only-signal" }),
       recommendation({ id: "rec-only-b", subjectName: "Only Signal B", subjectKey: "only-signal" }),
       recommendation({ id: "rec-six-bit", subjectName: "6 Bit", targetDossierId: "six-bit", evidenceSummary: "Canonical update signal." }),
+      recommendation({ id: "rec-public-only-a", subjectName: "Public Only", targetDossierId: "public-only" }),
+      recommendation({ id: "rec-public-only-b", subjectName: "Public Only", targetDossierId: "public-only" }),
     ],
   });
 
@@ -2311,11 +2317,11 @@ test("population audit consolidation plans classify target/source records withou
   assert.equal(mergePlan?.automationTier, "Source File merge candidate");
 
   const attachPlan = audit.unattachedBnlRecommendations.find((item) => item.id === "rec-attach");
-  assert.equal(attachPlan?.planClassification, "Recommendation attach candidate");
+  assert.equal(attachPlan?.planClassification, "Attach to Existing Source File candidate");
   assert.equal(attachPlan?.likelyTargetId, "attach-target");
 
   const sixBitPlan = plans.find((plan) => plan.groupId.includes("public-dossier-six-bit"));
-  assert.equal(sixBitPlan?.automationTier, "Dossier update candidate");
+  assert.equal(sixBitPlan?.automationTier, "Attach to Existing Source File candidate");
   assert.equal(sixBitPlan?.targetRecord?.id, "six-bit-source");
   assert.equal(sixBitPlan?.targetDisplayName, "6 Bit");
   assert.equal(sixBitPlan?.targetSourceFileLabel, "6 Bit’s");
@@ -2327,16 +2333,28 @@ test("population audit consolidation plans classify target/source records withou
   const reviewPlan = plans.find((plan) => plan.targetRecord?.id === "proposed-a" || plan.sourceRecords.some((record) => record.id === "proposed-a"));
   assert.equal(reviewPlan?.automationTier, "Review required");
 
-  const blockedPlan = plans.find((plan) => plan.groupType === "normalized_name" && plan.targetRecord?.name === "Blocked Same");
+  const blockedPlan = plans.find((plan) => plan.groupId.includes("normalized-name-blocked-same"));
   assert.equal(blockedPlan?.automationTier, "Blocked");
   assert.match(blockedPlan?.blockedReasons.join(" ") ?? "", /Different public dossier matches/);
 
-  const recommendationOnlyPlan = plans.find((plan) => plan.automationTier === "Recommendation-only duplicate group");
-  assert.ok(recommendationOnlyPlan);
-  assert.equal(recommendationOnlyPlan.targetRecord, undefined);
-  assert.match(recommendationOnlyPlan.recommendedNextStep, /no Source File target exists/i);
-  assert.match(recommendationOnlyPlan.blockedReasons.join(" "), /No Source File target resolved/);
-  assert.doesNotMatch(recommendationOnlyPlan.targetSelectionReason, /source and target records could not be resolved/i);
+  const sourceFileCreationPlan = plans.find((plan) => plan.groupId.includes("recommendation-subject-key-only-signal"));
+  assert.equal(sourceFileCreationPlan?.automationTier, "Create Source File candidate");
+  assert.equal(sourceFileCreationPlan?.targetRecord, undefined);
+  assert.equal(sourceFileCreationPlan?.suggestedWorkspace, "New Source File / Candidate");
+  assert.match(sourceFileCreationPlan?.recommendedNextStep ?? "", /no Source File target exists/i);
+  assert.match(sourceFileCreationPlan?.blockedReasons.join(" ") ?? "", /No Source File target resolved/);
+  assert.doesNotMatch(sourceFileCreationPlan?.targetSelectionReason ?? "", /source and target records could not be resolved/i);
+
+  const updateWorkspacePlan = plans.find((plan) => plan.groupId.includes("public-dossier-public-only"));
+  assert.equal(updateWorkspacePlan?.automationTier, "Create Dossier Update workspace candidate");
+  assert.equal(updateWorkspacePlan?.targetRecord, undefined);
+  assert.equal(updateWorkspacePlan?.suggestedWorkspace, "Dossier Update");
+  assert.equal(updateWorkspacePlan?.existingPublicDossier?.name, "Public Only");
+
+  const ambiguousPlan = plans.find((plan) => plan.groupId.includes("normalized-name-ambiguous-target"));
+  assert.equal(ambiguousPlan?.automationTier, "Select Target Manually");
+  assert.equal(ambiguousPlan?.targetRecord, undefined);
+  assert.equal(ambiguousPlan?.possibleTargetRecords.length, 2);
 
   assert.ok(activePlan?.sourceRecords.some((record) => record.type === "recommendation"));
   assert.notEqual(activePlan?.targetRecord?.type, "recommendation");
@@ -2353,6 +2371,14 @@ test("population audit consolidation plans classify target/source records withou
   assert.ok(activePlan?.mergePlanSections.some((section) => section.newInfoToAdd.length > 0));
   assert.ok(activePlan?.mergePlanSections.some((section) => section.noActionNeeded.join(" ").includes("Nothing publishes automatically")));
   assert.ok(blockedPlan?.mergePlanSections.some((section) => section.blockedReason.join(" ").includes("Different public dossier matches")));
+
+  const publicDossierBefore = JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit"));
+  workflow.createDossierPopulationAudit({
+    publicDossiers: [{ id: "six-bit", name: "6 Bit" }],
+    candidates: [],
+    recommendations: [recommendation({ id: "rec-public-readonly", subjectName: "6 Bit", targetDossierId: "six-bit" })],
+  });
+  assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit")), publicDossierBefore);
 });
 
 test("population audit planning UI uses incoming/target columns and disabled future action labels", () => {
@@ -2364,8 +2390,13 @@ test("population audit planning UI uses incoming/target columns and disabled fut
     "Target / Keep",
     "No Source File target resolved",
     "targetDisplayReason",
-    "Dossier Update Later",
+    "Suggested workspace to create",
+    "Recommended workspace:",
+    "Existing public dossier:",
+    "Create Dossier Update Later",
+    "Create Source File Later",
     "Attach Later",
+    "Select Target Later",
     "Merge Later",
     "Clean Later",
     "Needs Source File Target",
@@ -4837,7 +4868,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Review Update/);
   assert.match(dashboard, /Open Source File/);
   assert.match(dashboard, /Review Record/);
-  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info|Attach to Existing Source File/);
+  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info|>Attach to Existing Source File<|Attach to Existing Source File<\/button>/);
 
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2043,22 +2043,21 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Possible Duplicate / Same Subject Review",
     "Possible same-subject review",
     "Consolidation plan",
-    "Merging / Source",
-    "Merge Target / Keep",
+    "Merging / Incoming Info",
+    "Target / Keep",
     "Target selection:",
     "Automation tier",
-    "Confirmed aliases count:",
-    "Proposed aliases count:",
-    "Source notes count:",
-    "Recommendations count:",
+    "Incoming recommendation subject:",
+    "What this would add:",
+    "Already represented / duplicate:",
     "Public dossier match:",
-    "Field-level merge plan",
-    "Identity / aliases",
-    "Recommendations / BNL Signals",
-    "Source notes",
-    "Archives / BNL reports",
-    "Drafts / public dossiers",
-    "Safety",
+    "Field-level plan",
+    "New info to add",
+    "Already represented / duplicate info",
+    "Irrelevant to kept entry",
+    "Needs review",
+    "Blocked reason",
+    "No action needed",
     "Unattached BNL Signals / Recommendations",
     "BNL recommendations that need placement review",
     "Needs Source File target",
@@ -2072,6 +2071,8 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
   assert.match(page, /<details className="border border-accent\/40 bg-surface\/70 p-5">/);
   assert.match(page, /createDossierPopulationAudit/);
   assert.doesNotMatch(page, /Run Safe Cleanup|Remove Empty Duplicate|Attach Automatically|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
+  assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
+  assert.doesNotMatch(pageCopy, /source notes count 0/i);
 });
 
 test("population audit helper uses conservative duplicate signals and leaves proposed aliases out of confirmed matching", () => {
@@ -2242,6 +2243,7 @@ test("population audit consolidation plans classify target/source records withou
     publicDossiers: [
       { id: "public-keep", name: "Public Keep" },
       { id: "public-other", name: "Public Other" },
+      { id: "six-bit", name: "6 Bit" },
     ],
     drafts: [
       {
@@ -2278,6 +2280,7 @@ test("population audit consolidation plans classify target/source records withou
       candidate({ id: "blocked-a", name: "Blocked Same", existingDossierMatch: { id: "public-keep", name: "Public Keep", confidence: "high" } }),
       candidate({ id: "blocked-b", name: "Blocked Same", existingDossierMatch: { id: "public-other", name: "Public Other", confidence: "high" } }),
       candidate({ id: "attach-target", name: "Attach Me", identityLinks: [alias("attach-target", "Attach Alias")] }),
+      candidate({ id: "six-bit-source", name: "6 Bit’s", existingDossierMatch: { id: "six-bit", name: "6 Bit", confidence: "high" } }),
     ],
     recommendations: [
       recommendation({ id: "rec-public-loose", subjectName: "Public Keep", targetDossierId: "public-keep" }),
@@ -2285,6 +2288,7 @@ test("population audit consolidation plans classify target/source records withou
       recommendation({ id: "rec-attach", subjectName: "Attach Alias" }),
       recommendation({ id: "rec-only-a", subjectName: "Only Signal A", subjectKey: "only-signal" }),
       recommendation({ id: "rec-only-b", subjectName: "Only Signal B", subjectKey: "only-signal" }),
+      recommendation({ id: "rec-six-bit", subjectName: "6 Bit", targetDossierId: "six-bit", evidenceSummary: "Canonical update signal." }),
     ],
   });
 
@@ -2301,14 +2305,24 @@ test("population audit consolidation plans classify target/source records withou
   assert.ok(activePlan.sourceRecords.some((record) => record.type === "recommendation"));
 
   const cleanPlan = plans.find((plan) => plan.groupType === "normalized_name" && plan.targetRecord?.id === "clean-target");
-  assert.equal(cleanPlan?.automationTier, "Auto-clean candidate");
+  assert.equal(cleanPlan?.automationTier, "Empty duplicate cleanup candidate");
 
   const mergePlan = plans.find((plan) => plan.groupType === "confirmed_alias" && plan.targetRecord?.id === "confirmed-target");
-  assert.equal(mergePlan?.automationTier, "Auto-merge candidate");
+  assert.equal(mergePlan?.automationTier, "Source File merge candidate");
 
   const attachPlan = audit.unattachedBnlRecommendations.find((item) => item.id === "rec-attach");
-  assert.equal(attachPlan?.planClassification, "Auto-attach candidate");
+  assert.equal(attachPlan?.planClassification, "Recommendation attach candidate");
   assert.equal(attachPlan?.likelyTargetId, "attach-target");
+
+  const sixBitPlan = plans.find((plan) => plan.groupId.includes("public-dossier-six-bit"));
+  assert.equal(sixBitPlan?.automationTier, "Dossier update candidate");
+  assert.equal(sixBitPlan?.targetRecord?.id, "six-bit-source");
+  assert.equal(sixBitPlan?.targetDisplayName, "6 Bit");
+  assert.equal(sixBitPlan?.targetSourceFileLabel, "6 Bit’s");
+  assert.match(sixBitPlan?.targetDisplayReason ?? "", /public dossier match/);
+  assert.notEqual(sixBitPlan?.automationTier, "Source File merge candidate");
+  assert.ok(sixBitPlan?.sourceRecords.every((record) => record.type === "recommendation"));
+  assert.match(sixBitPlan?.reason ?? "", /not merged into a separate duplicate Source File/);
 
   const reviewPlan = plans.find((plan) => plan.targetRecord?.id === "proposed-a" || plan.sourceRecords.some((record) => record.id === "proposed-a"));
   assert.equal(reviewPlan?.automationTier, "Review required");
@@ -2319,18 +2333,51 @@ test("population audit consolidation plans classify target/source records withou
 
   const recommendationOnlyPlan = plans.find((plan) => plan.automationTier === "Recommendation-only duplicate group");
   assert.ok(recommendationOnlyPlan);
-  assert.match(recommendationOnlyPlan.recommendedNextStep, /Needs Source File target/);
+  assert.equal(recommendationOnlyPlan.targetRecord, undefined);
+  assert.match(recommendationOnlyPlan.recommendedNextStep, /no Source File target exists/i);
+  assert.match(recommendationOnlyPlan.blockedReasons.join(" "), /No Source File target resolved/);
   assert.doesNotMatch(recommendationOnlyPlan.targetSelectionReason, /source and target records could not be resolved/i);
+
+  assert.ok(activePlan?.sourceRecords.some((record) => record.type === "recommendation"));
+  assert.notEqual(activePlan?.targetRecord?.type, "recommendation");
 
   const sectionNames = activePlan?.mergePlanSections.map((section) => section.title) ?? [];
   assert.deepEqual(sectionNames, [
-    "Identity / aliases",
-    "Recommendations / BNL Signals",
-    "Source notes",
-    "Archives / BNL reports",
-    "Drafts / public dossiers",
-    "Safety",
+    "New info to add",
+    "Already represented / duplicate info",
+    "Irrelevant to kept entry",
+    "Needs review",
+    "Blocked reason",
+    "No action needed",
   ]);
+  assert.ok(activePlan?.mergePlanSections.some((section) => section.newInfoToAdd.length > 0));
+  assert.ok(activePlan?.mergePlanSections.some((section) => section.noActionNeeded.join(" ").includes("Nothing publishes automatically")));
+  assert.ok(blockedPlan?.mergePlanSections.some((section) => section.blockedReason.join(" ").includes("Different public dossier matches")));
+});
+
+test("population audit planning UI uses incoming/target columns and disabled future action labels", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+
+  for (const label of [
+    "Merging / Incoming Info",
+    "Target / Keep",
+    "No Source File target resolved",
+    "targetDisplayReason",
+    "Dossier Update Later",
+    "Attach Later",
+    "Merge Later",
+    "Clean Later",
+    "Needs Source File Target",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  assert.match(page, /<button disabled/);
+  assert.doesNotMatch(pageCopy, /Run Safe Cleanup|Attach Automatically|Remove Empty Duplicate|Auto-Merge Safe Duplicate/);
+  assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
+  assert.doesNotMatch(pageCopy, /Proposed aliases count: \{record\.proposedAliasCount\}/);
+  assert.doesNotMatch(pageCopy, /Archive\/report status: \{record\.hasLatestArchiveOrReport/);
 });
 
 test("owner review page is a placeholder lane without publishing", () => {


### PR DESCRIPTION
### Motivation
- Replace the previous unsafe automation attempt with a conservative, non‑mutating consolidation classifier and planning UI so the system can prove safe target/source selection before any mutations are enabled.
- Make the Source File Population Audit useful as a consolidation planning tool by surfacing a chosen target, source candidates, why the target was chosen, field‑level plans, and an automation tier for each duplicate group.
- Keep this PR strictly read‑only for workflow data: no merge/archive/delete/attach mutations or live cleanup actions are introduced. 

### Description
- Added consolidation model and planner to the workflow types and audit output in `src/lib/dossier-workflow.ts`, including `DossierPopulationConsolidationPlan`, automation tiers, `createConsolidationPlan`, improved audit record metadata (`activeDraftStatus`, `sourceNotesCount`, `hasLatestArchiveOrReport`, `uniqueInfo`), and recommendation planning fields (`likelyTargetId`, `planClassification`, `matchReason`, `wouldHappenLater`).
- Enhanced `createDossierPopulationAudit` to accept `drafts` and to build `possibleDuplicateGroups[].consolidationPlan` and improved unattached recommendation rows with likely target and classification but no side‑effects. 
- Implemented conservative target selection and tier classification rules (prefer public dossier match, active draft, active Source File, confirmed aliases, archive/evidence, then older stable record), and assembled field‑level merge plan sections (Identity/Aliases, Recommendations, Source notes, Archives, Drafts/Public dossiers, Safety).
- Added a two‑column merge‑planning UI in `src/app/admin/dossiers/page.tsx` that renders “Merging / Source” and “Merge Target / Keep”, shows `targetSelectionReason`, `uniqueInfo`, field‑level plans, and disabled future action affordances (e.g. disabled “Auto‑Merge Later” / “Clean Later” buttons); updated unattached recommendation table to show likely target, match reason, classification, and “what would happen later”.
- Updated tests in `tests/admin-dossiers.test.mjs` to cover the new audit outputs, consolidation plan structure, target preference behavior, automation tier routing, recommendation planning, and to assert that no live mutation buttons are present.
- No API routes, mutation logic, bot code, public dossier publishing, or middleware were changed. 

### Testing
- Ran the full dossier admin test suite with `node --test tests/admin-dossiers.test.mjs` and all tests passed.
- Type‑checked with `npx tsc --noEmit` and it completed without errors.
- Performed a lint run (`npm run lint`) as an extra check which surfaced unrelated pre‑existing lint errors in archived / other components, but these are outside this PR’s scope and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b0660bd808321b63f675f84e1eb07)