### PR TITLE
Site PR #194 — Live Source File Consolidation Actions from Audit Screen

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -9,6 +9,8 @@ import {
   type DossierCandidate,
   type DossierDraft,
   type DossierDuplicateGroup,
+  type DossierPopulationAuditRecord,
+  type DossierPopulationConsolidationPlan,
   type DossierRecommendation,
 } from "@/lib/dossier-workflow";
 
@@ -42,6 +44,13 @@ type ConsolidationResult = {
   mergedRecordCount: number;
   cleanedDuplicateCount: number;
   createdWorkspaces: Array<{ id: string; href: string; type: string; name: string }>;
+  bnlRefreshes: Array<{
+    targetId: string;
+    targetName?: string;
+    status: "queued" | "already_pending" | "needed" | "unavailable";
+    requestId?: string;
+    message: string;
+  }>;
   skipped: Array<{ id: string; reason: string }>;
   blocked: Array<{ id: string; reason: string }>;
   message: string;
@@ -190,6 +199,75 @@ function consolidationActionForTier(tier: string): { action: string; label: stri
     return { action: "keepConsolidationSeparate", label: "Keep Separate / Not Same Subject" };
   }
   return null;
+}
+
+function cleanTransferDeltaText(value: string): string | null {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  if (/bridge source lane mapping|source_blind_memory_trace|local_knowledge_store|unknown\s*[-→>]+\s*unknown|archive key|chunk key|source digest|ingest key/i.test(text)) {
+    return null;
+  }
+  return text.length > 150 ? `${text.slice(0, 147)}…` : text;
+}
+
+function cleanTransferDeltas(values: string[]): string[] {
+  const cleaned = values
+    .map(cleanTransferDeltaText)
+    .filter((value): value is string => Boolean(value));
+  return Array.from(new Set(cleaned)).slice(0, 4);
+}
+
+function summarizeIncomingRecords(records: DossierPopulationAuditRecord[]) {
+  const recommendationRecords = records.filter((record) => record.type === "recommendation");
+  const candidateRecords = records.filter((record) => record.type !== "recommendation");
+  const lanes = Array.from(new Set(records.flatMap((record) => record.sourceLanes ?? []))).slice(0, 6);
+  const newInfo = cleanTransferDeltas(records.flatMap((record) => record.incomingInfo));
+  const duplicateInfo = cleanTransferDeltas(records.flatMap((record) => record.duplicateInfo));
+  return { recommendationRecords, candidateRecords, lanes, newInfo, duplicateInfo };
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function actionNounForTier(tier: string) {
+  if (tier === "Attach to Existing Source File candidate") return "attach";
+  if (tier === "Source File merge candidate") return "merge";
+  if (tier === "Create Dossier Update workspace candidate" || tier === "Create Source File candidate") return "create";
+  if (tier === "Empty duplicate cleanup candidate") return "clean";
+  return "review";
+}
+
+function transferPlanRows(plan: DossierPopulationConsolidationPlan) {
+  const incoming = summarizeIncomingRecords(plan.sourceRecords);
+  const targetName = plan.targetDisplayName ?? plan.targetRecord?.displayName ?? plan.targetRecord?.name ?? plan.existingPublicDossier?.name ?? "the kept workspace";
+  const recommendationCount = incoming.recommendationRecords.length;
+  const candidateCount = incoming.candidateRecords.length;
+  const willAttach = recommendationCount > 0
+    ? [`${countLabel(recommendationCount, "BNL recommendation")} will be attached to ${targetName} as review-only Source File material.`, "Original recommendation IDs, source lanes, ingest metadata, and review-only status will be preserved."]
+    : [];
+  const willMerge = plan.automationTier === "Source File merge candidate"
+    ? [`${countLabel(candidateCount, "Source File/candidate record")} will merge into ${targetName}.`, "Source notes, recommendation links, identity links, and supported history move to the kept Source File."]
+    : [];
+  const willCreate = plan.automationTier === "Create Dossier Update workspace candidate"
+    ? [`Create an internal Dossier Update workspace for ${plan.existingPublicDossier?.name ?? plan.existingPublicDossier?.id}.`]
+    : plan.automationTier === "Create Source File candidate"
+      ? ["Create a new internal Source File / Candidate workspace from these coherent incoming signals."]
+      : [];
+  const needsAdmin = [
+    ...plan.mergePlanSections.flatMap((section) => cleanTransferDeltas(section.needsReview)),
+    ...(plan.requiresReview ? [plan.recommendedNextStep] : []),
+  ];
+  return [
+    { title: "Will attach", items: willAttach },
+    { title: "Will merge", items: willMerge },
+    { title: "Will create", items: willCreate },
+    { title: "Already represented", items: incoming.duplicateInfo.length ? incoming.duplicateInfo : ["No duplicate facts were identified by the clean transfer pass."] },
+    { title: "Needs BNL review / refresh", items: plan.automationTier === "Empty duplicate cleanup candidate" ? ["No BNL refresh needed for empty duplicate cleanup."] : ["BNL Source File refresh will be queued or marked required after this consolidation so the kept Source File can be recompiled."] },
+    { title: "Needs admin review", items: needsAdmin.length ? needsAdmin : ["No extra admin review blocker detected for this action tier."] },
+    { title: "Will not change", items: ["Public dossier text", "Published database page", "Existing proposed dossier copy", "Internal alias visibility", "Publishing state"] },
+    { title: "Blocked reason", items: plan.blockedReasons.length ? plan.blockedReasons : ["No blocker detected by the current server-side plan."] },
+  ];
 }
 
 function StatusPill({ children }: { children: React.ReactNode }) {
@@ -542,6 +620,7 @@ export default function DossierControlCenterPage() {
         mergedRecordCount: 0,
         cleanedDuplicateCount: 0,
         createdWorkspaces: [],
+        bnlRefreshes: [],
         skipped: [],
         blocked: [{ id: groupId ?? action, reason: message }],
         message,
@@ -895,6 +974,12 @@ export default function DossierControlCenterPage() {
                 <p>Attached recommendations: {consolidationResult.attachedRecommendationCount}</p>
                 <p>Merged records: {consolidationResult.mergedRecordCount}</p>
                 <p>Cleaned duplicates: {consolidationResult.cleanedDuplicateCount}</p>
+                {consolidationResult.targetHref && (
+                  <p><Link href={consolidationResult.targetHref} className="underline">Open updated target</Link></p>
+                )}
+                {consolidationResult.bnlRefreshes.length > 0 && (
+                  <p>BNL refresh status: {consolidationResult.bnlRefreshes.map((refresh) => `${refresh.targetName ?? refresh.targetId}: ${refresh.status} — ${refresh.message}`).join("; ")}</p>
+                )}
                 {consolidationResult.skipped.length > 0 && (
                   <p>Skipped: {consolidationResult.skipped.map((item) => `${item.id}: ${item.reason}`).join("; ")}</p>
                 )}
@@ -991,169 +1076,171 @@ export default function DossierControlCenterPage() {
                       const plan = group.consolidationPlan;
                       const consolidationAction = consolidationActionForTier(plan.automationTier);
                       const justResolved = consolidationResult?.groupId === group.id;
+                      const incomingSummary = summarizeIncomingRecords(plan.sourceRecords);
+                      const targetName = plan.targetDisplayName ?? plan.targetRecord?.displayName ?? plan.targetRecord?.name ?? plan.existingPublicDossier?.name ?? "New workspace";
+                      const primaryActionLabel = plan.automationTier === "Source File merge candidate"
+                        ? "Merge Into Kept Source File"
+                        : plan.automationTier === "Create Source File candidate"
+                          ? "Create Source File from These Signals"
+                          : consolidationAction?.label;
                       return (
                       <article
                         key={group.id}
                         className={justResolved ? "border border-accent bg-accent/10 p-4 text-sm text-muted" : "border border-border/70 bg-background/20 p-4 text-sm text-muted"}
                       >
-                        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                          <div>
-                            <p className="font-semibold text-foreground">
-                              Consolidation plan — Automation tier: {plan.automationTier}
-                            </p>
-                            <p>Match reason: {plan.reason}</p>
-                            <p>Target selection: {plan.targetSelectionReason}</p>
-                            <p>Recommended next step: {plan.recommendedNextStep}</p>
+                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                          <div className="space-y-1">
+                            <p className="text-xs uppercase tracking-[0.35em] text-accent">Consolidation Task</p>
+                            <h4 className="text-lg font-bold text-foreground">{targetName}</h4>
+                            <p>System is trying to {actionNounForTier(plan.automationTier)} {countLabel(plan.sourceRecords.length, "incoming item")} into the kept Source File/workspace.</p>
+                            <p>Classification: {plan.automationTier}</p>
+                            <p>Why grouped: {group.reason}</p>
                             {plan.blockedReasons.length > 0 && (
-                              <p>Blocked because: {plan.blockedReasons.join(" ")}</p>
-                            )}
-                            {group.publicDossierMatch && (
-                              <p>
-                                Public dossier match: {" "}
-                                {group.publicDossierMatch.name ??
-                                  group.publicDossierMatch.id}
-                              </p>
+                              <p>Blocked reason: {plan.blockedReasons.join(" ")}</p>
                             )}
                           </div>
-                          <StatusPill>{plan.confidence} confidence</StatusPill>
+                          <div className="flex flex-col items-start gap-2 md:items-end">
+                            <StatusPill>{plan.confidence} confidence</StatusPill>
+                            {consolidationAction && plan.automationTier !== "Blocked" ? (
+                              <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() => runConsolidationAction(consolidationAction.action, group.id)}
+                                className="border border-accent bg-accent px-4 py-2 text-xs uppercase tracking-widest text-background hover:bg-background hover:text-accent disabled:opacity-50"
+                              >
+                                {primaryActionLabel}
+                              </button>
+                            ) : (
+                              <span className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted">No mutation available</span>
+                            )}
+                          </div>
                         </div>
+
                         <div className="mt-3 grid gap-3 lg:grid-cols-2">
                           <div className="border border-border/60 bg-background/30 p-3">
                             <p className="text-xs uppercase tracking-[0.3em] text-accent">
-                              Merging / Incoming Info
+                              Incoming Info / Will Transfer
                             </p>
                             {plan.sourceRecords.length === 0 ? (
                               <p className="mt-2">No incoming information selected yet.</p>
                             ) : (
-                              <div className="mt-2 space-y-3">
+                              <div className="mt-2 space-y-2">
+                                {incomingSummary.recommendationRecords.length > 0 && (
+                                  <p>{countLabel(incomingSummary.recommendationRecords.length, "BNL recommendation")} will be attached as review-only Source File material.</p>
+                                )}
+                                {incomingSummary.candidateRecords.length > 0 && (
+                                  <p>{countLabel(incomingSummary.candidateRecords.length, "candidate/Source File record")} will be evaluated for merge or cleanup.</p>
+                                )}
+                                <p>Incoming subjects: {plan.sourceRecords.map((record) => record.displayName ?? record.name).join("; ")}</p>
+                                {incomingSummary.lanes.length > 0 && (
+                                  <p>Source lanes summarized: {incomingSummary.lanes.join(", ")}</p>
+                                )}
+                                {incomingSummary.recommendationRecords.length > 0 && (
+                                  <p>Recommendation IDs: {incomingSummary.recommendationRecords.map((record) => record.recommendationId ?? record.id).join(", ")}</p>
+                                )}
+                                <p>New extractable info: {incomingSummary.newInfo.join("; ") || "No clean public fact extracted yet."}</p>
+                                <p>Already represented: {incomingSummary.duplicateInfo.join("; ") || "No duplicate facts were identified by the clean transfer pass."}</p>
+                                <p>Not useful enough to transfer as a clean fact: {plan.mergePlanSections.flatMap((section) => cleanTransferDeltas(section.irrelevantToKeptEntry)).join("; ") || "None flagged by this pass."}</p>
+                                <p>Review-only material: yes — BNL refresh will recompile this into the target Source File after attach/merge/create where supported.</p>
+                              </div>
+                            )}
+                            <details className="mt-3 border border-border/50 bg-background/40 p-3">
+                              <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Raw recommendation details / debug details</summary>
+                              <div className="mt-2 space-y-2">
                                 {plan.sourceRecords.map((record) => (
-                                  <div key={`${group.id}-source-${record.type}-${record.id}`}>
-                                    <p className="font-semibold text-foreground">{record.displayName ?? record.name}</p>
-                                    {record.type === "recommendation" ? (
-                                      <p>Incoming recommendation subject: {record.name}</p>
-                                    ) : (
-                                      <p>Incoming record: {record.type} / {record.status}</p>
-                                    )}
-                                    {record.sourceLanes && record.sourceLanes.length > 0 && (
-                                      <p>Source lanes: {record.sourceLanes.join(", ")}</p>
-                                    )}
-                                    {(record.publicDossierName || record.publicDossierId) && (
-                                      <p>Public dossier match: {record.publicDossierName ?? record.publicDossierId}</p>
-                                    )}
-                                    <p>Why included: {group.reason}</p>
-                                    {record.incomingInfo.length > 0 && (
-                                      <p>What new info this adds: {record.incomingInfo.join("; ")}</p>
-                                    )}
-                                    {record.duplicateInfo.length > 0 && (
-                                      <p>Already represented: {record.duplicateInfo.join("; ")}</p>
-                                    )}
-                                    {record.uniqueInfo.length === 0 && record.incomingInfo.length === 0 && (
-                                      <p>Duplicate / no-new-info: no meaningful incoming fields detected.</p>
-                                    )}
-                                    {plan.mergePlanSections.flatMap((section) => section.irrelevantToKeptEntry).length > 0 && (
-                                      <p>Irrelevant/no-action: {plan.mergePlanSections.flatMap((section) => section.irrelevantToKeptEntry).join("; ")}</p>
-                                    )}
-                                    {!plan.targetRecord && (
-                                      <p>Needs Source File or Dossier Update workspace target before attach/merge.</p>
-                                    )}
+                                  <div key={`${group.id}-raw-${record.type}-${record.id}`}>
+                                    <p>{record.type}: {record.displayName ?? record.name}</p>
+                                    <p>Raw transfer notes: {[...record.incomingInfo, ...record.duplicateInfo].join("; ") || "—"}</p>
                                     {record.href && (
-                                      <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">
-                                        {record.type === "recommendation" ? "Open incoming recommendation" : "Open source Source File"}
+                                      <Link href={record.href} className="inline-flex border border-border px-2 py-1 text-[0.65rem] uppercase tracking-widest text-muted hover:border-accent hover:text-accent">
+                                        {record.type === "recommendation" ? "Open Recommendation" : "Open Source File"}
                                       </Link>
                                     )}
                                   </div>
                                 ))}
                               </div>
-                            )}
+                            </details>
                           </div>
+
                           <div className={plan.targetRecord ? "border border-accent/50 bg-accent/5 p-3" : "border border-border/60 bg-background/30 p-3"}>
                             <p className="text-xs uppercase tracking-[0.3em] text-accent">
-                              Target / Keep
+                              Kept Source File / Target
                             </p>
                             {plan.targetRecord ? (
-                              <div className="mt-2">
-                                <p className="font-semibold text-foreground">{plan.targetDisplayName ?? plan.targetRecord.displayName ?? plan.targetRecord.name}</p>
-                                {plan.targetDisplayReason && (
-                                  <p>{plan.targetDisplayReason}</p>
-                                )}
-                                {plan.targetSourceFileLabel && plan.targetDisplayName !== plan.targetSourceFileLabel && (
-                                  <p>Source File label: {plan.targetSourceFileLabel}</p>
+                              <div className="mt-2 space-y-1">
+                                <p className="font-semibold text-foreground">Kept Source File: {targetName}</p>
+                                {plan.targetRecord.candidateId && (
+                                  <p>Target ID: {plan.targetRecord.candidateId}</p>
                                 )}
                                 <p>Target type/status: {plan.targetRecord.type} / {plan.targetRecord.status}</p>
-                                <p>Why selected: {plan.targetSelectionReason}</p>
                                 {(plan.targetRecord.publicDossierName || plan.targetRecord.publicDossierId) && (
-                                  <p>Dossier status: public dossier match {plan.targetRecord.publicDossierName ?? plan.targetRecord.publicDossierId}</p>
+                                  <p>Existing public dossier match: {plan.targetRecord.publicDossierName ?? plan.targetRecord.publicDossierId}</p>
                                 )}
                                 {plan.targetRecord.activeDraftStatus && (
-                                  <p>Draft status: {plan.targetRecord.activeDraftStatus}</p>
+                                  <p>Proposed dossier/draft status: {plan.targetRecord.activeDraftStatus}</p>
                                 )}
-                                {plan.targetRecord.uniqueInfo.length > 0 && (
-                                  <p>Target already has: {plan.targetRecord.uniqueInfo.join("; ")}</p>
-                                )}
-                                {plan.targetRecord.candidateId && (
-                                  <p>Target Source File ID: {plan.targetRecord.candidateId}</p>
-                                )}
-                                <p>What will be added to it: {plan.mergePlanSections.flatMap((section) => section.newInfoToAdd).join("; ") || "No new info detected."}</p>
-                                <p>What will not change: public dossier text, public publishing state, and internal alias visibility.</p>
-                                <p>Action available: {plan.automationTier}</p>
+                                <p>Why this target: {plan.targetSelectionReason}</p>
+                                <p>Already has: {plan.targetRecord.uniqueInfo.join("; ") || "No populated target fields detected."}</p>
+                                <p>Will add: {incomingSummary.recommendationRecords.length > 0 ? `${countLabel(incomingSummary.recommendationRecords.length, "incoming recommendation")} as review-only source material` : incomingSummary.newInfo.join("; ") || "No clean transfer delta detected."}</p>
+                                <p>BNL Refresh After Consolidation: {plan.automationTier === "Empty duplicate cleanup candidate" ? "not needed for empty cleanup" : "queue or mark Source File refresh for this kept target"}</p>
                                 {plan.targetRecord.href && (
                                   <Link href={plan.targetRecord.href} className="mt-2 inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
-                                    Open target Source File
+                                    Open kept Source File
                                   </Link>
                                 )}
                               </div>
                             ) : (
-                              <div className="mt-2">
-                                <p className="font-semibold text-foreground">Suggested workspace to create</p>
+                              <div className="mt-2 space-y-1">
+                                <p className="font-semibold text-foreground">Kept Source File / Target: workspace will be created</p>
                                 {plan.existingPublicDossier && (
-                                  <p>Existing public dossier: {plan.existingPublicDossier.name ?? plan.existingPublicDossier.id}</p>
+                                  <p>Existing public dossier match: {plan.existingPublicDossier.name ?? plan.existingPublicDossier.id}</p>
                                 )}
                                 {plan.suggestedWorkspace && (
-                                  <p>Recommended workspace: {plan.suggestedWorkspace}</p>
+                                  <p>Will create: {plan.suggestedWorkspace}</p>
                                 )}
                                 {plan.possibleTargetRecords.length > 0 && (
-                                  <p>Possible targets: {plan.possibleTargetRecords.map((record) => record.displayName ?? record.name).join("; ")}</p>
+                                  <p>Possible targets needing admin choice: {plan.possibleTargetRecords.map((record) => record.displayName ?? record.name).join("; ")}</p>
                                 )}
-                                <p>No Source File target resolved</p>
-                                <p>{plan.recommendedNextStep}</p>
+                                <p>Why this target: {plan.targetSelectionReason}</p>
+                                <p>Will add: {incomingSummary.recommendationRecords.length > 0 ? `${countLabel(incomingSummary.recommendationRecords.length, "incoming recommendation")} as review-only source material` : "incoming source material"}</p>
+                                <p>BNL Refresh After Consolidation: queue or mark refresh for the created workspace if supported.</p>
                               </div>
                             )}
                           </div>
                         </div>
+
                         <div className="mt-4 space-y-2">
-                          <p className="text-xs uppercase tracking-[0.3em] text-accent">Field-level plan</p>
-                          <p className="sr-only">New info to add Already represented / duplicate info Irrelevant to kept entry Needs review Blocked reason No action needed</p>
-                          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-                            {plan.mergePlanSections.map((section) => (
+                          <p className="text-xs uppercase tracking-[0.3em] text-accent">Transfer Plan</p>
+                          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                            {transferPlanRows(plan).map((section) => (
                               <div key={`${group.id}-${section.title}`} className="border border-border/60 bg-background/30 p-3">
                                 <p className="font-semibold text-foreground">{section.title}</p>
-                                <p>New info to add: {section.newInfoToAdd.join("; ") || "—"}</p>
-                                <p>Already represented / duplicate info: {section.alreadyRepresented.join("; ") || "—"}</p>
-                                <p>Irrelevant to kept entry: {section.irrelevantToKeptEntry.join("; ") || "—"}</p>
-                                <p>Needs review: {section.needsReview.join("; ") || "—"}</p>
-                                <p>Blocked reason: {section.blockedReason.join("; ") || "—"}</p>
-                                <p>No action needed: {section.noActionNeeded.join("; ") || "—"}</p>
+                                <ul className="mt-2 list-disc space-y-1 pl-4">
+                                  {section.items.map((item) => (
+                                    <li key={`${group.id}-${section.title}-${item}`}>{item}</li>
+                                  ))}
+                                </ul>
                               </div>
                             ))}
                           </div>
                           <div className="flex flex-wrap gap-2">
-                            {consolidationAction ? (
+                            {consolidationAction && plan.automationTier !== "Blocked" ? (
                               <button
                                 type="button"
                                 disabled={saving}
                                 onClick={() => runConsolidationAction(consolidationAction.action, group.id)}
                                 className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
                               >
-                                {consolidationAction.label}
+                                {primaryActionLabel}
                               </button>
                             ) : (
                               <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
-                                No Safe Action
+                                Blocked — No Safe Mutation
                               </button>
                             )}
                             {plan.automationTier === "Select Target Manually" && (
                               <select disabled className="bg-background border border-border px-3 py-1.5 text-xs text-muted">
-                                <option>Select target manually (read-only)</option>
+                                <option>Select Target Manually (read-only)</option>
                                 {plan.possibleTargetRecords.map((record) => (
                                   <option key={record.id}>{record.displayName ?? record.name}</option>
                                 ))}

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -33,6 +33,20 @@ type WorkflowPayload = {
   publicDossiers?: Array<{ id: string; name: string }>;
 };
 
+type ConsolidationResult = {
+  actionType: string;
+  groupId?: string;
+  targetId?: string;
+  targetHref?: string;
+  attachedRecommendationCount: number;
+  mergedRecordCount: number;
+  cleanedDuplicateCount: number;
+  createdWorkspaces: Array<{ id: string; href: string; type: string; name: string }>;
+  skipped: Array<{ id: string; reason: string }>;
+  blocked: Array<{ id: string; reason: string }>;
+  message: string;
+};
+
 type ManualRecommendationForm = {
   subjectName: string;
   type: DossierRecommendation["type"];
@@ -154,6 +168,28 @@ function candidateProvenance(candidate: DossierCandidate) {
   }
   if (candidate.source === "manual") return "Added by an operator";
   return "Internal note";
+}
+
+function consolidationActionForTier(tier: string): { action: string; label: string } | null {
+  if (tier === "Attach to Existing Source File candidate") {
+    return { action: "consolidateAttachIncomingRecommendations", label: "Attach Incoming Recommendations" };
+  }
+  if (tier === "Create Dossier Update workspace candidate") {
+    return { action: "createDossierUpdateWorkspace", label: "Create Dossier Update Workspace" };
+  }
+  if (tier === "Create Source File candidate") {
+    return { action: "createSourceFileFromIncomingInfo", label: "Create Source File from Incoming Info" };
+  }
+  if (tier === "Source File merge candidate") {
+    return { action: "mergeConsolidationIntoTarget", label: "Merge Into Target" };
+  }
+  if (tier === "Empty duplicate cleanup candidate") {
+    return { action: "cleanDuplicateConsolidation", label: "Clean Duplicate" };
+  }
+  if (tier === "Select Target Manually" || tier === "Review required" || tier === "Blocked") {
+    return { action: "keepConsolidationSeparate", label: "Keep Separate / Not Same Subject" };
+  }
+  return null;
 }
 
 function StatusPill({ children }: { children: React.ReactNode }) {
@@ -307,6 +343,8 @@ export default function DossierControlCenterPage() {
   const [selectedDossierByCandidate, setSelectedDossierByCandidate] = useState<
     Record<string, string>
   >({});
+  const [consolidationResult, setConsolidationResult] =
+    useState<ConsolidationResult | null>(null);
 
   async function loadWorkflow() {
     setError(null);
@@ -466,6 +504,7 @@ export default function DossierControlCenterPage() {
         candidate?: DossierCandidate;
         draft?: DossierDraft;
         recommendation?: DossierRecommendation;
+        consolidation?: ConsolidationResult;
         error?: string;
         message?: string;
       };
@@ -480,6 +519,34 @@ export default function DossierControlCenterPage() {
       return data;
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function runConsolidationAction(action: string, groupId?: string) {
+    try {
+      const data = await postWorkflow({ action, groupId });
+      if (data.consolidation) {
+        setConsolidationResult(data.consolidation);
+        setNotice(data.consolidation.message);
+      }
+      if (data.candidates && data.drafts && data.workflow) {
+        setPayload(data as WorkflowPayload);
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Consolidation action failed.";
+      setConsolidationResult({
+        actionType: action,
+        groupId,
+        attachedRecommendationCount: 0,
+        mergedRecordCount: 0,
+        cleanedDuplicateCount: 0,
+        createdWorkspaces: [],
+        skipped: [],
+        blocked: [{ id: groupId ?? action, reason: message }],
+        message,
+      });
+      setNotice(message);
     }
   }
 
@@ -814,9 +881,28 @@ export default function DossierControlCenterPage() {
               The site can only audit records and recommendations already
               present in the workflow store. Active Discord members who have not
               been ingested by BNL will not appear here yet. This panel is
-              review-only: it does not merge, delete, publish, or mutate records
-              automatically.
+              admin-triggered only: it never mutates on page load, never publishes,
+              and every action is revalidated server-side before mutation.
             </p>
+
+            {consolidationResult && (
+              <div className={`border p-4 text-sm ${consolidationResult.blocked.length > 0 ? "border-red-400/70 bg-red-950/20 text-red-200" : "border-accent/70 bg-accent/10 text-accent"}`}>
+                <p className="font-semibold text-foreground">Consolidation result</p>
+                <p>{consolidationResult.message}</p>
+                {consolidationResult.createdWorkspaces.length > 0 && (
+                  <p>Created workspace(s): {consolidationResult.createdWorkspaces.map((workspace) => `${workspace.type} ${workspace.id}`).join(", ")}</p>
+                )}
+                <p>Attached recommendations: {consolidationResult.attachedRecommendationCount}</p>
+                <p>Merged records: {consolidationResult.mergedRecordCount}</p>
+                <p>Cleaned duplicates: {consolidationResult.cleanedDuplicateCount}</p>
+                {consolidationResult.skipped.length > 0 && (
+                  <p>Skipped: {consolidationResult.skipped.map((item) => `${item.id}: ${item.reason}`).join("; ")}</p>
+                )}
+                {consolidationResult.blocked.length > 0 && (
+                  <p>Blocked: {consolidationResult.blocked.map((item) => `${item.id}: ${item.reason}`).join("; ")}</p>
+                )}
+              </div>
+            )}
 
             <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-3 text-xs text-muted">
               {[
@@ -871,6 +957,19 @@ export default function DossierControlCenterPage() {
               ))}
             </div>
 
+            <div className="border border-border/70 bg-background/30 p-4 text-sm text-muted">
+              <p className="font-semibold text-foreground">Run Safe Consolidation</p>
+              <p>Bulk safe action summary: {populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Attach to Existing Source File candidate").reduce((total, group) => total + group.consolidationPlan.sourceRecords.filter((record) => record.type === "recommendation").length, 0)} recommendations will attach; {populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Empty duplicate cleanup candidate").length} empty duplicate group(s) will clean; {populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Create Dossier Update workspace candidate").length} dossier update workspace(s) will be created; {populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Create Source File candidate").length} new Source File(s) will be created; 0 public dossiers will be changed; 0 public pages will be published; {populationAudit.possibleDuplicateGroups.filter((group) => !["Attach to Existing Source File candidate", "Empty duplicate cleanup candidate", "Create Dossier Update workspace candidate", "Create Source File candidate"].includes(group.consolidationPlan.automationTier)).length} item(s) will remain blocked/review-required.</p>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => runConsolidationAction("runSafeConsolidation")}
+                className="mt-3 border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+              >
+                Run Safe Consolidation
+              </button>
+            </div>
+
             <section className="space-y-3">
               <div>
                 <p className="text-xs uppercase tracking-[0.35em] text-muted">
@@ -890,10 +989,12 @@ export default function DossierControlCenterPage() {
                     .slice(0, 10)
                     .map((group) => {
                       const plan = group.consolidationPlan;
+                      const consolidationAction = consolidationActionForTier(plan.automationTier);
+                      const justResolved = consolidationResult?.groupId === group.id;
                       return (
                       <article
                         key={group.id}
-                        className="border border-border/70 bg-background/20 p-4 text-sm text-muted"
+                        className={justResolved ? "border border-accent bg-accent/10 p-4 text-sm text-muted" : "border border-border/70 bg-background/20 p-4 text-sm text-muted"}
                       >
                         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                           <div>
@@ -939,14 +1040,21 @@ export default function DossierControlCenterPage() {
                                     {(record.publicDossierName || record.publicDossierId) && (
                                       <p>Public dossier match: {record.publicDossierName ?? record.publicDossierId}</p>
                                     )}
+                                    <p>Why included: {group.reason}</p>
                                     {record.incomingInfo.length > 0 && (
-                                      <p>What this would add: {record.incomingInfo.join("; ")}</p>
+                                      <p>What new info this adds: {record.incomingInfo.join("; ")}</p>
                                     )}
                                     {record.duplicateInfo.length > 0 && (
-                                      <p>Already represented / duplicate: {record.duplicateInfo.join("; ")}</p>
+                                      <p>Already represented: {record.duplicateInfo.join("; ")}</p>
+                                    )}
+                                    {record.uniqueInfo.length === 0 && record.incomingInfo.length === 0 && (
+                                      <p>Duplicate / no-new-info: no meaningful incoming fields detected.</p>
+                                    )}
+                                    {plan.mergePlanSections.flatMap((section) => section.irrelevantToKeptEntry).length > 0 && (
+                                      <p>Irrelevant/no-action: {plan.mergePlanSections.flatMap((section) => section.irrelevantToKeptEntry).join("; ")}</p>
                                     )}
                                     {!plan.targetRecord && (
-                                      <p>Needs Source File target before any future action.</p>
+                                      <p>Needs Source File or Dossier Update workspace target before attach/merge.</p>
                                     )}
                                     {record.href && (
                                       <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">
@@ -982,7 +1090,12 @@ export default function DossierControlCenterPage() {
                                 {plan.targetRecord.uniqueInfo.length > 0 && (
                                   <p>Target already has: {plan.targetRecord.uniqueInfo.join("; ")}</p>
                                 )}
-                                <p>What would be updated later: {plan.automationTier}</p>
+                                {plan.targetRecord.candidateId && (
+                                  <p>Target Source File ID: {plan.targetRecord.candidateId}</p>
+                                )}
+                                <p>What will be added to it: {plan.mergePlanSections.flatMap((section) => section.newInfoToAdd).join("; ") || "No new info detected."}</p>
+                                <p>What will not change: public dossier text, public publishing state, and internal alias visibility.</p>
+                                <p>Action available: {plan.automationTier}</p>
                                 {plan.targetRecord.href && (
                                   <Link href={plan.targetRecord.href} className="mt-2 inline-flex border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">
                                     Open target Source File
@@ -1023,21 +1136,30 @@ export default function DossierControlCenterPage() {
                               </div>
                             ))}
                           </div>
-                          <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
-                            {plan.automationTier === "Create Dossier Update workspace candidate"
-                              ? "Create Dossier Update Later"
-                              : plan.automationTier === "Create Source File candidate"
-                                ? "Create Source File Later"
-                                : plan.automationTier === "Attach to Existing Source File candidate"
-                                  ? "Attach Later"
-                                  : plan.automationTier === "Select Target Manually"
-                                    ? "Select Target Later"
-                                    : plan.automationTier === "Source File merge candidate"
-                                      ? "Merge Later"
-                                      : plan.automationTier === "Empty duplicate cleanup candidate"
-                                        ? "Clean Later"
-                                        : "Needs Source File Target"}
-                          </button>
+                          <div className="flex flex-wrap gap-2">
+                            {consolidationAction ? (
+                              <button
+                                type="button"
+                                disabled={saving}
+                                onClick={() => runConsolidationAction(consolidationAction.action, group.id)}
+                                className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                              >
+                                {consolidationAction.label}
+                              </button>
+                            ) : (
+                              <button disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">
+                                No Safe Action
+                              </button>
+                            )}
+                            {plan.automationTier === "Select Target Manually" && (
+                              <select disabled className="bg-background border border-border px-3 py-1.5 text-xs text-muted">
+                                <option>Select target manually (read-only)</option>
+                                {plan.possibleTargetRecords.map((record) => (
+                                  <option key={record.id}>{record.displayName ?? record.name}</option>
+                                ))}
+                              </select>
+                            )}
+                          </div>
                         </div>
                       </article>
                       );

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -35,6 +35,13 @@ import {
   archiveDossierRecommendation,
   attachCandidateToExistingDossier,
   attachRecommendationToCandidate,
+  attachIncomingRecommendationsFromConsolidation,
+  cleanDuplicateFromConsolidation,
+  createDossierUpdateWorkspaceFromConsolidation,
+  createSourceFileFromIncomingConsolidation,
+  keepConsolidationSeparate,
+  mergeConsolidationIntoTarget,
+  runSafeConsolidation,
   createIdentityLinkFromRecommendation,
   confirmDossierIdentityLink,
   buildDossierDuplicateGroups,
@@ -147,6 +154,13 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "archiveDossierRecommendation",
   "attachCandidateToExistingDossier",
   "markCandidateAsExistingDossierUpdate",
+  "consolidateAttachIncomingRecommendations",
+  "createDossierUpdateWorkspace",
+  "createSourceFileFromIncomingInfo",
+  "mergeConsolidationIntoTarget",
+  "cleanDuplicateConsolidation",
+  "keepConsolidationSeparate",
+  "runSafeConsolidation",
 ]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
@@ -453,6 +467,41 @@ export async function POST(req: Request) {
   }
 
   try {
+    if (
+      action === "consolidateAttachIncomingRecommendations" ||
+      action === "createDossierUpdateWorkspace" ||
+      action === "createSourceFileFromIncomingInfo" ||
+      action === "mergeConsolidationIntoTarget" ||
+      action === "cleanDuplicateConsolidation" ||
+      action === "keepConsolidationSeparate" ||
+      action === "runSafeConsolidation"
+    ) {
+      const groupId = typeof body.groupId === "string" ? body.groupId.trim() : "";
+      const actor = typeof body.actor === "string" ? body.actor : undefined;
+      if (action !== "runSafeConsolidation" && !groupId) {
+        return NextResponse.json(
+          { error: "groupId is required for consolidation actions" },
+          { status: 400 },
+        );
+      }
+      const consolidation =
+        action === "consolidateAttachIncomingRecommendations"
+          ? await attachIncomingRecommendationsFromConsolidation({ groupId, actor })
+          : action === "createDossierUpdateWorkspace"
+            ? await createDossierUpdateWorkspaceFromConsolidation({ groupId, actor })
+            : action === "createSourceFileFromIncomingInfo"
+              ? await createSourceFileFromIncomingConsolidation({ groupId, actor })
+              : action === "mergeConsolidationIntoTarget"
+                ? await mergeConsolidationIntoTarget({ groupId, actor })
+                : action === "cleanDuplicateConsolidation"
+                  ? await cleanDuplicateFromConsolidation({ groupId, actor })
+                  : action === "keepConsolidationSeparate"
+                    ? await keepConsolidationSeparate({ groupId, actor })
+                    : await runSafeConsolidation({ actor });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, consolidation, ...payload });
+    }
+
     if (action === "updateSourceFileSummary") {
       const input = sourceFileSummaryInputFromBody(body);
       if (!input) {
@@ -858,6 +907,12 @@ export async function POST(req: Request) {
     if (error instanceof DossierWorkflowInputError) {
       return NextResponse.json(
         { error: error.message, code: error.code, ...error.details },
+        { status: error.status },
+      );
+    }
+    if (error instanceof DossierMergeError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
         { status: error.status },
       );
     }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -42,9 +42,12 @@ import {
   type DossierSourceFileNoteType,
   type DossierDuplicateRisk,
   type DossierWorkflowLink,
+  createDossierPopulationAudit,
   isActiveSourceFileCandidate,
   isSourceFileEnrichmentAttachableCandidate,
   matchDossierRecommendationSubject,
+  type DossierPopulationAutomationTier,
+  type DossierPopulationConsolidationPlan,
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 
@@ -5562,6 +5565,14 @@ export async function mergeDossierCandidates(
       publicSafetyNotes: uniqueStrings(
         ...primaryFirstSources.map((candidate) => candidate.publicSafetyNotes),
       ),
+      sourceFileNotes: primaryFirstSources.flatMap((candidate) => candidate.sourceFileNotes ?? []),
+      identityLinks: primaryFirstSources.flatMap((candidate) => candidate.identityLinks ?? []),
+      sourceRecommendationIds: uniqueStrings(
+        ...primaryFirstSources.map((candidate) => candidate.sourceRecommendationIds),
+      ),
+      connectedRecommendationIds: uniqueStrings(
+        ...primaryFirstSources.map((candidate) => candidate.connectedRecommendationIds),
+      ),
       status:
         primary.status === "draft_ready" || primary.status === "draft_requested"
           ? "draft_ready"
@@ -5698,6 +5709,431 @@ export async function mergeDossierCandidates(
     };
   });
 
+  return result;
+}
+
+export type DossierConsolidationActionResult = {
+  ok: true;
+  actionType: string;
+  groupId?: string;
+  targetId?: string;
+  targetHref?: string;
+  sourceIds: string[];
+  recommendationIds: string[];
+  attachedRecommendationCount: number;
+  mergedRecordCount: number;
+  cleanedDuplicateCount: number;
+  createdWorkspaces: Array<{ id: string; href: string; type: string; name: string }>;
+  skipped: Array<{ id: string; reason: string }>;
+  blocked: Array<{ id: string; reason: string }>;
+  message: string;
+};
+
+function publicDossierRefsFor(candidate: DossierCandidate): string[] {
+  return candidate.existingDossierMatch?.id ? [candidate.existingDossierMatch.id] : [];
+}
+
+function activeDraftsForCandidate(state: DossierWorkflowState, candidateId: string): DossierDraft[] {
+  return state.drafts.filter(
+    (draft) =>
+      draft.candidateId === candidateId &&
+      (draft.status === "draft" ||
+        draft.status === "owner_changes_requested" ||
+        draft.status === "ready_for_owner_review"),
+  );
+}
+
+function candidateHasMeaningfulConsolidationData(state: DossierWorkflowState, candidate: DossierCandidate): boolean {
+  return Boolean(
+    (candidate.sourceFileNotes ?? []).some((note) => note.status === "active" && note.text.trim()) ||
+      (candidate.identityLinks ?? []).length > 0 ||
+      (candidate.sourceRecommendationIds ?? []).length > 0 ||
+      (candidate.connectedRecommendationIds ?? []).length > 0 ||
+      state.recommendations.some(
+        (recommendation) =>
+          recommendation.targetCandidateId === candidate.id ||
+          recommendation.connectedCandidateId === candidate.id ||
+          recommendation.connectedSourceFileCandidateId === candidate.id,
+      ) ||
+      candidate.latestSourceFileArchiveId ||
+      candidate.latestSourceFileArchiveUpdatedAt ||
+      candidate.latestSourceFileArchive?.caseReportPresent ||
+      activeDraftsForCandidate(state, candidate.id).length > 0 ||
+      candidate.existingDossierMatch,
+  );
+}
+
+function attachRecommendationToWorkspace(input: {
+  recommendation: DossierRecommendation;
+  candidate: DossierCandidate;
+  now: string;
+  auditText: string;
+}): { recommendation: DossierRecommendation; candidate: DossierCandidate } {
+  assertRecommendationIsOpen(input.recommendation);
+  const note = routingNote({
+    candidateId: input.candidate.id,
+    now: input.now,
+    text: `${input.auditText}\n\n${input.recommendation.ingestSource?.startsWith("bnl") ? bnlAutoCandidateNoteText(input.recommendation) : recommendationSourceNoteText(input.recommendation)}`,
+    source: "bnl_recommendation",
+    createdBy: input.recommendation.createdBy,
+    ingestKey: input.recommendation.ingestKey,
+    ingestedAt: input.recommendation.ingestedAt,
+    ingestSource: input.recommendation.ingestSource,
+  });
+  return {
+    recommendation: {
+      ...input.recommendation,
+      status: attachmentStatusForCandidate(input.candidate),
+      targetCandidateId: input.candidate.id,
+      connectedCandidateId: input.candidate.id,
+      connectedSourceFileCandidateId: input.candidate.id,
+      routingReason: input.auditText,
+      updatedAt: input.now,
+    },
+    candidate: mergeCandidateSignal({
+      candidate: input.candidate,
+      now: input.now,
+      note,
+      evidenceSummary: input.recommendation.evidenceSummary,
+      connectedRecommendationId: input.recommendation.id,
+      routingReason: input.auditText,
+      identityReviewStatus: "not_required",
+    }),
+  };
+}
+
+function consolidationPlanForGroup(state: DossierWorkflowState, groupId: string): DossierPopulationConsolidationPlan {
+  const audit = createDossierPopulationAudit({
+    candidates: state.candidates,
+    recommendations: state.recommendations,
+    publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })),
+    drafts: state.drafts,
+  });
+  const plan = audit.possibleDuplicateGroups.find((group) => group.id === groupId)?.consolidationPlan;
+  if (!plan) {
+    throw new DossierWorkflowInputError(
+      "Consolidation group no longer exists after server-side revalidation. Refresh the audit and review the current plan.",
+      409,
+      "consolidation_group_not_found",
+    );
+  }
+  return plan;
+}
+
+function assertConsolidationTier(plan: DossierPopulationConsolidationPlan, allowed: DossierPopulationAutomationTier[]): void {
+  if (allowed.includes(plan.automationTier)) return;
+  throw new DossierWorkflowInputError(
+    `Server-side revalidation classified this group as ${plan.automationTier}; refresh the audit before mutating anything.`,
+    409,
+    "consolidation_tier_changed",
+    { automationTier: plan.automationTier, allowedTiers: allowed },
+  );
+}
+
+function resultBase(actionType: string, groupId?: string): DossierConsolidationActionResult {
+  return {
+    ok: true,
+    actionType,
+    groupId,
+    sourceIds: [],
+    recommendationIds: [],
+    attachedRecommendationCount: 0,
+    mergedRecordCount: 0,
+    cleanedDuplicateCount: 0,
+    createdWorkspaces: [],
+    skipped: [],
+    blocked: [],
+    message: "No public dossier text changed. No public pages were published. Internal aliases remain internal.",
+  };
+}
+
+export async function attachIncomingRecommendationsFromConsolidation(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const now = new Date().toISOString();
+  const result = resultBase("attach_incoming_recommendations", input.groupId);
+  await updateDossierWorkflowState((currentState) => {
+    const plan = consolidationPlanForGroup(currentState, input.groupId);
+    assertConsolidationTier(plan, ["Attach to Existing Source File candidate"]);
+    const targetId = plan.targetRecord?.candidateId;
+    const recommendationIds = plan.sourceRecords.filter((record) => record.type === "recommendation" && record.recommendationId).map((record) => record.recommendationId!);
+    if (!targetId || recommendationIds.length === 0) {
+      throw new DossierWorkflowInputError("No target Source File and incoming recommendations remained after revalidation.", 409, "consolidation_attach_empty");
+    }
+    let target = currentState.candidates.find((candidate) => candidate.id === targetId);
+    if (!target || !isActiveSourceFileCandidate(target)) {
+      throw new DossierWorkflowInputError("Target is no longer an active Source File after revalidation.", 409, "consolidation_target_changed");
+    }
+    const recommendations = currentState.recommendations.map((recommendation) => {
+      if (!recommendationIds.includes(recommendation.id)) return recommendation;
+      const attached = attachRecommendationToWorkspace({
+        recommendation,
+        candidate: target!,
+        now,
+        auditText: `Consolidation attach by ${input.actor ?? "admin"} at ${now}; group ${input.groupId}; no public dossier text changed.`,
+      });
+      target = attached.candidate;
+      result.recommendationIds.push(recommendation.id);
+      result.attachedRecommendationCount += 1;
+      return attached.recommendation;
+    });
+    result.targetId = target.id;
+    result.targetHref = `/admin/dossiers/candidates/${target.id}`;
+    result.sourceIds = recommendationIds;
+    result.message = `Attached ${result.attachedRecommendationCount} incoming recommendation(s) to ${target.name}. No public dossier text changed. No public pages were published.`;
+    return {
+      ...currentState,
+      recommendations,
+      candidates: currentState.candidates.map((candidate) => candidate.id === target!.id ? target! : candidate),
+      updatedAt: now,
+    };
+  });
+  return result;
+}
+
+export async function createDossierUpdateWorkspaceFromConsolidation(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const now = new Date().toISOString();
+  const result = resultBase("create_dossier_update_workspace", input.groupId);
+  await updateDossierWorkflowState((currentState) => {
+    const plan = consolidationPlanForGroup(currentState, input.groupId);
+    assertConsolidationTier(plan, ["Create Dossier Update workspace candidate"]);
+    const dossierId = plan.existingPublicDossier?.id;
+    if (!dossierId) throw new DossierWorkflowInputError("No exact public dossier match remained after revalidation.", 409, "consolidation_public_target_missing");
+    const entry = databasePage.entries.find((item) => item.id === dossierId);
+    if (!entry) throw new DossierWorkflowInputError("Existing public dossier target was not found.", 400, "existing_dossier_not_found");
+    const existing = currentState.candidates.find((candidate) => candidate.status === "existing_dossier_update" && candidate.existingDossierMatch?.id === dossierId);
+    const recommendationIds = plan.sourceRecords.filter((record) => record.type === "recommendation" && record.recommendationId).map((record) => record.recommendationId!);
+    if (existing) throw new DossierWorkflowInputError("A Dossier Update workspace now exists; refresh and use Attach Incoming Recommendations.", 409, "consolidation_workspace_now_exists", { targetId: existing.id });
+    let workspace: DossierCandidate = {
+      id: createCandidateId(),
+      name: entry.name,
+      candidateType: candidateTypeFromPublicDossierEntry(entry),
+      source: "website_read_model",
+      tier: "review_candidate",
+      score: 58,
+      whyNow: "Admin created a review-only Dossier Update workspace from a safe consolidation plan.",
+      reason: `Consolidation workspace for existing public dossier ${entry.id} / ${entry.name}.`,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      evidenceSummary: `Review-only update workspace created from consolidation group ${input.groupId}; no public dossier text changed.`,
+      evidenceItems: [],
+      evidenceCount: 0,
+      knownFacts: [`Existing public dossier target: ${entry.id} / ${entry.name}.`],
+      confidence: "medium",
+      duplicateRisk: "high",
+      existingDossierMatch: { id: entry.id, name: entry.name, confidence: "high" },
+      recommendedCategory: entry.category,
+      recommendedKind: entry.kind,
+      recommendedEcosystemLane: entry.ecosystemLane,
+      recommendedIdentityAuthority: entry.identityAuthority,
+      recommendedStatus: entry.status,
+      recommendedClearance: entry.clearance,
+      recommendedOrigin: entry.origin,
+      recommendedTags: entry.tags,
+      proposedTags: [],
+      missingInfo: ["Review incoming recommendations before applying any public dossier update."],
+      doNotSay: ["Do not treat update recommendations as public copy."],
+      publicSafetyNotes: ["No public dossier text changed during consolidation."],
+      sourceFileNotes: [],
+      identityLinks: [],
+      sourceLanes: ["website_dossier"],
+      status: "existing_dossier_update",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const recommendations = currentState.recommendations.map((recommendation) => {
+      if (!recommendationIds.includes(recommendation.id)) return recommendation;
+      const attached = attachRecommendationToWorkspace({
+        recommendation,
+        candidate: workspace,
+        now,
+        auditText: `Consolidation dossier-update workspace created by ${input.actor ?? "admin"} at ${now}; group ${input.groupId}; no public dossier text changed.`,
+      });
+      workspace = attached.candidate;
+      result.recommendationIds.push(recommendation.id);
+      result.attachedRecommendationCount += 1;
+      return attached.recommendation;
+    });
+    result.targetId = workspace.id;
+    result.targetHref = `/admin/dossiers/candidates/${workspace.id}`;
+    result.createdWorkspaces.push({ id: workspace.id, href: `/admin/dossiers/candidates/${workspace.id}`, type: "Dossier Update", name: workspace.name });
+    result.message = `Created Dossier Update workspace ${workspace.id} and attached ${result.attachedRecommendationCount} recommendation(s). No public dossier text changed. No public pages were published.`;
+    return { ...currentState, candidates: [workspace, ...currentState.candidates], recommendations, updatedAt: now };
+  });
+  return result;
+}
+
+export async function createSourceFileFromIncomingConsolidation(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const now = new Date().toISOString();
+  const result = resultBase("create_source_file_from_incoming", input.groupId);
+  await updateDossierWorkflowState((currentState) => {
+    const plan = consolidationPlanForGroup(currentState, input.groupId);
+    assertConsolidationTier(plan, ["Create Source File candidate"]);
+    const recommendationIds = plan.sourceRecords.filter((record) => record.type === "recommendation" && record.recommendationId).map((record) => record.recommendationId!);
+    if (plan.possibleTargetRecords.length > 0 || plan.existingPublicDossier) {
+      throw new DossierWorkflowInputError("A possible existing target appeared during revalidation; refresh before creating a new Source File.", 409, "consolidation_possible_target_changed");
+    }
+    const firstRecommendation = currentState.recommendations.find((recommendation) => recommendationIds.includes(recommendation.id));
+    if (!firstRecommendation) throw new DossierWorkflowInputError("No open incoming recommendations remained after revalidation.", 409, "consolidation_recommendations_missing");
+    let candidate = buildCandidateFromRecommendation({
+      recommendation: firstRecommendation,
+      now,
+      source: firstRecommendation.ingestSource === "bnl_source_knowledge_bridge" ? "bnl_source_knowledge_bridge" : "bnl_dynamic_candidate_discovery",
+      noteText: `Consolidation-created Source File by ${input.actor ?? "admin"} at ${now}; group ${input.groupId}; no public dossier text changed.\n\n${bnlAutoCandidateNoteText(firstRecommendation)}`,
+    });
+    candidate = { ...candidate, status: "active_source_file", updatedAt: now };
+    const recommendations = currentState.recommendations.map((recommendation) => {
+      if (!recommendationIds.includes(recommendation.id)) return recommendation;
+      if (recommendation.id === firstRecommendation.id) {
+        result.recommendationIds.push(recommendation.id);
+        result.attachedRecommendationCount += 1;
+        return { ...recommendation, status: "converted_to_source_file" as const, targetCandidateId: candidate.id, connectedCandidateId: candidate.id, connectedSourceFileCandidateId: candidate.id, routingReason: `Consolidation-created Source File from group ${input.groupId}.`, updatedAt: now };
+      }
+      const attached = attachRecommendationToWorkspace({
+        recommendation,
+        candidate,
+        now,
+        auditText: `Consolidation attach to newly created Source File by ${input.actor ?? "admin"} at ${now}; group ${input.groupId}; no public dossier text changed.`,
+      });
+      candidate = attached.candidate;
+      result.recommendationIds.push(recommendation.id);
+      result.attachedRecommendationCount += 1;
+      return attached.recommendation;
+    });
+    result.targetId = candidate.id;
+    result.targetHref = `/admin/dossiers/candidates/${candidate.id}`;
+    result.createdWorkspaces.push({ id: candidate.id, href: `/admin/dossiers/candidates/${candidate.id}`, type: "Source File / Candidate", name: candidate.name });
+    result.message = `Created Source File ${candidate.id} and attached ${result.attachedRecommendationCount} recommendation(s). No public dossier text changed. No public pages were published.`;
+    return { ...currentState, candidates: [candidate, ...currentState.candidates], recommendations, updatedAt: now };
+  });
+  return result;
+}
+
+export async function cleanDuplicateFromConsolidation(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const now = new Date().toISOString();
+  const result = resultBase("clean_duplicate", input.groupId);
+  await updateDossierWorkflowState((currentState) => {
+    const plan = consolidationPlanForGroup(currentState, input.groupId);
+    assertConsolidationTier(plan, ["Empty duplicate cleanup candidate"]);
+    const sourceIds = plan.sourceRecords.filter((record) => record.candidateId).map((record) => record.candidateId!);
+    if (!plan.targetRecord?.candidateId || sourceIds.length === 0) {
+      throw new DossierWorkflowInputError("No duplicate cleanup source remained after revalidation.", 409, "consolidation_cleanup_empty");
+    }
+    const blocked = sourceIds.filter((id) => {
+      const candidate = currentState.candidates.find((item) => item.id === id);
+      return !candidate || candidateHasMeaningfulConsolidationData(currentState, candidate);
+    });
+    if (blocked.length > 0) {
+      throw new DossierWorkflowInputError("Duplicate cleanup refused because a source now has meaningful linked data.", 409, "consolidation_cleanup_refused", { blocked });
+    }
+    const candidates = currentState.candidates.map((candidate) =>
+      sourceIds.includes(candidate.id)
+        ? {
+            ...candidate,
+            status: "merged" as const,
+            mergedIntoCandidateId: plan.targetRecord!.candidateId,
+            mergedAt: now,
+            mergeNote: `Empty duplicate cleaned by ${input.actor ?? "admin"} from consolidation group ${input.groupId}; no meaningful linked data was present.`,
+            updatedAt: now,
+          }
+        : candidate,
+    );
+    result.targetId = plan.targetRecord.candidateId;
+    result.targetHref = `/admin/dossiers/candidates/${plan.targetRecord.candidateId}`;
+    result.sourceIds = sourceIds;
+    result.cleanedDuplicateCount = sourceIds.length;
+    result.message = `Cleaned ${sourceIds.length} empty duplicate record(s) by marking them merged. No public dossier text changed. No public pages were published.`;
+    return { ...currentState, candidates, updatedAt: now };
+  });
+  return result;
+}
+
+export async function mergeConsolidationIntoTarget(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const state = await getDossierWorkflowState();
+  const plan = consolidationPlanForGroup(state, input.groupId);
+  assertConsolidationTier(plan, ["Source File merge candidate"]);
+  if (!plan.targetRecord?.candidateId) throw new DossierWorkflowInputError("No merge target remained after revalidation.", 409, "consolidation_target_missing");
+  const sourceIds = plan.sourceRecords.filter((record) => record.candidateId).map((record) => record.candidateId!);
+  const candidates = [plan.targetRecord.candidateId, ...sourceIds].map((id) => state.candidates.find((candidate) => candidate.id === id)).filter((candidate): candidate is DossierCandidate => Boolean(candidate));
+  const publicMatches = new Set(candidates.flatMap(publicDossierRefsFor));
+  if (publicMatches.size > 1) throw new DossierWorkflowInputError("Merge blocked because different public dossier matches are present.", 409, "consolidation_public_dossier_conflict");
+  if (candidates.filter((candidate) => activeDraftsForCandidate(state, candidate.id).length > 0).length > 1) throw new DossierWorkflowInputError("Merge blocked because competing active proposed dossiers are present.", 409, "consolidation_active_draft_conflict");
+  const mergeResult = await mergeDossierCandidates({
+    primaryCandidateId: plan.targetRecord.candidateId,
+    sourceCandidateIds: sourceIds,
+    createMasterDraft: false,
+    mergeNote: `Source File consolidation by ${input.actor ?? "admin"} at ${new Date().toISOString()}; group ${input.groupId}; no public dossier text changed and no public pages were published.`,
+  });
+  const result = resultBase("merge_into_target", input.groupId);
+  result.targetId = mergeResult?.masterCandidate.id;
+  result.targetHref = mergeResult?.masterCandidate.id ? `/admin/dossiers/candidates/${mergeResult.masterCandidate.id}` : undefined;
+  result.sourceIds = sourceIds;
+  result.mergedRecordCount = mergeResult?.mergedCandidateIds.length ?? 0;
+  result.message = `Merged ${result.mergedRecordCount} Source File record(s) into ${mergeResult?.masterCandidate.name ?? plan.targetRecord.name}. No public dossier text changed. No public pages were published.`;
+  return result;
+}
+
+export async function keepConsolidationSeparate(input: {
+  groupId: string;
+  actor?: string;
+}): Promise<DossierConsolidationActionResult> {
+  const state = await getDossierWorkflowState();
+  const plan = consolidationPlanForGroup(state, input.groupId);
+  const result = resultBase("keep_separate", input.groupId);
+  result.skipped.push({ id: input.groupId, reason: "Suppression markers are not supported by the current workflow store, so no records were mutated." });
+  result.message = `Reviewed ${plan.groupId} as keep separate. The current workflow store has no durable suppression marker, so no records were mutated.`;
+  return result;
+}
+
+export async function runSafeConsolidation(input: { actor?: string }): Promise<DossierConsolidationActionResult> {
+  const state = await getDossierWorkflowState();
+  const audit = createDossierPopulationAudit({
+    candidates: state.candidates,
+    recommendations: state.recommendations,
+    publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })),
+    drafts: state.drafts,
+  });
+  const result = resultBase("run_safe_consolidation");
+  for (const group of audit.possibleDuplicateGroups) {
+    const tier = group.consolidationPlan.automationTier;
+    try {
+      if (tier === "Attach to Existing Source File candidate") {
+        const partial = await attachIncomingRecommendationsFromConsolidation({ groupId: group.id, actor: input.actor });
+        result.attachedRecommendationCount += partial.attachedRecommendationCount;
+        result.recommendationIds.push(...partial.recommendationIds);
+      } else if (tier === "Create Dossier Update workspace candidate") {
+        const partial = await createDossierUpdateWorkspaceFromConsolidation({ groupId: group.id, actor: input.actor });
+        result.attachedRecommendationCount += partial.attachedRecommendationCount;
+        result.createdWorkspaces.push(...partial.createdWorkspaces);
+      } else if (tier === "Create Source File candidate") {
+        const partial = await createSourceFileFromIncomingConsolidation({ groupId: group.id, actor: input.actor });
+        result.attachedRecommendationCount += partial.attachedRecommendationCount;
+        result.createdWorkspaces.push(...partial.createdWorkspaces);
+      } else if (tier === "Empty duplicate cleanup candidate") {
+        const partial = await cleanDuplicateFromConsolidation({ groupId: group.id, actor: input.actor });
+        result.cleanedDuplicateCount += partial.cleanedDuplicateCount;
+        result.sourceIds.push(...partial.sourceIds);
+      } else {
+        result.skipped.push({ id: group.id, reason: `${tier} is not a zero-conflict bulk action.` });
+      }
+    } catch (error) {
+      result.blocked.push({ id: group.id, reason: error instanceof Error ? error.message : "Action blocked during server-side revalidation." });
+    }
+  }
+  result.message = `Safe consolidation complete: ${result.attachedRecommendationCount} recommendation(s) attached, ${result.cleanedDuplicateCount} duplicate(s) cleaned, ${result.createdWorkspaces.length} workspace(s) created, ${result.skipped.length} skipped, ${result.blocked.length} blocked. No public dossier text changed. No public pages were published.`;
   return result;
 }
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -5712,6 +5712,14 @@ export async function mergeDossierCandidates(
   return result;
 }
 
+export type DossierConsolidationRefreshStatus = {
+  targetId: string;
+  targetName?: string;
+  status: "queued" | "already_pending" | "needed" | "unavailable";
+  requestId?: string;
+  message: string;
+};
+
 export type DossierConsolidationActionResult = {
   ok: true;
   actionType: string;
@@ -5724,10 +5732,54 @@ export type DossierConsolidationActionResult = {
   mergedRecordCount: number;
   cleanedDuplicateCount: number;
   createdWorkspaces: Array<{ id: string; href: string; type: string; name: string }>;
+  bnlRefreshes: DossierConsolidationRefreshStatus[];
   skipped: Array<{ id: string; reason: string }>;
   blocked: Array<{ id: string; reason: string }>;
   message: string;
 };
+
+function queueConsolidationBnlRefresh(input: {
+  state: DossierWorkflowState;
+  candidate: DossierCandidate;
+  now: string;
+  actionType: string;
+  actor?: string;
+}): { state: DossierWorkflowState; refresh: DossierConsolidationRefreshStatus } {
+  if (!isSourceFileEnrichmentAttachableCandidate(input.candidate)) {
+    return {
+      state: input.state,
+      refresh: {
+        targetId: input.candidate.id,
+        targetName: input.candidate.name,
+        status: "needed",
+        message:
+          "BNL refresh required, but this workspace is not currently eligible for the existing Source File refresh queue. Use the Source File refresh action after review.",
+      },
+    };
+  }
+  const upserted = upsertSourceFileRefreshRequestInState({
+    state: input.state,
+    candidate: input.candidate,
+    reason: `Consolidation ${input.actionType} added new review-only source material; BNL should recompile this Source File.`,
+    requestSource: "manual_admin",
+    priority: 92,
+    requestedBy: input.actor ?? "admin_consolidation",
+    now: input.now,
+    force: true,
+  });
+  return {
+    state: upserted.state,
+    refresh: {
+      targetId: input.candidate.id,
+      targetName: input.candidate.name,
+      status: upserted.created ? "queued" : "already_pending",
+      requestId: upserted.request.id,
+      message: upserted.created
+        ? "BNL Source File refresh queued after consolidation."
+        : "BNL Source File refresh already pending; consolidation updated the request priority/reason.",
+    },
+  };
+}
 
 function publicDossierRefsFor(candidate: DossierCandidate): string[] {
   return candidate.existingDossierMatch?.id ? [candidate.existingDossierMatch.id] : [];
@@ -5841,6 +5893,7 @@ function resultBase(actionType: string, groupId?: string): DossierConsolidationA
     mergedRecordCount: 0,
     cleanedDuplicateCount: 0,
     createdWorkspaces: [],
+    bnlRefreshes: [],
     skipped: [],
     blocked: [],
     message: "No public dossier text changed. No public pages were published. Internal aliases remain internal.",
@@ -5881,13 +5934,22 @@ export async function attachIncomingRecommendationsFromConsolidation(input: {
     result.targetId = target.id;
     result.targetHref = `/admin/dossiers/candidates/${target.id}`;
     result.sourceIds = recommendationIds;
-    result.message = `Attached ${result.attachedRecommendationCount} incoming recommendation(s) to ${target.name}. No public dossier text changed. No public pages were published.`;
-    return {
+    const stateWithAttachment = {
       ...currentState,
       recommendations,
       candidates: currentState.candidates.map((candidate) => candidate.id === target!.id ? target! : candidate),
       updatedAt: now,
     };
+    const refresh = queueConsolidationBnlRefresh({
+      state: stateWithAttachment,
+      candidate: target,
+      now,
+      actionType: "attach incoming recommendations",
+      actor: input.actor,
+    });
+    result.bnlRefreshes.push(refresh.refresh);
+    result.message = `Attached ${result.attachedRecommendationCount} incoming recommendation(s) to ${target.name}. ${refresh.refresh.message} No public dossier text changed. No public pages were published.`;
+    return refresh.state;
   });
   return result;
 }
@@ -5961,8 +6023,17 @@ export async function createDossierUpdateWorkspaceFromConsolidation(input: {
     result.targetId = workspace.id;
     result.targetHref = `/admin/dossiers/candidates/${workspace.id}`;
     result.createdWorkspaces.push({ id: workspace.id, href: `/admin/dossiers/candidates/${workspace.id}`, type: "Dossier Update", name: workspace.name });
-    result.message = `Created Dossier Update workspace ${workspace.id} and attached ${result.attachedRecommendationCount} recommendation(s). No public dossier text changed. No public pages were published.`;
-    return { ...currentState, candidates: [workspace, ...currentState.candidates], recommendations, updatedAt: now };
+    const stateWithWorkspace = { ...currentState, candidates: [workspace, ...currentState.candidates], recommendations, updatedAt: now };
+    const refresh = queueConsolidationBnlRefresh({
+      state: stateWithWorkspace,
+      candidate: workspace,
+      now,
+      actionType: "create dossier update workspace",
+      actor: input.actor,
+    });
+    result.bnlRefreshes.push(refresh.refresh);
+    result.message = `Created Dossier Update workspace ${workspace.id} and attached ${result.attachedRecommendationCount} recommendation(s). ${refresh.refresh.message} No public dossier text changed. No public pages were published.`;
+    return refresh.state;
   });
   return result;
 }
@@ -6010,8 +6081,17 @@ export async function createSourceFileFromIncomingConsolidation(input: {
     result.targetId = candidate.id;
     result.targetHref = `/admin/dossiers/candidates/${candidate.id}`;
     result.createdWorkspaces.push({ id: candidate.id, href: `/admin/dossiers/candidates/${candidate.id}`, type: "Source File / Candidate", name: candidate.name });
-    result.message = `Created Source File ${candidate.id} and attached ${result.attachedRecommendationCount} recommendation(s). No public dossier text changed. No public pages were published.`;
-    return { ...currentState, candidates: [candidate, ...currentState.candidates], recommendations, updatedAt: now };
+    const stateWithSourceFile = { ...currentState, candidates: [candidate, ...currentState.candidates], recommendations, updatedAt: now };
+    const refresh = queueConsolidationBnlRefresh({
+      state: stateWithSourceFile,
+      candidate,
+      now,
+      actionType: "create source file from signals",
+      actor: input.actor,
+    });
+    result.bnlRefreshes.push(refresh.refresh);
+    result.message = `Created Source File ${candidate.id} and attached ${result.attachedRecommendationCount} recommendation(s). ${refresh.refresh.message} No public dossier text changed. No public pages were published.`;
+    return refresh.state;
   });
   return result;
 }
@@ -6082,7 +6162,25 @@ export async function mergeConsolidationIntoTarget(input: {
   result.targetHref = mergeResult?.masterCandidate.id ? `/admin/dossiers/candidates/${mergeResult.masterCandidate.id}` : undefined;
   result.sourceIds = sourceIds;
   result.mergedRecordCount = mergeResult?.mergedCandidateIds.length ?? 0;
-  result.message = `Merged ${result.mergedRecordCount} Source File record(s) into ${mergeResult?.masterCandidate.name ?? plan.targetRecord.name}. No public dossier text changed. No public pages were published.`;
+  if (mergeResult?.masterCandidate.id) {
+    const refresh = await requestDossierSourceFileRefresh({
+      candidateId: mergeResult.masterCandidate.id,
+      reason: "Consolidation merge added source material; BNL should recompile this kept Source File.",
+      requestSource: "manual_admin",
+      requestedBy: input.actor ?? "admin_consolidation",
+      priority: 92,
+    });
+    result.bnlRefreshes.push({
+      targetId: mergeResult.masterCandidate.id,
+      targetName: mergeResult.masterCandidate.name,
+      status: refresh.created ? "queued" : "already_pending",
+      requestId: refresh.request.id,
+      message: refresh.created
+        ? "BNL Source File refresh queued after consolidation."
+        : "BNL Source File refresh already pending; consolidation updated the request priority/reason.",
+    });
+  }
+  result.message = `Merged ${result.mergedRecordCount} Source File record(s) into ${mergeResult?.masterCandidate.name ?? plan.targetRecord.name}. ${result.bnlRefreshes[0]?.message ?? "BNL refresh required for the kept Source File."} No public dossier text changed. No public pages were published.`;
   return result;
 }
 
@@ -6114,14 +6212,17 @@ export async function runSafeConsolidation(input: { actor?: string }): Promise<D
         const partial = await attachIncomingRecommendationsFromConsolidation({ groupId: group.id, actor: input.actor });
         result.attachedRecommendationCount += partial.attachedRecommendationCount;
         result.recommendationIds.push(...partial.recommendationIds);
+        result.bnlRefreshes.push(...partial.bnlRefreshes);
       } else if (tier === "Create Dossier Update workspace candidate") {
         const partial = await createDossierUpdateWorkspaceFromConsolidation({ groupId: group.id, actor: input.actor });
         result.attachedRecommendationCount += partial.attachedRecommendationCount;
         result.createdWorkspaces.push(...partial.createdWorkspaces);
+        result.bnlRefreshes.push(...partial.bnlRefreshes);
       } else if (tier === "Create Source File candidate") {
         const partial = await createSourceFileFromIncomingConsolidation({ groupId: group.id, actor: input.actor });
         result.attachedRecommendationCount += partial.attachedRecommendationCount;
         result.createdWorkspaces.push(...partial.createdWorkspaces);
+        result.bnlRefreshes.push(...partial.bnlRefreshes);
       } else if (tier === "Empty duplicate cleanup candidate") {
         const partial = await cleanDuplicateFromConsolidation({ groupId: group.id, actor: input.actor });
         result.cleanedDuplicateCount += partial.cleanedDuplicateCount;
@@ -6133,7 +6234,7 @@ export async function runSafeConsolidation(input: { actor?: string }): Promise<D
       result.blocked.push({ id: group.id, reason: error instanceof Error ? error.message : "Action blocked during server-side revalidation." });
     }
   }
-  result.message = `Safe consolidation complete: ${result.attachedRecommendationCount} recommendation(s) attached, ${result.cleanedDuplicateCount} duplicate(s) cleaned, ${result.createdWorkspaces.length} workspace(s) created, ${result.skipped.length} skipped, ${result.blocked.length} blocked. No public dossier text changed. No public pages were published.`;
+  result.message = `Safe consolidation complete: ${result.attachedRecommendationCount} recommendation(s) attached, ${result.cleanedDuplicateCount} duplicate(s) cleaned, ${result.createdWorkspaces.length} workspace(s) created, ${result.bnlRefreshes.length} BNL refresh(es) queued/marked, ${result.skipped.length} skipped, ${result.blocked.length} blocked. No public dossier text changed. No public pages were published.`;
   return result;
 }
 

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -1152,8 +1152,8 @@ function createConsolidationPlan(input: {
   ].includes(automationTier);
   const requiresReview = !canBeAutomatedLater || records.some((record) => record.proposedAliasCount > 0);
   const noTargetExplanation = sharedPublicTarget
-    ? `These are duplicate or related BNL recommendations for an existing public dossier, but no Dossier Update workspace exists in this group yet. The next action is to create/select a Dossier Update workspace later.`
-    : "These are duplicate or related BNL recommendations, but no Source File target exists in this group yet. The next action is to attach them to an existing Source File if one matches, or create/select a Source File target later.";
+    ? `These are duplicate or related BNL recommendations for an existing public dossier, but no Dossier Update workspace exists in this group yet. The next action is to create/select a Dossier Update workspace.`
+    : "These are duplicate or related BNL recommendations, but no Source File target exists in this group yet. The next action is to attach them to an existing Source File if one matches, or create/select a Source File target.";
   const publicDossierUpdateExplanation =
     (targetRecord?.publicDossierId || (hasOnlyRecommendations && sharedPublicTarget)) &&
     hasRecommendationSources
@@ -1190,8 +1190,8 @@ function createConsolidationPlan(input: {
       : hasOnlyRecommendations
         ? noTargetExplanation
         : canBeAutomatedLater
-          ? `${automationTier}: review the deltas below before enabling any real action in a future PR.`
-          : "Admin review required before any future automation.",
+          ? `${automationTier}: review the deltas below, then run the matching admin action after server-side revalidation.`
+          : "Admin review required before any consolidation action.",
     canBeAutomatedLater,
     requiresReview,
     blockedReasons: hasOnlyRecommendations && !sharedPublicTarget
@@ -1247,7 +1247,7 @@ function createConsolidationPlan(input: {
           "Public dossier copy will not change.",
           "Internal aliases stay internal.",
           "Nothing publishes automatically.",
-          "No merge/delete/archive/attach/create action is live in this PR.",
+          "Consolidation actions are admin-triggered only and revalidated server-side before mutation.",
         ],
       }),
     ],
@@ -2126,6 +2126,13 @@ export type DossierWorkflowAction =
   | "markCandidateAsExistingDossierUpdate"
   | "detectDuplicateCandidates"
   | "mergeCandidates"
+  | "consolidateAttachIncomingRecommendations"
+  | "createDossierUpdateWorkspace"
+  | "createSourceFileFromIncomingInfo"
+  | "mergeConsolidationIntoTarget"
+  | "cleanDuplicateConsolidation"
+  | "keepConsolidationSeparate"
+  | "runSafeConsolidation"
   | "createMasterDraftFromMerge";
 
 export type DossierSourceBoundary = {
@@ -2175,6 +2182,13 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "markCandidateAsExistingDossierUpdate",
   "detectDuplicateCandidates",
   "mergeCandidates",
+  "consolidateAttachIncomingRecommendations",
+  "createDossierUpdateWorkspace",
+  "createSourceFileFromIncomingInfo",
+  "mergeConsolidationIntoTarget",
+  "cleanDuplicateConsolidation",
+  "keepConsolidationSeparate",
+  "runSafeConsolidation",
   "createMasterDraftFromMerge",
 ];
 

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2048,8 +2048,8 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Target selection:",
     "Automation tier",
     "Incoming recommendation subject:",
-    "What this would add:",
-    "Already represented / duplicate:",
+    "What new info this adds:",
+    "Already represented:",
     "Public dossier match:",
     "Field-level plan",
     "New info to add",
@@ -2063,14 +2063,16 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Needs Source File target",
     "What would happen later",
     "The site can only audit records and recommendations already present in the workflow store. Active Discord members who have not been ingested by BNL will not appear here yet.",
-    "it does not merge, delete, publish, or mutate records automatically",
+    "admin-triggered only: it never mutates on page load",
+    "Run Safe Consolidation",
+    "Attach Incoming Recommendations",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
 
   assert.match(page, /<details className="border border-accent\/40 bg-surface\/70 p-5">/);
   assert.match(page, /createDossierPopulationAudit/);
-  assert.doesNotMatch(page, /Run Safe Cleanup|Remove Empty Duplicate|Attach Automatically|Merge Now|Delete Duplicate|auto-create|autoCreate|autoMerge/);
+  assert.doesNotMatch(page, /Run Safe Cleanup|Attach Automatically|Delete Duplicate|auto-create|autoCreate|autoMerge/);
   assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /source notes count 0/i);
 });
@@ -2369,7 +2371,7 @@ test("population audit consolidation plans classify target/source records withou
     "No action needed",
   ]);
   assert.ok(activePlan?.mergePlanSections.some((section) => section.newInfoToAdd.length > 0));
-  assert.ok(activePlan?.mergePlanSections.some((section) => section.noActionNeeded.join(" ").includes("Nothing publishes automatically")));
+  assert.ok(activePlan?.mergePlanSections.some((section) => section.noActionNeeded.join(" ").includes("Nothing publishes automatically") || section.noActionNeeded.join(" ").includes("server-side")));
   assert.ok(blockedPlan?.mergePlanSections.some((section) => section.blockedReason.join(" ").includes("Different public dossier matches")));
 
   const publicDossierBefore = JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit"));
@@ -2381,7 +2383,7 @@ test("population audit consolidation plans classify target/source records withou
   assert.equal(JSON.stringify(databasePage.entries.find((entry) => entry.name === "6 Bit")), publicDossierBefore);
 });
 
-test("population audit planning UI uses incoming/target columns and disabled future action labels", () => {
+test("population audit planning UI uses incoming/target columns and live safe action labels", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
 
@@ -2393,19 +2395,19 @@ test("population audit planning UI uses incoming/target columns and disabled fut
     "Suggested workspace to create",
     "Recommended workspace:",
     "Existing public dossier:",
-    "Create Dossier Update Later",
-    "Create Source File Later",
-    "Attach Later",
-    "Select Target Later",
-    "Merge Later",
-    "Clean Later",
-    "Needs Source File Target",
+    "Create Dossier Update Workspace",
+    "Create Source File from Incoming Info",
+    "Attach Incoming Recommendations",
+    "Select target manually (read-only)",
+    "Merge Into Target",
+    "Clean Duplicate",
+    "Keep Separate / Not Same Subject",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
 
-  assert.match(page, /<button disabled/);
-  assert.doesNotMatch(pageCopy, /Run Safe Cleanup|Attach Automatically|Remove Empty Duplicate|Auto-Merge Safe Duplicate/);
+  assert.match(page, /runConsolidationAction/);
+  assert.doesNotMatch(pageCopy, /Run Safe Cleanup|Attach Automatically|Auto-Merge Safe Duplicate/);
   assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /Proposed aliases count: \{record\.proposedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /Archive\/report status: \{record\.hasLatestArchiveOrReport/);
@@ -5233,6 +5235,241 @@ test("BNL dynamic discovery dedupes by ingestKey and exact subject candidate", a
   assert.equal(state.recommendations.length, 2);
   assert.equal(state.candidates[0].sourceFileNotes.length, 2);
   assert.equal(state.drafts.length, 0);
+});
+
+function consolidationFixtureCandidate(overrides) {
+  const now = "2026-06-11T00:00:00.000Z";
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: overrides.score ?? 60,
+    whyNow: overrides.whyNow ?? "Fixture",
+    reason: overrides.reason ?? "Fixture",
+    evidenceSummary: overrides.evidenceSummary ?? "Fixture evidence",
+    status: overrides.status ?? "active_source_file",
+    sourceFileNotes: overrides.sourceFileNotes ?? [],
+    identityLinks: overrides.identityLinks ?? [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function consolidationFixtureRecommendation(overrides) {
+  const now = "2026-06-11T00:00:00.000Z";
+  return {
+    id: overrides.id,
+    type: overrides.type ?? "new_subject",
+    subjectName: overrides.subjectName,
+    subjectKey: overrides.subjectKey,
+    targetDossierId: overrides.targetDossierId,
+    status: overrides.status ?? "new",
+    reason: overrides.reason ?? "BNL fixture reason",
+    evidenceSummary: overrides.evidenceSummary ?? "BNL evidence summary",
+    confidence: overrides.confidence ?? "high",
+    sourceLanes: overrides.sourceLanes ?? ["public_discord"],
+    createdAt: now,
+    updatedAt: now,
+    createdBy: "bnl",
+    ingestSource: overrides.ingestSource ?? "bnl_dynamic_candidate_discovery",
+    ingestKey: overrides.ingestKey ?? overrides.id,
+    ...overrides,
+  };
+}
+
+function consolidationFixtureAlias(candidateId, label, status = "confirmed") {
+  const now = "2026-06-11T00:00:00.000Z";
+  return {
+    id: `${candidateId}-${label}`,
+    candidateId,
+    label,
+    normalizedLabel: workflow.normalizeDossierSubjectName(label),
+    type: "alias",
+    visibility: "internal_only",
+    status,
+    source: "admin_manual",
+    useForMatching: true,
+    useInPublicDossier: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function seedConsolidationWorkflow({ candidates = [], recommendations = [], drafts = [] }) {
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates,
+    recommendations,
+    drafts,
+    sourceFileRefreshRequests: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+}
+
+function groupForTier(state, tier) {
+  return workflow.createDossierPopulationAudit({
+    candidates: state.candidates,
+    recommendations: state.recommendations,
+    publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })),
+    drafts: state.drafts,
+  }).possibleDuplicateGroups.find((group) => group.consolidationPlan.automationTier === tier);
+}
+
+test("live consolidation attaches incoming recommendations after server-side revalidation without publishing", async () => {
+  await seedConsolidationWorkflow({
+    candidates: [consolidationFixtureCandidate({ id: "target-attach", name: "Attach Subject" })],
+    recommendations: [consolidationFixtureRecommendation({ id: "rec-attach-live", subjectName: "Attach Subject" })],
+  });
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const group = groupForTier(await store.getDossierWorkflowState(), "Attach to Existing Source File candidate");
+  assert.ok(group, "expected attach candidate group");
+  const response = await authedPost({ action: "consolidateAttachIncomingRecommendations", groupId: group.id });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.consolidation.attachedRecommendationCount, 1);
+  assert.match(payload.consolidation.message, /No public dossier text changed/);
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.find((item) => item.id === "rec-attach-live").targetCandidateId, "target-attach");
+  assert.equal(state.recommendations.find((item) => item.id === "rec-attach-live").status, "attached_to_source_file");
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+});
+
+test("live consolidation creates dossier update workspace and source file workspaces from recommendation clusters", async () => {
+  await seedConsolidationWorkflow({
+    recommendations: [
+      consolidationFixtureRecommendation({ id: "rec-update-a", subjectName: "6 Bit", targetDossierId: "EN-001" }),
+      consolidationFixtureRecommendation({ id: "rec-update-b", subjectName: "6 Bit", targetDossierId: "EN-001" }),
+    ],
+  });
+  let group = groupForTier(await store.getDossierWorkflowState(), "Create Dossier Update workspace candidate");
+  assert.ok(group, "expected dossier update workspace candidate");
+  let response = await authedPost({ action: "createDossierUpdateWorkspace", groupId: group.id });
+  assert.equal(response.status, 200);
+  let payload = await response.json();
+  assert.equal(payload.consolidation.createdWorkspaces[0].type, "Dossier Update");
+  assert.equal(payload.candidates.find((candidate) => candidate.id === payload.consolidation.targetId).status, "existing_dossier_update");
+  assert.equal(payload.recommendations.filter((recommendation) => recommendation.status === "attached_to_existing_dossier_update").length, 2);
+
+  await seedConsolidationWorkflow({
+    recommendations: [
+      consolidationFixtureRecommendation({ id: "rec-source-a", subjectName: "New Cluster A", subjectKey: "new-cluster" }),
+      consolidationFixtureRecommendation({ id: "rec-source-b", subjectName: "New Cluster B", subjectKey: "new-cluster" }),
+    ],
+  });
+  group = groupForTier(await store.getDossierWorkflowState(), "Create Source File candidate");
+  assert.ok(group, "expected source file creation candidate");
+  response = await authedPost({ action: "createSourceFileFromIncomingInfo", groupId: group.id });
+  assert.equal(response.status, 200);
+  payload = await response.json();
+  assert.equal(payload.consolidation.createdWorkspaces[0].type, "Source File / Candidate");
+  assert.equal(payload.candidates.find((candidate) => candidate.id === payload.consolidation.targetId).status, "active_source_file");
+  assert.equal(payload.recommendations.filter((recommendation) => ["converted_to_source_file", "attached_to_source_file"].includes(recommendation.status)).length, 2);
+});
+
+test("live consolidation merge moves notes and internal aliases but blocks public/draft conflicts", async () => {
+  const note = { id: "note-source", candidateId: "merge-source", type: "fact", text: "Additive source note", source: "admin_manual", status: "active", createdAt: "2026-06-11T00:00:00.000Z", updatedAt: "2026-06-11T00:00:00.000Z" };
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "merge-target", name: "Merge Subject", latestSourceFileArchiveUpdatedAt: "2026-06-11T00:00:00.000Z" }),
+      consolidationFixtureCandidate({ id: "merge-source", name: "Merge Subject", sourceFileNotes: [note], identityLinks: [consolidationFixtureAlias("merge-source", "Secret Internal Alias")] }),
+    ],
+  });
+  const group = groupForTier(await store.getDossierWorkflowState(), "Source File merge candidate");
+  assert.ok(group, "expected safe merge candidate");
+  const response = await authedPost({ action: "mergeConsolidationIntoTarget", groupId: group.id });
+  assert.equal(response.status, 200);
+  const state = await store.getDossierWorkflowState();
+  const target = state.candidates.find((candidate) => candidate.id === "merge-target");
+  assert.ok(target.sourceFileNotes.some((item) => item.text === "Additive source note"));
+  assert.ok(target.identityLinks.some((item) => item.label === "Secret Internal Alias" && item.visibility === "internal_only"));
+  assert.equal(state.candidates.find((candidate) => candidate.id === "merge-source").status, "merged");
+
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "conflict-a", name: "Conflict", existingDossierMatch: { id: "EN-001", name: "6 Bit", confidence: "high" } }),
+      consolidationFixtureCandidate({ id: "conflict-b", name: "Conflict", existingDossierMatch: { id: "EN-003", name: "Mac Modem", confidence: "high" } }),
+    ],
+  });
+  const blocked = workflow.createDossierPopulationAudit({ candidates: (await store.getDossierWorkflowState()).candidates, recommendations: [], publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })), drafts: [] }).possibleDuplicateGroups[0];
+  const blockedResponse = await authedPost({ action: "mergeConsolidationIntoTarget", groupId: blocked.id });
+  assert.equal(blockedResponse.status, 409);
+
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "draft-a", name: "Draft Conflict" }),
+      consolidationFixtureCandidate({ id: "draft-b", name: "Draft Conflict" }),
+    ],
+    drafts: [
+      { id: "draft-a-open", candidateId: "draft-a", status: "draft", fields: { name: "Draft A", files: [] }, createdAt: "2026-06-11T00:00:00.000Z", updatedAt: "2026-06-11T00:00:00.000Z" },
+      { id: "draft-b-open", candidateId: "draft-b", status: "draft", fields: { name: "Draft B", files: [] }, createdAt: "2026-06-11T00:00:00.000Z", updatedAt: "2026-06-11T00:00:00.000Z" },
+    ],
+  });
+  const draftBlocked = workflow.createDossierPopulationAudit({ candidates: (await store.getDossierWorkflowState()).candidates, recommendations: [], publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })), drafts: (await store.getDossierWorkflowState()).drafts }).possibleDuplicateGroups[0];
+  const draftBlockedResponse = await authedPost({ action: "mergeConsolidationIntoTarget", groupId: draftBlocked.id });
+  assert.equal(draftBlockedResponse.status, 409);
+});
+
+test("clean duplicate refuses meaningful data and bulk skips review-required groups", async () => {
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "clean-target-live", name: "Clean Live", latestSourceFileArchiveUpdatedAt: "2026-06-11T00:00:00.000Z" }),
+      consolidationFixtureCandidate({ id: "clean-source-live", name: "Clean Live", status: "candidate_intake", reason: "", whyNow: "", evidenceSummary: "" }),
+      consolidationFixtureCandidate({ id: "review-a", name: "Review Alias", identityLinks: [consolidationFixtureAlias("review-a", "Maybe Alias", "proposed")] }),
+      consolidationFixtureCandidate({ id: "review-b", name: "Review Alias" }),
+    ],
+  });
+  const group = groupForTier(await store.getDossierWorkflowState(), "Empty duplicate cleanup candidate");
+  assert.ok(group, "expected empty duplicate cleanup candidate");
+  let response = await authedPost({ action: "cleanDuplicateConsolidation", groupId: group.id });
+  assert.equal(response.status, 200);
+  let payload = await response.json();
+  assert.equal(payload.consolidation.cleanedDuplicateCount, 1);
+  assert.equal(payload.candidates.find((candidate) => candidate.id === "clean-source-live").status, "merged");
+
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "meaning-target", name: "Meaningful", latestSourceFileArchiveUpdatedAt: "2026-06-11T00:00:00.000Z" }),
+      consolidationFixtureCandidate({ id: "meaning-source", name: "Meaningful", status: "candidate_intake", reason: "", whyNow: "", evidenceSummary: "", sourceFileNotes: [{ id: "meaning-note", candidateId: "meaning-source", type: "fact", text: "Do not delete", source: "admin_manual", status: "active", createdAt: "2026-06-11T00:00:00.000Z", updatedAt: "2026-06-11T00:00:00.000Z" }] }),
+    ],
+  });
+  const unsafeGroup = workflow.createDossierPopulationAudit({ candidates: (await store.getDossierWorkflowState()).candidates, recommendations: [], publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })), drafts: [] }).possibleDuplicateGroups[0];
+  response = await authedPost({ action: "cleanDuplicateConsolidation", groupId: unsafeGroup.id });
+  assert.equal(response.status, 409);
+
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "bulk-target", name: "Bulk Attach" }),
+      consolidationFixtureCandidate({ id: "bulk-review-a", name: "Bulk Review", identityLinks: [consolidationFixtureAlias("bulk-review-a", "Bulk Maybe", "proposed")] }),
+      consolidationFixtureCandidate({ id: "bulk-review-b", name: "Bulk Review" }),
+    ],
+    recommendations: [consolidationFixtureRecommendation({ id: "bulk-rec", subjectName: "Bulk Attach" })],
+  });
+  response = await authedPost({ action: "runSafeConsolidation" });
+  assert.equal(response.status, 200);
+  payload = await response.json();
+  assert.equal(payload.consolidation.attachedRecommendationCount, 1);
+  assert.ok(payload.consolidation.skipped.some((item) => /Review required/.test(item.reason)));
+});
+
+test("keep separate reports unsupported suppression without mutating records", async () => {
+  await seedConsolidationWorkflow({
+    candidates: [
+      consolidationFixtureCandidate({ id: "separate-a", name: "Separate Maybe", identityLinks: [consolidationFixtureAlias("separate-a", "Separate Proposed", "proposed")] }),
+      consolidationFixtureCandidate({ id: "separate-b", name: "Separate Maybe" }),
+    ],
+  });
+  const before = await store.getDossierWorkflowState();
+  const group = workflow.createDossierPopulationAudit({ candidates: before.candidates, recommendations: [], publicDossiers: databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })), drafts: [] }).possibleDuplicateGroups[0];
+  const response = await authedPost({ action: "keepConsolidationSeparate", groupId: group.id });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.match(payload.consolidation.message, /no records were mutated/i);
+  const after = await store.getDossierWorkflowState();
+  assert.deepEqual(after.candidates, before.candidates);
 });
 
 test("BNL dynamic identity and possible duplicate recommendations remain review-only", async () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2042,26 +2042,25 @@ test("Dossier Control Center population audit maps counts, duplicate review, una
     "Records missing latest BNL case report or source enrichment",
     "Possible Duplicate / Same Subject Review",
     "Possible same-subject review",
-    "Consolidation plan",
-    "Merging / Incoming Info",
-    "Target / Keep",
-    "Target selection:",
-    "Automation tier",
-    "Incoming recommendation subject:",
-    "What new info this adds:",
+    "Consolidation Task",
+    "Incoming Info / Will Transfer",
+    "Kept Source File / Target",
+    "Why this target:",
+    "Classification:",
+    "Incoming subjects:",
+    "New extractable info:",
     "Already represented:",
-    "Public dossier match:",
-    "Field-level plan",
-    "New info to add",
-    "Already represented / duplicate info",
-    "Irrelevant to kept entry",
-    "Needs review",
+    "Existing public dossier match:",
+    "Transfer Plan",
+    "Will attach",
+    "Will merge",
+    "Will create",
+    "Needs admin review",
     "Blocked reason",
-    "No action needed",
+    "Needs BNL review / refresh",
     "Unattached BNL Signals / Recommendations",
     "BNL recommendations that need placement review",
-    "Needs Source File target",
-    "What would happen later",
+    "BNL Refresh After Consolidation",
     "The site can only audit records and recommendations already present in the workflow store. Active Discord members who have not been ingested by BNL will not appear here yet.",
     "admin-triggered only: it never mutates on page load",
     "Run Safe Consolidation",
@@ -2388,18 +2387,17 @@ test("population audit planning UI uses incoming/target columns and live safe ac
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
 
   for (const label of [
-    "Merging / Incoming Info",
-    "Target / Keep",
-    "No Source File target resolved",
-    "targetDisplayReason",
-    "Suggested workspace to create",
-    "Recommended workspace:",
-    "Existing public dossier:",
+    "Incoming Info / Will Transfer",
+    "Kept Source File / Target",
+    "Kept Source File:",
+    "workspace will be created",
+    "Will create:",
+    "Existing public dossier match:",
     "Create Dossier Update Workspace",
-    "Create Source File from Incoming Info",
+    "Create Source File from These Signals",
     "Attach Incoming Recommendations",
-    "Select target manually (read-only)",
-    "Merge Into Target",
+    "Select Target Manually (read-only)",
+    "Merge Into Kept Source File",
     "Clean Duplicate",
     "Keep Separate / Not Same Subject",
   ]) {
@@ -2411,6 +2409,13 @@ test("population audit planning UI uses incoming/target columns and live safe ac
   assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /Proposed aliases count: \{record\.proposedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /Archive\/report status: \{record\.hasLatestArchiveOrReport/);
+  assert.match(page, /<details className="mt-3 border border-border\/50 bg-background\/40 p-3">/);
+  assertIncludesCopy(pageCopy, "Raw recommendation details / debug details");
+  assertIncludesCopy(pageCopy, "Raw transfer notes:");
+  assert.ok(page.indexOf("[...record.incomingInfo") > page.indexOf("Raw transfer notes:"));
+  assertIncludesCopy(pageCopy, "Open Recommendation");
+  assert.ok(pageCopy.indexOf("Open Recommendation") > pageCopy.indexOf("Raw recommendation details / debug details"));
+  assertIncludesCopy(pageCopy, "BNL refresh status:");
 });
 
 test("owner review page is a placeholder lane without publishing", () => {
@@ -5332,6 +5337,7 @@ test("live consolidation attaches incoming recommendations after server-side rev
   const payload = await response.json();
   assert.equal(payload.consolidation.attachedRecommendationCount, 1);
   assert.match(payload.consolidation.message, /No public dossier text changed/);
+  assert.ok(payload.consolidation.bnlRefreshes.some((refresh) => ["queued", "already_pending"].includes(refresh.status)));
   const state = await store.getDossierWorkflowState();
   assert.equal(state.recommendations.find((item) => item.id === "rec-attach-live").targetCandidateId, "target-attach");
   assert.equal(state.recommendations.find((item) => item.id === "rec-attach-live").status, "attached_to_source_file");
@@ -5351,6 +5357,7 @@ test("live consolidation creates dossier update workspace and source file worksp
   assert.equal(response.status, 200);
   let payload = await response.json();
   assert.equal(payload.consolidation.createdWorkspaces[0].type, "Dossier Update");
+  assert.ok(payload.consolidation.bnlRefreshes.some((refresh) => ["queued", "already_pending"].includes(refresh.status)));
   assert.equal(payload.candidates.find((candidate) => candidate.id === payload.consolidation.targetId).status, "existing_dossier_update");
   assert.equal(payload.recommendations.filter((recommendation) => recommendation.status === "attached_to_existing_dossier_update").length, 2);
 
@@ -5366,6 +5373,7 @@ test("live consolidation creates dossier update workspace and source file worksp
   assert.equal(response.status, 200);
   payload = await response.json();
   assert.equal(payload.consolidation.createdWorkspaces[0].type, "Source File / Candidate");
+  assert.ok(payload.consolidation.bnlRefreshes.some((refresh) => ["queued", "already_pending"].includes(refresh.status)));
   assert.equal(payload.candidates.find((candidate) => candidate.id === payload.consolidation.targetId).status, "active_source_file");
   assert.equal(payload.recommendations.filter((recommendation) => ["converted_to_source_file", "attached_to_source_file"].includes(recommendation.status)).length, 2);
 });
@@ -5382,6 +5390,8 @@ test("live consolidation merge moves notes and internal aliases but blocks publi
   assert.ok(group, "expected safe merge candidate");
   const response = await authedPost({ action: "mergeConsolidationIntoTarget", groupId: group.id });
   assert.equal(response.status, 200);
+  const mergePayload = await response.json();
+  assert.ok(mergePayload.consolidation.bnlRefreshes.some((refresh) => ["queued", "already_pending"].includes(refresh.status)));
   const state = await store.getDossierWorkflowState();
   const target = state.candidates.find((candidate) => candidate.id === "merge-target");
   assert.ok(target.sourceFileNotes.some((item) => item.text === "Additive source note"));
@@ -5452,6 +5462,7 @@ test("clean duplicate refuses meaningful data and bulk skips review-required gro
   assert.equal(response.status, 200);
   payload = await response.json();
   assert.equal(payload.consolidation.attachedRecommendationCount, 1);
+  assert.ok(payload.consolidation.bnlRefreshes.length >= 1);
   assert.ok(payload.consolidation.skipped.some((item) => /Review required/.test(item.reason)));
 });
 


### PR DESCRIPTION
### Motivation
- Turn the read-only consolidation planner into a usable admin workflow that can perform safe merges, attachments, workspace creation, and empty-duplicate cleanup only after explicit admin intent and server-side revalidation. 
- Make the UI show exactly what will happen and report exactly what changed while ensuring no public dossier text is edited, nothing is published, and internal aliases remain internal. 
- Provide a zero-conflict bulk `Run Safe Consolidation` path for fully-automatable items while refusing or surfacing review-required / blocked groups. 

### Description
- Add new consolidation action types to the workflow contract and surface them in the admin API, including `consolidateAttachIncomingRecommendations`, `createDossierUpdateWorkspace`, `createSourceFileFromIncomingInfo`, `mergeConsolidationIntoTarget`, `cleanDuplicateConsolidation`, `keepConsolidationSeparate`, and `runSafeConsolidation` (changed: `src/lib/dossier-workflow.ts`, `src/app/api/admin/dossiers/route.ts`).
- Implement server-side revalidation and safe mutation handlers that rebuild the consolidation plan from current state before any mutation and produce an auditable action result (changed: `src/lib/dossier-workflow-store.ts`).
- Wire the admin API to call the new server-side consolidation handlers and return payload + consolidation result for UI refresh (changed: `src/app/api/admin/dossiers/route.ts`).
- Update the Dossier Control Center UI to show concise incoming/target deltas, hide irrelevant zero-count fields, display actionable buttons by automation tier, present a bulk `Run Safe Consolidation` summary/button, and render a clear consolidation result panel after actions (changed: `src/app/admin/dossiers/page.tsx`).
- Add and extend tests covering live attach/create/merge/clean/bulk flows, server-side revalidation, protection against public edits, and internal alias preservation (changed: `tests/admin-dossiers.test.mjs`).
- Files changed: `src/app/admin/dossiers/page.tsx`, `src/app/api/admin/dossiers/route.ts`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `tests/admin-dossiers.test.mjs` — each change is narrowly scoped to enable admin-triggered consolidation, server revalidation, UI feedback, and test coverage.

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all relevant tests (including the new consolidation tests) passed.
- Ran `npx tsc --noEmit` and the type-check completed with no blocking errors.
- Ran `npm run lint` and saw pre-existing unrelated lint errors in archived/unrelated files; the changes in this PR did not introduce type or test failures and the consolidation feature tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b137a6f888321965275c5a35fcf21)