### PR TITLE
Site PR #196 — Population Method Audit and Intake Map

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   createDossierPopulationAudit,
+  createDossierPopulationMethodAudit,
   getDossierSourceFileMetrics,
   isConsolidationResolvedCandidate,
   isDiagnosticTestArtifactCandidate,
@@ -498,6 +499,17 @@ export default function DossierControlCenterPage() {
       }),
     [candidates, recommendations, publicDossiers, drafts],
   );
+  const populationMethodAudit = useMemo(
+    () =>
+      createDossierPopulationMethodAudit({
+        candidates,
+        recommendations,
+        publicDossiers,
+        drafts,
+      }),
+    [candidates, recommendations, publicDossiers, drafts],
+  );
+  const populationMethodHealthy = populationMethodAudit.warnings.length === 0;
   const consolidationAttachGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Attach to Existing Source File candidate");
   const consolidationCleanGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Empty duplicate cleanup candidate");
   const consolidationDossierUpdateGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Create Dossier Update workspace candidate");
@@ -1017,6 +1029,120 @@ export default function DossierControlCenterPage() {
               </div>
             )}
           </section>
+
+          <details className="border border-border bg-background/30 p-4" open={!populationMethodHealthy}>
+            <summary className="cursor-pointer text-sm font-semibold text-foreground">
+              Population Method: {populationMethodHealthy ? "healthy" : "needs review"}
+              {!populationMethodHealthy ? ` — ${populationMethodAudit.warnings.length} intake records need population review.` : ""}
+            </summary>
+            <div className="mt-4 space-y-5">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-muted">Population Method Audit</p>
+                <h2 className="text-xl font-bold text-foreground">Population Method Audit / Intake Map</h2>
+                <p className="mt-2 text-sm text-muted">Admin-only read-only diagnostic map for how Source Files, Dossier Updates, recommendations, diagnostics, and public dossier update signals entered the system, which lane they belong in, and whether hidden records have destinations.</p>
+                {populationMethodHealthy && (
+                  <p className="mt-3 border border-accent/40 bg-accent/10 p-3 text-sm text-accent">All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.</p>
+                )}
+              </div>
+
+              <section className="grid gap-3 md:grid-cols-2">
+                <div className="border border-border/70 bg-surface/60 p-4">
+                  <h3 className="font-semibold text-foreground">Intake Summary</h3>
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
+                    <dt>BNL recommendations</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["BNL recommendation"] + populationMethodAudit.countsByOrigin["BNL source knowledge bridge"] + populationMethodAudit.countsByOrigin["BNL dynamic candidate discovery"]}</dd>
+                    <dt>manual admin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["manual admin creation"]}</dd>
+                    <dt>public dossier update signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["public dossier update signal"]}</dd>
+                    <dt>source file refresh/archive records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["source file refresh"] + populationMethodAudit.countsByOrigin["source file archive"]}</dd>
+                    <dt>diagnostic/test artifacts</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["diagnostic/test artifact"]}</dd>
+                    <dt>unknown origin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["unknown / insufficient metadata"]}</dd>
+                  </dl>
+                </div>
+                <div className="border border-border/70 bg-surface/60 p-4">
+                  <h3 className="font-semibold text-foreground">Lane Map</h3>
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
+                    <dt>Active Source Files</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Active Source File"]}</dd>
+                    <dt>Candidate Intake</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Candidate Intake"]}</dd>
+                    <dt>Dossier Update Workspaces</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Dossier Update Workspace"]}</dd>
+                    <dt>Public Dossier Update Signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Public Dossier Update Signal"]}</dd>
+                    <dt>Resolved Incoming Records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Resolved Incoming Record"] + populationMethodAudit.countsByLane["Merged Source Record"]}</dd>
+                    <dt>Diagnostics</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Diagnostic/Test Artifact"]}</dd>
+                    <dt>Archived/Closed</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Archived / Closed"]}</dd>
+                    <dt>Needs Population Review</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Needs Population Review"]}</dd>
+                  </dl>
+                </div>
+              </section>
+
+              {populationMethodAudit.warnings.length > 0 && (
+                <section className="space-y-3">
+                  <h3 className="font-semibold text-foreground">Warnings / Problems</h3>
+                  {populationMethodAudit.warnings.slice(0, 8).map((warning) => (
+                    <article key={warning.id} className="border border-accent/50 bg-accent/10 p-4 text-sm">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="font-semibold text-accent">{warning.issueTitle}</p>
+                          <p className="mt-1 text-foreground">Affected subject: {warning.affectedSubject}</p>
+                        </div>
+                        <button type="button" onClick={() => navigator.clipboard?.writeText(warning.affectedIds.join(", "))} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Copy Record IDs</button>
+                      </div>
+                      <dl className="mt-3 grid gap-2 text-xs text-muted md:grid-cols-2">
+                        <div><dt>Affected IDs</dt><dd className="text-foreground">{warning.affectedIds.join(", ") || "—"}</dd></div>
+                        <div><dt>Source type</dt><dd className="text-foreground">{warning.sourceType}</dd></div>
+                        <div><dt>Current status</dt><dd className="text-foreground">{warning.currentStatus}</dd></div>
+                        <div><dt>Expected lane</dt><dd className="text-foreground">{warning.expectedLane}</dd></div>
+                        <div><dt>Detected destination</dt><dd className="text-foreground">{warning.detectedDestination ?? "—"}</dd></div>
+                        <div><dt>Recommended admin next step</dt><dd className="text-foreground">{warning.recommendedAdminNextStep}</dd></div>
+                      </dl>
+                    </article>
+                  ))}
+                </section>
+              )}
+
+              <details className="border border-border/70 bg-surface/40 p-3">
+                <summary className="cursor-pointer text-sm font-semibold text-foreground">Hidden Records With Destinations ({populationMethodAudit.hiddenWithDestinations.length})</summary>
+                <div className="mt-3 space-y-2 text-sm">
+                  {populationMethodAudit.hiddenWithDestinations.slice(0, 8).map((record) => (
+                    <div key={`hidden-destination-${record.id}`} className="border border-border/60 p-3">
+                      <p className="font-semibold text-foreground">{record.subject}</p>
+                      <p className="text-xs text-muted">{record.origin} → {record.destinationSubject ?? "destination"}</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {record.href && <Link href={record.href} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
+                        {record.destinationHref && <Link href={record.destinationHref} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
+                        {record.publicDossierId && <Link href={`/database/${record.publicDossierId}`} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Public Dossier Match</Link>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </details>
+
+              {populationMethodAudit.hiddenWithoutDestination.length > 0 && (
+                <section className="border border-accent/50 bg-accent/10 p-4">
+                  <h3 className="font-semibold text-accent">Hidden Records Without Destinations</h3>
+                  <div className="mt-3 space-y-2 text-sm">
+                    {populationMethodAudit.hiddenWithoutDestination.slice(0, 8).map((record) => (
+                      <div key={`hidden-orphan-${record.id}`} className="border border-border/60 bg-background/30 p-3">
+                        <p className="font-semibold text-foreground">{record.subject}</p>
+                        <p className="text-xs text-muted">{record.origin} · {record.currentStatus} · expected lane: {record.intendedLane}</p>
+                        {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              <details className="border border-border/70 bg-surface/40 p-3" open={!populationMethodHealthy}>
+                <summary className="cursor-pointer text-sm font-semibold text-foreground">Destination Workspaces ({populationMethodAudit.visibleDestinationWorkspaces.length})</summary>
+                <div className="mt-3 grid gap-2 md:grid-cols-2">
+                  {populationMethodAudit.visibleDestinationWorkspaces.slice(0, 10).map((record) => (
+                    <div key={`destination-${record.id}`} className="border border-border/60 p-3 text-sm">
+                      <p className="font-semibold text-foreground">{record.subject}</p>
+                      <p className="text-xs text-muted">{record.intendedLane} · received records: {populationMethodAudit.intakeFlows.filter((flow) => flow.destinationId === record.id).length}</p>
+                      {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
+                    </div>
+                  ))}
+                </div>
+              </details>
+            </div>
+          </details>
 
           <section className="space-y-3">
             <div>

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -930,6 +930,420 @@ export type DossierPopulationAudit = {
   unattachedBnlRecommendations: DossierPopulationAuditUnattachedRecommendation[];
 };
 
+
+export type DossierPopulationMethodOrigin =
+  | "BNL recommendation"
+  | "BNL source knowledge bridge"
+  | "BNL dynamic candidate discovery"
+  | "manual admin creation"
+  | "public dossier update signal"
+  | "existing public dossier workspace"
+  | "source file refresh"
+  | "source file archive"
+  | "identity/alias link"
+  | "diagnostic/test artifact"
+  | "website read model"
+  | "unknown / insufficient metadata";
+
+export type DossierPopulationMethodLane =
+  | "Active Source File"
+  | "Candidate Intake"
+  | "Dossier Update Workspace"
+  | "Public Dossier Update Signal"
+  | "BNL Recommendation Inbox"
+  | "Diagnostic/Test Artifact"
+  | "Resolved Incoming Record"
+  | "Merged Source Record"
+  | "Archived / Closed"
+  | "Needs Population Review"
+  | "Unknown / Unclassified";
+
+export type DossierPopulationMethodVisibility =
+  | "visible"
+  | "hidden_with_destination"
+  | "hidden_without_destination"
+  | "hidden_valid_archive_or_diagnostic"
+  | "hidden_destination_workspace";
+
+export type DossierPopulationMethodAuditRecord = {
+  id: string;
+  subject: string;
+  sourceType: "candidate" | "recommendation" | "draft" | "source_file_refresh_request";
+  currentStatus: string;
+  origin: DossierPopulationMethodOrigin;
+  intendedLane: DossierPopulationMethodLane;
+  visibility: DossierPopulationMethodVisibility;
+  href?: string;
+  candidateId?: string;
+  recommendationId?: string;
+  draftId?: string;
+  publicDossierId?: string;
+  publicDossierName?: string;
+  destinationId?: string;
+  destinationSubject?: string;
+  destinationLane?: DossierPopulationMethodLane;
+  destinationHref?: string;
+  destinationVisible?: boolean;
+  reason: string;
+  recommendedAdminNextStep: string;
+};
+
+export type DossierPopulationMethodAuditWarning = {
+  id: string;
+  issueTitle: string;
+  affectedSubject: string;
+  affectedIds: string[];
+  sourceType: string;
+  currentStatus: string;
+  expectedLane: DossierPopulationMethodLane;
+  detectedDestination?: string;
+  recommendedAdminNextStep: string;
+};
+
+export type DossierPopulationMethodAudit = {
+  countsByOrigin: Record<DossierPopulationMethodOrigin, number>;
+  countsByLane: Record<DossierPopulationMethodLane, number>;
+  countsByVisibility: Record<DossierPopulationMethodVisibility, number>;
+  intakeFlows: DossierPopulationMethodAuditRecord[];
+  orphanedRecords: DossierPopulationMethodAuditRecord[];
+  hiddenWithoutDestination: DossierPopulationMethodAuditRecord[];
+  hiddenWithDestinations: DossierPopulationMethodAuditRecord[];
+  visibleDestinationWorkspaces: DossierPopulationMethodAuditRecord[];
+  diagnosticArtifacts: DossierPopulationMethodAuditRecord[];
+  recordsNeedingPopulationReview: DossierPopulationMethodAuditRecord[];
+  publicDossierUpdateSignals: DossierPopulationMethodAuditRecord[];
+  sourceFileRefreshLinks: DossierPopulationMethodAuditRecord[];
+  warnings: DossierPopulationMethodAuditWarning[];
+};
+
+const populationMethodOrigins: DossierPopulationMethodOrigin[] = [
+  "BNL recommendation",
+  "BNL source knowledge bridge",
+  "BNL dynamic candidate discovery",
+  "manual admin creation",
+  "public dossier update signal",
+  "existing public dossier workspace",
+  "source file refresh",
+  "source file archive",
+  "identity/alias link",
+  "diagnostic/test artifact",
+  "website read model",
+  "unknown / insufficient metadata",
+];
+
+const populationMethodLanes: DossierPopulationMethodLane[] = [
+  "Active Source File",
+  "Candidate Intake",
+  "Dossier Update Workspace",
+  "Public Dossier Update Signal",
+  "BNL Recommendation Inbox",
+  "Diagnostic/Test Artifact",
+  "Resolved Incoming Record",
+  "Merged Source Record",
+  "Archived / Closed",
+  "Needs Population Review",
+  "Unknown / Unclassified",
+];
+
+const populationMethodVisibilities: DossierPopulationMethodVisibility[] = [
+  "visible",
+  "hidden_with_destination",
+  "hidden_without_destination",
+  "hidden_valid_archive_or_diagnostic",
+  "hidden_destination_workspace",
+];
+
+function emptyCountMap<T extends string>(labels: T[]): Record<T, number> {
+  return Object.fromEntries(labels.map((label) => [label, 0])) as Record<T, number>;
+}
+
+function publicDossierKey(value?: string) {
+  return value ? normalizeDossierPossessiveVariantName(value) : "";
+}
+
+function candidatePublicDossierMatch(
+  candidate: DossierCandidate,
+  publicDossiersById: Map<string, { id: string; name: string }>,
+  publicDossiersByName: Map<string, { id: string; name: string }>,
+) {
+  return candidate.existingDossierMatch ?? publicDossiersByName.get(publicDossierKey(candidate.name)) ?? (candidate.ingestKey ? publicDossiersById.get(candidate.ingestKey) : undefined);
+}
+
+function candidatePopulationMethodOrigin(candidate: DossierCandidate): DossierPopulationMethodOrigin {
+  const text = [
+    candidate.source,
+    candidate.ingestSource,
+    candidate.ingestKey,
+    candidate.routingReason,
+    candidate.mergeNote,
+    candidate.reason,
+    candidate.whyNow,
+    ...(candidate.sourceLanes ?? []),
+  ].filter(Boolean).join(" ");
+  if (isDiagnosticTestArtifactCandidate(candidate)) return "diagnostic/test artifact";
+  if ((candidate.identityLinks ?? []).length > 0 || candidate.connectedCandidateId || candidate.connectedSourceFileCandidateId) return "identity/alias link";
+  if (candidate.source === "bnl_source_knowledge_bridge" || candidate.ingestSource === "bnl_source_knowledge_bridge") return "BNL source knowledge bridge";
+  if (candidate.source === "bnl_dynamic_candidate_discovery" || candidate.ingestSource === "bnl_dynamic_candidate_discovery") return "BNL dynamic candidate discovery";
+  if (/source file refresh|refresh request|missing_bnl_refresh|stale_source_file/i.test(text)) return "source file refresh";
+  if (candidate.latestSourceFileArchiveId || candidate.latestSourceFileArchiveUpdatedAt || (candidate.sourceFileArchiveIds ?? []).length > 0) return "source file archive";
+  if (candidate.source === "website_read_model" || (candidate.sourceLanes ?? []).includes("website_dossier")) return "website read model";
+  if (candidate.status === "existing_dossier_update" || candidate.existingDossierMatch || /public dossier update|existing dossier update|dossier update/i.test(text)) return "public dossier update signal";
+  if (candidate.source === "manual") return "manual admin creation";
+  if (candidate.source === "bnl_source_file_enrichment" || candidate.ingestSource === "bnl_source_file_enrichment") return "source file refresh";
+  return "unknown / insufficient metadata";
+}
+
+function recommendationPopulationMethodOrigin(recommendation: DossierRecommendation): DossierPopulationMethodOrigin {
+  if (isDiagnosticTestArtifactRecommendation(recommendation)) return "diagnostic/test artifact";
+  if (recommendation.type === "identity_link" || recommendation.connectedCandidateId || recommendation.connectedSourceFileCandidateId) return "identity/alias link";
+  if (recommendation.ingestSource === "bnl_source_knowledge_bridge") return "BNL source knowledge bridge";
+  if (recommendation.ingestSource === "bnl_dynamic_candidate_discovery") return "BNL dynamic candidate discovery";
+  if (recommendation.ingestSource === "bnl_source_file_enrichment") return "source file refresh";
+  if (recommendation.targetDossierId || recommendation.type === "modify_existing_dossier" || (recommendation.sourceLanes ?? []).includes("website_dossier")) return "public dossier update signal";
+  if (recommendation.createdBy === "bnl" || recommendation.ingestSource === "bnl") return "BNL recommendation";
+  if ((recommendation.sourceLanes ?? []).includes("admin_manual") || recommendation.createdBy === "admin" || recommendation.createdBy === "operator") return "manual admin creation";
+  return "unknown / insufficient metadata";
+}
+
+function candidatePopulationMethodLane(candidate: DossierCandidate, origin: DossierPopulationMethodOrigin): DossierPopulationMethodLane {
+  if (isDiagnosticTestArtifactCandidate(candidate)) return "Diagnostic/Test Artifact";
+  if (candidate.status === "merged") return "Merged Source Record";
+  if (candidate.status === "archived" || candidate.status === "denied") return "Archived / Closed";
+  if (candidate.mergedIntoCandidateId || isConsolidationResolvedCandidate(candidate)) return "Resolved Incoming Record";
+  if (candidate.status === "candidate_intake") return "Candidate Intake";
+  if (candidate.status === "existing_dossier_update") return "Dossier Update Workspace";
+  if (origin === "unknown / insufficient metadata") return "Needs Population Review";
+  return "Active Source File";
+}
+
+function recommendationPopulationMethodLane(recommendation: DossierRecommendation, origin: DossierPopulationMethodOrigin): DossierPopulationMethodLane {
+  if (origin === "diagnostic/test artifact") return "Diagnostic/Test Artifact";
+  if (recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored") return "Archived / Closed";
+  if (isResolvedDossierRecommendation(recommendation)) return "Resolved Incoming Record";
+  if (origin === "public dossier update signal") return "Public Dossier Update Signal";
+  if (origin === "unknown / insufficient metadata") return "Needs Population Review";
+  return "BNL Recommendation Inbox";
+}
+
+function visibleDestinationCandidate(candidate?: DossierCandidate) {
+  return Boolean(candidate && !isDiagnosticTestArtifactCandidate(candidate) && !isConsolidationResolvedCandidate(candidate) && candidate.status !== "archived" && candidate.status !== "denied" && candidate.status !== "merged");
+}
+
+function isPublicDossierSignal(origin: DossierPopulationMethodOrigin, lane: DossierPopulationMethodLane) {
+  return origin === "public dossier update signal" || lane === "Public Dossier Update Signal";
+}
+
+export function createDossierPopulationMethodAudit(input: {
+  candidates: DossierCandidate[];
+  recommendations?: DossierRecommendation[];
+  drafts?: DossierDraft[];
+  publicDossiers?: Array<{ id: string; name: string }>;
+  sourceFileRefreshRequests?: DossierSourceFileRefreshRequest[];
+}): DossierPopulationMethodAudit {
+  const recommendations = input.recommendations ?? [];
+  const drafts = input.drafts ?? [];
+  const publicDossiers = input.publicDossiers ?? [];
+  const publicDossiersById = new Map(publicDossiers.map((dossier) => [dossier.id, dossier]));
+  const publicDossiersByName = new Map(publicDossiers.map((dossier) => [publicDossierKey(dossier.name), dossier]));
+  const candidatesById = new Map(input.candidates.map((candidate) => [candidate.id, candidate]));
+  const recommendationsById = new Map(recommendations.map((recommendation) => [recommendation.id, recommendation]));
+  const draftsByCandidateId = new Map(drafts.map((draft) => [draft.candidateId, draft]));
+  const visibleWorkspaceByPublicDossierId = new Map<string, DossierCandidate>();
+  const hiddenWorkspaceByPublicDossierId = new Map<string, DossierCandidate>();
+
+  for (const candidate of input.candidates) {
+    const match = candidatePublicDossierMatch(candidate, publicDossiersById, publicDossiersByName);
+    if (!match?.id) continue;
+    if (candidate.status !== "existing_dossier_update") continue;
+    if (visibleDestinationCandidate(candidate)) visibleWorkspaceByPublicDossierId.set(match.id, candidate);
+    else hiddenWorkspaceByPublicDossierId.set(match.id, candidate);
+  }
+
+  const records: DossierPopulationMethodAuditRecord[] = [];
+  const warnings: DossierPopulationMethodAuditWarning[] = [];
+
+  function candidateDestination(candidate: DossierCandidate, publicMatch?: { id: string; name: string } | null) {
+    const direct = candidate.mergedIntoCandidateId ? candidatesById.get(candidate.mergedIntoCandidateId) : undefined;
+    const connected = candidate.connectedSourceFileCandidateId ? candidatesById.get(candidate.connectedSourceFileCandidateId) : candidate.connectedCandidateId ? candidatesById.get(candidate.connectedCandidateId) : undefined;
+    const byPublic = publicMatch?.id ? visibleWorkspaceByPublicDossierId.get(publicMatch.id) ?? hiddenWorkspaceByPublicDossierId.get(publicMatch.id) : undefined;
+    const byRecommendation = (candidate.sourceRecommendationIds ?? []).concat(candidate.connectedRecommendationIds ?? [], candidate.createdFromRecommendationId ? [candidate.createdFromRecommendationId] : [])
+      .map((id) => recommendationsById.get(id))
+      .find((recommendation) => recommendation?.targetCandidateId || recommendation?.connectedCandidateId || recommendation?.connectedSourceFileCandidateId);
+    const byRecommendationCandidate = byRecommendation ? candidatesById.get(byRecommendation.targetCandidateId ?? byRecommendation.connectedCandidateId ?? byRecommendation.connectedSourceFileCandidateId ?? "") : undefined;
+    return direct ?? connected ?? byRecommendationCandidate ?? byPublic;
+  }
+
+  function recommendationDestination(recommendation: DossierRecommendation) {
+    const direct = candidatesById.get(recommendation.targetCandidateId ?? "") ?? candidatesById.get(recommendation.connectedCandidateId ?? "") ?? candidatesById.get(recommendation.connectedSourceFileCandidateId ?? "");
+    if (direct) return direct;
+    if (recommendation.targetDossierId) return visibleWorkspaceByPublicDossierId.get(recommendation.targetDossierId) ?? hiddenWorkspaceByPublicDossierId.get(recommendation.targetDossierId);
+    const nameMatch = publicDossiersByName.get(publicDossierKey(recommendation.subjectName));
+    return nameMatch ? visibleWorkspaceByPublicDossierId.get(nameMatch.id) ?? hiddenWorkspaceByPublicDossierId.get(nameMatch.id) : undefined;
+  }
+
+  function addWarning(record: DossierPopulationMethodAuditRecord, issueTitle: string, recommendedAdminNextStep: string) {
+    warnings.push({
+      id: `${issueTitle}:${record.id}`.replace(/[^a-z0-9]+/gi, "-").toLowerCase(),
+      issueTitle,
+      affectedSubject: record.subject,
+      affectedIds: [record.id, record.destinationId].filter(Boolean) as string[],
+      sourceType: record.sourceType,
+      currentStatus: record.currentStatus,
+      expectedLane: record.intendedLane,
+      detectedDestination: record.destinationSubject,
+      recommendedAdminNextStep,
+    });
+  }
+
+  for (const candidate of input.candidates) {
+    const origin = candidatePopulationMethodOrigin(candidate);
+    const lane = candidatePopulationMethodLane(candidate, origin);
+    const publicMatch = candidatePublicDossierMatch(candidate, publicDossiersById, publicDossiersByName);
+    const destination = candidateDestination(candidate, publicMatch);
+    const hidden = isConsolidationResolvedCandidate(candidate) || candidate.status === "archived" || candidate.status === "denied" || candidate.status === "merged";
+    const destinationVisible = visibleDestinationCandidate(destination);
+    const visibility: DossierPopulationMethodVisibility = hidden
+      ? destination
+        ? destinationVisible
+          ? "hidden_with_destination"
+          : "hidden_without_destination"
+        : origin === "diagnostic/test artifact" || candidate.status === "archived" || candidate.status === "denied"
+          ? "hidden_valid_archive_or_diagnostic"
+          : "hidden_without_destination"
+      : lane === "Dossier Update Workspace" && isConsolidationResolvedCandidate(candidate)
+        ? "hidden_destination_workspace"
+        : "visible";
+    const record: DossierPopulationMethodAuditRecord = {
+      id: candidate.id,
+      subject: candidate.name,
+      sourceType: "candidate",
+      currentStatus: candidate.status,
+      origin,
+      intendedLane: lane,
+      visibility,
+      href: `/admin/dossiers/candidates/${candidate.id}`,
+      candidateId: candidate.id,
+      publicDossierId: publicMatch?.id,
+      publicDossierName: publicMatch?.name,
+      destinationId: destination?.id,
+      destinationSubject: destination?.existingDossierMatch?.name ?? destination?.name,
+      destinationLane: destination ? candidatePopulationMethodLane(destination, candidatePopulationMethodOrigin(destination)) : undefined,
+      destinationHref: destination ? `/admin/dossiers/candidates/${destination.id}` : undefined,
+      destinationVisible,
+      reason: destination ? `Routes to ${destination.name}.` : "No destination workspace detected.",
+      recommendedAdminNextStep: destination ? "Review the destination workspace if the source record needs follow-up." : "Review origin metadata and decide whether this should become a Source File, Dossier Update workspace, archive item, or manual review item.",
+    };
+    records.push(record);
+
+    if (candidate.mergedIntoCandidateId && !candidatesById.has(candidate.mergedIntoCandidateId)) addWarning(record, "Merged source record points nowhere", "Reconnect the merged source record to a valid destination or unhide it for manual review.");
+    if (visibility === "hidden_without_destination") addWarning(record, isPublicDossierSignal(origin, lane) ? `Public dossier update signals for ${record.subject} were resolved, but no visible ${record.subject} Dossier Update workspace was found.` : "Hidden incoming record has no visible destination", "Create or attach a visible destination workspace, or mark the record as archived/diagnostic with clear metadata.");
+    if (!hidden && origin === "diagnostic/test artifact" && lane !== "Diagnostic/Test Artifact") addWarning(record, "Diagnostic/test artifact is visible in a normal lane", "Archive the diagnostic artifact or keep it isolated from normal active lanes.");
+    if (origin === "unknown / insufficient metadata") addWarning(record, "Source File record is missing clear origin metadata", "Add non-public origin metadata or move the record to population review.");
+    if (candidate.status === "existing_dossier_update" && !hidden && !(candidate.sourceRecommendationIds ?? []).length && !(candidate.connectedRecommendationIds ?? []).length && !(candidate.sourceFileNotes ?? []).length && !publicMatch?.id && !draftsByCandidateId.has(candidate.id)) addWarning(record, "Dossier Update workspace has no bundled source links", "Confirm the workspace has sourceRecommendationIds, connectedRecommendationIds, source notes, or a public dossier match.");
+    if (candidate.status === "existing_dossier_update" && hidden) addWarning(record, `Destination workspace for ${record.subject} exists but is currently hidden by resolved-candidate filtering.`, "Unhide the destination workspace or move the incoming records to a visible workspace.");
+    if (isPublicDossierSignal(origin, lane) && hidden && !destinationVisible) addWarning(record, `Visible destination missing for canonical public dossier target ${record.publicDossierName ?? record.subject}.`, "Ensure the canonical public dossier target has a visible Dossier Update workspace.");
+  }
+
+  for (const recommendation of recommendations) {
+    const origin = recommendationPopulationMethodOrigin(recommendation);
+    const lane = recommendationPopulationMethodLane(recommendation, origin);
+    const destination = recommendationDestination(recommendation);
+    const hidden = isResolvedDossierRecommendation(recommendation) || recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored";
+    const destinationVisible = visibleDestinationCandidate(destination);
+    const publicMatch = recommendation.targetDossierId ? publicDossiersById.get(recommendation.targetDossierId) : publicDossiersByName.get(publicDossierKey(recommendation.subjectName));
+    const visibility: DossierPopulationMethodVisibility = hidden
+      ? destination
+        ? destinationVisible
+          ? "hidden_with_destination"
+          : "hidden_without_destination"
+        : origin === "diagnostic/test artifact" || recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored"
+          ? "hidden_valid_archive_or_diagnostic"
+          : "hidden_without_destination"
+      : "visible";
+    const record: DossierPopulationMethodAuditRecord = {
+      id: recommendation.id,
+      subject: recommendation.subjectName,
+      sourceType: "recommendation",
+      currentStatus: recommendation.status,
+      origin,
+      intendedLane: lane,
+      visibility,
+      href: `/admin/dossiers/recommendations/${recommendation.id}`,
+      recommendationId: recommendation.id,
+      publicDossierId: publicMatch?.id,
+      publicDossierName: publicMatch?.name,
+      destinationId: destination?.id,
+      destinationSubject: destination?.existingDossierMatch?.name ?? destination?.name,
+      destinationLane: destination ? candidatePopulationMethodLane(destination, candidatePopulationMethodOrigin(destination)) : undefined,
+      destinationHref: destination ? `/admin/dossiers/candidates/${destination.id}` : undefined,
+      destinationVisible,
+      reason: destination ? `Routes to ${destination.name}.` : "No destination workspace detected.",
+      recommendedAdminNextStep: destination ? "Review the destination workspace if the source record needs follow-up." : "Review whether this inbox item should attach to a Source File, become a Dossier Update workspace, or be archived.",
+    };
+    records.push(record);
+
+    for (const targetId of [recommendation.targetCandidateId, recommendation.connectedCandidateId, recommendation.connectedSourceFileCandidateId].filter(Boolean) as string[]) {
+      if (!candidatesById.has(targetId)) addWarning(record, "Recommendation points to a missing candidate destination", "Reconnect targetCandidateId / connectedCandidateId to a valid workspace or return the recommendation to review.");
+    }
+    if (visibility === "hidden_without_destination") addWarning(record, isPublicDossierSignal(origin, lane) ? `Public dossier update signals for ${record.subject} were resolved, but no visible ${record.subject} Dossier Update workspace was found.` : "Hidden incoming record has no visible destination", "Create or attach a visible destination workspace, or mark the record as archived/diagnostic with clear metadata.");
+    if (origin === "diagnostic/test artifact" && !hidden) addWarning(record, "Diagnostic/test artifact is visible in a normal lane", "Archive the diagnostic artifact or keep it isolated from normal active lanes.");
+    if (origin === "unknown / insufficient metadata") addWarning(record, "Incoming record has unknown origin metadata", "Add source, ingestSource, source lanes, or createdBy metadata before routing.");
+    if (isPublicDossierSignal(origin, lane) && hidden && !destinationVisible) addWarning(record, `Visible destination missing for canonical public dossier target ${record.publicDossierName ?? record.subject}.`, "Ensure the canonical public dossier target has a visible Dossier Update workspace.");
+  }
+
+  for (const request of input.sourceFileRefreshRequests ?? []) {
+    const destination = request.candidateId ? candidatesById.get(request.candidateId) : undefined;
+    records.push({
+      id: request.id,
+      subject: request.subjectName,
+      sourceType: "source_file_refresh_request",
+      currentStatus: request.status,
+      origin: "source file refresh",
+      intendedLane: request.status === "completed" || request.status === "skipped" || request.status === "cancelled" ? "Resolved Incoming Record" : "Active Source File",
+      visibility: destination ? "hidden_with_destination" : request.status === "completed" ? "hidden_without_destination" : "visible",
+      href: destination ? `/admin/dossiers/candidates/${destination.id}` : undefined,
+      candidateId: request.candidateId,
+      destinationId: destination?.id,
+      destinationSubject: destination?.name,
+      destinationHref: destination ? `/admin/dossiers/candidates/${destination.id}` : undefined,
+      destinationVisible: visibleDestinationCandidate(destination),
+      reason: request.reason,
+      recommendedAdminNextStep: destination ? "Review the linked Source File refresh result." : "Find or create the Source File destination for this refresh request.",
+    });
+  }
+
+  const countsByOrigin = emptyCountMap(populationMethodOrigins);
+  const countsByLane = emptyCountMap(populationMethodLanes);
+  const countsByVisibility = emptyCountMap(populationMethodVisibilities);
+  for (const record of records) {
+    countsByOrigin[record.origin] += 1;
+    countsByLane[record.intendedLane] += 1;
+    countsByVisibility[record.visibility] += 1;
+  }
+
+  const hiddenWithoutDestination = records.filter((record) => record.visibility === "hidden_without_destination");
+  const hiddenWithDestinations = records.filter((record) => record.visibility === "hidden_with_destination");
+  const diagnosticArtifacts = records.filter((record) => record.origin === "diagnostic/test artifact" || record.intendedLane === "Diagnostic/Test Artifact");
+  const recordsNeedingPopulationReview = records.filter((record) => record.intendedLane === "Needs Population Review" || record.origin === "unknown / insufficient metadata" || warnings.some((warning) => warning.affectedIds.includes(record.id)));
+  const visibleDestinationWorkspaces = records.filter((record) => record.sourceType === "candidate" && record.destinationVisible !== false && (record.intendedLane === "Active Source File" || record.intendedLane === "Dossier Update Workspace") && record.visibility === "visible");
+
+  return {
+    countsByOrigin,
+    countsByLane,
+    countsByVisibility,
+    intakeFlows: records,
+    orphanedRecords: records.filter((record) => !record.destinationId && (record.intendedLane === "Needs Population Review" || record.visibility === "hidden_without_destination")),
+    hiddenWithoutDestination,
+    hiddenWithDestinations,
+    visibleDestinationWorkspaces,
+    diagnosticArtifacts,
+    recordsNeedingPopulationReview,
+    publicDossierUpdateSignals: records.filter((record) => isPublicDossierSignal(record.origin, record.intendedLane)),
+    sourceFileRefreshLinks: records.filter((record) => record.origin === "source file refresh" || record.origin === "source file archive"),
+    warnings,
+  };
+}
+
 function isBnlRecommendation(
   recommendation: Pick<DossierRecommendation, "ingestSource" | "createdBy">,
 ): boolean {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2122,6 +2122,182 @@ test("Subject Consolidation Queue renders action summary, review cards, blocked 
 });
 
 
+
+test("Population Method Audit renders read-only admin intake map states", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+
+  for (const label of [
+    "Population Method Audit",
+    "Population Method: {populationMethodHealthy ? \"healthy\" : \"needs review\"}",
+    "Population Method Audit / Intake Map",
+    "All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.",
+    "intake records need population review.",
+    "Intake Summary",
+    "BNL recommendations",
+    "manual admin records",
+    "public dossier update signals",
+    "source file refresh/archive records",
+    "diagnostic/test artifacts",
+    "unknown origin records",
+    "Lane Map",
+    "Active Source Files",
+    "Candidate Intake",
+    "Dossier Update Workspaces",
+    "Public Dossier Update Signals",
+    "Resolved Incoming Records",
+    "Diagnostics",
+    "Archived/Closed",
+    "Needs Population Review",
+    "Warnings / Problems",
+    "Affected subject:",
+    "Affected IDs",
+    "Source type",
+    "Current status",
+    "Expected lane",
+    "Detected destination",
+    "Recommended admin next step",
+    "Hidden Records With Destinations",
+    "Hidden Records Without Destinations",
+    "Destination Workspaces",
+    "View Source Record",
+    "View Destination Workspace",
+    "View Public Dossier Match",
+    "Copy Record IDs",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  assert.match(page, /createDossierPopulationMethodAudit/);
+  assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Population Method Audit|Intake Map|Copy Record IDs/);
+
+  const auditCopy = pageCopy.slice(
+    pageCopy.indexOf("Population Method Audit"),
+    pageCopy.indexOf("Similar or ambiguous subjects requiring admin judgment"),
+  );
+  assert.doesNotMatch(auditCopy, /fix automatically|Fix Automatically|Run Subject Consolidation|Confirm Consolidation|merge candidates|Merge button|publish public pages|change public dossier text/i);
+});
+
+test("Population Method Audit classifies origins, lanes, visibility, destinations, and warnings", () => {
+  const now = "2026-06-12T00:00:00.000Z";
+  const candidate = (overrides) => ({
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 5,
+    whyNow: "Population audit fixture",
+    reason: "Population audit fixture",
+    evidenceSummary: "Population audit fixture",
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  const recommendation = (overrides) => ({
+    id: overrides.id,
+    type: "new_subject",
+    subjectName: overrides.subjectName,
+    status: "new",
+    reason: "Population audit fixture",
+    confidence: "medium",
+    sourceLanes: ["public_discord"],
+    createdAt: now,
+    updatedAt: now,
+    createdBy: "bnl",
+    ingestSource: "bnl",
+    ...overrides,
+  });
+
+  const publicDossiers = [{ id: "PUB-196", name: "Public Subject" }];
+  const candidates = [
+    candidate({ id: "active-source", name: "Active Source", status: "active_source_file", source: "bnl_dynamic_candidate_discovery", latestSourceFileArchiveUpdatedAt: now }),
+    candidate({ id: "candidate-intake", name: "Candidate Intake", status: "candidate_intake", source: "manual" }),
+    candidate({ id: "dossier-update", name: "Public Subject", status: "existing_dossier_update", source: "manual", existingDossierMatch: { id: "PUB-196", name: "Public Subject", confidence: "high" }, sourceRecommendationIds: ["resolved-public-signal"] }),
+    candidate({ id: "archived-source", name: "Archived Source", status: "archived", source: "manual" }),
+    candidate({ id: "merged-valid", name: "Merged Valid", status: "merged", source: "manual", mergedIntoCandidateId: "active-source" }),
+    candidate({ id: "merged-missing", name: "Merged Missing", status: "merged", source: "manual", mergedIntoCandidateId: "missing-target" }),
+    candidate({ id: "hidden-public-signal", name: "Public Subject", status: "candidate_intake", source: "manual", existingDossierMatch: { id: "PUB-196", name: "Public Subject", confidence: "high" }, routingReason: "bundled_into_dossier_update" }),
+    candidate({ id: "hidden-public-orphan", name: "Orphan Public", status: "candidate_intake", source: "manual", existingDossierMatch: { id: "PUB-MISSING", name: "Orphan Public", confidence: "high" }, routingReason: "bundled_into_dossier_update" }),
+    candidate({ id: "hidden-workspace", name: "Hidden Workspace", status: "existing_dossier_update", source: "manual", existingDossierMatch: { id: "PUB-HIDDEN", name: "Hidden Workspace", confidence: "high" }, routingReason: "bundled_into_dossier_update" }),
+    candidate({ id: "diagnostic-active", name: "Diagnostic Probe", status: "active_source_file", source: "manual", reason: "manual endpoint smoke test" }),
+    candidate({ id: "source-refresh", name: "Refresh Source", status: "active_source_file", source: "bnl_source_file_enrichment", ingestSource: "bnl_source_file_enrichment" }),
+    candidate({ id: "source-archive", name: "Archive Source", status: "active_source_file", source: "manual", latestSourceFileArchiveId: "archive-1" }),
+    candidate({ id: "alias-link", name: "Alias Source", status: "active_source_file", source: "manual", identityLinks: [{ id: "alias-1", label: "Alias", normalizedLabel: "alias", status: "confirmed", useForMatching: true, createdAt: now, updatedAt: now }] }),
+    candidate({ id: "website-read", name: "Website Read", status: "candidate_intake", source: "website_read_model" }),
+    candidate({ id: "unknown-origin", name: "Unknown Origin", status: "active_source_file", source: "combined" }),
+  ];
+  const recommendations = [
+    recommendation({ id: "bnl-recommendation", subjectName: "BNL Subject", ingestSource: "bnl" }),
+    recommendation({ id: "bnl-bridge", subjectName: "Bridge Subject", ingestSource: "bnl_source_knowledge_bridge" }),
+    recommendation({ id: "bnl-discovery", subjectName: "Discovery Subject", ingestSource: "bnl_dynamic_candidate_discovery" }),
+    recommendation({ id: "manual-recommendation", subjectName: "Manual Recommendation", createdBy: "admin", ingestSource: "system", sourceLanes: ["admin_manual"] }),
+    recommendation({ id: "resolved-public-signal", subjectName: "Public Subject", type: "modify_existing_dossier", status: "attached_to_existing_dossier_update", targetDossierId: "PUB-196", ingestSource: "bnl" }),
+    recommendation({ id: "orphan-public-signal", subjectName: "Missing Public", type: "modify_existing_dossier", status: "attached_to_existing_dossier_update", targetDossierId: "PUB-MISSING", ingestSource: "bnl" }),
+    recommendation({ id: "missing-target-recommendation", subjectName: "Missing Target", status: "new", targetCandidateId: "missing-target", ingestSource: "bnl" }),
+    recommendation({ id: "diagnostic-recommendation", subjectName: "Diagnostic Test", status: "new", reason: "diagnostic probe", ingestSource: "bnl" }),
+    recommendation({ id: "unknown-recommendation", subjectName: "Unknown Recommendation", status: "new", createdBy: undefined, ingestSource: "unknown", sourceLanes: ["unknown"] }),
+  ];
+
+  const audit = workflow.createDossierPopulationMethodAudit({
+    candidates,
+    recommendations,
+    publicDossiers,
+    drafts: [{ id: "draft-update", candidateId: "dossier-update", status: "draft", fields: { name: "Public Subject" }, createdAt: now, updatedAt: now }],
+    sourceFileRefreshRequests: [{ id: "refresh-request", candidateId: "source-refresh", subjectName: "Refresh Source", normalizedSubjectKey: "refresh-source", status: "completed", reason: "case report missing", requestSource: "case_report_missing", requestedAt: now, updatedAt: now, priority: 1 }],
+  });
+
+  assert.equal(audit.countsByOrigin["BNL recommendation"], 2);
+  assert.equal(audit.countsByOrigin["BNL source knowledge bridge"], 1);
+  assert.equal(audit.countsByOrigin["BNL dynamic candidate discovery"], 2);
+  assert.equal(audit.countsByOrigin["manual admin creation"] >= 2, true);
+  assert.equal(audit.countsByOrigin["public dossier update signal"] >= 4, true);
+  assert.equal(audit.countsByOrigin["diagnostic/test artifact"], 2);
+  assert.equal(audit.countsByOrigin["source file refresh"], 2);
+  assert.equal(audit.countsByOrigin["source file archive"], 1);
+  assert.equal(audit.countsByOrigin["website read model"], 1);
+  assert.equal(audit.countsByOrigin["identity/alias link"], 1);
+  assert.equal(audit.countsByOrigin["unknown / insufficient metadata"], 2);
+
+  assert.equal(audit.intakeFlows.find((record) => record.id === "active-source").intendedLane, "Active Source File");
+  assert.equal(audit.intakeFlows.find((record) => record.id === "candidate-intake").intendedLane, "Candidate Intake");
+  assert.equal(audit.intakeFlows.find((record) => record.id === "dossier-update").intendedLane, "Dossier Update Workspace");
+  assert.equal(audit.intakeFlows.find((record) => record.id === "archived-source").intendedLane, "Archived / Closed");
+  assert.equal(audit.intakeFlows.find((record) => record.id === "merged-valid").intendedLane, "Merged Source Record");
+
+  assert.ok(audit.hiddenWithDestinations.some((record) => record.id === "merged-valid" && record.destinationId === "active-source"));
+  assert.ok(audit.hiddenWithoutDestination.some((record) => record.id === "merged-missing"));
+  assert.ok(audit.hiddenWithoutDestination.some((record) => record.id === "orphan-public-signal"));
+  assert.ok(audit.visibleDestinationWorkspaces.some((record) => record.id === "dossier-update"));
+  assert.ok(audit.diagnosticArtifacts.some((record) => record.id === "diagnostic-active"));
+  assert.ok(audit.publicDossierUpdateSignals.some((record) => record.id === "resolved-public-signal"));
+  assert.ok(audit.sourceFileRefreshLinks.some((record) => record.id === "source-refresh"));
+  assert.ok(audit.recordsNeedingPopulationReview.some((record) => record.id === "unknown-origin"));
+
+  const warningTitles = audit.warnings.map((warning) => warning.issueTitle).join("\n");
+  assert.match(warningTitles, /Merged source record points nowhere/);
+  assert.match(warningTitles, /Recommendation points to a missing candidate destination/);
+  assert.match(warningTitles, /Diagnostic\/test artifact is visible in a normal lane/);
+  assert.match(warningTitles, /Public dossier update signals for Missing Public were resolved, but no visible Missing Public Dossier Update workspace was found\./);
+  assert.match(warningTitles, /Destination workspace for Hidden Workspace exists but is currently hidden by resolved-candidate filtering\./);
+  assert.match(warningTitles, /Visible destination missing for canonical public dossier target/);
+});
+
+test("Population Method Audit preserves existing dossier admin and public boundaries", () => {
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+  const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const publicPage = normalizedSource("src/app/database/[slug]/page.tsx");
+  const publicView = normalizedSource("src/components/DossierPageView.tsx");
+
+  assertIncludesCopy(pageCopy, "Dossier Control Center");
+  assertIncludesCopy(pageCopy, "Subject Consolidation Queue");
+  assertIncludesCopy(sourceFilePage, "Case File / BNL Source File");
+  assertIncludesCopy(publicPage, "<DossierPageView dossier={databaseEntryToDossierPageViewModel(entry)} />");
+  assert.doesNotMatch(publicPage + publicView, /Population Method Audit|Intake Map|internal aliases|Copy Record IDs/);
+  assert.doesNotMatch(pageCopy, /publicPagesPublished: [1-9]|publicDossierTextChanged: [1-9]/);
+});
+
 test("canonical subject clustering collapses public-dossier variants into one subject cluster", () => {
   const now = "2026-06-11T00:00:00.000Z";
   const publicEntry =


### PR DESCRIPTION
### Motivation
- Provide admins a read-only diagnostic/audit surface that explains how records entered the system and where they are routed so consolidation stops expanding without visibility.
- Surface origin, intended lane, visibility, and destination information so orphaned/misrouted/hidden records can be detected without changing public data or adding automated fixes.
- Catch class of issues described (hidden public signals without visible workspaces, hidden destinations, missing targets, diagnostics leaking into active lanes) in a generic way.

### Description
- Added a shared helper `createDossierPopulationMethodAudit` in `src/lib/dossier-workflow.ts` that classifies records by origin, intended lane, visibility, destination, and emits structured counts, intake flows, and warnings for candidates, recommendations, drafts, public dossiers, and optional source-file refresh requests.
- Implemented origin labels (BNL variants, manual admin, public dossier signals, source refresh/archive, identity/alias, diagnostics, website read model, unknown) and lane mappings (Active Source File, Candidate Intake, Dossier Update Workspace, Public Dossier Update Signal, etc.), plus visibility/destination checks and generic warnings for the scenarios required.
- Integrated a read-only Population Method Audit panel into the existing Dossier Control Center at `src/app/admin/dossiers/page.tsx` below the Subject Consolidation Queue, with collapsed healthy state (`Population Method: healthy`) and expanded audit sections (Intake Summary, Lane Map, Warnings, Hidden With/Without Destinations, Destination Workspaces) and only non-mutating actions (`View Source Record`, `View Destination Workspace`, `View Public Dossier Match`, `Copy Record IDs`).
- Updated/added unit tests in `tests/admin-dossiers.test.mjs` to assert rendering, healthy/needs-review copy, classification of origins/lanes/visibility/destinations, expected warning detection, and that no public pages or public-dossier text changes or mutation buttons were introduced.

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed.
- Ran `npx tsc --noEmit` and TypeScript type-check passed.

Files changed
- `src/lib/dossier-workflow.ts` — new audit types and `createDossierPopulationMethodAudit` implementation.
- `src/app/admin/dossiers/page.tsx` — UI integration of Population Method Audit panel (admin-only, read-only).
- `tests/admin-dossiers.test.mjs` — added tests covering rendering, classification, warnings, and boundary checks.

All changes are admin-only and read-only by design; no public pages, public dossier text, publishing behavior, BNL summary generation, or mutation buttons were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b50a6fcc4832188dc2d56c0b2ec72)