### PR TITLE
Add authenticated BNL Population Context endpoint

### DIFF
--- a/src/app/api/bnl/population-context/route.ts
+++ b/src/app/api/bnl/population-context/route.ts
@@ -1,0 +1,363 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { databasePage, type DatabaseEntry } from "@/content";
+import {
+  isActiveSourceFileCandidate,
+  normalizeDossierSubjectName,
+  type DossierCandidate,
+  type DossierIdentityLink,
+  type DossierRecommendation,
+  type DossierSourceFileRefreshRequest,
+} from "@/lib/dossier-workflow";
+import { getDossierWorkflowState } from "@/lib/dossier-workflow-store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const CACHE_CONTROL = "private, no-store";
+const VERSION = "population_context_v1";
+
+type RouteLane =
+  | "source_file"
+  | "candidate_intake"
+  | "dossier_update_workspace"
+  | "resolved_record";
+
+function bearerToken(req: Request): string {
+  const authorization = req.headers.get("authorization") ?? "";
+  if (authorization.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+  return (
+    req.headers.get("x-bnl-api-key")?.trim() ??
+    req.headers.get("x-bnl-token")?.trim() ??
+    req.headers.get("x-bnl-source-file-read-token")?.trim() ??
+    ""
+  );
+}
+
+function configuredTokens(): string[] {
+  return [
+    process.env.BNL_API_KEY,
+    process.env.BNL_TOKEN,
+    process.env.BNL_SOURCE_FILE_READ_TOKEN,
+  ]
+    .map((token) => token?.trim())
+    .filter((token): token is string => Boolean(token));
+}
+
+function tokenMatches(providedToken: string): boolean {
+  if (!providedToken) return false;
+  return configuredTokens().some((expectedToken) => {
+    const expected = Buffer.from(expectedToken);
+    const provided = Buffer.from(providedToken);
+    return (
+      expected.length === provided.length && timingSafeEqual(expected, provided)
+    );
+  });
+}
+
+function slugifyPublicDossierName(name: string) {
+  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+}
+
+function publicDossierPath(entry: DatabaseEntry) {
+  return `/database/${slugifyPublicDossierName(entry.name)}`;
+}
+
+function publicDossierRegistryItem(entry: DatabaseEntry) {
+  const normalizedSubjectKey = normalizeDossierSubjectName(entry.name);
+  return {
+    id: entry.id,
+    name: entry.name,
+    slug: slugifyPublicDossierName(entry.name),
+    status: entry.status,
+    aliases: [] as string[],
+    canonicalSubjectKey: normalizedSubjectKey,
+    normalizedSubjectKey,
+    path: publicDossierPath(entry),
+  };
+}
+
+function adminRoute(candidateId: string, lane: RouteLane) {
+  const path = `/admin/dossiers/candidates/${encodeURIComponent(candidateId)}`;
+  return { path, lane };
+}
+
+function publicDossierMatchFor(candidate: DossierCandidate) {
+  const match = candidate.existingDossierMatch ?? null;
+  if (!match) return null;
+  const entry = databasePage.entries.find((item) => item.id === match.id);
+  return {
+    id: match.id,
+    name: match.name,
+    confidence: match.confidence,
+    path: entry ? publicDossierPath(entry) : null,
+  };
+}
+
+function adminSummaryFlags(candidate: DossierCandidate) {
+  const generatedAt = candidate.sourceFileSummary?.updatedAt ?? null;
+  const latestSourceUpdate =
+    candidate.latestSourceFileArchiveUpdatedAt ??
+    candidate.latestSourceFileArchive?.updatedAt ??
+    null;
+  return {
+    hasAdminSummary: Boolean(candidate.sourceFileSummary),
+    adminSummaryStale: Boolean(
+      generatedAt && latestSourceUpdate && latestSourceUpdate > generatedAt,
+    ),
+    adminSummaryGeneratedAt: generatedAt,
+  };
+}
+
+function updateSummaryFlags(candidate: DossierCandidate) {
+  const flags = adminSummaryFlags(candidate);
+  return {
+    hasUpdateSummary: flags.hasAdminSummary,
+    updateSummaryStale: flags.adminSummaryStale,
+    updateSummaryGeneratedAt: flags.adminSummaryGeneratedAt,
+  };
+}
+
+function latestRefreshStatus(
+  candidate: DossierCandidate,
+  refreshRequests: DossierSourceFileRefreshRequest[],
+) {
+  const related = refreshRequests
+    .filter(
+      (request) =>
+        request.candidateId === candidate.id ||
+        request.normalizedSubjectKey === normalizeDossierSubjectName(candidate.name),
+    )
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  const latest = related[0];
+  if (!latest) return null;
+  return {
+    id: latest.id,
+    status: latest.status,
+    requestSource: latest.requestSource,
+    updatedAt: latest.updatedAt,
+    requestedAt: latest.requestedAt,
+  };
+}
+
+function sourceFileItem(candidate: DossierCandidate) {
+  return {
+    candidateId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: normalizeDossierSubjectName(candidate.name),
+    candidateType: candidate.candidateType,
+    status: candidate.status,
+    publicDossierMatch: publicDossierMatchFor(candidate),
+    publicDossierId: candidate.existingDossierMatch?.id ?? null,
+    latestSourceFileArchiveId: candidate.latestSourceFileArchiveId ?? null,
+    latestSourceFileArchiveUpdatedAt:
+      candidate.latestSourceFileArchiveUpdatedAt ??
+      candidate.latestSourceFileArchive?.updatedAt ??
+      null,
+    sourceFileArchiveIds: candidate.sourceFileArchiveIds ?? [],
+    sourceLanes: candidate.sourceLanes ?? [],
+    ...adminSummaryFlags(candidate),
+    route: adminRoute(candidate.id, "source_file"),
+  };
+}
+
+function candidateIntakeItem(candidate: DossierCandidate) {
+  return {
+    candidateId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: normalizeDossierSubjectName(candidate.name),
+    candidateType: candidate.candidateType,
+    status: candidate.status,
+    score: candidate.score,
+    tier: candidate.tier,
+    source: candidate.source,
+    ingestSource: candidate.ingestSource ?? null,
+    publicDossierMatch: publicDossierMatchFor(candidate),
+    createdFromRecommendationId: candidate.createdFromRecommendationId ?? null,
+    connectedRecommendationIds: candidate.connectedRecommendationIds ?? [],
+    sourceRecommendationIds: candidate.sourceRecommendationIds ?? [],
+    route: adminRoute(candidate.id, "candidate_intake"),
+  };
+}
+
+function dossierUpdateWorkspaceItem(
+  candidate: DossierCandidate,
+  refreshRequests: DossierSourceFileRefreshRequest[],
+) {
+  return {
+    candidateId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: normalizeDossierSubjectName(candidate.name),
+    status: candidate.status,
+    publicDossierId: candidate.existingDossierMatch?.id ?? null,
+    publicDossierName: candidate.existingDossierMatch?.name ?? null,
+    existingDossierMatch: publicDossierMatchFor(candidate),
+    sourceRecommendationIds: candidate.sourceRecommendationIds ?? [],
+    connectedRecommendationIds: candidate.connectedRecommendationIds ?? [],
+    sourceFileNotesCount: candidate.sourceFileNotes?.length ?? 0,
+    ...updateSummaryFlags(candidate),
+    bnlRefreshStatus: latestRefreshStatus(candidate, refreshRequests),
+    route: adminRoute(candidate.id, "dossier_update_workspace"),
+  };
+}
+
+function privateIdentityKey(candidateId: string, link: DossierIdentityLink) {
+  const digest = createHash("sha256")
+    .update(`${candidateId}:${link.id}:${link.normalizedLabel}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `internal_identity_key:${digest}`;
+}
+
+function identityLinkItem(candidate: DossierCandidate, link: DossierIdentityLink) {
+  const publicSafe = link.visibility === "public_safe" && link.useInPublicDossier;
+  return {
+    sourceCandidateId: link.candidateId || candidate.id,
+    targetCandidateId: candidate.id,
+    normalizedLabel: publicSafe
+      ? link.normalizedLabel
+      : privateIdentityKey(candidate.id, link),
+    status: link.status,
+    useForMatching: link.useForMatching,
+    confidence: link.confidence ?? null,
+    publicSafe,
+  };
+}
+
+function destinationLane(candidate: DossierCandidate | undefined) {
+  if (!candidate) return null;
+  if (candidate.status === "existing_dossier_update") {
+    return "dossier_update_workspace";
+  }
+  if (candidate.status === "candidate_intake") return "candidate_intake";
+  if (isActiveSourceFileCandidate(candidate)) return "source_file";
+  return "resolved_record";
+}
+
+function resolvedCandidateItem(
+  candidate: DossierCandidate,
+  candidatesById: Map<string, DossierCandidate>,
+) {
+  const destination = candidate.mergedIntoCandidateId
+    ? candidatesById.get(candidate.mergedIntoCandidateId)
+    : undefined;
+  return {
+    recordId: candidate.id,
+    subjectName: candidate.name,
+    normalizedSubjectKey: normalizeDossierSubjectName(candidate.name),
+    status: candidate.status,
+    resolvedReason: candidate.mergeNote ?? candidate.routingReason ?? candidate.status,
+    destinationCandidateId: candidate.mergedIntoCandidateId ?? null,
+    destinationSubjectName: destination?.name ?? null,
+    destinationLane: destinationLane(destination),
+    publicDossierId: candidate.existingDossierMatch?.id ?? null,
+  };
+}
+
+function resolvedRecommendationItem(
+  recommendation: DossierRecommendation,
+  candidatesById: Map<string, DossierCandidate>,
+) {
+  const destinationCandidateId =
+    recommendation.targetCandidateId ??
+    recommendation.connectedSourceFileCandidateId ??
+    recommendation.connectedCandidateId ??
+    null;
+  const destination = destinationCandidateId
+    ? candidatesById.get(destinationCandidateId)
+    : undefined;
+  return {
+    recordId: recommendation.id,
+    subjectName: recommendation.subjectName,
+    normalizedSubjectKey:
+      recommendation.subjectKey ??
+      normalizeDossierSubjectName(recommendation.subjectName),
+    status: recommendation.status,
+    resolvedReason: recommendation.routingReason ?? recommendation.status,
+    destinationCandidateId,
+    destinationSubjectName: destination?.name ?? null,
+    destinationLane: destinationLane(destination),
+    publicDossierId: recommendation.targetDossierId ?? null,
+  };
+}
+
+function isResolvedRecommendation(recommendation: DossierRecommendation) {
+  return (
+    recommendation.status === "attached_to_source_file" ||
+    recommendation.status === "attached_to_candidate_intake" ||
+    recommendation.status === "attached_to_existing_dossier_update" ||
+    recommendation.status === "converted_to_source_file" ||
+    recommendation.status === "identity_link_created" ||
+    recommendation.status === "ignored" ||
+    recommendation.status === "dismissed" ||
+    recommendation.status === "archived"
+  );
+}
+
+export async function GET(req: Request) {
+  if (!tokenMatches(bearerToken(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const state = await getDossierWorkflowState();
+  const candidatesById = new Map(
+    state.candidates.map((candidate) => [candidate.id, candidate]),
+  );
+  const publicDossiers = databasePage.entries.map(publicDossierRegistryItem);
+  const sourceFiles = state.candidates
+    .filter(isActiveSourceFileCandidate)
+    .map(sourceFileItem);
+  const candidates = state.candidates
+    .filter((candidate) => candidate.status === "candidate_intake")
+    .map(candidateIntakeItem);
+  const dossierUpdateWorkspaces = state.candidates
+    .filter((candidate) => candidate.status === "existing_dossier_update")
+    .map((candidate) =>
+      dossierUpdateWorkspaceItem(candidate, state.sourceFileRefreshRequests),
+    );
+  const identityLinks = state.candidates.flatMap((candidate) =>
+    (candidate.identityLinks ?? []).map((identityLink) =>
+      identityLinkItem(candidate, identityLink),
+    ),
+  );
+  const resolvedRecords = [
+    ...state.candidates
+      .filter(
+        (candidate) =>
+          candidate.status === "merged" ||
+          candidate.status === "archived" ||
+          candidate.status === "denied",
+      )
+      .map((candidate) => resolvedCandidateItem(candidate, candidatesById)),
+    ...state.recommendations
+      .filter(isResolvedRecommendation)
+      .map((recommendation) =>
+        resolvedRecommendationItem(recommendation, candidatesById),
+      ),
+  ];
+
+  return NextResponse.json(
+    {
+      ok: true,
+      generatedAt: new Date().toISOString(),
+      version: VERSION,
+      publicDossiers,
+      sourceFiles,
+      candidates,
+      dossierUpdateWorkspaces,
+      identityLinks,
+      resolvedRecords,
+      diagnostics: {
+        publicDossierCount: publicDossiers.length,
+        sourceFileCount: sourceFiles.length,
+        candidateCount: candidates.length,
+        dossierUpdateWorkspaceCount: dossierUpdateWorkspaces.length,
+        identityLinkCount: identityLinks.length,
+        resolvedRecordCount: resolvedRecords.length,
+      },
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -53,6 +53,7 @@ const store = require("../src/lib/dossier-workflow-store.ts");
 const { databasePage } = require("../src/content.ts");
 const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const sourceFilesReadModel = require("../src/app/api/bnl/source-files/route.ts");
+const populationContextRoute = require("../src/app/api/bnl/population-context/route.ts");
 const sourceFileRefreshRequestsRoute = require("../src/app/api/bnl/source-files/refresh-requests/route.ts");
 const noteDisplay = require("../src/lib/dossier-note-display.ts");
 const sourceFileSummary = require("../src/lib/dossier-source-file-summary.ts");
@@ -264,6 +265,14 @@ async function sourceFilesGet(query, token = "test-source-file-read-token") {
   return sourceFilesReadModel.GET(
     new Request(`https://example.test/api/bnl/source-files${query}`, {
       headers: { authorization: `Bearer ${token}` },
+    }),
+  );
+}
+
+async function populationContextGet(token) {
+  return populationContextRoute.GET(
+    new Request("https://example.test/api/bnl/population-context", {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
     }),
   );
 }
@@ -8803,4 +8812,232 @@ test("Source File brief leads with Subject Read and renders Current Take once", 
 
   const panelSource = source("src/components/DossierSourceFileSummaryPanel.tsx");
   assert.doesNotMatch(panelSource, /lg:grid-cols-2[\s\S]{0,260}BNL take/i);
+});
+
+test("BNL population context endpoint is authenticated, compact, and routing-safe", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_API_KEY = "test-population-context-token";
+  const now = new Date().toISOString();
+  const older = new Date(Date.now() - 60_000).toISOString();
+  const baseCandidate = (overrides) => ({
+    id: overrides.id,
+    name: overrides.name,
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 50,
+    whyNow: "Routing context only.",
+    reason: "Population context fixture.",
+    evidenceSummary: "Fixture evidence summary should not include raw messages.",
+    status: "needs_review",
+    createdAt: older,
+    updatedAt: now,
+    ...overrides,
+  });
+  const baseRecommendation = (overrides) => ({
+    id: overrides.id,
+    type: "modify_existing_dossier",
+    subjectName: overrides.subjectName,
+    status: "new",
+    reason: "Recommendation routing fixture.",
+    sourceLanes: ["website_dossier"],
+    createdAt: older,
+    updatedAt: now,
+    ...overrides,
+  });
+
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [
+      baseCandidate({
+        id: "active-source-file",
+        name: "Active Subject",
+        status: "active_source_file",
+        sourceLanes: ["broadcast_memory"],
+        latestSourceFileArchiveId: "archive-active-1",
+        latestSourceFileArchiveUpdatedAt: now,
+        sourceFileArchiveIds: ["archive-active-1"],
+        sourceFileSummary: { summaryText: "private admin summary text", updatedAt: older },
+        identityLinks: [
+          {
+            id: "private-alias",
+            candidateId: "active-source-file",
+            label: "Private Raw Alias Text",
+            normalizedLabel: "private raw alias text",
+            type: "alias",
+            visibility: "internal_only",
+            status: "confirmed",
+            source: "admin_manual",
+            confidence: "high",
+            useForMatching: true,
+            useInPublicDossier: false,
+            note: "private note",
+            createdAt: older,
+            updatedAt: now,
+          },
+          {
+            id: "public-alias",
+            candidateId: "active-source-file",
+            label: "Public Safe Alias",
+            normalizedLabel: "public safe alias",
+            type: "alias",
+            visibility: "public_safe",
+            status: "confirmed",
+            source: "owner_confirmed",
+            confidence: "confirmed",
+            useForMatching: true,
+            useInPublicDossier: true,
+            createdAt: older,
+            updatedAt: now,
+          },
+        ],
+      }),
+      baseCandidate({
+        id: "candidate-intake",
+        name: "Intake Subject",
+        status: "candidate_intake",
+        source: "bnl_dynamic_candidate_discovery",
+        ingestSource: "bnl",
+        createdFromRecommendationId: "rec-intake",
+        connectedRecommendationIds: ["rec-intake"],
+        sourceRecommendationIds: ["rec-intake"],
+      }),
+      baseCandidate({
+        id: "dossier-update-workspace",
+        name: "6 Bit",
+        status: "existing_dossier_update",
+        existingDossierMatch: { id: "EN-001", name: "6 Bit", confidence: "high" },
+        sourceRecommendationIds: ["rec-update"],
+        connectedRecommendationIds: ["rec-update", "rec-update-connected"],
+        sourceFileNotes: [
+          {
+            id: "workspace-note",
+            candidateId: "dossier-update-workspace",
+            type: "fact",
+            text: "private workspace note",
+            source: "bnl_recommendation",
+            status: "active",
+            createdAt: older,
+            updatedAt: now,
+          },
+        ],
+        sourceFileSummary: { summaryText: "private update summary", updatedAt: now },
+      }),
+      baseCandidate({
+        id: "merged-record",
+        name: "Merged Subject",
+        status: "merged",
+        mergedIntoCandidateId: "active-source-file",
+        mergeNote: "merged duplicate into active source file",
+      }),
+    ],
+    drafts: [],
+    recommendations: [
+      baseRecommendation({
+        id: "rec-intake",
+        subjectName: "Intake Subject",
+        status: "attached_to_candidate_intake",
+        targetCandidateId: "candidate-intake",
+        connectedCandidateId: "candidate-intake",
+        ingestSource: "bnl",
+      }),
+      baseRecommendation({
+        id: "rec-update",
+        subjectName: "6 Bit",
+        status: "attached_to_existing_dossier_update",
+        targetDossierId: "EN-001",
+        targetCandidateId: "dossier-update-workspace",
+        connectedCandidateId: "dossier-update-workspace",
+        connectedSourceFileCandidateId: "dossier-update-workspace",
+      }),
+    ],
+    sourceFileRefreshRequests: [
+      {
+        id: "refresh-update",
+        candidateId: "dossier-update-workspace",
+        subjectName: "6 Bit",
+        normalizedSubjectKey: "6 bit",
+        status: "pending",
+        reason: "Refresh workspace fixture.",
+        requestedAt: older,
+        updatedAt: now,
+        requestSource: "existing_dossier_update_review",
+        priority: 75,
+      },
+    ],
+    updatedAt: now,
+  });
+
+  const unauthorized = await populationContextGet();
+  assert.equal(unauthorized.status, 401);
+
+  const response = await populationContextGet("test-population-context-token");
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+  const payload = await response.json();
+
+  assert.equal(payload.ok, true);
+  assert.equal(payload.version, "population_context_v1");
+  assert.ok(Array.isArray(payload.publicDossiers));
+  assert.ok(Array.isArray(payload.sourceFiles));
+  assert.ok(Array.isArray(payload.candidates));
+  assert.ok(Array.isArray(payload.dossierUpdateWorkspaces));
+  assert.ok(Array.isArray(payload.identityLinks));
+  assert.ok(Array.isArray(payload.resolvedRecords));
+  assert.equal(payload.diagnostics.publicDossierCount, payload.publicDossiers.length);
+  assert.equal(payload.diagnostics.sourceFileCount, payload.sourceFiles.length);
+  assert.equal(payload.diagnostics.candidateCount, payload.candidates.length);
+  assert.equal(payload.diagnostics.dossierUpdateWorkspaceCount, payload.dossierUpdateWorkspaces.length);
+  assert.equal(payload.diagnostics.identityLinkCount, payload.identityLinks.length);
+  assert.equal(payload.diagnostics.resolvedRecordCount, payload.resolvedRecords.length);
+
+  const sourceFile = payload.sourceFiles.find((item) => item.candidateId === "active-source-file");
+  assert.equal(sourceFile.subjectName, "Active Subject");
+  assert.equal(sourceFile.normalizedSubjectKey, "active subject");
+  assert.equal(sourceFile.status, "active_source_file");
+  assert.equal(sourceFile.route.path, "/admin/dossiers/candidates/active-source-file");
+  assert.equal(sourceFile.hasAdminSummary, true);
+  assert.equal(sourceFile.adminSummaryStale, true);
+
+  const intake = payload.candidates.find((item) => item.candidateId === "candidate-intake");
+  assert.equal(intake.source, "bnl_dynamic_candidate_discovery");
+  assert.equal(intake.ingestSource, "bnl");
+
+  const workspace = payload.dossierUpdateWorkspaces.find((item) => item.candidateId === "dossier-update-workspace");
+  assert.equal(workspace.publicDossierId, "EN-001");
+  assert.equal(workspace.publicDossierName, "6 Bit");
+  assert.deepEqual(workspace.sourceRecommendationIds, ["rec-update"]);
+  assert.deepEqual(workspace.connectedRecommendationIds, ["rec-update", "rec-update-connected"]);
+  assert.equal(workspace.sourceFileNotesCount, 1);
+  assert.equal(workspace.hasUpdateSummary, true);
+  assert.equal(workspace.bnlRefreshStatus.status, "pending");
+
+  const privateLink = payload.identityLinks.find((item) => item.publicSafe === false);
+  assert.equal(privateLink.useForMatching, true);
+  assert.match(privateLink.normalizedLabel, /^internal_identity_key:/);
+  const publicLink = payload.identityLinks.find((item) => item.publicSafe === true);
+  assert.equal(publicLink.normalizedLabel, "public safe alias");
+
+  const mergedRecord = payload.resolvedRecords.find((item) => item.recordId === "merged-record");
+  assert.equal(mergedRecord.destinationCandidateId, "active-source-file");
+  assert.equal(mergedRecord.destinationSubjectName, "Active Subject");
+  assert.equal(mergedRecord.destinationLane, "source_file");
+
+  const serialized = JSON.stringify(payload);
+  assert.doesNotMatch(serialized, /relationship_journal|raw Discord message|raw discord message/i);
+  assert.doesNotMatch(serialized, /protected_system|private_admin|internal_controlled/i);
+  assert.doesNotMatch(serialized, /token|secret/i);
+  assert.doesNotMatch(serialized, /Private Raw Alias Text|private raw alias text|private admin summary text|private update summary|private workspace note|private note/);
+  assert.doesNotMatch(serialized, /summaryText|evidenceItems|rawProvenance|sourcePackage|relationshipSignals|conversationHighlights/i);
+
+  const routeSource = source("src/app/api/bnl/population-context/route.ts");
+  assert.doesNotMatch(routeSource, /export async function POST|export async function PUT|export async function PATCH|export async function DELETE/);
+  assert.doesNotMatch(routeSource, /databasePage\.entries\s*=|summary:\s*|notes:\s*|role:\s*/);
+  assert.match(source("src/app/api/bnl/read-model/route.ts"), /export async function GET/);
+  assert.match(source("src/app/admin/dossiers/page.tsx"), /Dossier Control Center/);
+  assert.match(source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx"), /Source File/);
+  assert.match(source("src/lib/dossier-workflow-store.ts"), /Subject Consolidation/);
+
+  delete process.env.BNL_API_KEY;
 });


### PR DESCRIPTION
### Motivation
- Provide BNL (admin) with a read-only routing map so the population recommender can resolve internal destinations (Source Files, Candidate Intake, Dossier Update workspaces, identity links, and resolved mappings) without exposing raw/private evidence. 
- Keep the public read model unchanged while enabling authenticated BNL tooling to answer routing questions and avoid duplicate or misrouted enrichment. 

### Description
- Added a new authenticated read-only API route at `GET /api/bnl/population-context` implemented in `src/app/api/bnl/population-context/route.ts` that accepts existing BNL-style tokens and returns a compact JSON `version: "population_context_v1"` payload. 
- The endpoint uses existing BNL auth patterns (`BNL_API_KEY`, `BNL_TOKEN`, `BNL_SOURCE_FILE_READ_TOKEN`) and returns `401` when unauthenticated, and is explicitly read-only with no POST/PUT/PATCH/DELETE handlers. 
- The response includes `publicDossiers`, `sourceFiles`, `candidates`, `dossierUpdateWorkspaces`, `identityLinks`, `resolvedRecords`, and `diagnostics` with routing-safe fields only (no raw transcripts, relationship_journal, private notes, tokens, or raw source blobs). 
- Added test coverage in `tests/admin-dossiers.test.mjs` to exercise unauthenticated/authenticated access, validate response shape and diagnostics counts, assert privacy/safety filters, and confirm existing admin/public read-model surfaces remain present. 

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and the suite passed (all admin-dossiers assertions succeeded). 
- Ran `npx tsc --noEmit` and TypeScript type-check passed. 
- Ran `node --test tests/bnl-read-model.test.mjs` for related read-model checks and it reported existing string-expectation failures unrelated to this endpoint; those failures were not caused by the new route and are noted for follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6607e82c832182594a418083c72b)