### PR TITLE
Add Population Review fields & admin actions for BNL population recommendations

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -330,7 +330,7 @@ function isPopulationRecommendation(recommendation: DossierRecommendation) {
 }
 
 function isPopulationOpen(recommendation: DossierRecommendation) {
-  return ["new", "reviewing", "needs_more_info"].includes(recommendation.status);
+  return ["new", "reviewing"].includes(recommendation.status);
 }
 
 function isNonDossierPopulationSignal(recommendation: DossierRecommendation) {
@@ -348,14 +348,26 @@ function isAlreadyRepresentedPopulationSignal(recommendation: DossierRecommendat
   );
 }
 
-function populationRecommendationSearchText(recommendation: DossierRecommendation) {
+function populationRecommendationSearchText(
+  recommendation: DossierRecommendation,
+  candidates: DossierCandidate[],
+) {
+  const candidateIds = [
+    recommendation.matchedExistingCandidateId,
+    recommendation.matchedDossierUpdateCandidateId,
+    recommendation.targetCandidateId,
+  ].filter(Boolean);
+  const matchedCandidateNames = candidateIds.flatMap((candidateId) =>
+    candidates
+      .filter((candidate) => candidate.id === candidateId)
+      .map((candidate) => candidate.name),
+  );
   return [
     recommendation.subjectName,
     recommendation.subjectKey,
     recommendation.matchedPublicDossierName,
     recommendation.matchedPublicDossierId,
-    recommendation.matchedExistingCandidateId,
-    recommendation.matchedDossierUpdateCandidateId,
+    ...matchedCandidateNames,
   ]
     .filter(Boolean)
     .join(" ")
@@ -484,7 +496,7 @@ export default function DossierControlCenterPage() {
     .at(-1);
   const filteredPopulationRecommendations = populationRecommendations.filter((recommendation) => {
     const query = populationSearch.trim().toLowerCase();
-    const matchesSearch = !query || populationRecommendationSearchText(recommendation).includes(query);
+    const matchesSearch = !query || populationRecommendationSearchText(recommendation, candidates).includes(query);
     const matchesFilter =
       populationFilter === "all" ? true :
       populationFilter === "new" ? isPopulationOpen(recommendation) :
@@ -1656,7 +1668,7 @@ export default function DossierControlCenterPage() {
                           {recommendation.missingInfo?.length ? <p><span className="text-foreground">Missing info:</span> {recommendation.missingInfo.join("; ")}</p> : null}
                           {recommendation.publicSafetyNotes?.length || recommendation.doNotPublishReason ? <p><span className="text-foreground">Public safety notes:</span> {[recommendation.doNotPublishReason, ...(recommendation.publicSafetyNotes ?? [])].filter(Boolean).join("; ")}</p> : null}
                           {recommendation.possibleTargets?.length ? <p><span className="text-foreground">Possible targets:</span> {recommendation.possibleTargets.map((target) => target.name ?? target.id).filter(Boolean).join(", ")}</p> : null}
-                          <p><span className="text-foreground">Risk:</span> duplicate {recommendation.duplicateRisk ?? "unset"} · identity {recommendation.identityRisk ?? "unset"} · rawEvidenceRefs {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} internal ref(s)</p>
+                          <p><span className="text-foreground">Risk:</span> duplicate {recommendation.duplicateRisk ?? "unset"} · identity {recommendation.identityRisk ?? "unset"} · internal evidence refs {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}</p>
                           <details className="border border-border/70 bg-background/30 p-3">
                             <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Internal refs</summary>
                             <p className="mt-2 text-xs text-muted">Raw evidence references are preserved internally but hidden from normal card copy. Count: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}.</p>

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -295,6 +295,95 @@ function archiveActionLabel() {
   return "Review Record";
 }
 
+type PopulationQueueFilter =
+  | "all"
+  | "new"
+  | "high"
+  | "needs_review"
+  | "existing_source_file"
+  | "dossier_update"
+  | "candidate_intake"
+  | "already_represented"
+  | "non_dossier"
+  | "dismissed";
+
+const populationQueueFilters: Array<{ id: PopulationQueueFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "new", label: "New" },
+  { id: "high", label: "High confidence" },
+  { id: "needs_review", label: "Needs review" },
+  { id: "existing_source_file", label: "Existing Source File" },
+  { id: "dossier_update", label: "Dossier Update" },
+  { id: "candidate_intake", label: "Candidate Intake" },
+  { id: "already_represented", label: "Already Represented" },
+  { id: "non_dossier", label: "Non-dossier signals" },
+  { id: "dismissed", label: "Dismissed" },
+];
+
+function isPopulationRecommendation(recommendation: DossierRecommendation) {
+  return (
+    recommendation.type === "population_recommendation" ||
+    recommendation.populationRecommendation === true ||
+    recommendation.createdBy === "bnl_population_recommender" ||
+    recommendation.ingestSource === "bnl_population_recommender"
+  );
+}
+
+function isPopulationOpen(recommendation: DossierRecommendation) {
+  return ["new", "reviewing", "needs_more_info"].includes(recommendation.status);
+}
+
+function isNonDossierPopulationSignal(recommendation: DossierRecommendation) {
+  return ["show_state_note", "broadcast_memory_note", "not_population_subject"].includes(
+    recommendation.recommendedAction ?? recommendation.recommendedLane ?? "",
+  );
+}
+
+function isAlreadyRepresentedPopulationSignal(recommendation: DossierRecommendation) {
+  return (
+    recommendation.recommendedAction === "mark_duplicate_no_new_info" ||
+    recommendation.recommendedAction === "mark_no_new_info" ||
+    recommendation.recommendedLane === "already_represented" ||
+    recommendation.duplicateRisk === "high"
+  );
+}
+
+function populationRecommendationSearchText(recommendation: DossierRecommendation) {
+  return [
+    recommendation.subjectName,
+    recommendation.subjectKey,
+    recommendation.matchedPublicDossierName,
+    recommendation.matchedPublicDossierId,
+    recommendation.matchedExistingCandidateId,
+    recommendation.matchedDossierUpdateCandidateId,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function populationDestinationLabel(recommendation: DossierRecommendation, candidates: DossierCandidate[]) {
+  const candidateId = recommendation.matchedExistingCandidateId ?? recommendation.matchedDossierUpdateCandidateId ?? recommendation.targetCandidateId;
+  const candidate = candidateId ? candidates.find((item) => item.id === candidateId) : undefined;
+  if (candidate) return candidate.name;
+  return recommendation.matchedPublicDossierName ?? recommendation.targetDossierId ?? "Needs admin target";
+}
+
+function populationPublicDossierHref(recommendation: DossierRecommendation, publicDossiers: Array<{ id: string; name: string }>) {
+  const dossier = publicDossiers.find((item) => item.id === (recommendation.matchedPublicDossierId ?? recommendation.targetDossierId));
+  if (!dossier) return undefined;
+  return `/database/${dossier.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+}
+
+function PopulationActionButton({ children, onClick, disabled }: { children: React.ReactNode; onClick: () => void; disabled?: boolean }) {
+  return (
+    <button type="button" disabled={disabled} onClick={onClick} className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50">
+      {children}
+    </button>
+  );
+}
+
+
 function DashboardCard({
   eyebrow,
   title,
@@ -334,6 +423,8 @@ export default function DossierControlCenterPage() {
   const [resolvedJustNow, setResolvedJustNow] = useState<{ groupId: string; subject: string; message: string; kind: "consolidate" | "source_file" | "dossier_update" | "keep_separate"; href?: string; absorbedCount: number; notesMoved: number; archivedCount: number; refreshStatus: string } | null>(null);
   const [recommendationForm, setRecommendationForm] =
     useState<ManualRecommendationForm>(emptyRecommendationForm);
+  const [populationFilter, setPopulationFilter] = useState<PopulationQueueFilter>("all");
+  const [populationSearch, setPopulationSearch] = useState("");
   const [createdDraftIdByCandidate, setCreatedDraftIdByCandidate] = useState<
     Record<string, string>
   >({});
@@ -386,6 +477,68 @@ export default function DossierControlCenterPage() {
     () => payload?.publicDossiers ?? [],
     [payload?.publicDossiers],
   );
+  const populationRecommendations = recommendations.filter(isPopulationRecommendation);
+  const populationLastUpdated = populationRecommendations
+    .map((recommendation) => recommendation.generatedAt ?? recommendation.lastSeenAt ?? recommendation.updatedAt)
+    .sort()
+    .at(-1);
+  const filteredPopulationRecommendations = populationRecommendations.filter((recommendation) => {
+    const query = populationSearch.trim().toLowerCase();
+    const matchesSearch = !query || populationRecommendationSearchText(recommendation).includes(query);
+    const matchesFilter =
+      populationFilter === "all" ? true :
+      populationFilter === "new" ? isPopulationOpen(recommendation) :
+      populationFilter === "high" ? recommendation.confidence === "high" :
+      populationFilter === "needs_review" ? recommendation.recommendedLane === "needs_population_review" || recommendation.recommendedAction === "admin_review_required" :
+      populationFilter === "existing_source_file" ? recommendation.recommendedLane === "active_source_file" || recommendation.recommendedAction === "attach_to_existing_source_file" :
+      populationFilter === "dossier_update" ? ["existing_dossier_update", "public_dossier_update_signal"].includes(recommendation.recommendedLane ?? "") || ["attach_to_existing_dossier_update", "create_dossier_update_workspace"].includes(recommendation.recommendedAction ?? "") :
+      populationFilter === "candidate_intake" ? recommendation.recommendedLane === "candidate_intake" || recommendation.recommendedAction === "create_source_file_candidate" :
+      populationFilter === "already_represented" ? isAlreadyRepresentedPopulationSignal(recommendation) :
+      populationFilter === "non_dossier" ? isNonDossierPopulationSignal(recommendation) :
+      populationFilter === "dismissed" ? ["dismissed", "ignored", "archived", "no_new_info", "not_population_subject"].includes(recommendation.status) :
+      true;
+    return matchesSearch && matchesFilter;
+  });
+  const populationQueueGroups = [
+    {
+      id: "existing-source-file",
+      title: "Attach to Existing Source File",
+      description: "BNL thinks this evidence belongs on an already active Source File.",
+      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "active_source_file" || recommendation.recommendedAction === "attach_to_existing_source_file"),
+    },
+    {
+      id: "existing-dossier-update",
+      title: "Dossier Update Workspace",
+      description: "BNL found an existing internal update workspace for a public dossier subject.",
+      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "existing_dossier_update" || recommendation.recommendedAction === "attach_to_existing_dossier_update"),
+    },
+    {
+      id: "create-dossier-update",
+      title: "Create Dossier Update Workspace",
+      description: "BNL sees a public dossier update signal, but no workspace is linked yet.",
+      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "public_dossier_update_signal" || recommendation.recommendedAction === "create_dossier_update_workspace"),
+    },
+    {
+      id: "candidate-intake",
+      title: "Candidate Intake / New Source File",
+      description: "BNL thinks this should start as a private candidate/source-file workflow record.",
+      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "candidate_intake" || recommendation.recommendedAction === "create_source_file_candidate"),
+    },
+    {
+      id: "admin-review",
+      title: "Admin Review Required",
+      description: "BNL is unsure; choose the safe internal route manually.",
+      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "needs_population_review" || recommendation.recommendedAction === "admin_review_required"),
+    },
+    {
+      id: "already-represented",
+      title: "Already Represented / Duplicate",
+      description: "BNL believes the subject is already represented or no new dossier work is needed.",
+      items: filteredPopulationRecommendations.filter(isAlreadyRepresentedPopulationSignal),
+    },
+  ];
+  const nonDossierPopulationSignals = filteredPopulationRecommendations.filter(isNonDossierPopulationSignal);
+
   const diagnosticRecommendations = recommendations.filter(isDiagnosticTestArtifactRecommendation);
   const resolvedCandidateIds = new Set(
     candidates.filter(isConsolidationResolvedCandidate).map((candidate) => candidate.id),
@@ -414,6 +567,9 @@ export default function DossierControlCenterPage() {
       "identity_link_created",
       "ignored",
       "dismissed",
+      "no_new_info",
+      "not_population_subject",
+      "needs_more_info",
       "archived",
     ].includes(recommendation.status),
   );
@@ -822,6 +978,37 @@ export default function DossierControlCenterPage() {
       setNotice(
         err instanceof Error ? err.message : "Candidate action failed.",
       );
+    }
+  }
+
+  async function populationRecommendationAction(
+    recommendation: DossierRecommendation,
+    action:
+      | "attach_to_existing_source_file"
+      | "attach_to_existing_dossier_update"
+      | "create_dossier_update_workspace"
+      | "create_source_file_candidate"
+      | "mark_no_new_info"
+      | "mark_not_population_subject"
+      | "dismiss_population_recommendation"
+      | "reopen_population_recommendation"
+      | "mark_needs_more_info",
+  ) {
+    try {
+      await postWorkflow({
+        action,
+        recommendationId: recommendation.id,
+        candidateId:
+          recommendation.matchedExistingCandidateId ??
+          recommendation.matchedDossierUpdateCandidateId ??
+          recommendation.targetCandidateId,
+        dossierId: recommendation.matchedPublicDossierId ?? recommendation.targetDossierId,
+        actionBy: "admin",
+        actionReason: `Population Review Queue: ${action}`,
+      });
+      setNotice("Population recommendation updated internally. No public dossier text changed and no public page was published.");
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Population recommendation action failed.");
     }
   }
 
@@ -1396,6 +1583,128 @@ export default function DossierControlCenterPage() {
               </details>
             </div>
           </details>
+
+        <DashboardCard
+          eyebrow="BNL Population Scan"
+          title="Population Review Queue"
+          aside={<StatusPill>{populationRecommendations.filter(isPopulationOpen).length} new / unreviewed</StatusPill>}
+        >
+          <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-3 text-xs text-muted">
+            {[
+              ["Total", populationRecommendations.length],
+              ["New / unreviewed", populationRecommendations.filter(isPopulationOpen).length],
+              ["High", populationRecommendations.filter((item) => item.confidence === "high").length],
+              ["Medium", populationRecommendations.filter((item) => item.confidence === "medium").length],
+              ["Low", populationRecommendations.filter((item) => item.confidence === "low").length],
+              ["Blocked", populationRecommendations.filter((item) => item.publicSafetyLevel === "blocked" || item.identityRisk === "blocked").length],
+              ["Already represented", populationRecommendations.filter(isAlreadyRepresentedPopulationSignal).length],
+              ["Non-subject skipped", populationRecommendations.filter(isNonDossierPopulationSignal).length],
+            ].map(([label, value]) => (
+              <div key={label} className="border border-border/70 bg-background/30 p-3">
+                <p className="uppercase tracking-[0.25em] text-accent mb-2">{label}</p>
+                <p className="text-2xl font-bold text-foreground">{value}</p>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between text-xs uppercase tracking-widest text-muted">
+            <p>Source of recommendation: BNL Population Scan · Last updated / generatedAt: {formatDate(populationLastUpdated)}</p>
+            <label className="space-y-2 md:min-w-72">
+              <span>Search subject, normalized key, dossier, or Source File</span>
+              <input value={populationSearch} onChange={(event) => setPopulationSearch(event.target.value)} className={textInputClass()} />
+            </label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {populationQueueFilters.map((filter) => (
+              <button key={filter.id} type="button" onClick={() => setPopulationFilter(filter.id)} className={`border px-3 py-1.5 text-xs uppercase tracking-widest ${populationFilter === filter.id ? "border-accent text-accent" : "border-border text-muted hover:border-accent hover:text-accent"}`}>
+                {filter.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-sm text-muted">This queue only changes private workflow records. It does not publish public pages, does not edit public dossier text, does not auto-approve recommendations, and keeps raw/private evidence plus internal aliases out of public display.</p>
+
+          <div className="space-y-5">
+            {populationQueueGroups.map((group) => (
+              <section key={group.id} className="border border-border/70 bg-background/20 p-4 space-y-3">
+                <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <h3 className="text-lg font-bold text-foreground">{group.title}</h3>
+                    <p className="text-sm text-muted">{group.description}</p>
+                  </div>
+                  <StatusPill>{group.items.length} recommendation{group.items.length === 1 ? "" : "s"}</StatusPill>
+                </div>
+                {group.items.length === 0 ? (
+                  <p className="text-sm text-muted">No matching population recommendations in this lane.</p>
+                ) : (
+                  <div className="grid gap-3 lg:grid-cols-2">
+                    {group.items.map((recommendation) => {
+                      const targetHref = recommendation.targetCandidateId || recommendation.matchedExistingCandidateId || recommendation.matchedDossierUpdateCandidateId ? `/admin/dossiers/candidates/${recommendation.targetCandidateId ?? recommendation.matchedExistingCandidateId ?? recommendation.matchedDossierUpdateCandidateId}` : undefined;
+                      const publicHref = populationPublicDossierHref(recommendation, publicDossiers);
+                      return (
+                        <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
+                          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                            <div>
+                              <h4 className="text-xl font-bold text-foreground">{recommendation.subjectName}</h4>
+                              <p>BNL thinks: {recommendation.recommendedNextStep ?? recommendation.recommendedAction ?? recommendation.suggestedAction ?? "Needs admin review"}</p>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <StatusPill>{recommendation.confidence ?? "confidence unset"}</StatusPill>
+                              <StatusPill>{recommendation.status}</StatusPill>
+                            </div>
+                          </div>
+                          <p><span className="text-foreground">Destination:</span> {populationDestinationLabel(recommendation, candidates)}</p>
+                          <p><span className="text-foreground">Why:</span> {recommendation.adminSummary ?? recommendation.evidenceSummary ?? recommendation.reason}</p>
+                          {recommendation.missingInfo?.length ? <p><span className="text-foreground">Missing info:</span> {recommendation.missingInfo.join("; ")}</p> : null}
+                          {recommendation.publicSafetyNotes?.length || recommendation.doNotPublishReason ? <p><span className="text-foreground">Public safety notes:</span> {[recommendation.doNotPublishReason, ...(recommendation.publicSafetyNotes ?? [])].filter(Boolean).join("; ")}</p> : null}
+                          {recommendation.possibleTargets?.length ? <p><span className="text-foreground">Possible targets:</span> {recommendation.possibleTargets.map((target) => target.name ?? target.id).filter(Boolean).join(", ")}</p> : null}
+                          <p><span className="text-foreground">Risk:</span> duplicate {recommendation.duplicateRisk ?? "unset"} · identity {recommendation.identityRisk ?? "unset"} · rawEvidenceRefs {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} internal ref(s)</p>
+                          <details className="border border-border/70 bg-background/30 p-3">
+                            <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Internal refs</summary>
+                            <p className="mt-2 text-xs text-muted">Raw evidence references are preserved internally but hidden from normal card copy. Count: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}.</p>
+                          </details>
+                          <div className="flex flex-wrap gap-2">
+                            {group.id === "existing-source-file" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "attach_to_existing_source_file")}>Attach evidence to Source File</PopulationActionButton>}
+                            {group.id === "existing-dossier-update" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "attach_to_existing_dossier_update")}>Attach to existing update workspace</PopulationActionButton>}
+                            {group.id === "create-dossier-update" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_dossier_update_workspace")}>Create Dossier Update Workspace</PopulationActionButton>}
+                            {group.id === "candidate-intake" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_source_file_candidate")}>Create Source File Candidate</PopulationActionButton>}
+                            {group.id === "candidate-intake" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_needs_more_info")}>Mark needs more info</PopulationActionButton>}
+                            {group.id === "admin-review" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_source_file_candidate")}>Convert to Source File Candidate</PopulationActionButton>}
+                            {group.id === "admin-review" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "attach_to_existing_source_file")}>Attach to Existing Source File</PopulationActionButton>}
+                            {group.id === "admin-review" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_dossier_update_workspace")}>Create Dossier Update Workspace</PopulationActionButton>}
+                            {group.id === "admin-review" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_not_population_subject")}>Mark not a dossier subject</PopulationActionButton>}
+                            {group.id === "already-represented" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_no_new_info")}>Mark no-new-info</PopulationActionButton>}
+                            {group.id === "already-represented" && <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "reopen_population_recommendation")}>Reopen as review</PopulationActionButton>}
+                            {targetHref && <Link href={targetHref} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">{group.id === "existing-source-file" ? "View Source File" : "Open workspace"}</Link>}
+                            {publicHref && <Link href={publicHref} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View public dossier</Link>}
+                            <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_no_new_info")}>Mark no-new-info</PopulationActionButton>
+                            <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "dismiss_population_recommendation")}>Dismiss</PopulationActionButton>
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            ))}
+            <details className="border border-border/70 bg-background/20 p-4">
+              <summary className="cursor-pointer text-lg font-bold text-foreground">Non-dossier signals ({nonDossierPopulationSignals.length})</summary>
+              <p className="mt-2 text-sm text-muted">Show-state notes, broadcast memory notes, and not-population-subject items stay out of the main dossier work queue.</p>
+              <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                {nonDossierPopulationSignals.map((recommendation) => (
+                  <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
+                    <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
+                    <p>{recommendation.adminSummary ?? recommendation.recommendedNextStep ?? recommendation.reason}</p>
+                    <p>Internal refs: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} preserved; raw/private content hidden.</p>
+                    <div className="flex flex-wrap gap-2">
+                      <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_not_population_subject")}>Ignore for dossier work</PopulationActionButton>
+                      <button type="button" disabled className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted opacity-60">Send to broadcast memory review</button>
+                      <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "dismiss_population_recommendation")}>Dismiss</PopulationActionButton>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </details>
+          </div>
+        </DashboardCard>
 
         <DashboardCard
           eyebrow="Candidates"

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/dossier-workflow";
 import {
   addDossierIdentityLink,
+  applyPopulationReviewRecommendationAction,
   addDossierSourceFileNote,
   updateDossierSourceFileSummary,
   archiveDossierCandidate,
@@ -150,6 +151,15 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "markCandidateAsExistingDossierUpdate",
   "runSubjectConsolidation",
   "consolidateSubjectGroup",
+  "attach_to_existing_source_file",
+  "attach_to_existing_dossier_update",
+  "create_dossier_update_workspace",
+  "create_source_file_candidate",
+  "mark_no_new_info",
+  "mark_not_population_subject",
+  "dismiss_population_recommendation",
+  "reopen_population_recommendation",
+  "mark_needs_more_info",
 ]);
 
 async function isAuthenticated(req: Request): Promise<boolean> {
@@ -684,6 +694,37 @@ export async function POST(req: Request) {
         recommendation,
         ...payload,
       });
+    }
+
+
+    if (
+      action === "attach_to_existing_source_file" ||
+      action === "attach_to_existing_dossier_update" ||
+      action === "create_dossier_update_workspace" ||
+      action === "create_source_file_candidate" ||
+      action === "mark_no_new_info" ||
+      action === "mark_not_population_subject" ||
+      action === "dismiss_population_recommendation" ||
+      action === "reopen_population_recommendation" ||
+      action === "mark_needs_more_info"
+    ) {
+      const recommendationId = recommendationIdFromBody(body);
+      if (!recommendationId) {
+        return NextResponse.json(
+          { error: "recommendationId is required" },
+          { status: 400 },
+        );
+      }
+      const result = await applyPopulationReviewRecommendationAction({
+        recommendationId,
+        action,
+        candidateId: candidateIdFromBody(body) || undefined,
+        dossierId: typeof body.dossierId === "string" ? body.dossierId : undefined,
+        actionBy: typeof body.actionBy === "string" ? body.actionBy : "admin",
+        actionReason: typeof body.actionReason === "string" ? body.actionReason : undefined,
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, ...result, ...payload });
     }
 
     if (action === "createIdentityLinkFromRecommendation") {

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -24,6 +24,7 @@ const RECOMMENDATION_TYPES = [
   "modify_existing_dossier",
   "identity_link",
   "possible_connection_review",
+  "population_recommendation",
 ] as const satisfies readonly DossierRecommendationType[];
 const SOURCE_LANES = [
   "public_discord",
@@ -412,7 +413,8 @@ function supportedIngestSource(value: unknown): CreateDossierRecommendationInput
   if (
     normalized === "bnl_dynamic_candidate_discovery" ||
     normalized === "bnl_source_knowledge_bridge" ||
-    normalized === "bnl_source_file_enrichment"
+    normalized === "bnl_source_file_enrichment" ||
+    normalized === "bnl_population_recommender"
   ) {
     return normalized;
   }
@@ -460,8 +462,9 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   const payload = value as Record<string, unknown>;
   if (Object.keys(payload).length === 0) throw new Error("Invalid payload");
 
-  const ingestSource = supportedIngestSource(payload.ingestSource);
+  const ingestSource = supportedIngestSource(payload.ingestSource ?? (payload.createdBy === "bnl_population_recommender" ? "bnl_population_recommender" : undefined));
   const isBridgeIngest = ingestSource === "bnl_source_knowledge_bridge";
+  const isPopulationIngest = ingestSource === "bnl_population_recommender" || payload.type === "population_recommendation";
   const isStructuredBnlSourceIngest =
     isBridgeIngest || ingestSource === "bnl_source_file_enrichment";
   const sourceLanesInput = payload.sourceLanes;
@@ -537,6 +540,8 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     bestEvidenceToReview?.[0] ??
     usefulEvidence?.[0] ??
     conversationHighlights?.[0] ??
+    text(payload.adminSummary, 1200) ??
+    text(payload.recommendedNextStep, 1000) ??
     recommendedAction;
   const evidenceSummary =
     payload.evidenceSummary &&
@@ -559,7 +564,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   }
 
   return {
-    type: enumValue(payload.type ?? "new_subject", RECOMMENDATION_TYPES, "type") ?? "new_subject",
+    type: enumValue(payload.type ?? (isPopulationIngest ? "population_recommendation" : "new_subject"), RECOMMENDATION_TYPES, "type") ?? (isPopulationIngest ? "population_recommendation" : "new_subject"),
     subjectName,
     subjectKey: text(payload.subjectKey, 200),
     targetCandidateId: text(payload.targetCandidateId, 200),
@@ -596,6 +601,23 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     queueSubmissionStatus,
     queueSubmissionNote,
     recommendedAction,
+    recommendedLane: text(payload.recommendedLane, 120) as CreateDossierRecommendationInput["recommendedLane"],
+    matchedExistingCandidateId: text(payload.matchedExistingCandidateId, 200),
+    matchedPublicDossierId: text(payload.matchedPublicDossierId, 200),
+    matchedPublicDossierName: text(payload.matchedPublicDossierName, 200),
+    matchedDossierUpdateCandidateId: text(payload.matchedDossierUpdateCandidateId, 200),
+    possibleTargets: Array.isArray(payload.possibleTargets) ? payload.possibleTargets as CreateDossierRecommendationInput["possibleTargets"] : undefined,
+    duplicateRisk: text(payload.duplicateRisk, 40) as CreateDossierRecommendationInput["duplicateRisk"],
+    identityRisk: text(payload.identityRisk, 40) as CreateDossierRecommendationInput["identityRisk"],
+    publicSafetyLevel: text(payload.publicSafetyLevel, 40) as CreateDossierRecommendationInput["publicSafetyLevel"],
+    adminSummary: text(payload.adminSummary, 1200),
+    recommendedNextStep: text(payload.recommendedNextStep, 1000),
+    doNotPublishReason: text(payload.doNotPublishReason, 1000),
+    rawEvidenceRefs: stringList(payload.rawEvidenceRefs, 500),
+    inputHash: text(payload.inputHash, 300),
+    stale: payload.stale === true,
+    generatedAt: text(payload.generatedAt, 80),
+    populationRecommendation: isPopulationIngest ? true : undefined,
     sourceAuthority,
     rawProvenance,
     missingInfo: stringList(payload.missingInfo),
@@ -614,7 +636,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
       IDENTITY_AUTHORITIES,
       "taxonomy",
     ),
-    createdBy: text(payload.createdBy, 200) ?? "bnl",
+    createdBy: text(payload.createdBy, 200) ?? (isPopulationIngest ? "bnl_population_recommender" : "bnl"),
     ingestKey: text(payload.ingestKey, 300),
     ingestedAt: new Date().toISOString(),
     ingestSource,

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -637,7 +637,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
       "taxonomy",
     ),
     createdBy: text(payload.createdBy, 200) ?? (isPopulationIngest ? "bnl_population_recommender" : "bnl"),
-    ingestKey: text(payload.ingestKey, 300),
+    ingestKey: text(payload.ingestKey, 300) ?? (isPopulationIngest ? text(payload.recommendationId, 300) : undefined),
     ingestedAt: new Date().toISOString(),
     ingestSource,
   };

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -2904,12 +2904,20 @@ export async function createDossierRecommendationIdempotent(
         ? currentState.recommendations.find(
             (item) => item.inputHash === recommendation.inputHash,
           )
-        : currentState.recommendations.find(
-            (item) =>
-              isActiveRecommendation(item) &&
-              fallbackRecommendationDedupeKey(item) ===
-                fallbackRecommendationDedupeKey(recommendation),
-          );
+        : recommendation.populationRecommendation
+          ? currentState.recommendations.find(
+              (item) =>
+                item.populationRecommendation &&
+                recommendationDedupeSubject(item.subjectName) ===
+                  recommendationDedupeSubject(recommendation.subjectName) &&
+                item.recommendedAction === recommendation.recommendedAction,
+            )
+          : currentState.recommendations.find(
+              (item) =>
+                isActiveRecommendation(item) &&
+                fallbackRecommendationDedupeKey(item) ===
+                  fallbackRecommendationDedupeKey(recommendation),
+            );
 
     if (existing) {
       if (

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -41,6 +41,7 @@ import {
   type DossierSourceFileNoteSource,
   type DossierSourceFileNoteType,
   type DossierDuplicateRisk,
+  type DossierPopulationRecommendedAction,
   type DossierWorkflowLink,
   createDossierPopulationAudit,
   isActiveSourceFileCandidate,
@@ -907,6 +908,7 @@ const RECOMMENDATION_TYPES: DossierRecommendationType[] = [
   "modify_existing_dossier",
   "identity_link",
   "possible_connection_review",
+  "population_recommendation",
 ];
 const RECOMMENDATION_SOURCE_LANES: DossierRecommendationSourceLane[] = [
   "public_discord",
@@ -1407,10 +1409,42 @@ function normalizeRecommendationInput(
       input.ingestSource === "bnl_dynamic_candidate_discovery" ||
       input.ingestSource === "bnl_source_knowledge_bridge" ||
       input.ingestSource === "bnl_source_file_enrichment" ||
+      input.ingestSource === "bnl_population_recommender" ||
       input.ingestSource === "system" ||
       input.ingestSource === "unknown"
         ? input.ingestSource
         : undefined,
+    populationRecommendation:
+      input.populationRecommendation === true ||
+      input.type === "population_recommendation" ||
+      input.createdBy === "bnl_population_recommender" ||
+      input.ingestSource === "bnl_population_recommender"
+        ? true
+        : undefined,
+    recommendedLane: input.recommendedLane,
+    matchedExistingCandidateId: boundedText(input.matchedExistingCandidateId, 200) || undefined,
+    matchedPublicDossierId: boundedText(input.matchedPublicDossierId, 200) || undefined,
+    matchedPublicDossierName: boundedText(input.matchedPublicDossierName, 200) || undefined,
+    matchedDossierUpdateCandidateId: boundedText(input.matchedDossierUpdateCandidateId, 200) || undefined,
+    possibleTargets: Array.isArray(input.possibleTargets)
+      ? input.possibleTargets.slice(0, 8).map((target) => ({
+          id: boundedText(target?.id, 200),
+          name: boundedText(target?.name, 200),
+          lane: boundedText(target?.lane, 100),
+          confidence: boundedText(target?.confidence, 50),
+        })).filter((target) => target.id || target.name)
+      : undefined,
+    duplicateRisk: input.duplicateRisk,
+    identityRisk: input.identityRisk,
+    publicSafetyLevel: input.publicSafetyLevel,
+    adminSummary: boundedText(input.adminSummary, 1200) || undefined,
+    recommendedNextStep: boundedText(input.recommendedNextStep, 1000) || undefined,
+    doNotPublishReason: boundedText(input.doNotPublishReason, 1000) || undefined,
+    rawEvidenceRefs: normalizeStringArray(input.rawEvidenceRefs).slice(0, 100),
+    rawEvidenceRefCount: normalizeStringArray(input.rawEvidenceRefs).length,
+    inputHash: boundedText(input.inputHash, 300) || undefined,
+    stale: input.stale === true,
+    generatedAt: boundedText(input.generatedAt, 80) || undefined,
   };
 }
 
@@ -1427,6 +1461,9 @@ function isAutoConvertibleBnlSourceRecommendation(
 function bnlIngestLabel(
   recommendation: Pick<DossierRecommendation, "ingestSource">,
 ): string {
+  if (recommendation.ingestSource === "bnl_population_recommender") {
+    return "BNL Population Scan";
+  }
   if (recommendation.ingestSource === "bnl_source_file_enrichment") {
     return "BNL Source File Enrichment";
   }
@@ -1486,6 +1523,13 @@ function bnlAutoCandidateSourceNotes(
       "Source Knowledge Bridge origin: BNL local knowledge stores.",
       "Public use requires review before any public dossier copy is written.",
       "Internal/private review required for bridge-derived context.",
+    ];
+  }
+  if (recommendation.ingestSource === "bnl_population_recommender") {
+    return [
+      "BNL Population Scan origin: BNL-generated population routing recommendation.",
+      "Review-only internal queue material; not public copy.",
+      "Admin action is required before any Source File or Dossier Update workflow change.",
     ];
   }
   if (recommendation.ingestSource === "bnl_source_file_enrichment") {
@@ -2856,12 +2900,16 @@ export async function createDossierRecommendationIdempotent(
       ? currentState.recommendations.find(
           (item) => item.ingestKey === recommendation.ingestKey,
         )
-      : currentState.recommendations.find(
-          (item) =>
-            isActiveRecommendation(item) &&
-            fallbackRecommendationDedupeKey(item) ===
-              fallbackRecommendationDedupeKey(recommendation),
-        );
+      : recommendation.inputHash
+        ? currentState.recommendations.find(
+            (item) => item.inputHash === recommendation.inputHash,
+          )
+        : currentState.recommendations.find(
+            (item) =>
+              isActiveRecommendation(item) &&
+              fallbackRecommendationDedupeKey(item) ===
+                fallbackRecommendationDedupeKey(recommendation),
+          );
 
     if (existing) {
       if (
@@ -2960,6 +3008,30 @@ export async function createDossierRecommendationIdempotent(
         };
       }
 
+      if (recommendation.populationRecommendation && existing.populationRecommendation) {
+        savedRecommendation = {
+          ...existing,
+          ...recommendation,
+          id: existing.id,
+          status: existing.status,
+          createdAt: existing.createdAt,
+          firstSeenAt: existing.firstSeenAt ?? existing.createdAt,
+          lastSeenAt: now,
+          seenCount: (existing.seenCount ?? 1) + 1,
+          rawEvidenceRefs: uniqueStrings(existing.rawEvidenceRefs, recommendation.rawEvidenceRefs),
+          rawEvidenceRefCount: uniqueStrings(existing.rawEvidenceRefs, recommendation.rawEvidenceRefs).length,
+          populationReviewActions: existing.populationReviewActions,
+          updatedAt: now,
+        };
+        duplicate = true;
+        return {
+          ...currentState,
+          recommendations: currentState.recommendations.map((item) =>
+            item.id === existing.id ? savedRecommendation : item,
+          ),
+          updatedAt: now,
+        };
+      }
       savedRecommendation = existing;
       duplicate = true;
       return currentState;
@@ -4298,6 +4370,194 @@ async function setRecommendationStatus(
   });
   return updatedRecommendation!;
 }
+
+export type PopulationReviewRecommendationActionInput = {
+  recommendationId: string;
+  action: DossierPopulationRecommendedAction | "mark_needs_more_info";
+  candidateId?: string;
+  dossierId?: string;
+  actionBy?: string;
+  actionReason?: string;
+};
+
+function populationActionStatus(
+  action: PopulationReviewRecommendationActionInput["action"],
+  candidate?: DossierCandidate,
+): DossierRecommendationStatus {
+  if (action === "dismiss_population_recommendation") return "dismissed";
+  if (action === "mark_no_new_info") return "no_new_info";
+  if (action === "mark_not_population_subject") return "not_population_subject";
+  if (action === "mark_needs_more_info") return "needs_more_info";
+  if (action === "attach_to_existing_dossier_update") return "attached_to_existing_dossier_update";
+  if (action === "attach_to_existing_source_file") return "attached_to_source_file";
+  if (action === "create_dossier_update_workspace") return "attached_to_existing_dossier_update";
+  if (action === "create_source_file_candidate") return "attached_to_candidate_intake";
+  return candidate ? attachmentStatusForCandidate(candidate) : "reviewing";
+}
+
+function populationActionNoteText(recommendation: DossierRecommendation, action: string): string {
+  return [
+    `Population Review Queue action: ${action}.`,
+    recommendation.adminSummary ? `Admin summary: ${recommendation.adminSummary}` : undefined,
+    recommendation.evidenceSummary ? `Evidence summary: ${recommendation.evidenceSummary}` : undefined,
+    recommendation.recommendedNextStep ? `Recommended next step: ${recommendation.recommendedNextStep}` : undefined,
+    recommendation.rawEvidenceRefCount || recommendation.rawEvidenceRefs?.length
+      ? `Internal evidence refs preserved: ${recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}.`
+      : undefined,
+    "No public dossier text was changed and no public page was published by this action.",
+  ].filter(Boolean).join("\n\n").slice(0, 4000);
+}
+
+export async function applyPopulationReviewRecommendationAction(
+  input: PopulationReviewRecommendationActionInput,
+): Promise<{ recommendation: DossierRecommendation; candidate?: DossierCandidate }> {
+  if (input.action === "reopen_population_recommendation") {
+    const now = new Date().toISOString();
+    let updated: DossierRecommendation | null = null;
+    await updateDossierWorkflowState((currentState) => ({
+      ...currentState,
+      recommendations: currentState.recommendations.map((recommendation) => {
+        if (recommendation.id !== input.recommendationId) return recommendation;
+        updated = {
+          ...recommendation,
+          status: "reviewing",
+          routingReason: input.actionReason || "Reopened from Population Review Queue.",
+          populationReviewActions: [
+            ...(recommendation.populationReviewActions ?? []),
+            { action: input.action, actionAt: now, actionBy: input.actionBy, actionReason: input.actionReason },
+          ],
+          updatedAt: now,
+        };
+        return updated;
+      }),
+      updatedAt: now,
+    }));
+    if (!updated) throw new DossierWorkflowInputError("Recommendation not found", 404, "recommendation_not_found");
+    return { recommendation: updated };
+  }
+
+  const now = new Date().toISOString();
+  let result: { recommendation: DossierRecommendation; candidate?: DossierCandidate } | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const recommendation = currentState.recommendations.find((item) => item.id === input.recommendationId);
+    if (!recommendation) throw new DossierWorkflowInputError("Recommendation not found", 404, "recommendation_not_found");
+    assertRecommendationIsOpen(recommendation);
+
+    let candidates = currentState.candidates;
+    let targetCandidate = input.candidateId
+      ? candidates.find((candidate) => candidate.id === input.candidateId)
+      : undefined;
+    if (!targetCandidate && recommendation.matchedExistingCandidateId) {
+      targetCandidate = candidates.find((candidate) => candidate.id === recommendation.matchedExistingCandidateId);
+    }
+    if (!targetCandidate && recommendation.matchedDossierUpdateCandidateId) {
+      targetCandidate = candidates.find((candidate) => candidate.id === recommendation.matchedDossierUpdateCandidateId);
+    }
+    if (!targetCandidate && recommendation.targetCandidateId) {
+      targetCandidate = candidates.find((candidate) => candidate.id === recommendation.targetCandidateId);
+    }
+
+    if (input.action === "create_source_file_candidate") {
+      const existingMatch = matchDossierRecommendationSubject({ recommendation, candidates });
+      targetCandidate = existingMatch.exactCandidateId
+        ? candidates.find((candidate) => candidate.id === existingMatch.exactCandidateId)
+        : undefined;
+      if (!targetCandidate) {
+        targetCandidate = buildCandidateFromRecommendation({
+          recommendation,
+          now,
+          source: recommendation.ingestSource === "bnl_population_recommender" ? "bnl_dynamic_candidate_discovery" : bnlIngestCandidateSource(recommendation),
+          noteText: populationActionNoteText(recommendation, input.action),
+        });
+        targetCandidate = { ...targetCandidate, status: "candidate_intake" };
+        candidates = [targetCandidate, ...candidates];
+      }
+    }
+
+    if (input.action === "create_dossier_update_workspace") {
+      const dossierId = input.dossierId || recommendation.matchedPublicDossierId || recommendation.targetDossierId;
+      const entry = databasePage.entries.find((item) => item.id === dossierId);
+      if (!entry) throw new DossierWorkflowInputError("dossierId is required", 400, "dossier_id_required");
+      targetCandidate = candidates.find((candidate) => candidate.status === "existing_dossier_update" && candidate.existingDossierMatch?.id === entry.id);
+      if (!targetCandidate) {
+        targetCandidate = buildCandidateFromRecommendation({
+          recommendation: { ...recommendation, subjectName: entry.name, targetDossierId: entry.id },
+          now,
+          source: "website_read_model",
+          noteText: populationActionNoteText(recommendation, input.action),
+        });
+        targetCandidate = {
+          ...targetCandidate,
+          name: entry.name,
+          status: "existing_dossier_update",
+          existingDossierMatch: { id: entry.id, name: entry.name, confidence: "high" as const },
+        };
+        candidates = [targetCandidate, ...candidates];
+      }
+    }
+
+    if ((input.action === "attach_to_existing_source_file" || input.action === "attach_to_existing_dossier_update") && !targetCandidate) {
+      throw new DossierWorkflowInputError("Target workflow record not found", 404, "target_candidate_not_found");
+    }
+
+    const nextStatus = populationActionStatus(input.action, targetCandidate);
+    const updatedRecommendation: DossierRecommendation = {
+      ...recommendation,
+      status: nextStatus,
+      targetCandidateId: targetCandidate?.id ?? recommendation.targetCandidateId,
+      targetDossierId: input.dossierId ?? recommendation.matchedPublicDossierId ?? recommendation.targetDossierId,
+      connectedCandidateId: targetCandidate?.id ?? recommendation.connectedCandidateId,
+      connectedSourceFileCandidateId: targetCandidate?.id ?? recommendation.connectedSourceFileCandidateId,
+      routingReason: input.actionReason || `Population Review Queue action: ${input.action}`,
+      populationReviewActions: [
+        ...(recommendation.populationReviewActions ?? []),
+        {
+          action: input.action,
+          actionAt: now,
+          actionBy: input.actionBy,
+          actionReason: input.actionReason,
+          targetCandidateId: targetCandidate?.id,
+          targetDossierId: input.dossierId ?? recommendation.matchedPublicDossierId ?? recommendation.targetDossierId,
+        },
+      ],
+      updatedAt: now,
+    };
+
+    if (targetCandidate && ["attach_to_existing_source_file", "attach_to_existing_dossier_update", "create_dossier_update_workspace", "create_source_file_candidate"].includes(input.action)) {
+      const note = routingNote({
+        candidateId: targetCandidate.id,
+        now,
+        text: populationActionNoteText(recommendation, input.action),
+        source: "bnl_recommendation",
+        createdBy: recommendation.createdBy,
+        ingestKey: recommendation.ingestKey,
+        ingestedAt: recommendation.ingestedAt,
+        ingestSource: recommendation.ingestSource,
+      });
+      candidates = candidates.map((candidate) => candidate.id === targetCandidate!.id ? {
+        ...candidate,
+        sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+        connectedRecommendationIds: uniqueStrings(candidate.connectedRecommendationIds, [recommendation.id]),
+        sourceRecommendationIds: uniqueStrings(candidate.sourceRecommendationIds, [recommendation.id]),
+        updatedAt: now,
+      } : candidate);
+      targetCandidate = candidates.find((candidate) => candidate.id === targetCandidate!.id) ?? targetCandidate;
+    }
+
+    result = { recommendation: updatedRecommendation, candidate: targetCandidate };
+    return {
+      ...currentState,
+      recommendations: currentState.recommendations.map((item) => item.id === recommendation.id ? updatedRecommendation : item),
+      candidates,
+      updatedAt: now,
+    };
+  });
+
+  if (!result) throw new DossierWorkflowInputError("Recommendation not found", 404, "recommendation_not_found");
+  return result;
+}
+
 
 export function ignoreDossierRecommendation(
   recommendationId: string,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -234,15 +234,6 @@ export type DossierSourceFileNote = {
   ingestKey?: string;
   ingestedAt?: string;
   ingestSource?: DossierRecommendationIngestSource;
-  connectedCandidateId?: string;
-  connectedSourceFileCandidateId?: string;
-  connectedRecommendationIds?: string[];
-  possibleMatchCandidateIds?: string[];
-  possibleMatchDossierIds?: string[];
-  identityReviewStatus?: "not_required" | "needs_confirmation" | "confirmed";
-  routingReason?: string;
-  routedFromRecommendationId?: string;
-  sourceRecommendationIds?: string[];
 };
 
 export type DossierIdentityLinkType =
@@ -449,7 +440,8 @@ export type DossierRecommendationType =
   | "new_subject"
   | "modify_existing_dossier"
   | "identity_link"
-  | "possible_connection_review";
+  | "possible_connection_review"
+  | "population_recommendation";
 
 export type DossierRecommendationStatus =
   | "new"
@@ -461,6 +453,9 @@ export type DossierRecommendationStatus =
   | "identity_link_created"
   | "ignored"
   | "dismissed"
+  | "no_new_info"
+  | "not_population_subject"
+  | "needs_more_info"
   | "archived";
 
 export type DossierRecommendationSourceLane =
@@ -479,8 +474,47 @@ export type DossierRecommendationIngestSource =
   | "bnl_dynamic_candidate_discovery"
   | "bnl_source_knowledge_bridge"
   | "bnl_source_file_enrichment"
+  | "bnl_population_recommender"
   | "system"
   | "unknown";
+
+
+export type DossierPopulationRecommendedLane =
+  | "active_source_file"
+  | "existing_dossier_update"
+  | "public_dossier_update_signal"
+  | "candidate_intake"
+  | "needs_population_review"
+  | "already_represented"
+  | "show_state_note"
+  | "broadcast_memory_note"
+  | "not_population_subject"
+  | "unknown";
+
+export type DossierPopulationRecommendedAction =
+  | "attach_to_existing_source_file"
+  | "attach_to_existing_dossier_update"
+  | "create_dossier_update_workspace"
+  | "create_source_file_candidate"
+  | "admin_review_required"
+  | "mark_duplicate_no_new_info"
+  | "mark_no_new_info"
+  | "mark_not_population_subject"
+  | "show_state_note"
+  | "broadcast_memory_note"
+  | "not_population_subject"
+  | "dismiss_population_recommendation"
+  | "reopen_population_recommendation"
+  | "unknown";
+
+export type DossierPopulationReviewAction = {
+  action: DossierPopulationRecommendedAction | "mark_needs_more_info";
+  actionAt: string;
+  actionBy?: string;
+  actionReason?: string;
+  targetCandidateId?: string;
+  targetDossierId?: string;
+};
 
 export type DossierSourceFileRefreshRequestStatus =
   | "pending"
@@ -644,6 +678,28 @@ export type DossierRecommendation = {
   routingReason?: string;
   routedFromRecommendationId?: string;
   sourceRecommendationIds?: string[];
+  populationRecommendation?: boolean;
+  recommendedLane?: DossierPopulationRecommendedLane;
+  matchedExistingCandidateId?: string;
+  matchedPublicDossierId?: string;
+  matchedPublicDossierName?: string;
+  matchedDossierUpdateCandidateId?: string;
+  possibleTargets?: Array<{ id?: string; name?: string; lane?: string; confidence?: string }>;
+  duplicateRisk?: DossierDuplicateRisk | "blocked";
+  identityRisk?: DossierDuplicateRisk | "blocked";
+  publicSafetyLevel?: "low" | "medium" | "high" | "blocked";
+  adminSummary?: string;
+  recommendedNextStep?: string;
+  doNotPublishReason?: string;
+  rawEvidenceRefs?: string[];
+  rawEvidenceRefCount?: number;
+  inputHash?: string;
+  stale?: boolean;
+  generatedAt?: string;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+  seenCount?: number;
+  populationReviewActions?: DossierPopulationReviewAction[];
 };
 
 export type DossierSourceDepthLabel = "Low" | "Medium" | "Strong";
@@ -1118,7 +1174,7 @@ function candidatePopulationMethodLane(candidate: DossierCandidate, origin: Doss
 
 function recommendationPopulationMethodLane(recommendation: DossierRecommendation, origin: DossierPopulationMethodOrigin): DossierPopulationMethodLane {
   if (origin === "diagnostic/test artifact") return "Diagnostic/Test Artifact";
-  if (recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored") return "Archived / Closed";
+  if (["archived", "dismissed", "ignored", "no_new_info", "not_population_subject"].includes(recommendation.status)) return "Archived / Closed";
   if (isResolvedDossierRecommendation(recommendation)) return "Resolved Incoming Record";
   if (origin === "public dossier update signal") return "Public Dossier Update Signal";
   if (origin === "unknown / insufficient metadata") return "Needs Population Review";
@@ -1248,7 +1304,7 @@ export function createDossierPopulationMethodAudit(input: {
     const origin = recommendationPopulationMethodOrigin(recommendation);
     const lane = recommendationPopulationMethodLane(recommendation, origin);
     const destination = recommendationDestination(recommendation);
-    const hidden = isResolvedDossierRecommendation(recommendation) || recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored";
+    const hidden = isResolvedDossierRecommendation(recommendation) || ["archived", "dismissed", "ignored", "no_new_info", "not_population_subject"].includes(recommendation.status);
     const destinationVisible = visibleDestinationCandidate(destination);
     const publicMatch = recommendation.targetDossierId ? publicDossiersById.get(recommendation.targetDossierId) : publicDossiersByName.get(publicDossierKey(recommendation.subjectName));
     const visibility: DossierPopulationMethodVisibility = hidden
@@ -1256,7 +1312,7 @@ export function createDossierPopulationMethodAudit(input: {
         ? destinationVisible
           ? "hidden_with_destination"
           : "hidden_without_destination"
-        : origin === "diagnostic/test artifact" || recommendation.status === "archived" || recommendation.status === "dismissed" || recommendation.status === "ignored"
+        : origin === "diagnostic/test artifact" || ["archived", "dismissed", "ignored", "no_new_info", "not_population_subject"].includes(recommendation.status)
           ? "hidden_valid_archive_or_diagnostic"
           : "hidden_without_destination"
       : "visible";
@@ -1454,6 +1510,8 @@ export function isResolvedDossierRecommendation(
     "identity_link_created",
     "ignored",
     "dismissed",
+    "no_new_info",
+    "not_population_subject",
     "archived",
   ].includes(recommendation.status);
 }
@@ -2827,6 +2885,23 @@ export type CreateDossierRecommendationInput = {
   ingestKey?: string;
   ingestedAt?: string;
   ingestSource?: DossierRecommendationIngestSource;
+  populationRecommendation?: boolean;
+  recommendedLane?: DossierPopulationRecommendedLane;
+  matchedExistingCandidateId?: string;
+  matchedPublicDossierId?: string;
+  matchedPublicDossierName?: string;
+  matchedDossierUpdateCandidateId?: string;
+  possibleTargets?: Array<{ id?: string; name?: string; lane?: string; confidence?: string }>;
+  duplicateRisk?: DossierDuplicateRisk | "blocked";
+  identityRisk?: DossierDuplicateRisk | "blocked";
+  publicSafetyLevel?: "low" | "medium" | "high" | "blocked";
+  adminSummary?: string;
+  recommendedNextStep?: string;
+  doNotPublishReason?: string;
+  rawEvidenceRefs?: string[];
+  inputHash?: string;
+  stale?: boolean;
+  generatedAt?: string;
 };
 
 export type MergeDossierCandidatesInput = {
@@ -2879,7 +2954,16 @@ export type DossierWorkflowAction =
   | "consolidateSubjectGroup"
   | "detectDuplicateCandidates"
   | "mergeCandidates"
-  | "createMasterDraftFromMerge";
+  | "createMasterDraftFromMerge"
+  | "attach_to_existing_source_file"
+  | "attach_to_existing_dossier_update"
+  | "create_dossier_update_workspace"
+  | "create_source_file_candidate"
+  | "mark_no_new_info"
+  | "mark_not_population_subject"
+  | "dismiss_population_recommendation"
+  | "reopen_population_recommendation"
+  | "mark_needs_more_info";
 
 export type DossierSourceBoundary = {
   source: DossierCandidateSource;
@@ -2931,6 +3015,15 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "detectDuplicateCandidates",
   "mergeCandidates",
   "createMasterDraftFromMerge",
+  "attach_to_existing_source_file",
+  "attach_to_existing_dossier_update",
+  "create_dossier_update_workspace",
+  "create_source_file_candidate",
+  "mark_no_new_info",
+  "mark_not_population_subject",
+  "dismiss_population_recommendation",
+  "reopen_population_recommendation",
+  "mark_needs_more_info",
 ];
 
 export const DOSSIER_CANDIDATE_SCORING_POLICY = {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -9224,3 +9224,230 @@ test("Population Review Queue actions update internal workflow records without p
   assert.equal(JSON.stringify(context).includes("existing-source-file-pop"), true);
   assert.equal(JSON.stringify(context).includes("relationship_journal:private-row"), false);
 });
+
+test("Population Review Queue search includes matched candidate names and reviewed need-more-info leaves unreviewed count", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+  assert.match(page, /populationRecommendationSearchText\(recommendation, candidates\)/);
+  assert.match(page, /matchedCandidateNames/);
+  assert.match(page, /candidate\.name/);
+  assert.match(page, /return \["new", "reviewing"\]\.includes\(recommendation\.status\)/);
+  assertIncludesCopy(pageCopy, "Search subject, normalized key, dossier, or Source File");
+  assertIncludesCopy(pageCopy, "Mark needs more info");
+});
+
+test("Population recommendation ingest dedupes by recommendationId and by subject plus action", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const byId = await bnlIngestPost({
+    type: "population_recommendation",
+    recommendationId: "bnl-pop-rec-same-id",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Same External Recommendation",
+    adminSummary: "First summary.",
+    recommendedLane: "candidate_intake",
+    recommendedAction: "create_source_file_candidate",
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(byId.status, 200);
+  const byIdAgain = await bnlIngestPost({
+    type: "population_recommendation",
+    recommendationId: "bnl-pop-rec-same-id",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Same External Recommendation",
+    adminSummary: "Refreshed summary.",
+    recommendedLane: "candidate_intake",
+    recommendedAction: "create_source_file_candidate",
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(byIdAgain.status, 200);
+  assert.equal((await byIdAgain.json()).duplicate, true);
+
+  const bySubjectAction = await bnlIngestPost({
+    type: "population_recommendation",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Same Subject Action",
+    adminSummary: "First subject/action summary.",
+    recommendedLane: "needs_population_review",
+    recommendedAction: "admin_review_required",
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(bySubjectAction.status, 200);
+  const bySubjectActionAgain = await bnlIngestPost({
+    type: "population_recommendation",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Same Subject Action",
+    adminSummary: "Updated subject/action summary.",
+    recommendedLane: "needs_population_review",
+    recommendedAction: "admin_review_required",
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(bySubjectActionAgain.status, 200);
+  assert.equal((await bySubjectActionAgain.json()).duplicate, true);
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.filter((item) => item.subjectName === "Same External Recommendation").length, 1);
+  assert.equal(state.recommendations.filter((item) => item.subjectName === "Same Subject Action").length, 1);
+});
+
+test("Population Review Queue create and attach actions route to existing internal workflows", async () => {
+  await resetWorkflowStore();
+  const now = new Date().toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [
+      {
+        id: "existing-update-pop",
+        name: "6 Bit",
+        candidateType: "entity",
+        source: "website_read_model",
+        tier: "review_candidate",
+        score: 58,
+        whyNow: "Existing dossier update workspace.",
+        reason: "Existing dossier update workspace.",
+        status: "existing_dossier_update",
+        existingDossierMatch: { id: "EN-001", name: "6 Bit", confidence: "high" },
+        createdAt: now,
+        updatedAt: now,
+        sourceFileNotes: [],
+      },
+    ],
+    drafts: [],
+    recommendations: [
+      {
+        id: "pop-create-candidate",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Brand New Population Subject",
+        status: "new",
+        reason: "Create candidate only.",
+        adminSummary: "Create an internal Source File candidate.",
+        recommendedLane: "candidate_intake",
+        recommendedAction: "create_source_file_candidate",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "pop-create-workspace",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "6 Bit",
+        status: "new",
+        reason: "Create update workspace only.",
+        adminSummary: "Create an internal Dossier Update workspace.",
+        recommendedLane: "public_dossier_update_signal",
+        recommendedAction: "create_dossier_update_workspace",
+        matchedPublicDossierId: "EN-001",
+        matchedPublicDossierName: "6 Bit",
+        sourceLanes: ["website_dossier"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "pop-attach-update",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "6 Bit",
+        status: "new",
+        reason: "Attach to update workspace only.",
+        adminSummary: "Attach to existing Dossier Update workspace.",
+        recommendedLane: "existing_dossier_update",
+        recommendedAction: "attach_to_existing_dossier_update",
+        matchedDossierUpdateCandidateId: "existing-update-pop",
+        matchedPublicDossierId: "EN-001",
+        matchedPublicDossierName: "6 Bit",
+        sourceLanes: ["website_dossier"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "pop-dismiss",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Dismiss Me",
+        status: "new",
+        reason: "Dismiss only.",
+        recommendedLane: "needs_population_review",
+        recommendedAction: "admin_review_required",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "pop-needs-info",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Needs Info Subject",
+        status: "new",
+        reason: "Needs info only.",
+        recommendedLane: "candidate_intake",
+        recommendedAction: "create_source_file_candidate",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const candidatePayload = await (await authedPost({
+    action: "create_source_file_candidate",
+    recommendationId: "pop-create-candidate",
+    actionBy: "admin-test",
+  })).json();
+  assert.equal(candidatePayload.recommendation.status, "attached_to_candidate_intake");
+  assert.equal(candidatePayload.candidate.status, "candidate_intake");
+  assert.equal(candidatePayload.candidate.name, "Brand New Population Subject");
+
+  const workspacePayload = await (await authedPost({
+    action: "create_dossier_update_workspace",
+    recommendationId: "pop-create-workspace",
+    dossierId: "EN-001",
+    actionBy: "admin-test",
+  })).json();
+  assert.equal(workspacePayload.recommendation.status, "attached_to_existing_dossier_update");
+  assert.equal(workspacePayload.candidate.status, "existing_dossier_update");
+  assert.equal(workspacePayload.candidate.existingDossierMatch.id, "EN-001");
+
+  const attachPayload = await (await authedPost({
+    action: "attach_to_existing_dossier_update",
+    recommendationId: "pop-attach-update",
+    candidateId: "existing-update-pop",
+    actionBy: "admin-test",
+  })).json();
+  assert.equal(attachPayload.recommendation.status, "attached_to_existing_dossier_update");
+  assert.equal(attachPayload.recommendation.connectedCandidateId, "existing-update-pop");
+
+  const dismissPayload = await (await authedPost({
+    action: "dismiss_population_recommendation",
+    recommendationId: "pop-dismiss",
+    actionBy: "admin-test",
+  })).json();
+  assert.equal(dismissPayload.recommendation.status, "dismissed");
+
+  const needsInfoPayload = await (await authedPost({
+    action: "mark_needs_more_info",
+    recommendationId: "pop-needs-info",
+    actionBy: "admin-test",
+  })).json();
+  assert.equal(needsInfoPayload.recommendation.status, "needs_more_info");
+  assert.ok(needsInfoPayload.recommendation.populationReviewActions[0].actionAt);
+
+  const finalState = await store.getDossierWorkflowState();
+  assert.equal(finalState.drafts.length, 0);
+  assert.equal(finalState.recommendations.find((item) => item.id === "pop-dismiss").status, "dismissed");
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2124,7 +2124,7 @@ test("Subject Consolidation Queue renders action summary, review cards, blocked 
   assert.match(page, /!isConsolidationResolvedCandidate\(candidate\)/);
   assert.match(source("src/lib/dossier-workflow-store.ts"), /bundleExactPublicDossierUpdateSignals/);
   assert.doesNotMatch(pageCopy, /Source File Population Audit|Population Audit|Open Recommendation|Open Source File|Open Target|Open Incoming|Merge Into Kept Source File|Attach to Kept Source File|Create Source File From These Signals|Create Dossier Update Workspace without public dossier\/context/);
-  const queueCopy = pageCopy.slice(pageCopy.indexOf("Subject Consolidation Queue"), pageCopy.indexOf("Candidates", pageCopy.indexOf("Subject Consolidation Queue")));
+  const queueCopy = pageCopy.slice(pageCopy.indexOf("Subject Consolidation Queue"), pageCopy.indexOf("Population Method Audit", pageCopy.indexOf("Subject Consolidation Queue")));
   assert.doesNotMatch(queueCopy, /recommendation\.reason|recommendation\.evidenceSummary|raw recommendation\.reason|raw recommendation\.summary/);
   assert.doesNotMatch(pageCopy, /Confirmed aliases count: \{record\.confirmedAliasCount\}/);
   assert.doesNotMatch(pageCopy, /source notes count 0/i);
@@ -2184,7 +2184,7 @@ test("Population Method Audit renders read-only admin intake map states", () => 
 
   const auditCopy = pageCopy.slice(
     pageCopy.indexOf("Population Method Audit"),
-    pageCopy.indexOf("Candidates", pageCopy.indexOf("Population Method Audit")),
+    pageCopy.indexOf("Population Review Queue", pageCopy.indexOf("Population Method Audit")),
   );
   assert.doesNotMatch(auditCopy, /fix automatically|Fix Automatically|Run Subject Consolidation|Confirm Consolidation|Consolidate Into|Create Source File|Create Dossier Update|Keep Separate|Select Different Target|merge candidates|Merge button|publish public pages|change public dossier text/i);
 });
@@ -2197,7 +2197,7 @@ test("Population Method Audit renders independently of Subject Consolidation sta
   const consolidationResultIndex = page.indexOf("consolidationResult &&");
   const subjectConditionalCloseIndex = page.indexOf("open={!populationMethodHealthy}", subjectConditionalIndex);
   const populationAuditIndex = page.indexOf("Population Method Audit");
-  const candidatesIndex = page.indexOf("<DashboardCard", populationAuditIndex);
+  const candidatesIndex = page.indexOf("Population Review Queue", populationAuditIndex);
   const clearBranch = page.slice(subjectConditionalIndex, subjectQueueIndex);
   const fullQueueBranch = page.slice(subjectQueueIndex, subjectConditionalCloseIndex);
 
@@ -2205,7 +2205,7 @@ test("Population Method Audit renders independently of Subject Consolidation sta
   assert.ok(subjectQueueIndex > subjectConditionalIndex, "Subject Consolidation queue state still renders");
   assert.ok(consolidationResultIndex > subjectQueueIndex, "consolidationResult state still renders inside the queue state");
   assert.ok(populationAuditIndex > subjectConditionalCloseIndex, "Population Method Audit renders after the Subject Consolidation conditional");
-  assert.ok(candidatesIndex > populationAuditIndex, "Population Method Audit renders before the Candidates section");
+  assert.ok(candidatesIndex > populationAuditIndex, "Population Method Audit renders before the Population Review Queue section");
   assert.doesNotMatch(clearBranch, /Population Method Audit|Population Method:/);
   assert.doesNotMatch(fullQueueBranch, /Population Method Audit|Population Method:/);
   assertIncludesCopy(pageCopy, "Subject Consolidation: clear");
@@ -5627,7 +5627,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   assert.match(dashboard, /Review Update/);
   assert.match(dashboard, /Review Source File/);
   assert.match(dashboard, /Review Record/);
-  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info|>Attach to Existing Source File<|Attach to Existing Source File<\/button>/);
+  assert.doesNotMatch(dashboard, /Review Identity|Add Missing Info/);
 
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
@@ -9040,4 +9040,187 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   assert.match(source("src/lib/dossier-workflow-store.ts"), /Subject Consolidation/);
 
   delete process.env.BNL_API_KEY;
+});
+
+test("Population Review Queue renders grouped sections and safe admin actions", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+
+  for (const label of [
+    "Population Review Queue",
+    "Source of recommendation: BNL Population Scan",
+    "Attach to Existing Source File",
+    "Dossier Update Workspace",
+    "Create Dossier Update Workspace",
+    "Candidate Intake / New Source File",
+    "Admin Review Required",
+    "Already Represented / Duplicate",
+    "Non-dossier signals",
+    "Attach evidence to Source File",
+    "View Source File",
+    "Attach to existing update workspace",
+    "Open workspace",
+    "Create Source File Candidate",
+    "Convert to Source File Candidate",
+    "Mark not a dossier subject",
+    "Mark no-new-info",
+    "Ignore for dossier work",
+    "Dismiss",
+    "Raw evidence references are preserved internally but hidden from normal card copy.",
+    "No public dossier text changed and no public page was published.",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  for (const action of [
+    "attach_to_existing_source_file",
+    "attach_to_existing_dossier_update",
+    "create_dossier_update_workspace",
+    "create_source_file_candidate",
+    "mark_no_new_info",
+    "mark_not_population_subject",
+    "dismiss_population_recommendation",
+    "reopen_population_recommendation",
+  ]) {
+    assert.match(page, new RegExp(action));
+    assert.match(source("src/app/api/admin/dossiers/route.ts"), new RegExp(action));
+    assert.match(source("src/lib/dossier-workflow-store.ts"), new RegExp(action));
+  }
+
+  assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Population Review Queue|BNL Population Scan|rawEvidenceRefs|Internal refs/);
+  assert.doesNotMatch(pageCopy, /raw Discord message|relationship_journal|private relationship journal|internal alias label/i);
+});
+
+test("Population recommendation ingest dedupes by input hash and preserves raw refs internally", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const first = await bnlIngestPost({
+    type: "population_recommendation",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Population Queue Subject",
+    adminSummary: "BNL sees one safe routing signal.",
+    recommendedLane: "candidate_intake",
+    recommendedAction: "create_source_file_candidate",
+    confidence: "high",
+    inputHash: "population-hash-1",
+    rawEvidenceRefs: ["discord:private-message-1"],
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(first.status, 200);
+  const second = await bnlIngestPost({
+    type: "population_recommendation",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Population Queue Subject",
+    adminSummary: "BNL sees one safe routing signal, refreshed.",
+    recommendedLane: "candidate_intake",
+    recommendedAction: "create_source_file_candidate",
+    confidence: "high",
+    inputHash: "population-hash-1",
+    rawEvidenceRefs: ["discord:private-message-2"],
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(second.status, 200);
+  const duplicatePayload = await second.json();
+  assert.equal(duplicatePayload.duplicate, true);
+
+  const state = await store.getDossierWorkflowState();
+  const populationRecommendations = state.recommendations.filter((item) => item.type === "population_recommendation");
+  assert.equal(populationRecommendations.length, 1);
+  assert.equal(populationRecommendations[0].rawEvidenceRefs.length, 2);
+  assert.equal(populationRecommendations[0].seenCount, 2);
+});
+
+test("Population Review Queue actions update internal workflow records without publishing", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_API_KEY = "test-population-context-token";
+  const now = new Date().toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [
+      {
+        id: "existing-source-file-pop",
+        name: "Existing Population Source",
+        candidateType: "artist",
+        source: "manual",
+        tier: "review_candidate",
+        score: 70,
+        whyNow: "Existing source file.",
+        reason: "Existing source file.",
+        status: "active_source_file",
+        createdAt: now,
+        updatedAt: now,
+        sourceFileNotes: [],
+      },
+    ],
+    drafts: [],
+    recommendations: [
+      {
+        id: "pop-rec-attach",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Existing Population Source",
+        status: "new",
+        reason: "Attach safe summary only.",
+        adminSummary: "Attach this to the existing Source File.",
+        recommendedLane: "active_source_file",
+        recommendedAction: "attach_to_existing_source_file",
+        matchedExistingCandidateId: "existing-source-file-pop",
+        confidence: "high",
+        sourceLanes: ["broadcast_memory"],
+        rawEvidenceRefs: ["relationship_journal:private-row"],
+        rawEvidenceRefCount: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "pop-rec-nonsubject",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Show State Note",
+        status: "new",
+        reason: "Broadcast memory note only.",
+        recommendedLane: "broadcast_memory_note",
+        recommendedAction: "broadcast_memory_note",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const attachResponse = await authedPost({
+    action: "attach_to_existing_source_file",
+    recommendationId: "pop-rec-attach",
+    candidateId: "existing-source-file-pop",
+    actionBy: "admin-test",
+    actionReason: "Attach from population queue.",
+  });
+  assert.equal(attachResponse.status, 200);
+  const attachPayload = await attachResponse.json();
+  assert.equal(attachPayload.recommendation.status, "attached_to_source_file");
+  assert.equal(attachPayload.candidates.find((item) => item.id === "existing-source-file-pop").sourceFileNotes.length, 1);
+
+  const ignoreResponse = await authedPost({
+    action: "mark_not_population_subject",
+    recommendationId: "pop-rec-nonsubject",
+    actionBy: "admin-test",
+  });
+  assert.equal(ignoreResponse.status, 200);
+  const ignorePayload = await ignoreResponse.json();
+  assert.equal(ignorePayload.recommendation.status, "not_population_subject");
+  assert.equal(ignorePayload.candidates.length, 1);
+
+  const contextResponse = await populationContextGet("test-population-context-token");
+  assert.equal(contextResponse.status, 200);
+  const context = await contextResponse.json();
+  assert.equal(JSON.stringify(context).includes("existing-source-file-pop"), true);
+  assert.equal(JSON.stringify(context).includes("relationship_journal:private-row"), false);
 });


### PR DESCRIPTION
### Motivation

- Provide a safe, admin-only review surface and actionable workflow support for BNL population recommendations so they can be reviewed, attached, or routed without touching public dossier text or publishing.
- Reuse the existing DossierRecommendation / workflow storage and UI flow (Dossier Control Center / Subject Consolidation) rather than creating a separate dossier system.

### Description

- Extended dossier types to recognize population recommendations and related metadata by adding new enums/types and fields to `src/lib/dossier-workflow.ts` (e.g., `population_recommendation`, `DossierPopulationRecommendedLane`, `DossierPopulationRecommendedAction`, review-action types and additional recommendation fields such as `populationRecommendation`, `recommendedLane`, `possibleTargets`, `rawEvidenceRefs`, `inputHash`, `seenCount`, timestamps, and an array `populationReviewActions`).
- Extended ingest normalization and the idempotent recommendation creation flow in `src/lib/dossier-workflow-store.ts` to accept `bnl_population_recommender` as an ingest source, populate the new population fields, and dedupe population recommendations using `inputHash` and merged evidence refs instead of creating duplicates.
- Added server-side population-review mutation: `applyPopulationReviewRecommendationAction` (inserted into `src/lib/dossier-workflow-store.ts`) that implements safe admin-only actions (`attach_to_existing_source_file`, `attach_to_existing_dossier_update`, `create_dossier_update_workspace`, `create_source_file_candidate`, `mark_no_new_info`, `mark_not_population_subject`, `dismiss_population_recommendation`, `reopen_population_recommendation`, plus `mark_needs_more_info`), and records `populationReviewActions` with `actionAt`/`actionBy`/`actionReason` while preserving raw evidence refs internally and not changing public dossier text or publishing.
- Improved enrichment dedupe/refresh handling for BNL source-file enrichments and population recommendations so refreshed enrichment merges safely into existing recommendations or attaches to candidates without creating public side effects.
- Added mapping and small helpers to convert population recommendation actions into internal routing/note text and candidate attachments (notes are created as internal `bnl_recommendation` source notes; internal aliases and raw content remain internal and collapsed by default).
- Kept all changes bounded to internal workflow store and types; no public pages or public dossier copy is modified by these actions.

Files changed (key):
- src/lib/dossier-workflow.ts — new population-related types and extra recommendation fields.
- src/lib/dossier-workflow-store.ts — ingest normalization updates, new ingest source handling, idempotent dedupe by `inputHash`, merge/refresh logic for population recommendations, and new `applyPopulationReviewRecommendationAction` implementation.

### Testing

- No automated test suite was executed in this editing environment; the following tests and checks should be run before merging: `node --test tests/admin-dossiers.test.mjs` and `npx tsc --noEmit`.
- The changes are implemented to preserve existing behavior and to keep population actions internal-only; please run the repository tests to verify that all existing dossier/workflow tests (particularly `tests/admin-dossiers.test.mjs`) and TypeScript type-check pass in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6cd2641083218fa559f727a0b7ed)