### PR TITLE
Accept and normalize BNL population source lanes

### DIFF
--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -421,15 +421,18 @@ function supportedIngestSource(value: unknown): CreateDossierRecommendationInput
   return "bnl";
 }
 
-function normalizeBridgeSourceLane(value: unknown): {
+function normalizeBnlSourceLane(value: unknown): {
   lane: DossierRecommendationSourceLane;
   original?: string;
 } {
-  if (typeof value !== "string") throw new Error("Invalid source lane");
+  if (typeof value !== "string") {
+    throw new Error("Invalid source lane: sourceLanes entries must be strings");
+  }
   if (SOURCE_LANES.includes(value as DossierRecommendationSourceLane)) {
     return { lane: value as DossierRecommendationSourceLane };
   }
-  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const original = value.trim();
+  const normalized = original.toLowerCase().replace(/[^a-z0-9]+/g, "_");
   const mapped: Record<string, DossierRecommendationSourceLane> = {
     source_blind_memory_trace: "broadcast_memory",
     memory_trace: "broadcast_memory",
@@ -451,8 +454,25 @@ function normalizeBridgeSourceLane(value: unknown): {
     existing_dossier_update: "website_dossier",
     local_knowledge_store: "admin_manual",
     operator_notes: "admin_manual",
+    conversations: "public_discord",
+    public_home: "public_discord",
+    public_context: "public_discord",
+    sealed_test: "admin_manual",
+    user_memory_facts: "admin_manual",
+    relationship_journal: "admin_manual",
+    relationship_state: "admin_manual",
+    broadcast_memory: "broadcast_memory",
+    memory_tiers: "admin_manual",
+    community_presence: "public_discord",
+    entity_evidence_events: "admin_manual",
+    needs_population_review: "admin_manual",
+    public_dossier_update_signal: "website_dossier",
+    already_represented: "admin_manual",
+    not_population_subject: "admin_manual",
+    broadcast_memory_note: "broadcast_memory",
+    show_state_note: "broadcast_memory",
   };
-  return { lane: mapped[normalized] ?? "unknown", original: value.trim() };
+  return { lane: mapped[normalized] ?? "unknown", original };
 }
 
 function normalizePayload(value: unknown): CreateDossierRecommendationInput {
@@ -469,17 +489,25 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     isBridgeIngest || ingestSource === "bnl_source_file_enrichment";
   const sourceLanesInput = payload.sourceLanes;
   let sourceLanes: DossierRecommendationSourceLane[];
-  const bridgeSourceLaneDetails: string[] = [];
+  const normalizedSourceLaneDetails: string[] = [];
   if (sourceLanesInput === undefined) {
     sourceLanes = ["unknown"];
   } else {
-    if (!Array.isArray(sourceLanesInput)) throw new Error("Invalid source lane");
-    if (isStructuredBnlSourceIngest) {
-      const normalized = sourceLanesInput.map(normalizeBridgeSourceLane);
+    if (!Array.isArray(sourceLanesInput)) {
+      throw new Error("Invalid source lane: sourceLanes must be a list");
+    }
+    if (sourceLanesInput.length > 25) {
+      throw new Error("Invalid source lane: sourceLanes has too many entries");
+    }
+    if (sourceLanesInput.some((lane) => typeof lane !== "string")) {
+      throw new Error("Invalid source lane: sourceLanes entries must be strings");
+    }
+    if (isStructuredBnlSourceIngest || isPopulationIngest) {
+      const normalized = sourceLanesInput.map(normalizeBnlSourceLane);
       sourceLanes = normalized.map((item) => item.lane);
-      bridgeSourceLaneDetails.push(
+      normalizedSourceLaneDetails.push(
         ...normalized
-          .filter((item) => item.original)
+          .filter((item) => item.original && item.original !== item.lane)
           .map((item) => `${item.original} -> ${item.lane}`),
       );
     } else {
@@ -549,15 +577,16 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     !Array.isArray(payload.evidenceSummary)
       ? JSON.stringify(payload.evidenceSummary).slice(0, 2000)
       : text(payload.evidenceSummary, 2000);
-  const bridgeEvidenceSummary = bridgeSourceLaneDetails.length
-    ? [
-        evidenceSummary,
-        `Bridge source lane mapping: ${bridgeSourceLaneDetails.join(", ")}`,
-      ]
+  const bridgeEvidenceSummary =
+    normalizedSourceLaneDetails.length && isStructuredBnlSourceIngest
+      ? [
+          evidenceSummary,
+          `Bridge source lane mapping: ${normalizedSourceLaneDetails.join(", ")}`,
+        ]
         .filter(Boolean)
         .join("\n\n")
         .slice(0, 2000)
-    : evidenceSummary;
+      : evidenceSummary;
   if (!subjectName) throw new Error("subjectName is required");
   if (!reason) {
     throw new Error("reason or structured source context is required");
@@ -620,6 +649,9 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     populationRecommendation: isPopulationIngest ? true : undefined,
     sourceAuthority,
     rawProvenance,
+    normalizedSourceLaneDetails: normalizedSourceLaneDetails.length
+      ? normalizedSourceLaneDetails
+      : undefined,
     missingInfo: stringList(payload.missingInfo),
     publicSafetyNotes: stringList(payload.publicSafetyNotes),
     doNotSay: stringList(payload.doNotSay),

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1393,6 +1393,7 @@ function normalizeRecommendationInput(
     recommendedAction: boundedText(input.recommendedAction, 1000) || undefined,
     sourceAuthority: normalizePacketStringArray(input.sourceAuthority),
     rawProvenance: cloneJsonValue(input.rawProvenance),
+    normalizedSourceLaneDetails: normalizeStringArray(input.normalizedSourceLaneDetails),
     missingInfo: normalizeStringArray(input.missingInfo),
     publicSafetyNotes: normalizeStringArray(input.publicSafetyNotes),
     doNotSay: normalizeStringArray(input.doNotSay),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -655,6 +655,7 @@ export type DossierRecommendation = {
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;
+  normalizedSourceLaneDetails?: string[];
   missingInfo?: string[];
   publicSafetyNotes?: string[];
   doNotSay?: string[];
@@ -2873,6 +2874,7 @@ export type CreateDossierRecommendationInput = {
   recommendedAction?: string;
   sourceAuthority?: string[];
   rawProvenance?: unknown;
+  normalizedSourceLaneDetails?: string[];
   missingInfo?: string[];
   publicSafetyNotes?: string[];
   doNotSay?: string[];

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -9091,6 +9091,143 @@ test("Population Review Queue renders grouped sections and safe admin actions", 
   assert.doesNotMatch(pageCopy, /raw Discord message|relationship_journal|private relationship journal|internal alias label/i);
 });
 
+test("BNL population ingest normalizes population source lanes into allowed site lanes", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const laneCases = [
+    ["relationship_state", ["admin_manual"]],
+    ["relationship_journal", ["admin_manual"]],
+    ["user_memory_facts", ["admin_manual"]],
+    ["entity_evidence_events", ["admin_manual"]],
+    ["community_presence", ["public_discord"]],
+    ["conversations", ["public_discord"]],
+    ["memory_tiers", ["admin_manual"]],
+    ["broadcast_memory_note", ["broadcast_memory"]],
+    ["show_state_note", ["broadcast_memory"]],
+    ["unmapped_safe_population_lane", ["unknown"]],
+  ];
+
+  for (const [lane, expectedSourceLanes] of laneCases) {
+    const response = await bnlIngestPost({
+      type: "population_recommendation",
+      ingestSource: "bnl_population_recommender",
+      subjectName: `Population ${lane}`,
+      adminSummary: `Safe population summary for ${lane}.`,
+      recommendedLane: "needs_population_review",
+      recommendedAction: "admin_review_required",
+      inputHash: `population-lane-${lane}`,
+      sourceLanes: [lane],
+    });
+    assert.equal(response.status, 200, `${lane} should ingest`);
+    const payload = await response.json();
+    assert.deepEqual(payload.recommendation.sourceLanes, expectedSourceLanes);
+    assert.deepEqual(
+      payload.recommendation.normalizedSourceLaneDetails,
+      [`${lane} -> ${expectedSourceLanes[0]}`],
+    );
+    assert.equal(payload.recommendation.populationRecommendation, true);
+  }
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.length, laneCases.length);
+  assert.ok(
+    state.recommendations.every(
+      (recommendation) => recommendation.type === "population_recommendation",
+    ),
+    "Population Review Queue receives every ingested population recommendation",
+  );
+  assert.deepEqual(
+    state.recommendations.find(
+      (recommendation) => recommendation.subjectName === "Population relationship_state",
+    )?.normalizedSourceLaneDetails,
+    ["relationship_state -> admin_manual"],
+  );
+});
+
+test("BNL population ingest accepts population recommended lanes", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  for (const recommendedLane of [
+    "needs_population_review",
+    "active_source_file",
+    "candidate_intake",
+    "existing_dossier_update",
+    "public_dossier_update_signal",
+  ]) {
+    const response = await bnlIngestPost({
+      type: "population_recommendation",
+      ingestSource: "bnl_population_recommender",
+      subjectName: `Population recommended ${recommendedLane}`,
+      adminSummary: `Safe population summary for ${recommendedLane}.`,
+      recommendedLane,
+      recommendedAction: "admin_review_required",
+      inputHash: `population-recommended-lane-${recommendedLane}`,
+      sourceLanes: [recommendedLane],
+    });
+    assert.equal(response.status, 200, `${recommendedLane} should ingest`);
+    const payload = await response.json();
+    assert.equal(payload.recommendation.recommendedLane, recommendedLane);
+  }
+
+  const state = await store.getDossierWorkflowState();
+  assert.equal(state.recommendations.length, 5);
+});
+
+test("BNL population source lane validation fails only malformed lane payloads", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const nonString = await bnlIngestPost({
+    type: "population_recommendation",
+    ingestSource: "bnl_population_recommender",
+    subjectName: "Population Non String Lane",
+    adminSummary: "Safe population summary.",
+    sourceLanes: ["relationship_state", 42],
+  });
+  assert.equal(nonString.status, 400);
+  assert.equal(
+    (await nonString.json()).error,
+    "Invalid source lane: sourceLanes entries must be strings",
+  );
+
+  const nonArray = await bnlIngestPost({
+    type: "population_recommendation",
+    ingestSource: "bnl_population_recommender",
+    subjectName: "Population Non Array Lane",
+    adminSummary: "Safe population summary.",
+    sourceLanes: "relationship_state",
+  });
+  assert.equal(nonArray.status, 400);
+  assert.equal(
+    (await nonArray.json()).error,
+    "Invalid source lane: sourceLanes must be a list",
+  );
+});
+
+test("BNL non-population recommendations still enforce allowed source lanes", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+
+  const invalid = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Strict Lane Subject",
+    reason: "Normal recommendations must keep strict source lanes.",
+    sourceLanes: ["relationship_state"],
+  });
+  assert.equal(invalid.status, 400);
+  assert.equal((await invalid.json()).error, "Invalid source lane");
+
+  const valid = await bnlIngestPost({
+    type: "new_subject",
+    subjectName: "Strict Lane Subject",
+    reason: "Normal recommendations may use allowed source lanes.",
+    sourceLanes: ["rd_context"],
+  });
+  assert.equal(valid.status, 200);
+});
+
 test("Population recommendation ingest dedupes by input hash and preserves raw refs internally", async () => {
   await resetWorkflowStore();
   process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";


### PR DESCRIPTION
### Motivation
- Population recommendation `send` mode was failing with `Invalid source lane` because population ingest lanes were not normalized against the site `SOURCE_LANES` allowlist. 
- The change ensures BNL population recommendations are accepted and routed into existing site lanes while preserving original lane details for internal review and audit. 

### Description
- Apply shared BNL lane normalization for structured BNL ingests and population ingests by adding `normalizeBnlSourceLane` and using it when `isStructuredBnlSourceIngest || isPopulationIngest` so population lanes are mapped instead of rejected. 
- Extend the mapping to cover population-specific labels such as `relationship_state`, `relationship_journal`, `user_memory_facts`, `entity_evidence_events`, `community_presence`, `conversations`, `memory_tiers`, `public_dossier_update_signal`, `active_source_file`, `candidate_intake`, `existing_dossier_update`, `needs_population_review`, `broadcast_memory_note`, `show_state_note`, and others, normalizing unknown strings to `unknown`. 
- Preserve original-to-normalized mappings in `normalizedSourceLaneDetails` (stored on the recommendation input and carried through the workflow types/store) instead of exposing raw data publicly. 
- Tighten malformed-lane validation messages to return clear 400 errors for non-array `sourceLanes` (`Invalid source lane: sourceLanes must be a list`) and non-string entries (`Invalid source lane: sourceLanes entries must be strings`), while still rejecting non-structured non-population lanes via the original strict `SOURCE_LANES` enum. 
- Files changed: `src/app/api/bnl/dossier-recommendations/route.ts` (add `normalizeBnlSourceLane`, apply normalization for population ingests, validation and store of `normalizedSourceLaneDetails`), `src/lib/dossier-workflow.ts` (add `normalizedSourceLaneDetails` type to recommendation/input types), `src/lib/dossier-workflow-store.ts` (accept and persist `normalizedSourceLaneDetails`), `tests/admin-dossiers.test.mjs` (add tests covering population lane normalization, recommended lanes, malformed lane payloads, and strict non-population behavior). 

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed (added population lane tests included). 
- Ran `npx tsc --noEmit` and TypeScript type-check passed. 
- The changes keep existing auth and safety checks intact and do not publish or modify any public dossier text or pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b743c1db08321a51d643ec3edeeb5)