### PR TITLE
Align population-context with Dossier Control Center candidate/recommendation queue

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -1719,8 +1719,8 @@ export default function DossierControlCenterPage() {
         </DashboardCard>
 
         <DashboardCard
-          eyebrow="Candidates"
-          title="Candidates"
+          eyebrow="Candidates & Recommendation Intake"
+          title="Candidates & Recommendation Intake"
           aside={
             <StatusPill>
               {candidateIntakeItems.length +
@@ -1729,6 +1729,9 @@ export default function DossierControlCenterPage() {
             </StatusPill>
           }
         >
+          <p className="mb-4 text-sm text-muted">
+            This section includes real Candidate Intake records and recommendation-backed subjects that still need review.
+          </p>
           <div className="mb-4">
             <details className="border border-border/70 bg-background/20 p-4">
               <summary className="cursor-pointer text-sm font-semibold text-foreground">
@@ -1832,6 +1835,7 @@ export default function DossierControlCenterPage() {
               <table className="w-full min-w-[820px] text-left text-sm text-muted">
                 <thead className="text-xs uppercase tracking-widest text-foreground">
                   <tr>
+                    <th className="py-2 pr-3">Review lane</th>
                     <th className="py-2 pr-3">Subject</th>
                     <th className="py-2 pr-3">Why BNL noticed</th>
                     <th className="py-2 pr-3">Strength / confidence</th>
@@ -1848,6 +1852,9 @@ export default function DossierControlCenterPage() {
                         key={recommendation.id}
                         className="border-t border-border/70 align-top"
                       >
+                        <td className="py-3 pr-3">
+                          <StatusPill>Recommendation</StatusPill>
+                        </td>
                         <td className="py-3 pr-3 font-semibold text-foreground">
                           {recommendation.subjectName}
                         </td>
@@ -1888,6 +1895,9 @@ export default function DossierControlCenterPage() {
                       key={candidate.id}
                       className="border-t border-border/70 align-top"
                     >
+                      <td className="py-3 pr-3">
+                        <StatusPill>Candidate Intake</StatusPill>
+                      </td>
                       <td className="py-3 pr-3 font-semibold text-foreground">
                         {candidate.name}
                       </td>

--- a/src/app/api/bnl/population-context/route.ts
+++ b/src/app/api/bnl/population-context/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { databasePage, type DatabaseEntry } from "@/content";
 import {
   isActiveSourceFileCandidate,
+  isDiagnosticTestArtifactRecommendation,
+  isResolvedDossierRecommendation,
   normalizeDossierSubjectName,
   type DossierCandidate,
   type DossierIdentityLink,
@@ -21,6 +23,7 @@ type RouteLane =
   | "source_file"
   | "candidate_intake"
   | "dossier_update_workspace"
+  | "candidate_recommendation"
   | "resolved_record";
 
 function bearerToken(req: Request): string {
@@ -58,7 +61,10 @@ function tokenMatches(providedToken: string): boolean {
 }
 
 function slugifyPublicDossierName(name: string) {
-  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
 }
 
 function publicDossierPath(entry: DatabaseEntry) {
@@ -128,7 +134,8 @@ function latestRefreshStatus(
     .filter(
       (request) =>
         request.candidateId === candidate.id ||
-        request.normalizedSubjectKey === normalizeDossierSubjectName(candidate.name),
+        request.normalizedSubjectKey ===
+          normalizeDossierSubjectName(candidate.name),
     )
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   const latest = related[0];
@@ -211,8 +218,12 @@ function privateIdentityKey(candidateId: string, link: DossierIdentityLink) {
   return `internal_identity_key:${digest}`;
 }
 
-function identityLinkItem(candidate: DossierCandidate, link: DossierIdentityLink) {
-  const publicSafe = link.visibility === "public_safe" && link.useInPublicDossier;
+function identityLinkItem(
+  candidate: DossierCandidate,
+  link: DossierIdentityLink,
+) {
+  const publicSafe =
+    link.visibility === "public_safe" && link.useInPublicDossier;
   return {
     sourceCandidateId: link.candidateId || candidate.id,
     targetCandidateId: candidate.id,
@@ -248,12 +259,17 @@ function resolvedCandidateItem(
     subjectName: candidate.name,
     normalizedSubjectKey: normalizeDossierSubjectName(candidate.name),
     status: candidate.status,
-    resolvedReason: candidate.mergeNote ?? candidate.routingReason ?? candidate.status,
+    resolvedReason:
+      candidate.mergeNote ?? candidate.routingReason ?? candidate.status,
     destinationCandidateId: candidate.mergedIntoCandidateId ?? null,
     destinationSubjectName: destination?.name ?? null,
     destinationLane: destinationLane(destination),
     publicDossierId: candidate.existingDossierMatch?.id ?? null,
   };
+}
+
+function recommendationRoute(recommendationId: string) {
+  return `/admin/dossiers/recommendations/${encodeURIComponent(recommendationId)}`;
 }
 
 function resolvedRecommendationItem(
@@ -280,7 +296,73 @@ function resolvedRecommendationItem(
     destinationSubjectName: destination?.name ?? null,
     destinationLane: destinationLane(destination),
     publicDossierId: recommendation.targetDossierId ?? null,
+    recommendationId: recommendation.id,
+    route: recommendationRoute(recommendation.id),
   };
+}
+
+function pendingCandidateRecommendationItem(
+  recommendation: DossierRecommendation,
+) {
+  const subjectName = recommendation.subjectName.trim();
+  const normalizedSubjectKey =
+    recommendation.subjectKey?.trim() ||
+    normalizeDossierSubjectName(subjectName);
+  return {
+    recordId: recommendation.id,
+    subjectName,
+    normalizedSubjectKey,
+    status: recommendation.status,
+    resolvedReason: "pending_candidate_recommendation",
+    destinationCandidateId: null,
+    destinationSubjectName: subjectName,
+    destinationLane: "candidate_recommendation" as const,
+    publicDossierId: recommendation.targetDossierId ?? null,
+    recommendationId: recommendation.id,
+    route: recommendationRoute(recommendation.id),
+  };
+}
+
+function isActiveCandidateRecommendation(
+  recommendation: DossierRecommendation,
+  resolvedCandidateIds: Set<string>,
+) {
+  const subjectName = recommendation.subjectName?.trim();
+  const normalizedSubjectKey =
+    recommendation.subjectKey?.trim() ||
+    (subjectName ? normalizeDossierSubjectName(subjectName) : "");
+  if (!subjectName || !normalizedSubjectKey) return false;
+  if (!["new", "reviewing"].includes(recommendation.status)) return false;
+  if (isResolvedDossierRecommendation(recommendation)) return false;
+  if (isDiagnosticTestArtifactRecommendation(recommendation)) return false;
+  if (
+    [
+      recommendation.targetCandidateId,
+      recommendation.connectedCandidateId,
+      recommendation.connectedSourceFileCandidateId,
+    ].some(
+      (candidateId) => candidateId && resolvedCandidateIds.has(candidateId),
+    )
+  ) {
+    return false;
+  }
+  if (
+    recommendation.type === "modify_existing_dossier" ||
+    Boolean(recommendation.targetDossierId) ||
+    Boolean(recommendation.targetCandidateId)
+  ) {
+    return false;
+  }
+  if (
+    recommendation.populationRecommendation &&
+    (recommendation.recommendedLane === "already_represented" ||
+      recommendation.recommendedAction === "mark_duplicate_no_new_info" ||
+      recommendation.recommendedAction === "mark_no_new_info" ||
+      recommendation.recommendedAction === "dismiss_population_recommendation")
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isResolvedRecommendation(recommendation: DossierRecommendation) {
@@ -317,6 +399,22 @@ export async function GET(req: Request) {
     .map((candidate) =>
       dossierUpdateWorkspaceItem(candidate, state.sourceFileRefreshRequests),
     );
+  const resolvedCandidateIds = new Set(
+    state.candidates
+      .filter(
+        (candidate) =>
+          candidate.status === "merged" ||
+          candidate.status === "archived" ||
+          candidate.status === "denied" ||
+          Boolean(candidate.mergedIntoCandidateId),
+      )
+      .map((candidate) => candidate.id),
+  );
+  const pendingRecommendationCandidateRecords = state.recommendations
+    .filter((recommendation) =>
+      isActiveCandidateRecommendation(recommendation, resolvedCandidateIds),
+    )
+    .map(pendingCandidateRecommendationItem);
   const identityLinks = state.candidates.flatMap((candidate) =>
     (candidate.identityLinks ?? []).map((identityLink) =>
       identityLinkItem(candidate, identityLink),
@@ -336,6 +434,7 @@ export async function GET(req: Request) {
       .map((recommendation) =>
         resolvedRecommendationItem(recommendation, candidatesById),
       ),
+    ...pendingRecommendationCandidateRecords,
   ];
 
   return NextResponse.json(
@@ -353,6 +452,8 @@ export async function GET(req: Request) {
         publicDossierCount: publicDossiers.length,
         sourceFileCount: sourceFiles.length,
         candidateCount: candidates.length,
+        pendingRecommendationCandidateCount:
+          pendingRecommendationCandidateRecords.length,
         dossierUpdateWorkspaceCount: dossierUpdateWorkspaces.length,
         identityLinkCount: identityLinks.length,
         resolvedRecordCount: resolvedRecords.length,

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1727,6 +1727,21 @@ function recommendationDedupeText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
+function activeNonPopulationRecommendationForSubject(
+  recommendations: DossierRecommendation[],
+  recommendation: DossierRecommendation,
+): DossierRecommendation | undefined {
+  const subjectKey = recommendationDedupeSubject(recommendation.subjectKey || recommendation.subjectName);
+  if (!subjectKey) return undefined;
+  return recommendations.find((item) => {
+    if (item.populationRecommendation || item.type === "population_recommendation") return false;
+    if (!["new", "reviewing"].includes(item.status)) return false;
+    if (!isActiveRecommendation(item)) return false;
+    const itemSubjectKey = recommendationDedupeSubject(item.subjectKey || item.subjectName);
+    return itemSubjectKey === subjectKey;
+  });
+}
+
 function fallbackRecommendationDedupeKey(
   recommendation: Pick<
     DossierRecommendation,
@@ -3044,6 +3059,33 @@ export async function createDossierRecommendationIdempotent(
       savedRecommendation = existing;
       duplicate = true;
       return currentState;
+    }
+
+    const matchingActiveRecommendation = recommendation.populationRecommendation
+      ? activeNonPopulationRecommendationForSubject(currentState.recommendations, recommendation)
+      : undefined;
+    if (matchingActiveRecommendation) {
+      savedRecommendation = {
+        ...recommendation,
+        status: "new",
+        recommendedLane: "already_represented",
+        recommendedAction: "mark_duplicate_no_new_info",
+        duplicateRisk: "high",
+        connectedRecommendationIds: uniqueStrings(recommendation.connectedRecommendationIds, [matchingActiveRecommendation.id]),
+        sourceRecommendationIds: uniqueStrings(recommendation.sourceRecommendationIds, [matchingActiveRecommendation.id]),
+        routingReason: `Already represented by active recommendation ${matchingActiveRecommendation.id}. Preserved population evidence refs internally; no extra Admin Review Required card is needed.`,
+        publicSafetyNotes: uniqueStrings(recommendation.publicSafetyNotes, [
+          "Population recommendation matched an unresolved recommendation-backed candidate/intake subject. Raw/private evidence refs remain internal and no public content was changed.",
+        ]),
+        rawEvidenceRefCount: recommendation.rawEvidenceRefs?.length ?? 0,
+        updatedAt: now,
+      };
+      duplicate = true;
+      return {
+        ...currentState,
+        recommendations: [savedRecommendation, ...currentState.recommendations],
+        updatedAt: now,
+      };
     }
 
     if (isEnrichmentIngest) {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -8951,6 +8951,40 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
         connectedCandidateId: "dossier-update-workspace",
         connectedSourceFileCandidateId: "dossier-update-workspace",
       }),
+      baseRecommendation({
+        id: "rec-pending-candidate",
+        type: "new_subject",
+        subjectName: "Recommendation Backed Subject",
+        subjectKey: "recommendation backed subject",
+        status: "new",
+        ingestSource: "bnl",
+        recommendedKind: "community_member",
+      }),
+      baseRecommendation({
+        id: "rec-mind-fanatic",
+        type: "new_subject",
+        subjectName: "Mind Fanatic [Barcode_Network]",
+        subjectKey: "mind fanatic barcode network",
+        status: "reviewing",
+        ingestSource: "bnl",
+        reason: "BNL-01_MEMBER_LOG / Orion candidate recommendation fixture.",
+        recommendedKind: "community_member",
+      }),
+      baseRecommendation({
+        id: "rec-diagnostic-artifact",
+        type: "new_subject",
+        subjectName: "Diagnostic Probe Candidate",
+        status: "new",
+        reason: "diagnostic test artifact should stay hidden",
+        ingestSource: "system",
+      }),
+      baseRecommendation({
+        id: "rec-terminal-candidate",
+        type: "new_subject",
+        subjectName: "Terminal Candidate",
+        status: "dismissed",
+        reason: "Resolved terminal recommendation should stay hidden",
+      }),
     ],
     sourceFileRefreshRequests: [
       {
@@ -8988,6 +9022,8 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   assert.equal(payload.diagnostics.publicDossierCount, payload.publicDossiers.length);
   assert.equal(payload.diagnostics.sourceFileCount, payload.sourceFiles.length);
   assert.equal(payload.diagnostics.candidateCount, payload.candidates.length);
+  assert.equal(payload.diagnostics.candidateCount, 1);
+  assert.equal(payload.diagnostics.pendingRecommendationCandidateCount, 2);
   assert.equal(payload.diagnostics.dossierUpdateWorkspaceCount, payload.dossierUpdateWorkspaces.length);
   assert.equal(payload.diagnostics.identityLinkCount, payload.identityLinks.length);
   assert.equal(payload.diagnostics.resolvedRecordCount, payload.resolvedRecords.length);
@@ -9024,6 +9060,22 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   assert.equal(mergedRecord.destinationSubjectName, "Active Subject");
   assert.equal(mergedRecord.destinationLane, "source_file");
 
+  const pendingRecommendation = payload.resolvedRecords.find((item) => item.recordId === "rec-pending-candidate");
+  assert.equal(pendingRecommendation.resolvedReason, "pending_candidate_recommendation");
+  assert.equal(pendingRecommendation.destinationLane, "candidate_recommendation");
+  assert.equal(pendingRecommendation.destinationSubjectName, "Recommendation Backed Subject");
+  assert.equal(pendingRecommendation.normalizedSubjectKey, "recommendation backed subject");
+  assert.equal(pendingRecommendation.recommendationId, "rec-pending-candidate");
+  assert.equal(pendingRecommendation.route, "/admin/dossiers/recommendations/rec-pending-candidate");
+
+  const mindFanaticRecord = payload.resolvedRecords.find((item) => item.recordId === "rec-mind-fanatic");
+  assert.equal(mindFanaticRecord.resolvedReason, "pending_candidate_recommendation");
+  assert.equal(mindFanaticRecord.normalizedSubjectKey, "mind fanatic barcode network");
+  assert.equal(mindFanaticRecord.destinationLane, "candidate_recommendation");
+
+  assert.equal(payload.resolvedRecords.some((item) => item.recordId === "rec-diagnostic-artifact"), false);
+  assert.equal(payload.resolvedRecords.some((item) => item.recordId === "rec-terminal-candidate" && item.resolvedReason === "pending_candidate_recommendation"), false);
+
   const serialized = JSON.stringify(payload);
   assert.doesNotMatch(serialized, /relationship_journal|raw Discord message|raw discord message/i);
   assert.doesNotMatch(serialized, /protected_system|private_admin|internal_controlled/i);
@@ -9036,6 +9088,7 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   assert.doesNotMatch(routeSource, /databasePage\.entries\s*=|summary:\s*|notes:\s*|role:\s*/);
   assert.match(source("src/app/api/bnl/read-model/route.ts"), /export async function GET/);
   assert.match(source("src/app/admin/dossiers/page.tsx"), /Dossier Control Center/);
+  assert.match(source("src/app/admin/dossiers/page.tsx"), /Candidates & Recommendation Intake/);
   assert.match(source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx"), /Source File/);
   assert.match(source("src/lib/dossier-workflow-store.ts"), /Subject Consolidation/);
 
@@ -9268,6 +9321,72 @@ test("Population recommendation ingest dedupes by input hash and preserves raw r
   assert.equal(populationRecommendations[0].seenCount, 2);
 });
 
+test("Population recommendation ingest marks matching active recommendations already represented", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
+  const now = new Date().toISOString();
+
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [],
+    drafts: [],
+    recommendations: [
+      {
+        id: "rec-active-mind-fanatic",
+        type: "new_subject",
+        subjectName: "Mind Fanatic [Barcode_Network]",
+        subjectKey: "mind fanatic barcode network",
+        status: "new",
+        reason: "BNL-01_MEMBER_LOG / Orion candidate recommendation fixture.",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+        createdBy: "bnl",
+        ingestSource: "bnl",
+      },
+    ],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const response = await bnlIngestPost({
+    type: "population_recommendation",
+    createdBy: "bnl_population_recommender",
+    subjectName: "Mind Fanatic [Barcode_Network]",
+    subjectKey: "mind fanatic barcode network",
+    adminSummary: "BNL sees a safe routing signal already queued elsewhere.",
+    recommendedLane: "needs_population_review",
+    recommendedAction: "admin_review_required",
+    confidence: "high",
+    inputHash: "population-mind-fanatic-duplicate",
+    rawEvidenceRefs: ["discord:private-relationship-row"],
+    sourceLanes: ["broadcast_memory"],
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.duplicate, true);
+  assert.equal(payload.recommendation.recommendedLane, "already_represented");
+  assert.equal(payload.recommendation.recommendedAction, "mark_duplicate_no_new_info");
+  assert.deepEqual(payload.recommendation.connectedRecommendationIds, ["rec-active-mind-fanatic"]);
+
+  const state = await store.getDossierWorkflowState();
+  const populationRecommendations = state.recommendations.filter((item) => item.populationRecommendation);
+  assert.equal(populationRecommendations.length, 1);
+  assert.equal(populationRecommendations[0].rawEvidenceRefs.length, 1);
+  assert.equal(populationRecommendations[0].recommendedLane, "already_represented");
+  assert.equal(populationRecommendations[0].recommendedAction, "mark_duplicate_no_new_info");
+  assert.equal(
+    state.recommendations.filter(
+      (item) =>
+        item.populationRecommendation &&
+        item.recommendedLane === "needs_population_review" &&
+        item.recommendedAction === "admin_review_required",
+    ).length,
+    0,
+  );
+});
+
 test("Population Review Queue actions update internal workflow records without publishing", async () => {
   await resetWorkflowStore();
   process.env.BNL_API_KEY = "test-population-context-token";
@@ -9367,6 +9486,7 @@ test("Population Review Queue search includes matched candidate names and review
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
   assert.match(page, /populationRecommendationSearchText\(recommendation, candidates\)/);
   assert.match(page, /matchedCandidateNames/);
+  assert.match(page, /Already Represented \/ Duplicate/);
   assert.match(page, /candidate\.name/);
   assert.match(page, /return \["new", "reviewing"\]\.includes\(recommendation\.status\)/);
   assertIncludesCopy(pageCopy, "Search subject, normalized key, dossier, or Source File");


### PR DESCRIPTION
### Motivation

- The Dossier Control Center's "Candidates" section mixes true candidate intake records and active recommendation-backed rows, but `/api/bnl/population-context` only exposed true candidate intake records so BNL produced duplicate population recommendations for subjects already queued as recommendation-backed candidates.
- The endpoint and duplicate-handling need to reflect the same candidate/recommendation reality so population ingest/dedupe avoids creating extra Admin Review Required cards for already-waiting subjects.

### Description

- Expose active recommendation-backed candidate destinations in the population context by converting active recommendations into pending destination records and including them in `resolvedRecords` with `resolvedReason: "pending_candidate_recommendation"`, `destinationLane: "candidate_recommendation"`, `recommendationId`, and `route` to the recommendation detail. (changed `src/app/api/bnl/population-context/route.ts`)
- Add `pendingRecommendationCandidateCount` to the population-context diagnostics and build `pendingRecommendationCandidateRecords` from active, non-terminal, non-diagnostic recommendations so BNL can see recommendation-backed intake subjects. (changed `src/app/api/bnl/population-context/route.ts`)
- Add server-side ingest dedupe for population recommendations so a population recommendation that matches an unresolved active non-population recommendation is marked `already_represented` / `mark_duplicate_no_new_info`, linked to the existing recommendation, preserves raw/internal evidence refs, and avoids producing a fresh Admin Review Required routing destination. (changed `src/lib/dossier-workflow-store.ts`)
- Clarify dashboard wording and visual row labels so operators can distinguish true Candidate Intake rows from recommendation-backed rows by renaming the card to "Candidates & Recommendation Intake", adding helper copy, and showing a small `StatusPill` indicator per row. (changed `src/app/admin/dossiers/page.tsx`)
- Add and update tests that validate: population-context includes pending recommendation destinations, diagnostics reflect pendingRecommendationCandidateCount, diagnostic/terminal recommendations are filtered, Mind Fanatic-style active recommendation appears as already represented in context, and population ingest dedupes/mutates population recommendations when matching active recommendations exist. (changed `tests/admin-dossiers.test.mjs`)

Files changed:
- `src/app/api/bnl/population-context/route.ts` — include active candidate recommendations as pending destination records and report `pendingRecommendationCandidateCount`.
- `src/lib/dossier-workflow-store.ts` — add matching logic to mark population recommendations as already represented when an unresolved active non-population recommendation for the same normalized subject exists.
- `src/app/admin/dossiers/page.tsx` — UI copy change to "Candidates & Recommendation Intake" and visual distinction of recommendation vs candidate rows.
- `tests/admin-dossiers.test.mjs` — fixtures and assertions added/updated to cover the new behavior.

No public dossier text or public pages were changed or published by this PR; internal-only identity labels and raw evidence references remain hidden in API outputs as before.

### Testing

- Ran the full focused admin dossier test file with `node --test tests/admin-dossiers.test.mjs`, which passed (all tests green). 
- Ran the TypeScript typecheck with `npx tsc --noEmit`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b7c10f00c8321859939b5c7d7d174)