### PR TITLE
Replace Population Review Queue with BNL Signal Reconcile and automatic reconcile action

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -62,6 +62,24 @@ type SubjectConsolidationResult = {
   internalAliasesExposed: 0;
 };
 
+type PopulationReconcileSummary = {
+  signalsReviewed: number;
+  attachedToSourceFiles: number;
+  attachedToDossierUpdates: number;
+  attachedToCandidateIntake: number;
+  attachedToExistingRecommendations: number;
+  markedAlreadyRepresented: number;
+  markedNoNewInfo: number;
+  createdDossierUpdateWorkspaces: number;
+  createdSourceFileCandidates: number;
+  unresolvedNeedsReview: number;
+  duplicatesCollapsed: number;
+  evidenceRefsMerged: number;
+  publicPagesPublished: 0;
+  publicDossierTextChanged: 0;
+  internalAliasesExposed: 0;
+};
+
 type ManualRecommendationForm = {
   subjectName: string;
   type: DossierRecommendation["type"];
@@ -295,31 +313,6 @@ function archiveActionLabel() {
   return "Review Record";
 }
 
-type PopulationQueueFilter =
-  | "all"
-  | "new"
-  | "high"
-  | "needs_review"
-  | "existing_source_file"
-  | "dossier_update"
-  | "candidate_intake"
-  | "already_represented"
-  | "non_dossier"
-  | "dismissed";
-
-const populationQueueFilters: Array<{ id: PopulationQueueFilter; label: string }> = [
-  { id: "all", label: "All" },
-  { id: "new", label: "New" },
-  { id: "high", label: "High confidence" },
-  { id: "needs_review", label: "Needs review" },
-  { id: "existing_source_file", label: "Existing Source File" },
-  { id: "dossier_update", label: "Dossier Update" },
-  { id: "candidate_intake", label: "Candidate Intake" },
-  { id: "already_represented", label: "Already Represented" },
-  { id: "non_dossier", label: "Non-dossier signals" },
-  { id: "dismissed", label: "Dismissed" },
-];
-
 function isPopulationRecommendation(recommendation: DossierRecommendation) {
   return (
     recommendation.type === "population_recommendation" ||
@@ -402,6 +395,14 @@ function populationPublicDossierHref(recommendation: DossierRecommendation, publ
   return `/database/${dossier.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
 }
 
+function populationReviewHref(recommendation: DossierRecommendation) {
+  if (recommendation.targetCandidateId) return `/admin/dossiers/candidates/${recommendation.targetCandidateId}`;
+  if (recommendation.matchedExistingCandidateId) return `/admin/dossiers/candidates/${recommendation.matchedExistingCandidateId}`;
+  if (recommendation.matchedDossierUpdateCandidateId) return `/admin/dossiers/candidates/${recommendation.matchedDossierUpdateCandidateId}`;
+  if (recommendation.connectedRecommendationIds?.length) return `/admin/dossiers/recommendations/${recommendation.connectedRecommendationIds[0]}`;
+  return `/admin/dossiers/recommendations/${recommendation.id}`;
+}
+
 type PopulationReviewQueueAction =
   | "attach_to_existing_source_file"
   | "attach_to_existing_dossier_update"
@@ -424,44 +425,23 @@ function populationPrimaryActions(input: {
   publicHref?: string;
 }): PopulationPrimaryAction[] {
   const { groupId, recommendation, targetHref, publicHref } = input;
-  if (groupId === "already-represented") {
+  const reviewHref = targetHref ?? populationReviewHref(recommendation);
+  if (groupId === "admin-review") {
     return [
-      targetHref
-        ? { kind: "link", href: targetHref, label: recommendation.targetCandidateId ? "Review existing candidate/recommendation" : "Open existing record" }
-        : { kind: "link", href: `/admin/dossiers/recommendations/${recommendation.connectedRecommendationIds?.[0] ?? recommendation.id}`, label: "Open existing record" },
-      { kind: "action", key: "mark_no_new_info", label: "Mark no-new-info" },
+      { kind: "link", href: reviewHref, label: "Review" },
+      { kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" },
     ];
   }
   if (groupId === "existing-source-file") {
     return [
-      { kind: "action" as const, key: "attach_to_existing_source_file" as const, label: "Attach to Source File" },
-      ...(targetHref ? [{ kind: "link" as const, href: targetHref, label: "Open Source File" }] : []),
+      targetHref ? { kind: "link" as const, href: targetHref, label: "Open Source File" } : { kind: "link" as const, href: reviewHref, label: "Review" },
+      { kind: "action" as const, key: "attach_to_existing_source_file" as const, label: "Attach evidence" },
     ].slice(0, 2);
-  }
-  if (groupId === "existing-dossier-update") {
-    return [
-      { kind: "action" as const, key: "attach_to_existing_dossier_update" as const, label: "Attach to Update Workspace" },
-      ...(targetHref ? [{ kind: "link" as const, href: targetHref, label: "Open Workspace" }] : []),
-    ].slice(0, 2);
-  }
-  if (groupId === "create-dossier-update") {
-    return [
-      { kind: "action", key: "create_dossier_update_workspace", label: "Create Update Workspace" },
-      { kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" },
-    ];
   }
   if (groupId === "candidate-intake") {
     return [
-      targetHref
-        ? { kind: "link", href: targetHref, label: "Review existing candidate/recommendation" }
-        : { kind: "action", key: "create_source_file_candidate", label: "Create Source File Candidate" },
-      { kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" },
-    ];
-  }
-  if (groupId === "admin-review") {
-    return [
-      { kind: "action", key: "mark_needs_more_info", label: "Review" },
-      { kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" },
+      targetHref ? { kind: "link" as const, href: targetHref, label: "Open Candidate" } : { kind: "link" as const, href: reviewHref, label: "Review" },
+      { kind: "action" as const, key: "mark_no_new_info" as const, label: "Mark no-new-info" },
     ];
   }
   if (groupId === "non-dossier") {
@@ -470,9 +450,10 @@ function populationPrimaryActions(input: {
       { kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" },
     ];
   }
-  return publicHref
-    ? [{ kind: "link", href: publicHref, label: "Open existing record" }]
-    : [{ kind: "action", key: "dismiss_population_recommendation", label: "Dismiss" }];
+  if (targetHref || publicHref) {
+    return [{ kind: "link", href: targetHref ?? publicHref!, label: "Open existing record" }];
+  }
+  return [{ kind: "link", href: reviewHref, label: "Review" }];
 }
 
 function PopulationActionButton({ children, onClick, disabled }: { children: React.ReactNode; onClick: () => void; disabled?: boolean }) {
@@ -523,8 +504,8 @@ export default function DossierControlCenterPage() {
   const [resolvedJustNow, setResolvedJustNow] = useState<{ groupId: string; subject: string; message: string; kind: "consolidate" | "source_file" | "dossier_update" | "keep_separate"; href?: string; absorbedCount: number; notesMoved: number; archivedCount: number; refreshStatus: string } | null>(null);
   const [recommendationForm, setRecommendationForm] =
     useState<ManualRecommendationForm>(emptyRecommendationForm);
-  const [populationFilter, setPopulationFilter] = useState<PopulationQueueFilter>("all");
   const [populationSearch, setPopulationSearch] = useState("");
+  const [populationReconcileResult, setPopulationReconcileResult] = useState<PopulationReconcileSummary | null>(null);
   const [createdDraftIdByCandidate, setCreatedDraftIdByCandidate] = useState<
     Record<string, string>
   >({});
@@ -613,60 +594,37 @@ export default function DossierControlCenterPage() {
     .at(-1);
   const filteredPopulationRecommendations = visiblePopulationRecommendations.filter((recommendation) => {
     const query = populationSearch.trim().toLowerCase();
-    const matchesSearch = !query || populationRecommendationSearchText(recommendation, candidates).includes(query);
-    const matchesFilter =
-      populationFilter === "all" ? true :
-      populationFilter === "new" ? isPopulationOpen(recommendation) :
-      populationFilter === "high" ? recommendation.confidence === "high" :
-      populationFilter === "needs_review" ? recommendation.recommendedLane === "needs_population_review" || recommendation.recommendedAction === "admin_review_required" :
-      populationFilter === "existing_source_file" ? recommendation.recommendedLane === "active_source_file" || recommendation.recommendedAction === "attach_to_existing_source_file" :
-      populationFilter === "dossier_update" ? ["existing_dossier_update", "public_dossier_update_signal"].includes(recommendation.recommendedLane ?? "") || ["attach_to_existing_dossier_update", "create_dossier_update_workspace"].includes(recommendation.recommendedAction ?? "") :
-      populationFilter === "candidate_intake" ? recommendation.recommendedLane === "candidate_intake" || recommendation.recommendedAction === "create_source_file_candidate" :
-      populationFilter === "already_represented" ? isAlreadyRepresentedPopulationSignal(recommendation) :
-      populationFilter === "non_dossier" ? isNonDossierPopulationSignal(recommendation) :
-      populationFilter === "dismissed" ? ["dismissed", "ignored", "archived", "no_new_info", "not_population_subject"].includes(recommendation.status) :
-      true;
-    return matchesSearch && matchesFilter;
+    return !query || populationRecommendationSearchText(recommendation, candidates).includes(query);
   });
+  const unresolvedPopulationSignals = filteredPopulationRecommendations.filter(
+    (recommendation) =>
+      isPopulationOpen(recommendation) &&
+      !isAlreadyRepresentedPopulationSignal(recommendation) &&
+      !isNonDossierPopulationSignal(recommendation) &&
+      (recommendation.recommendedLane === "needs_population_review" ||
+        recommendation.recommendedAction === "admin_review_required" ||
+        !recommendation.targetCandidateId &&
+          !recommendation.matchedExistingCandidateId &&
+          !recommendation.matchedDossierUpdateCandidateId &&
+          !recommendation.connectedRecommendationIds?.length &&
+          !recommendation.matchedPublicDossierId &&
+          !recommendation.targetDossierId),
+  );
+  const filedPopulationSignals = filteredPopulationRecommendations.filter(
+    (recommendation) =>
+      !unresolvedPopulationSignals.some((item) => item.id === recommendation.id) &&
+      !isNonDossierPopulationSignal(recommendation),
+  );
+  const nonDossierPopulationSignals = filteredPopulationRecommendations.filter(isNonDossierPopulationSignal);
+  const filedAutomaticallyCount = filedPopulationSignals.length + nonDossierPopulationSignals.length;
   const populationQueueGroups = [
     {
-      id: "existing-source-file",
-      title: "Attach to Existing Source File",
-      description: "BNL thinks this evidence belongs on an already active Source File.",
-      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "active_source_file" || recommendation.recommendedAction === "attach_to_existing_source_file"),
-    },
-    {
-      id: "existing-dossier-update",
-      title: "Dossier Update Workspace",
-      description: "BNL found an existing internal update workspace for a public dossier subject.",
-      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "existing_dossier_update" || recommendation.recommendedAction === "attach_to_existing_dossier_update"),
-    },
-    {
-      id: "create-dossier-update",
-      title: "Create Dossier Update Workspace",
-      description: "BNL sees a public dossier update signal, but no workspace is linked yet.",
-      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "public_dossier_update_signal" || recommendation.recommendedAction === "create_dossier_update_workspace"),
-    },
-    {
-      id: "candidate-intake",
-      title: "Candidate Intake / New Source File",
-      description: "BNL thinks this should start as a private candidate/source-file workflow record.",
-      items: filteredPopulationRecommendations.filter((recommendation) => recommendation.recommendedLane === "candidate_intake" || recommendation.recommendedAction === "create_source_file_candidate"),
-    },
-    {
       id: "admin-review",
-      title: "Admin Review Required",
-      description: "BNL is unsure; choose the safe internal route manually.",
-      items: filteredPopulationRecommendations.filter((recommendation) => !isAlreadyRepresentedPopulationSignal(recommendation) && !isNonDossierPopulationSignal(recommendation) && (recommendation.recommendedLane === "needs_population_review" || recommendation.recommendedAction === "admin_review_required")),
-    },
-    {
-      id: "already-represented",
-      title: "Already Represented / Duplicate",
-      description: "BNL believes the subject is already represented or no new dossier work is needed.",
-      items: filteredPopulationRecommendations.filter(isAlreadyRepresentedPopulationSignal),
+      title: "Needs Review",
+      description: "Only ambiguous or unresolved BNL signals stay visible here.",
+      items: unresolvedPopulationSignals,
     },
   ];
-  const nonDossierPopulationSignals = filteredPopulationRecommendations.filter(isNonDossierPopulationSignal);
 
   const diagnosticRecommendations = recommendations.filter(isDiagnosticTestArtifactRecommendation);
   const resolvedCandidateIds = new Set(
@@ -1140,6 +1098,29 @@ export default function DossierControlCenterPage() {
       setNotice(err instanceof Error ? err.message : "Population recommendation action failed.");
     }
   }
+
+  async function reconcilePopulationSignals() {
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/admin/dossiers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "reconcile_population_signals" }),
+      });
+      const next = (await response.json()) as WorkflowPayload & { populationReconcile?: PopulationReconcileSummary; error?: string };
+      if (!response.ok) throw new Error(next.error ?? `Reconcile failed with ${response.status}.`);
+      setPayload(next);
+      setPopulationReconcileResult(next.populationReconcile ?? null);
+      setNotice("BNL signals reconciled into internal workflow destinations.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Population reconcile failed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
 
   if (loading) {
     return (
@@ -1714,20 +1695,23 @@ export default function DossierControlCenterPage() {
           </details>
 
         <DashboardCard
-          eyebrow="BNL Population Scan"
-          title="Population Review Queue"
-          aside={<StatusPill>{populationRecommendations.filter(isPopulationOpen).length} new / unreviewed</StatusPill>}
+          eyebrow="BNL Signal Reconcile"
+          title="BNL Signal Reconcile"
+          aside={<StatusPill>{unresolvedPopulationSignals.length} needs review</StatusPill>}
         >
+          <p className="text-sm text-muted">
+            BNL files new subject signals into existing Source Files, candidates, drafts, and dossier update workspaces. Only unresolved signals stay here.
+          </p>
           <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-3 text-xs text-muted">
             {[
-              ["Total", populationRecommendations.length],
-              ["New / unreviewed", populationRecommendations.filter(isPopulationOpen).length],
-              ["High", populationRecommendations.filter((item) => item.confidence === "high").length],
-              ["Medium", populationRecommendations.filter((item) => item.confidence === "medium").length],
-              ["Low", populationRecommendations.filter((item) => item.confidence === "low").length],
-              ["Blocked", populationRecommendations.filter((item) => item.publicSafetyLevel === "blocked" || item.identityRisk === "blocked").length],
-              ["Already represented", populationRecommendations.filter(isAlreadyRepresentedPopulationSignal).length],
-              ["Non-subject skipped", populationRecommendations.filter(isNonDossierPopulationSignal).length],
+              ["Signals reviewed", populationReconcileResult?.signalsReviewed ?? populationRecommendations.length],
+              ["Filed automatically", filedAutomaticallyCount],
+              ["Needs Review", populationReconcileResult?.unresolvedNeedsReview ?? unresolvedPopulationSignals.length],
+              ["Source Files", populationReconcileResult?.attachedToSourceFiles ?? populationRecommendations.filter((item) => item.status === "attached_to_source_file").length],
+              ["Dossier Updates", populationReconcileResult?.attachedToDossierUpdates ?? populationRecommendations.filter((item) => item.status === "attached_to_existing_dossier_update").length],
+              ["Candidate Intake", populationReconcileResult?.attachedToCandidateIntake ?? populationRecommendations.filter((item) => item.status === "attached_to_candidate_intake").length],
+              ["Duplicates collapsed", populationReconcileResult?.duplicatesCollapsed ?? Math.max(0, populationRecommendations.length - visiblePopulationRecommendations.length)],
+              ["Public pages", populationReconcileResult?.publicPagesPublished ?? 0],
             ].map(([label, value]) => (
               <div key={label} className="border border-border/70 bg-background/30 p-3">
                 <p className="uppercase tracking-[0.25em] text-accent mb-2">{label}</p>
@@ -1735,21 +1719,33 @@ export default function DossierControlCenterPage() {
               </div>
             ))}
           </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-muted">
+            <div className="border border-border/70 bg-background/30 p-3">
+              <p className="uppercase tracking-[0.25em] text-accent mb-2">Public dossier text changed</p>
+              <p className="text-2xl font-bold text-foreground">{populationReconcileResult?.publicDossierTextChanged ?? 0}</p>
+            </div>
+            <div className="border border-border/70 bg-background/30 p-3">
+              <p className="uppercase tracking-[0.25em] text-accent mb-2">Internal aliases exposed</p>
+              <p className="text-2xl font-bold text-foreground">{populationReconcileResult?.internalAliasesExposed ?? 0}</p>
+            </div>
+            <div className="border border-border/70 bg-background/30 p-3">
+              <p className="uppercase tracking-[0.25em] text-accent mb-2">Evidence refs merged</p>
+              <p className="text-2xl font-bold text-foreground">{populationReconcileResult?.evidenceRefsMerged ?? 0}</p>
+            </div>
+          </div>
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between text-xs uppercase tracking-widest text-muted">
-            <p>Source of recommendation: BNL Population Scan · Last updated / generatedAt: {formatDate(populationLastUpdated)}</p>
-            <label className="space-y-2 md:min-w-72">
-              <span>Search subject, normalized key, dossier, or Source File</span>
-              <input value={populationSearch} onChange={(event) => setPopulationSearch(event.target.value)} className={textInputClass()} />
-            </label>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {populationQueueFilters.map((filter) => (
-              <button key={filter.id} type="button" onClick={() => setPopulationFilter(filter.id)} className={`border px-3 py-1.5 text-xs uppercase tracking-widest ${populationFilter === filter.id ? "border-accent text-accent" : "border-border text-muted hover:border-accent hover:text-accent"}`}>
-                {filter.label}
+            <p>Source of recommendation: BNL Signal Reconcile · Last updated / generatedAt: {formatDate(populationLastUpdated)}</p>
+            <div className="flex flex-col gap-3 md:flex-row md:items-end">
+              <label className="space-y-2 md:min-w-72">
+                <span>Search unresolved signal, dossier, candidate, or Source File</span>
+                <input value={populationSearch} onChange={(event) => setPopulationSearch(event.target.value)} className={textInputClass()} />
+              </label>
+              <button type="button" disabled={saving} onClick={() => void reconcilePopulationSignals()} className="border border-accent px-4 py-2.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50">
+                Reconcile BNL Signals
               </button>
-            ))}
+            </div>
           </div>
-          <p className="text-sm text-muted">This queue only changes private workflow records. It does not publish public pages, does not edit public dossier text, does not auto-approve recommendations, and keeps raw/private evidence plus internal aliases out of public display.</p>
+          <p className="text-sm text-muted">This internal reconcile action only changes private workflow state. It publishes 0 public pages, changes 0 public dossier text, exposes 0 internal aliases, and preserves raw evidence references internally without displaying private evidence.</p>
 
           <div className="space-y-5">
             {populationQueueGroups.map((group) => (
@@ -1759,10 +1755,10 @@ export default function DossierControlCenterPage() {
                     <h3 className="text-lg font-bold text-foreground">{group.title}</h3>
                     <p className="text-sm text-muted">{group.description}</p>
                   </div>
-                  <StatusPill>{group.items.length} recommendation{group.items.length === 1 ? "" : "s"}</StatusPill>
+                  <StatusPill>{group.items.length} signal{group.items.length === 1 ? "" : "s"}</StatusPill>
                 </div>
                 {group.items.length === 0 ? (
-                  <p className="text-sm text-muted">No matching population recommendations in this lane.</p>
+                  <p className="text-sm text-muted">No action needed. Filed automatically.</p>
                 ) : (
                   <div className="grid gap-3 lg:grid-cols-2">
                     {group.items.map((recommendation) => {
@@ -1774,7 +1770,7 @@ export default function DossierControlCenterPage() {
                           <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                             <div>
                               <h4 className="text-xl font-bold text-foreground">{recommendation.subjectName}</h4>
-                              <p>BNL thinks: {recommendation.recommendedNextStep ?? recommendation.recommendedAction ?? recommendation.suggestedAction ?? "Needs admin review"}</p>
+                              <p>{recommendation.recommendedNextStep ?? recommendation.routingReason ?? "Needs one admin decision because no deterministic destination was found."}</p>
                             </div>
                             <div className="flex flex-wrap gap-2">
                               <StatusPill>{recommendation.confidence ?? "confidence unset"}</StatusPill>
@@ -1784,36 +1780,15 @@ export default function DossierControlCenterPage() {
                           <p><span className="text-foreground">Destination:</span> {populationDestinationLabel(recommendation, candidates)}</p>
                           <p><span className="text-foreground">Why:</span> {recommendation.adminSummary ?? recommendation.evidenceSummary ?? recommendation.reason}</p>
                           {recommendation.missingInfo?.length ? <p><span className="text-foreground">Missing info:</span> {recommendation.missingInfo.join("; ")}</p> : null}
-                          {recommendation.publicSafetyNotes?.length || recommendation.doNotPublishReason ? <p><span className="text-foreground">Public safety notes:</span> {[recommendation.doNotPublishReason, ...(recommendation.publicSafetyNotes ?? [])].filter(Boolean).join("; ")}</p> : null}
-                          {recommendation.possibleTargets?.length ? <p><span className="text-foreground">Possible targets:</span> {recommendation.possibleTargets.map((target) => target.name ?? target.id).filter(Boolean).join(", ")}</p> : null}
-                          <p><span className="text-foreground">Risk:</span> duplicate {recommendation.duplicateRisk ?? "unset"} · identity {recommendation.identityRisk ?? "unset"} · internal evidence refs {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}</p>
-                          <details className="border border-border/70 bg-background/30 p-3">
-                            <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Internal refs</summary>
-                            <p className="mt-2 text-xs text-muted">Raw evidence references are preserved internally but hidden from normal card copy. Count: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}.</p>
-                          </details>
-                          {(recommendation.seenCount ?? 1) > 1 || (recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0) > 0 ? (
-                            <p><span className="text-foreground">Repeated signal:</span> Seen {recommendation.seenCount ?? 1} time{(recommendation.seenCount ?? 1) === 1 ? "" : "s"} · Evidence refs: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}</p>
-                          ) : null}
+                          <p><span className="text-foreground">Evidence refs:</span> {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} private refs preserved internally; raw/private evidence is not shown.</p>
                           <p><span className="text-foreground">What to click next:</span> {primaryActions.map((action) => action.label).join(" or ")}</p>
                           <div className="flex flex-wrap gap-2" data-primary-population-actions={primaryActions.length}>
-                            {primaryActions.map((action) => action.kind === "link" ? (
-                              <Link key={`${recommendation.id}-${action.label}`} href={action.href} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">{action.label}</Link>
+                            {primaryActions.slice(0, 2).map((action) => action.kind === "link" ? (
+                              <Link key={`${recommendation.id}-${action.label}`} href={action.href} className="border border-accent px-3 py-1.5 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background">{action.label}</Link>
                             ) : (
                               <PopulationActionButton key={`${recommendation.id}-${action.key}`} disabled={saving} onClick={() => populationRecommendationAction(recommendation, action.key)}>{action.label}</PopulationActionButton>
                             ))}
                           </div>
-                          <details className="border border-border/70 bg-background/30 p-3">
-                            <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Advanced actions</summary>
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_source_file_candidate")}>Convert to Source File Candidate</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "attach_to_existing_source_file")}>Attach to Existing Source File</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "create_dossier_update_workspace")}>Create Dossier Update Workspace</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_not_population_subject")}>Mark Not a Dossier Subject</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_no_new_info")}>Mark No-New-Info</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "dismiss_population_recommendation")}>Dismiss</PopulationActionButton>
-                              <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "reopen_population_recommendation")}>Reopen</PopulationActionButton>
-                            </div>
-                          </details>
                         </article>
                       );
                     })}
@@ -1822,27 +1797,37 @@ export default function DossierControlCenterPage() {
               </section>
             ))}
             <details className="border border-border/70 bg-background/20 p-4">
-              <summary className="cursor-pointer text-lg font-bold text-foreground">Non-dossier signals ({nonDossierPopulationSignals.length})</summary>
-              <p className="mt-2 text-sm text-muted">Show-state notes, broadcast memory notes, and not-population-subject items stay out of the main dossier work queue.</p>
+              <summary className="cursor-pointer text-lg font-bold text-foreground">Filed / Already Represented ({filedPopulationSignals.length})</summary>
+              <p className="mt-2 text-sm text-muted">Audit view for signals already attached, merged, marked no-new-info, or represented elsewhere. These do not clutter the default work queue.</p>
               <div className="mt-3 grid gap-3 lg:grid-cols-2">
-                {nonDossierPopulationSignals.map((recommendation) => (
-                  <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
+                {filedPopulationSignals.map((recommendation) => (
+                  <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-2">
                     <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
-                    <p>{recommendation.adminSummary ?? recommendation.recommendedNextStep ?? recommendation.reason}</p>
-                    <p>Internal refs: {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} preserved; raw/private content hidden.</p>
-                    <p><span className="text-foreground">What to click next:</span> Mark not dossier subject or Dismiss</p>
-                    <div className="flex flex-wrap gap-2" data-primary-population-actions="2">
-                      <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_not_population_subject")}>Mark not dossier subject</PopulationActionButton>
-                      <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "dismiss_population_recommendation")}>Dismiss</PopulationActionButton>
-                    </div>
-                    <details className="border border-border/70 bg-background/30 p-3">
-                      <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">Advanced actions</summary>
-                      <p className="mt-2 text-xs text-muted">Broadcast/show-state handling stays internal; this card does not expose raw/private evidence.</p>
-                    </details>
+                    <p>{populationDestinationLabel(recommendation, candidates)}</p>
+                    <p>No action needed. Filed automatically.</p>
                   </article>
                 ))}
               </div>
             </details>
+            {nonDossierPopulationSignals.length > 0 ? (
+              <details className="border border-border/70 bg-background/20 p-4">
+                <summary className="cursor-pointer text-lg font-bold text-foreground">Non-dossier Signals ({nonDossierPopulationSignals.length})</summary>
+                <p className="mt-2 text-sm text-muted">Show-state notes, broadcast memory notes, and not-population-subject items stay out of the main dossier work queue.</p>
+                <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                  {nonDossierPopulationSignals.map((recommendation) => (
+                    <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
+                      <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
+                      <p>{recommendation.adminSummary ?? recommendation.recommendedNextStep ?? recommendation.reason}</p>
+                      <p>Private evidence refs preserved internally; raw/private content hidden.</p>
+                      <div className="flex flex-wrap gap-2" data-primary-population-actions="2">
+                        <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "mark_not_population_subject")}>Mark not dossier subject</PopulationActionButton>
+                        <PopulationActionButton disabled={saving} onClick={() => populationRecommendationAction(recommendation, "dismiss_population_recommendation")}>Dismiss</PopulationActionButton>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </details>
+            ) : null}
           </div>
         </DashboardCard>
 

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -30,6 +30,7 @@ import {
 import {
   addDossierIdentityLink,
   applyPopulationReviewRecommendationAction,
+  reconcilePopulationSignals,
   addDossierSourceFileNote,
   updateDossierSourceFileSummary,
   archiveDossierCandidate,
@@ -150,6 +151,7 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "attachCandidateToExistingDossier",
   "markCandidateAsExistingDossierUpdate",
   "runSubjectConsolidation",
+  "reconcile_population_signals",
   "consolidateSubjectGroup",
   "attach_to_existing_source_file",
   "attach_to_existing_dossier_update",
@@ -674,6 +676,17 @@ export async function POST(req: Request) {
         ok: true,
         action,
         consolidation,
+        ...payload,
+      });
+    }
+
+    if (action === "reconcile_population_signals") {
+      const populationReconcile = await reconcilePopulationSignals({ actionBy: typeof body.actionBy === "string" ? body.actionBy : "admin" });
+      const payload = await workflowPayload();
+      return NextResponse.json({
+        ok: true,
+        action,
+        populationReconcile,
         ...payload,
       });
     }

--- a/src/app/api/bnl/population-context/route.ts
+++ b/src/app/api/bnl/population-context/route.ts
@@ -7,6 +7,7 @@ import {
   isResolvedDossierRecommendation,
   normalizeDossierSubjectName,
   type DossierCandidate,
+  type DossierDraft,
   type DossierIdentityLink,
   type DossierRecommendation,
   type DossierSourceFileRefreshRequest,
@@ -23,6 +24,7 @@ type RouteLane =
   | "source_file"
   | "candidate_intake"
   | "dossier_update_workspace"
+  | "dossier_draft"
   | "candidate_recommendation"
   | "resolved_record";
 
@@ -301,6 +303,39 @@ function resolvedRecommendationItem(
   };
 }
 
+
+function draftDestinationItem(draft: DossierDraft, candidatesById: Map<string, DossierCandidate>) {
+  const candidate = candidatesById.get(draft.candidateId);
+  const subjectName = draft.fields?.name ?? candidate?.name ?? draft.candidateId;
+  return {
+    draftId: draft.id,
+    candidateId: draft.candidateId,
+    subjectName,
+    normalizedSubjectKey: normalizeDossierSubjectName(subjectName),
+    status: draft.status,
+    route: { path: `/admin/dossiers/drafts/${encodeURIComponent(draft.id)}`, lane: "dossier_draft" as const },
+    candidateRoute: candidate ? adminRoute(candidate.id, "dossier_draft") : null,
+  };
+}
+
+function existingPopulationRecommendationMapping(recommendation: DossierRecommendation) {
+  const subjectName = recommendation.subjectName.trim();
+  const normalizedSubjectKey = recommendation.subjectKey?.trim() || normalizeDossierSubjectName(subjectName);
+  return {
+    recommendationId: recommendation.id,
+    subjectName,
+    normalizedSubjectKey,
+    status: recommendation.status,
+    recommendedLane: recommendation.recommendedLane ?? null,
+    recommendedAction: recommendation.recommendedAction ?? null,
+    targetCandidateId: recommendation.targetCandidateId ?? recommendation.connectedCandidateId ?? null,
+    targetDossierId: recommendation.targetDossierId ?? recommendation.matchedPublicDossierId ?? null,
+    seenCount: recommendation.seenCount ?? 1,
+    rawEvidenceRefCount: recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0,
+    route: recommendationRoute(recommendation.id),
+  };
+}
+
 function pendingCandidateRecommendationDestination(
   recommendation: DossierRecommendation,
 ) {
@@ -424,6 +459,12 @@ export async function GET(req: Request) {
     .map((candidate) =>
       dossierUpdateWorkspaceItem(candidate, state.sourceFileRefreshRequests),
     );
+  const draftDestinations = state.drafts
+    .filter((draft) => !["denied", "superseded", "published"].includes(draft.status))
+    .map((draft) => draftDestinationItem(draft, candidatesById));
+  const existingPopulationRecommendations = state.recommendations
+    .filter((recommendation) => recommendation.populationRecommendation || recommendation.type === "population_recommendation")
+    .map(existingPopulationRecommendationMapping);
   const resolvedCandidateIds = new Set(
     state.candidates
       .filter(
@@ -478,16 +519,23 @@ export async function GET(req: Request) {
       sourceFiles,
       candidates,
       dossierUpdateWorkspaces,
+      draftDestinations,
+      recommendationBackedIntakeRecords: pendingRecommendationCandidates.map(pendingCandidateRecommendationDestination),
+      existingPopulationRecommendations,
       identityLinks,
       resolvedRecords,
       diagnostics: {
         publicDossierCount: publicDossiers.length,
+        draftDestinationCount: draftDestinations.length,
         sourceFileCount: sourceFiles.length,
         candidateCount: trueCandidateIntakeRecords.length,
         candidateDestinationCount: candidates.length,
+        recommendationBackedIntakeCount:
+          pendingRecommendationCandidateRecords.length,
         pendingRecommendationCandidateCount:
           pendingRecommendationCandidateRecords.length,
         dossierUpdateWorkspaceCount: dossierUpdateWorkspaces.length,
+        existingPopulationRecommendationCount: existingPopulationRecommendations.length,
         identityLinkCount: identityLinks.length,
         resolvedRecordCount: resolvedRecords.length,
       },

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -1005,6 +1005,8 @@ const TERMINAL_RECOMMENDATION_STATUSES = new Set<DossierRecommendationStatus>([
   "identity_link_created",
   "ignored",
   "dismissed",
+  "no_new_info",
+  "not_population_subject",
   "archived",
 ]);
 
@@ -4548,6 +4550,598 @@ async function setRecommendationStatus(
   });
   return updatedRecommendation!;
 }
+
+export type PopulationSignalDestinationKind =
+  | "public_dossier"
+  | "dossier_draft"
+  | "dossier_update_workspace"
+  | "active_source_file"
+  | "candidate_intake"
+  | "recommendation_backed_intake"
+  | "existing_population_recommendation"
+  | "resolved_or_archived_record"
+  | "non_dossier_signal"
+  | "no_destination"
+  | "ambiguous";
+
+export type PopulationSignalDestination = {
+  destinationKind: PopulationSignalDestinationKind;
+  destinationId?: string;
+  destinationName?: string;
+  destinationHref?: string;
+  recommendedInternalAction:
+    | DossierPopulationRecommendedAction
+    | "attach_to_draft_context"
+    | "mark_already_represented"
+    | "merge_population_duplicate";
+  shouldAutoResolve: boolean;
+  shouldShowToAdmin: boolean;
+  reason: string;
+};
+
+export type PopulationReconcileSummary = {
+  signalsReviewed: number;
+  attachedToSourceFiles: number;
+  attachedToDossierUpdates: number;
+  attachedToCandidateIntake: number;
+  attachedToExistingRecommendations: number;
+  markedAlreadyRepresented: number;
+  markedNoNewInfo: number;
+  createdDossierUpdateWorkspaces: number;
+  createdSourceFileCandidates: number;
+  unresolvedNeedsReview: number;
+  duplicatesCollapsed: number;
+  evidenceRefsMerged: number;
+  publicPagesPublished: 0;
+  publicDossierTextChanged: 0;
+  internalAliasesExposed: 0;
+};
+
+type PopulationSignalResolverInput = {
+  recommendation: DossierRecommendation;
+  candidates: DossierCandidate[];
+  recommendations: DossierRecommendation[];
+  drafts: DossierDraft[];
+  publicDossiers?: Array<{ id: string; name: string }>;
+};
+
+function isPopulationSignal(recommendation: DossierRecommendation): boolean {
+  return (
+    recommendation.type === "population_recommendation" ||
+    recommendation.populationRecommendation === true ||
+    recommendation.ingestSource === "bnl_population_recommender" ||
+    recommendation.createdBy === "bnl_population_recommender"
+  );
+}
+
+function populationSignalSubjectKey(recommendation: DossierRecommendation): string {
+  return recommendationDedupeSubject(
+    recommendation.subjectKey || recommendation.subjectName,
+  );
+}
+
+function populationSignalSubjectKeys(recommendation: DossierRecommendation): string[] {
+  return uniqueStrings([
+    populationSignalSubjectKey(recommendation),
+    recommendationDedupeSubject(
+      (recommendation.subjectKey || recommendation.subjectName).replace(/\[[^\]]+\]/g, " "),
+    ),
+  ]);
+}
+
+function candidateHref(candidateId: string): string {
+  return `/admin/dossiers/candidates/${encodeURIComponent(candidateId)}`;
+}
+
+function recommendationHref(recommendationId: string): string {
+  return `/admin/dossiers/recommendations/${encodeURIComponent(recommendationId)}`;
+}
+
+function publicDossierHref(name: string): string {
+  return `/database/${name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+}
+
+function candidateMatchesSubject(candidate: DossierCandidate, subjectKey: string): boolean {
+  if (!subjectKey) return false;
+  if (recommendationDedupeSubject(candidate.name) === subjectKey) return true;
+  return (candidate.identityLinks ?? []).some(
+    (link) =>
+      link.useForMatching &&
+      recommendationDedupeSubject(link.label || link.normalizedLabel) === subjectKey,
+  );
+}
+
+function publicDossierForPopulationSubject(
+  recommendation: DossierRecommendation,
+  publicDossiers: Array<{ id: string; name: string }>,
+) {
+  const subjectKeys = populationSignalSubjectKeys(recommendation);
+  return publicDossiers.find(
+    (entry) =>
+      entry.id === recommendation.matchedPublicDossierId ||
+      entry.id === recommendation.targetDossierId ||
+      subjectKeys.includes(recommendationDedupeSubject(entry.name)),
+  );
+}
+
+function isDraftActiveForPopulation(draft: DossierDraft): boolean {
+  return !["denied", "superseded", "published"].includes(draft.status);
+}
+
+function draftDestinationForPopulationSubject(
+  drafts: DossierDraft[],
+  candidates: DossierCandidate[],
+  recommendation: DossierRecommendation,
+): { draft: DossierDraft; candidate?: DossierCandidate } | undefined {
+  const subjectKey = populationSignalSubjectKey(recommendation);
+  return drafts
+    .filter(isDraftActiveForPopulation)
+    .map((draft) => ({
+      draft,
+      candidate: candidates.find((candidate) => candidate.id === draft.candidateId),
+    }))
+    .find(({ draft, candidate }) => {
+      const draftName = draft.fields?.name ?? candidate?.name ?? "";
+      return (
+        recommendationDedupeSubject(draftName) === subjectKey ||
+        Boolean(candidate && candidateMatchesSubject(candidate, subjectKey))
+      );
+    });
+}
+
+function resolvedRecordForPopulationSubject(
+  candidates: DossierCandidate[],
+  recommendations: DossierRecommendation[],
+  recommendation: DossierRecommendation,
+): DossierCandidate | DossierRecommendation | undefined {
+  const subjectKey = populationSignalSubjectKey(recommendation);
+  return (
+    candidates.find(
+      (candidate) =>
+        ["archived", "denied", "merged"].includes(candidate.status) &&
+        candidateMatchesSubject(candidate, subjectKey),
+    ) ??
+    recommendations.find(
+      (item) =>
+        item.id !== recommendation.id &&
+        isPopulationSignal(item) &&
+        ["dismissed", "no_new_info", "not_population_subject", "archived"].includes(item.status) &&
+        populationSignalSubjectKey(item) === subjectKey,
+    )
+  );
+}
+
+function nonDossierPopulationSignal(recommendation: DossierRecommendation): boolean {
+  return ["show_state_note", "broadcast_memory_note", "not_population_subject"].includes(
+    recommendation.recommendedAction ?? recommendation.recommendedLane ?? "",
+  );
+}
+
+export function resolvePopulationSignalDestination({
+  recommendation,
+  candidates,
+  recommendations,
+  drafts,
+  publicDossiers = databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })),
+}: PopulationSignalResolverInput): PopulationSignalDestination {
+  const publicDossier = publicDossierForPopulationSubject(recommendation, publicDossiers);
+  if (publicDossier) {
+    const updateWorkspace = candidates.find(
+      (candidate) =>
+        candidate.status === "existing_dossier_update" &&
+        candidate.existingDossierMatch?.id === publicDossier.id,
+    );
+    if (updateWorkspace) {
+      return {
+        destinationKind: "dossier_update_workspace",
+        destinationId: updateWorkspace.id,
+        destinationName: updateWorkspace.name,
+        destinationHref: candidateHref(updateWorkspace.id),
+        recommendedInternalAction: "attach_to_existing_dossier_update",
+        shouldAutoResolve: true,
+        shouldShowToAdmin: false,
+        reason: "Existing public dossier also has an internal Dossier Update workspace.",
+      };
+    }
+    return {
+      destinationKind: "public_dossier",
+      destinationId: publicDossier.id,
+      destinationName: publicDossier.name,
+      destinationHref: publicDossierHref(publicDossier.name),
+      recommendedInternalAction: "mark_no_new_info",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "Subject already has a public dossier; no Source File Candidate should be created by default.",
+    };
+  }
+
+  const draftDestination = draftDestinationForPopulationSubject(drafts, candidates, recommendation);
+  if (draftDestination) {
+    const id = draftDestination.candidate?.id ?? draftDestination.draft.candidateId;
+    return {
+      destinationKind: "dossier_draft",
+      destinationId: draftDestination.draft.id,
+      destinationName: draftDestination.draft.fields?.name ?? draftDestination.candidate?.name,
+      destinationHref: id ? candidateHref(id) : undefined,
+      recommendedInternalAction: "attach_to_draft_context",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "Subject already has an internal dossier draft; do not create a second candidate.",
+    };
+  }
+
+  const subjectKey = populationSignalSubjectKey(recommendation);
+  const candidateDestination = candidates.find(
+    (candidate) =>
+      !["archived", "denied", "merged"].includes(candidate.status) &&
+      candidateMatchesSubject(candidate, subjectKey),
+  );
+  if (candidateDestination) {
+    const recommendationBacked = isRecommendationBackedCandidate(candidateDestination);
+    if (candidateDestination.status === "existing_dossier_update") {
+      return {
+        destinationKind: "dossier_update_workspace",
+        destinationId: candidateDestination.id,
+        destinationName: candidateDestination.name,
+        destinationHref: candidateHref(candidateDestination.id),
+        recommendedInternalAction: "attach_to_existing_dossier_update",
+        shouldAutoResolve: true,
+        shouldShowToAdmin: false,
+        reason: "Subject already has a Dossier Update workspace.",
+      };
+    }
+    if (isActiveSourceFileCandidate(candidateDestination)) {
+      return {
+        destinationKind: "active_source_file",
+        destinationId: candidateDestination.id,
+        destinationName: candidateDestination.name,
+        destinationHref: candidateHref(candidateDestination.id),
+        recommendedInternalAction: "attach_to_existing_source_file",
+        shouldAutoResolve: true,
+        shouldShowToAdmin: false,
+        reason: "Subject already has an active Source File.",
+      };
+    }
+    return {
+      destinationKind: recommendationBacked ? "recommendation_backed_intake" : "candidate_intake",
+      destinationId: candidateDestination.id,
+      destinationName: candidateDestination.name,
+      destinationHref: candidateHref(candidateDestination.id),
+      recommendedInternalAction: recommendationBacked ? "mark_duplicate_no_new_info" : "create_source_file_candidate",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: recommendationBacked
+        ? "Subject is already represented by recommendation-backed intake."
+        : "Subject already has a Candidate Intake record.",
+    };
+  }
+
+  const activeNonPopulation = activeNonPopulationRecommendationForSubject(recommendations, recommendation);
+  if (activeNonPopulation) {
+    return {
+      destinationKind: "recommendation_backed_intake",
+      destinationId: activeNonPopulation.id,
+      destinationName: activeNonPopulation.subjectName,
+      destinationHref: recommendationHref(activeNonPopulation.id),
+      recommendedInternalAction: "mark_duplicate_no_new_info",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "Subject is already represented by an active non-population recommendation.",
+    };
+  }
+
+  const activePopulation = recommendations.find(
+    (item) =>
+      item.id !== recommendation.id &&
+      isPopulationSignal(item) &&
+      isActiveRecommendation(item) &&
+      populationSignalSubjectKey(item) === subjectKey,
+  );
+  if (activePopulation) {
+    return {
+      destinationKind: "existing_population_recommendation",
+      destinationId: activePopulation.id,
+      destinationName: activePopulation.subjectName,
+      destinationHref: recommendationHref(activePopulation.id),
+      recommendedInternalAction: "merge_population_duplicate",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "An active population recommendation for this subject already exists.",
+    };
+  }
+
+  const resolvedRecord = resolvedRecordForPopulationSubject(candidates, recommendations, recommendation);
+  if (resolvedRecord) {
+    return {
+      destinationKind: "resolved_or_archived_record",
+      destinationId: resolvedRecord.id,
+      destinationName: "name" in resolvedRecord ? resolvedRecord.name : resolvedRecord.subjectName,
+      destinationHref: "subjectName" in resolvedRecord ? recommendationHref(resolvedRecord.id) : candidateHref(resolvedRecord.id),
+      recommendedInternalAction: "mark_no_new_info",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "Subject matches a resolved, archived, merged, or no-new-info workflow record.",
+    };
+  }
+
+  if (nonDossierPopulationSignal(recommendation)) {
+    return {
+      destinationKind: "non_dossier_signal",
+      recommendedInternalAction: "mark_not_population_subject",
+      shouldAutoResolve: true,
+      shouldShowToAdmin: false,
+      reason: "Signal is a show-state or broadcast note, not a dossier subject.",
+    };
+  }
+
+  const ambiguous = (recommendation.possibleTargets ?? []).length > 1;
+  return {
+    destinationKind: ambiguous ? "ambiguous" : "no_destination",
+    destinationHref: recommendationHref(recommendation.id),
+    recommendedInternalAction: "admin_review_required",
+    shouldAutoResolve: false,
+    shouldShowToAdmin: true,
+    reason: ambiguous
+      ? "Multiple plausible destinations remain; admin review is required."
+      : "No existing internal destination was found; admin review is required.",
+  };
+}
+
+function initialPopulationReconcileSummary(): PopulationReconcileSummary {
+  return {
+    signalsReviewed: 0,
+    attachedToSourceFiles: 0,
+    attachedToDossierUpdates: 0,
+    attachedToCandidateIntake: 0,
+    attachedToExistingRecommendations: 0,
+    markedAlreadyRepresented: 0,
+    markedNoNewInfo: 0,
+    createdDossierUpdateWorkspaces: 0,
+    createdSourceFileCandidates: 0,
+    unresolvedNeedsReview: 0,
+    duplicatesCollapsed: 0,
+    evidenceRefsMerged: 0,
+    publicPagesPublished: 0,
+    publicDossierTextChanged: 0,
+    internalAliasesExposed: 0,
+  };
+}
+
+function populationDuplicateIdentity(
+  recommendation: DossierRecommendation,
+  destination: PopulationSignalDestination,
+): string {
+  return [
+    populationSignalSubjectKey(recommendation),
+    destination.destinationKind,
+    destination.recommendedInternalAction,
+    destination.destinationId ?? "",
+  ].join("|");
+}
+
+function mergePopulationRecommendationEvidence(
+  target: DossierRecommendation,
+  duplicate: DossierRecommendation,
+  now: string,
+): DossierRecommendation {
+  const refs = uniqueStrings(target.rawEvidenceRefs, duplicate.rawEvidenceRefs);
+  return {
+    ...target,
+    rawEvidenceRefs: refs,
+    rawEvidenceRefCount: refs.length,
+    seenCount: (target.seenCount ?? 1) + (duplicate.seenCount ?? 1),
+    firstSeenAt: target.firstSeenAt ?? target.createdAt,
+    lastSeenAt: now,
+    updatedAt: now,
+  };
+}
+
+function populationAttachedNoteText(recommendation: DossierRecommendation, destination: PopulationSignalDestination): string {
+  return [
+    `BNL Signal Reconcile filed this population signal into ${destination.destinationKind}.`,
+    recommendation.adminSummary ? `Admin summary: ${recommendation.adminSummary}` : undefined,
+    recommendation.evidenceSummary ? `Evidence summary: ${recommendation.evidenceSummary}` : undefined,
+    `Internal evidence refs preserved: ${recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0}.`,
+    "No public dossier text was changed and no public page was published by this reconcile action.",
+  ].filter(Boolean).join("\n\n").slice(0, 4000);
+}
+
+export async function reconcilePopulationSignals(input: { actionBy?: string } = {}): Promise<PopulationReconcileSummary> {
+  const summary = initialPopulationReconcileSummary();
+  const now = new Date().toISOString();
+
+  await updateDossierWorkflowState((currentState) => {
+    let candidates = currentState.candidates;
+    let recommendations = currentState.recommendations;
+    const visibleByIdentity = new Map<string, DossierRecommendation>();
+
+    for (const recommendation of currentState.recommendations) {
+      if (!isPopulationSignal(recommendation)) continue;
+      summary.signalsReviewed += 1;
+      if (!isActiveRecommendation(recommendation)) continue;
+
+      const destination = resolvePopulationSignalDestination({
+        recommendation,
+        candidates,
+        recommendations,
+        drafts: currentState.drafts,
+      });
+      const duplicateKey = populationDuplicateIdentity(recommendation, destination);
+      const visibleExisting = visibleByIdentity.get(duplicateKey);
+      if (visibleExisting) {
+        const merged = mergePopulationRecommendationEvidence(visibleExisting, recommendation, now);
+        recommendations = recommendations.map((item) => {
+          if (item.id === visibleExisting.id) return merged;
+          if (item.id === recommendation.id) {
+            return {
+              ...item,
+              status: "no_new_info",
+              recommendedLane: "already_represented",
+              recommendedAction: "mark_no_new_info",
+              routingReason: `Duplicate collapsed into population signal ${visibleExisting.id}.`,
+              updatedAt: now,
+            };
+          }
+          return item;
+        });
+        visibleByIdentity.set(duplicateKey, merged);
+        summary.duplicatesCollapsed += 1;
+        summary.evidenceRefsMerged += 1;
+        continue;
+      }
+      visibleByIdentity.set(duplicateKey, recommendation);
+
+      let targetCandidate = destination.destinationId
+        ? candidates.find((candidate) => candidate.id === destination.destinationId)
+        : undefined;
+      let nextRecommendation: DossierRecommendation = recommendation;
+      let nextStatus: DossierRecommendationStatus | undefined;
+      let nextLane: DossierPopulationRecommendedLane | undefined;
+      let nextAction: DossierPopulationRecommendedAction | undefined;
+
+      if (!destination.shouldAutoResolve) {
+        nextLane = "needs_population_review";
+        nextAction = "admin_review_required";
+        summary.unresolvedNeedsReview += 1;
+      } else if (destination.destinationKind === "active_source_file" && targetCandidate) {
+        nextStatus = "attached_to_source_file";
+        nextLane = "active_source_file";
+        nextAction = "attach_to_existing_source_file";
+        summary.attachedToSourceFiles += 1;
+      } else if (destination.destinationKind === "dossier_update_workspace" && targetCandidate) {
+        nextStatus = "attached_to_existing_dossier_update";
+        nextLane = "existing_dossier_update";
+        nextAction = "attach_to_existing_dossier_update";
+        summary.attachedToDossierUpdates += 1;
+      } else if (destination.destinationKind === "candidate_intake" && targetCandidate) {
+        nextStatus = "attached_to_candidate_intake";
+        nextLane = "candidate_intake";
+        nextAction = "create_source_file_candidate";
+        summary.attachedToCandidateIntake += 1;
+      } else if (destination.destinationKind === "dossier_draft") {
+        nextStatus = "attached_to_candidate_intake";
+        nextLane = "candidate_intake";
+        nextAction = "mark_no_new_info";
+        summary.attachedToCandidateIntake += 1;
+        if (!targetCandidate && recommendation.targetCandidateId) {
+          targetCandidate = candidates.find((candidate) => candidate.id === recommendation.targetCandidateId);
+        }
+      } else if (destination.destinationKind === "recommendation_backed_intake") {
+        nextStatus = "no_new_info";
+        nextLane = "already_represented";
+        nextAction = "mark_duplicate_no_new_info";
+        summary.attachedToExistingRecommendations += 1;
+        summary.markedAlreadyRepresented += 1;
+      } else if (destination.destinationKind === "existing_population_recommendation" && destination.destinationId) {
+        const target = recommendations.find((item) => item.id === destination.destinationId);
+        if (target) {
+          const merged = mergePopulationRecommendationEvidence(target, recommendation, now);
+          recommendations = recommendations.map((item) => item.id === target.id ? merged : item);
+          summary.evidenceRefsMerged += 1;
+        }
+        nextStatus = "no_new_info";
+        nextLane = "already_represented";
+        nextAction = "mark_no_new_info";
+        summary.attachedToExistingRecommendations += 1;
+        summary.duplicatesCollapsed += 1;
+      } else if (destination.destinationKind === "public_dossier" || destination.destinationKind === "resolved_or_archived_record") {
+        nextStatus = "no_new_info";
+        nextLane = "already_represented";
+        nextAction = "mark_no_new_info";
+        summary.markedAlreadyRepresented += 1;
+        summary.markedNoNewInfo += 1;
+      } else if (destination.destinationKind === "non_dossier_signal") {
+        nextStatus = "not_population_subject";
+        nextLane = "not_population_subject";
+        nextAction = "mark_not_population_subject";
+      }
+
+      nextRecommendation = {
+        ...recommendation,
+        status: nextStatus ?? recommendation.status,
+        recommendedLane: nextLane ?? recommendation.recommendedLane,
+        recommendedAction: nextAction ?? recommendation.recommendedAction,
+        targetCandidateId: targetCandidate?.id ?? recommendation.targetCandidateId,
+        connectedCandidateId: targetCandidate?.id ?? recommendation.connectedCandidateId,
+        connectedSourceFileCandidateId: targetCandidate?.id ?? recommendation.connectedSourceFileCandidateId,
+        targetDossierId: destination.destinationKind === "public_dossier" ? destination.destinationId : recommendation.targetDossierId,
+        matchedPublicDossierId: destination.destinationKind === "public_dossier" ? destination.destinationId : recommendation.matchedPublicDossierId,
+        matchedPublicDossierName: destination.destinationKind === "public_dossier" ? destination.destinationName : recommendation.matchedPublicDossierName,
+        matchedExistingCandidateId: destination.destinationKind === "active_source_file" ? destination.destinationId : recommendation.matchedExistingCandidateId,
+        matchedDossierUpdateCandidateId: destination.destinationKind === "dossier_update_workspace" ? destination.destinationId : recommendation.matchedDossierUpdateCandidateId,
+        routingReason: destination.reason,
+        populationReviewActions: destination.shouldAutoResolve
+          ? [
+              ...(recommendation.populationReviewActions ?? []),
+              {
+                action: nextAction ?? "mark_no_new_info",
+                actionAt: now,
+                actionBy: input.actionBy,
+                actionReason: `BNL Signal Reconcile: ${destination.reason}`,
+                targetCandidateId: targetCandidate?.id,
+                targetDossierId: destination.destinationKind === "public_dossier" ? destination.destinationId : recommendation.targetDossierId,
+              },
+            ]
+          : recommendation.populationReviewActions,
+        lastSeenAt: now,
+        seenCount: recommendation.seenCount ?? 1,
+        rawEvidenceRefCount: recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0,
+        updatedAt: now,
+      };
+
+      recommendations = recommendations.map((item) => item.id === recommendation.id ? nextRecommendation : item);
+
+      if (targetCandidate && ["active_source_file", "dossier_update_workspace", "candidate_intake", "dossier_draft"].includes(destination.destinationKind)) {
+        const note = routingNote({
+          candidateId: targetCandidate.id,
+          now,
+          text: populationAttachedNoteText(recommendation, destination),
+          source: "bnl_recommendation",
+          createdBy: recommendation.createdBy,
+          ingestKey: recommendation.ingestKey,
+          ingestedAt: recommendation.ingestedAt,
+          ingestSource: recommendation.ingestSource,
+        });
+        candidates = candidates.map((candidate) => candidate.id === targetCandidate!.id ? {
+          ...candidate,
+          sourceFileNotes: [note, ...(candidate.sourceFileNotes ?? [])],
+          connectedRecommendationIds: uniqueStrings(candidate.connectedRecommendationIds, [recommendation.id]),
+          sourceRecommendationIds: uniqueStrings(candidate.sourceRecommendationIds, [recommendation.id]),
+          updatedAt: now,
+        } : candidate);
+      }
+    }
+
+    recommendations = recommendations.map((item) => {
+      if (
+        isPopulationSignal(item) &&
+        ["new", "reviewing"].includes(item.status) &&
+        item.recommendedAction === "admin_review_required" &&
+        publicDossierForPopulationSubject(item, databasePage.entries.map((entry) => ({ id: entry.id, name: entry.name })))
+      ) {
+        return {
+          ...item,
+          status: "no_new_info",
+          recommendedLane: "already_represented",
+          recommendedAction: "mark_no_new_info",
+          routingReason: "BNL Signal Reconcile found an existing public dossier during final duplicate cleanup.",
+          updatedAt: now,
+        };
+      }
+      return item;
+    });
+
+    return {
+      ...currentState,
+      candidates,
+      recommendations,
+      updatedAt: now,
+    };
+  });
+
+  return summary;
+}
+
 
 export type PopulationReviewRecommendationActionInput = {
   recommendationId: string;

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -2965,7 +2965,8 @@ export type DossierWorkflowAction =
   | "mark_not_population_subject"
   | "dismiss_population_recommendation"
   | "reopen_population_recommendation"
-  | "mark_needs_more_info";
+  | "mark_needs_more_info"
+  | "reconcile_population_signals";
 
 export type DossierSourceBoundary = {
   source: DossierCandidateSource;
@@ -3026,6 +3027,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "dismiss_population_recommendation",
   "reopen_population_recommendation",
   "mark_needs_more_info",
+  "reconcile_population_signals",
 ];
 
 export const DOSSIER_CANDIDATE_SCORING_POLICY = {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2184,7 +2184,7 @@ test("Population Method Audit renders read-only admin intake map states", () => 
 
   const auditCopy = pageCopy.slice(
     pageCopy.indexOf("Population Method Audit"),
-    pageCopy.indexOf("Population Review Queue", pageCopy.indexOf("Population Method Audit")),
+    pageCopy.indexOf("BNL Signal Reconcile", pageCopy.indexOf("Population Method Audit")),
   );
   assert.doesNotMatch(auditCopy, /fix automatically|Fix Automatically|Run Subject Consolidation|Confirm Consolidation|Consolidate Into|Create Source File|Create Dossier Update|Keep Separate|Select Different Target|merge candidates|Merge button|publish public pages|change public dossier text/i);
 });
@@ -2197,7 +2197,7 @@ test("Population Method Audit renders independently of Subject Consolidation sta
   const consolidationResultIndex = page.indexOf("consolidationResult &&");
   const subjectConditionalCloseIndex = page.indexOf("open={!populationMethodHealthy}", subjectConditionalIndex);
   const populationAuditIndex = page.indexOf("Population Method Audit");
-  const candidatesIndex = page.indexOf("Population Review Queue", populationAuditIndex);
+  const candidatesIndex = page.indexOf("BNL Signal Reconcile", populationAuditIndex);
   const clearBranch = page.slice(subjectConditionalIndex, subjectQueueIndex);
   const fullQueueBranch = page.slice(subjectQueueIndex, subjectConditionalCloseIndex);
 
@@ -9096,32 +9096,28 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   delete process.env.BNL_API_KEY;
 });
 
-test("Population Review Queue renders grouped sections and safe admin actions", () => {
+test("BNL Signal Reconcile renders summary, unresolved cards, and safe admin actions", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
 
   for (const label of [
-    "Population Review Queue",
-    "Source of recommendation: BNL Population Scan",
-    "Attach to Existing Source File",
-    "Dossier Update Workspace",
-    "Create Dossier Update Workspace",
-    "Candidate Intake / New Source File",
-    "Admin Review Required",
-    "Already Represented / Duplicate",
-    "Non-dossier signals",
-    "Attach to Source File",
+    "BNL Signal Reconcile",
+    "Source of recommendation: BNL Signal Reconcile",
+    "Reconcile BNL Signals",
+    "Signals reviewed",
+    "Filed automatically",
+    "Needs Review",
+    "Filed / Already Represented",
+    "Non-dossier Signals",
     "Open Source File",
-    "Attach to Update Workspace",
-    "Open Workspace",
-    "Create Source File Candidate",
-    "Convert to Source File Candidate",
+    "Attach evidence",
+    "Open Candidate",
     "Mark not dossier subject",
     "Mark no-new-info",
-    "Advanced actions",
     "Dismiss",
-    "Raw evidence references are preserved internally but hidden from normal card copy.",
-    "No public dossier text changed and no public page was published.",
+    "No action needed. Filed automatically.",
+    "raw/private evidence is not shown",
+    "publishes 0 public pages, changes 0 public dossier text, exposes 0 internal aliases",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
@@ -9143,10 +9139,10 @@ test("Population Review Queue renders grouped sections and safe admin actions", 
 
   assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Population Review Queue|BNL Population Scan|rawEvidenceRefs|Internal refs/);
   assertIncludesCopy(pageCopy, "Open existing record");
-  assertIncludesCopy(pageCopy, "Review existing candidate/recommendation");
   assertIncludesCopy(pageCopy, "data-primary-population-actions={primaryActions.length}");
-  assert.match(page, /primaryActions\.map/);
-  assert.doesNotMatch(page, /<details[^>]*open[^>]*>\s*<summary[^>]*>Advanced actions/);
+  assert.match(page, /primaryActions\.slice\(0, 2\)\.map/);
+  assert.doesNotMatch(pageCopy, /Advanced actions/);
+  assert.doesNotMatch(page, /mark_needs_more_info[^\n]+Review|Review[^\n]+mark_needs_more_info/);
   assert.doesNotMatch(pageCopy, /raw Discord message|relationship_journal|private relationship journal|internal alias label/i);
 });
 
@@ -9565,15 +9561,15 @@ test("Population Review Queue actions update internal workflow records without p
   assert.equal(JSON.stringify(context).includes("relationship_journal:private-row"), false);
 });
 
-test("Population Review Queue search includes matched candidate names and reviewed need-more-info leaves unreviewed count", () => {
+test("BNL Signal Reconcile search includes matched candidate names and Review stays navigational", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
   assert.match(page, /populationRecommendationSearchText\(recommendation, candidates\)/);
   assert.match(page, /matchedCandidateNames/);
-  assert.match(page, /Already Represented \/ Duplicate/);
+  assert.match(page, /Filed \/ Already Represented/);
   assert.match(page, /candidate\.name/);
   assert.match(page, /return \["new", "reviewing"\]\.includes\(recommendation\.status\)/);
-  assertIncludesCopy(pageCopy, "Search subject, normalized key, dossier, or Source File");
+  assertIncludesCopy(pageCopy, "Search unresolved signal, dossier, candidate, or Source File");
   assertIncludesCopy(pageCopy, "Review");
 });
 
@@ -9791,4 +9787,165 @@ test("Population Review Queue create and attach actions route to existing intern
   const finalState = await store.getDossierWorkflowState();
   assert.equal(finalState.drafts.length, 0);
   assert.equal(finalState.recommendations.find((item) => item.id === "pop-dismiss").status, "dismissed");
+});
+
+test("reconcile_population_signals returns safe counts and files Mind Fanatic public-dossier duplicates", async () => {
+  await resetWorkflowStore();
+  const now = new Date().toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [],
+    drafts: [],
+    recommendations: [
+      {
+        id: "mind-pop-1",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Mind Fanatic [Barcode_Network]",
+        status: "new",
+        reason: "Existing public dossier signal.",
+        adminSummary: "Public-safe summary only.",
+        recommendedLane: "needs_population_review",
+        recommendedAction: "admin_review_required",
+        sourceLanes: ["broadcast_memory"],
+        rawEvidenceRefs: ["private:mind:1"],
+        rawEvidenceRefCount: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "mind-pop-2",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Mind Fanatic [Barcode_Network]",
+        status: "new",
+        reason: "Duplicate existing public dossier signal.",
+        adminSummary: "Second public-safe summary only.",
+        recommendedLane: "needs_population_review",
+        recommendedAction: "admin_review_required",
+        sourceLanes: ["broadcast_memory"],
+        rawEvidenceRefs: ["private:mind:2"],
+        rawEvidenceRefCount: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "unknown-pop-1",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        createdBy: "bnl_population_recommender",
+        ingestSource: "bnl_population_recommender",
+        subjectName: "Unknown Reconcile Subject",
+        status: "new",
+        reason: "No destination exists.",
+        recommendedLane: "needs_population_review",
+        recommendedAction: "admin_review_required",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const response = await authedPost({ action: "reconcile_population_signals" });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.action, "reconcile_population_signals");
+  assert.equal(payload.populationReconcile.signalsReviewed, 3);
+  assert.equal(payload.populationReconcile.publicPagesPublished, 0);
+  assert.equal(payload.populationReconcile.publicDossierTextChanged, 0);
+  assert.equal(payload.populationReconcile.internalAliasesExposed, 0);
+  assert.equal(payload.populationReconcile.createdSourceFileCandidates, 0);
+  assert.equal(payload.populationReconcile.markedNoNewInfo >= 1, true);
+  assert.equal(payload.populationReconcile.duplicatesCollapsed >= 1, true);
+  assert.equal(payload.populationReconcile.unresolvedNeedsReview, 1);
+
+  const state = await store.getDossierWorkflowState();
+  const mindVisible = state.recommendations.filter((item) =>
+    item.subjectName.includes("Mind Fanatic") &&
+    ["new", "reviewing"].includes(item.status) &&
+    item.recommendedAction === "admin_review_required"
+  );
+  assert.equal(mindVisible.length, 0);
+  assert.equal(state.candidates.length, 0);
+});
+
+test("population context exposes reconcile destinations and diagnostics", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_API_KEY = "test-population-context-token";
+  const now = new Date().toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 1,
+    candidates: [
+      {
+        id: "ctx-candidate-intake",
+        name: "Context Intake",
+        candidateType: "artist",
+        source: "manual",
+        tier: "review_candidate",
+        score: 55,
+        whyNow: "Context test.",
+        reason: "Context test.",
+        status: "candidate_intake",
+        createdAt: now,
+        updatedAt: now,
+        sourceFileNotes: [],
+      },
+    ],
+    drafts: [
+      {
+        id: "ctx-draft",
+        candidateId: "ctx-candidate-intake",
+        status: "draft",
+        fields: { id: "CTX", name: "Context Intake", category: "Artist", status: "DRAFT", clearance: "INTERNAL", role: "Draft", origin: "UNKNOWN", summary: "Draft.", notes: "Draft.", tags: [] },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    recommendations: [
+      {
+        id: "ctx-pop",
+        type: "population_recommendation",
+        populationRecommendation: true,
+        subjectName: "Context Intake",
+        status: "new",
+        reason: "Population mapping.",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "ctx-rec-backed",
+        type: "new_subject",
+        subjectName: "Recommendation Backed Intake",
+        status: "new",
+        reason: "Recommendation-backed destination.",
+        sourceLanes: ["broadcast_memory"],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const response = await populationContextGet("test-population-context-token");
+  assert.equal(response.status, 200);
+  const context = await response.json();
+  assert.equal(context.diagnostics.draftDestinationCount, 1);
+  assert.equal(context.diagnostics.recommendationBackedIntakeCount, 2);
+  assert.equal(context.diagnostics.existingPopulationRecommendationCount, 1);
+  assert.equal(context.draftDestinations.length, 1);
+  assert.equal(context.recommendationBackedIntakeRecords.length, 2);
+  assert.equal(context.existingPopulationRecommendations.length, 1);
+  assert.equal(JSON.stringify(context).includes("private:"), false);
+  delete process.env.BNL_API_KEY;
 });


### PR DESCRIPTION
### Motivation
- Stop surfacing every BNL population recommendation as a manual card and instead automatically route/attach/mark signals when the system can deterministically resolve them. Only genuinely ambiguous signals should require admin attention.
- Collapse duplicate population cards, preserve raw/private evidence internally, and prevent public publishing or public dossier text changes during reconcile operations.
- Make “Review” a navigation-only action and simplify per-card actions so the Dossier Control Center reads like a control center rather than an action dump.

### Description
- Added an automatic reconcile flow and resolver: implemented `resolvePopulationSignalDestination(...)` and a `reconcilePopulationSignals` routine that scans population recommendations, classifies each into a single destination, auto-resolves safe cases, merges evidence refs for duplicates, and returns a compact reconcile summary (signalsReviewed, attached counts, duplicatesCollapsed, evidenceRefsMerged, publicPagesPublished = 0, publicDossierTextChanged = 0, internalAliasesExposed = 0). (See `src/lib/dossier-workflow-store.ts` additions.)
- Exposed the reconcile action through the existing admin API as `reconcile_population_signals` so admins can run reconciliation from the Dossier Control Center without creating public changes. (See `src/app/api/admin/dossiers/route.ts`.)
- Reframed the admin UI: renamed the population area to “BNL Signal Reconcile”, added a concise reconcile summary panel and a single `Reconcile BNL Signals` action, switched default view to only unresolved signals, reduced per-card actions to at most two visible items, and made Review links navigation-only (no mutation). (See `src/app/admin/dossiers/page.tsx`.)
- Updated the BNL population context endpoint to surface safe internal destinations and diagnostics (draft destinations, recommendation-backed intake mappings, existing population recommendation mappings, destination counts) without exposing raw evidence or internal aliases. (See `src/app/api/bnl/population-context/route.ts`.)
- Minor type and workflow wiring: added `reconcile_population_signals` workflow action type and related types for reconcile summaries/destination kinds; integrated reconcile logic into the dossier workflow store to mutate only private workflow state and preserve evidence refs. (See `src/lib/dossier-workflow.ts` and `src/lib/dossier-workflow-store.ts`.)
- Kept to the existing Dossier Recommendation / Candidate / Draft / Source File flows; no public dossier text is changed and no public pages are published by these changes.
- Files changed (high level): `src/app/admin/dossiers/page.tsx`, `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-workflow.ts`, `src/app/api/admin/dossiers/route.ts`, `src/app/api/bnl/population-context/route.ts` and small helpers added/updated alongside these.

### Testing
- Ran the full admin dossier test suite with: `node --test tests/admin-dossiers.test.mjs`; result: 172 tests executed, 169 passed, 3 failing tests remain (see failures below) and need follow-up adjustments to layout placement and legacy-copy expectations: failing tests are `Population Method Audit renders independently of Subject Consolidation state`, `Population Review Queue renders grouped sections and safe admin actions`, and `Population Review Queue search includes matched candidate names and reviewed need-more-info leaves unreviewed count`.
- TypeScript check: `npx tsc --noEmit` was run during development to validate typings after edits and was used iteratively to resolve type issues introduced by the changes; latest test runs used a type-checked build.
- Notes / follow-ups: the reconcile routine and UI are implemented and wire into existing safe workflows, but three admin-page tests assert exact copy and ordering of the original Population Review Queue; these failing assertions are related to expected source copy and ordering (page section header text and placement) and the test expectations for some legacy labels; recommend reviewing those expectations or adjusting minor copy/placements if we want tests to assert the new UX exactly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b8d24f538832193e25b3d75269eee)