### PR TITLE
Collapse healthy diagnostics & hide resolved Incoming BNL Signals

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -294,6 +294,42 @@ function firstListValue(values?: string[]) {
   return values?.find((value) => value.trim()) ?? "—";
 }
 
+function optionalText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isPlainUsefulSummary(value: string) {
+  if (!value) return false;
+  if (/^[\[{]/.test(value) || /[}\]]$/.test(value)) return false;
+  if (/\b(rawEvidenceRefs?|evidenceRefs?|sourcePackage|relationship[_-]journal|private_admin|internal_controlled)\b/i.test(value)) return false;
+  if (/^(ref|evidence|raw)[:#_-]/i.test(value)) return false;
+  if (/publishes? 0 public pages|changes? 0 public dossier text|exposes? 0 internal aliases|raw\/private evidence/i.test(value)) return false;
+  return true;
+}
+
+function compactUsefulSummary(value: string) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= 220) return normalized;
+  return `${normalized.slice(0, 217).trim()}…`;
+}
+
+function whyItMattersCopy(record: DossierCandidate | DossierRecommendation) {
+  const dynamicRecord = record as Record<string, unknown>;
+  const sourceFileSummary = dynamicRecord.sourceFileSummary as
+    | { summaryText?: unknown }
+    | undefined;
+  const candidates = [
+    optionalText(sourceFileSummary?.summaryText),
+    optionalText(dynamicRecord.adminSummary),
+    optionalText(dynamicRecord.whyNow),
+    optionalText(dynamicRecord.reason),
+    optionalText(dynamicRecord.evidenceSummary),
+    optionalText(dynamicRecord.recommendedNextStep),
+  ];
+  const selected = candidates.find(isPlainUsefulSummary);
+  return selected ? compactUsefulSummary(selected) : "Needs more evidence";
+}
+
 function candidateActionLabel() {
   return "Review Candidate";
 }
@@ -755,7 +791,25 @@ export default function DossierControlCenterPage() {
       }),
     [candidates, recommendations, publicDossiers, drafts],
   );
-  const populationMethodHealthy = populationMethodAudit.warnings.length === 0;
+  const populationMethodNeedsReviewCount =
+    populationMethodAudit.countsByLane["Needs Population Review"] +
+    populationMethodAudit.hiddenWithoutDestination.length;
+  const populationMethodHealthy =
+    populationMethodAudit.warnings.length === 0 &&
+    populationMethodNeedsReviewCount === 0;
+  const showIncomingBnlSignals = unresolvedPopulationSignals.length > 0;
+  const showBnlSignalStatus =
+    populationRecommendations.length > 0 || Boolean(populationReconcileResult);
+  const bnlSignalStatusText = unresolvedPopulationSignals.length > 0
+    ? `BNL Signals: ${unresolvedPopulationSignals.length} unresolved`
+    : filedAutomaticallyCount > 0
+      ? `BNL Signals: ${filedAutomaticallyCount} filed automatically, 0 need review`
+      : "BNL Signals: clear";
+  const populationMethodStatusText = populationMethodHealthy
+    ? "Population Method Audit: clear"
+    : populationMethodAudit.warnings.length > 0
+      ? `Population Method Audit: ${populationMethodAudit.warnings.length} warning${populationMethodAudit.warnings.length === 1 ? "" : "s"}`
+      : `Population Method Audit: ${populationMethodNeedsReviewCount} record${populationMethodNeedsReviewCount === 1 ? "" : "s"} need review`;
   const consolidationAttachGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Attach to Existing Source File candidate");
   const consolidationCleanGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Empty duplicate cleanup candidate");
   const consolidationDossierUpdateGroups = populationAudit.possibleDuplicateGroups.filter((group) => group.consolidationPlan.automationTier === "Create Dossier Update workspace candidate");
@@ -1166,6 +1220,16 @@ export default function DossierControlCenterPage() {
         )}
 
         <DashboardCard eyebrow="Summary" title="Summary">
+          <div className="mb-4 flex flex-wrap gap-2 text-xs text-muted" data-compact-diagnostic-status>
+            {showBnlSignalStatus ? (
+              <span className="border border-border/70 bg-background/30 px-3 py-1.5">
+                {bnlSignalStatusText}
+              </span>
+            ) : null}
+            <span className="border border-border/70 bg-background/30 px-3 py-1.5">
+              {populationMethodStatusText}
+            </span>
+          </div>
           <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-7 gap-3 text-xs text-muted">
             {[
               [
@@ -1180,14 +1244,7 @@ export default function DossierControlCenterPage() {
               ],
               ["Source Files", activeCandidates.length],
               ["Needs Info", sourceFilesNeedingInfo.length],
-              [
-                "Ready for Dossier",
-                activeCandidates.filter(
-                  (candidate) =>
-                    !linkedActiveDraftFor(candidate, drafts) &&
-                    candidate.status !== "needs_more_evidence",
-                ).length,
-              ],
+              ["Proposed Dossiers", proposedDossiers.length],
               ["Owner Review waiting", ownerReviewDrafts.length],
               [
                 "Archive / Dismissed / Trash",
@@ -1564,8 +1621,8 @@ export default function DossierControlCenterPage() {
 
           <details className="border border-border bg-background/30 p-4" open={!populationMethodHealthy}>
             <summary className="cursor-pointer text-sm font-semibold text-foreground">
-              Population Method: {populationMethodHealthy ? "healthy" : "needs review"}
-              {!populationMethodHealthy ? ` — ${populationMethodAudit.warnings.length} intake records need population review.` : ""}
+              {populationMethodHealthy ? "Population Method Audit: clear" : "Population Method Audit: needs review"}
+              {!populationMethodHealthy ? ` — ${populationMethodAudit.warnings.length} warnings, ${populationMethodNeedsReviewCount} records need attention.` : ""}
             </summary>
             <div className="mt-4 space-y-5">
               <div>
@@ -1573,7 +1630,7 @@ export default function DossierControlCenterPage() {
                 <h2 className="text-xl font-bold text-foreground">Population Method Audit / Intake Map</h2>
                 <p className="mt-2 text-sm text-muted">Admin-only read-only diagnostic map for how Source Files, Dossier Updates, recommendations, diagnostics, and public dossier update signals entered the system, which lane they belong in, and whether hidden records have destinations.</p>
                 {populationMethodHealthy && (
-                  <p className="mt-3 border border-accent/40 bg-accent/10 p-3 text-sm text-accent">All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.</p>
+                  <p className="mt-3 border border-accent/40 bg-accent/10 p-3 text-sm text-accent">Population Method Audit: clear. All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.</p>
                 )}
               </div>
 
@@ -1676,6 +1733,7 @@ export default function DossierControlCenterPage() {
             </div>
           </details>
 
+        {showIncomingBnlSignals ? (
         <DashboardCard
           eyebrow="Incoming BNL Signals"
           title="Incoming BNL Signals"
@@ -1743,7 +1801,7 @@ export default function DossierControlCenterPage() {
                           </div>
                         </div>
                         <p><span className="text-foreground">Destination:</span> {populationDestinationLabel(recommendation, candidates)}</p>
-                        <p><span className="text-foreground">Why:</span> {recommendation.adminSummary ?? recommendation.evidenceSummary ?? recommendation.reason}</p>
+                        <p><span className="text-foreground">Why:</span> {whyItMattersCopy(recommendation)}</p>
                         {recommendation.missingInfo?.length ? <p><span className="text-foreground">Missing info:</span> {recommendation.missingInfo.join("; ")}</p> : null}
                         <p><span className="text-foreground">Evidence refs:</span> {recommendation.rawEvidenceRefCount ?? recommendation.rawEvidenceRefs?.length ?? 0} private refs preserved internally; raw/private evidence is not shown.</p>
                         <p><span className="text-foreground">What to click next:</span> {primaryActions.map((action) => action.label).join(" or ")}</p>
@@ -1760,6 +1818,16 @@ export default function DossierControlCenterPage() {
                 </div>
               </section>
             ) : null}
+          </div>
+        </DashboardCard>
+        ) : null}
+
+
+        {(filedPopulationSignals.length > 0 || nonDossierPopulationSignals.length > 0) ? (
+          <details className="border border-border/70 bg-background/20 p-4">
+            <summary className="cursor-pointer text-sm font-semibold text-foreground">BNL Signal Diagnostics — filed/non-dossier details collapsed ({filedPopulationSignals.length + nonDossierPopulationSignals.length})</summary>
+            <p className="mt-2 text-sm text-muted">Filed, already-represented, and non-dossier signal details remain available for debugging without crowding the working dashboard.</p>
+            <div className="mt-4 space-y-4">
             <details className="border border-border/70 bg-background/20 p-4">
               <summary className="cursor-pointer text-lg font-bold text-foreground">Filed / Already Represented ({filedPopulationSignals.length})</summary>
               <p className="mt-2 text-sm text-muted">Audit view for signals already attached, merged, marked no-new-info, or represented elsewhere. These do not clutter the default work queue.</p>
@@ -1781,15 +1849,16 @@ export default function DossierControlCenterPage() {
                   {nonDossierPopulationSignals.map((recommendation) => (
                     <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
                       <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
-                      <p>{recommendation.adminSummary ?? recommendation.recommendedNextStep ?? recommendation.reason}</p>
+                      <p>{whyItMattersCopy(recommendation)}</p>
                       <p>Private evidence refs preserved internally; raw/private content hidden.</p>
                     </article>
                   ))}
                 </div>
               </details>
             ) : null}
-          </div>
-        </DashboardCard>
+            </div>
+          </details>
+        ) : null}
 
         <DashboardCard
           eyebrow="Candidates & Recommendation Intake"
@@ -1932,9 +2001,7 @@ export default function DossierControlCenterPage() {
                           {recommendation.subjectName}
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.reason ||
-                            recommendation.evidenceSummary ||
-                            recommendationProvenance(recommendation)}
+                          {whyItMattersCopy(recommendation)}
                         </td>
                         <td className="py-3 pr-3">
                           {recommendation.confidence ?? "unset"}
@@ -1975,9 +2042,7 @@ export default function DossierControlCenterPage() {
                         {candidate.name}
                       </td>
                       <td className="py-3 pr-3">
-                        {candidate.whyNow ||
-                          candidate.reason ||
-                          candidateProvenance(candidate)}
+                        {whyItMattersCopy(candidate)}
                       </td>
                       <td className="py-3 pr-3">
                         {candidate.confidence ?? candidate.tier} / score{" "}
@@ -2064,9 +2129,7 @@ export default function DossierControlCenterPage() {
                           {recommendation.subjectName}
                         </td>
                         <td className="py-3 pr-3">
-                          {recommendation.reason ||
-                            recommendation.evidenceSummary ||
-                            recommendationProvenance(recommendation)}
+                          {whyItMattersCopy(recommendation)}
                         </td>
                         <td className="py-3 pr-3">
                           {recommendation.confidence ?? "needs review"}
@@ -2104,9 +2167,7 @@ export default function DossierControlCenterPage() {
                       </td>
                       <td className="py-3 pr-3">{candidate.name}</td>
                       <td className="py-3 pr-3">
-                        {candidate.whyNow ||
-                          candidate.reason ||
-                          firstListValue(candidate.knownFacts)}
+                        {whyItMattersCopy(candidate)}
                       </td>
                       <td className="py-3 pr-3">
                         {candidate.existingDossierMatch?.confidence ??
@@ -2208,10 +2269,7 @@ export default function DossierControlCenterPage() {
                           {candidate.name}
                         </td>
                         <td className="py-3 pr-3">
-                          {candidate.sourceFileSummary?.summaryText ||
-                            candidate.evidenceSummary ||
-                            candidate.reason ||
-                            "—"}
+                          {whyItMattersCopy(candidate)}
                         </td>
                         <td className="py-3 pr-3">
                           {metrics?.sourceDepth ??

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1420,7 +1420,7 @@ test("admin dossier dashboard is a simplified subject sorting overview", () => {
     "Dossier Updates",
     "Source Files",
     "Needs Info",
-    "Ready for Dossier",
+    "Proposed Dossiers",
     "Owner Review waiting",
     "Archive / Dismissed / Trash",
     "Manual Signal",
@@ -2138,11 +2138,11 @@ test("Population Method Audit renders read-only admin intake map states", () => 
 
   for (const label of [
     "Population Method Audit",
-    "Population Method:",
-    "populationMethodHealthy ? \"healthy\" : \"needs review\"",
+    "Population Method Audit: clear",
+    "populationMethodHealthy ? \"Population Method Audit: clear\" : \"Population Method Audit: needs review\"",
     "Population Method Audit / Intake Map",
     "All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.",
-    "intake records need population review.",
+    "records need attention.",
     "Intake Summary",
     "BNL recommendations",
     "manual admin records",
@@ -2180,11 +2180,12 @@ test("Population Method Audit renders read-only admin intake map states", () => 
 
   assert.match(page, /createDossierPopulationMethodAudit/);
   assert.match(page, /open=\{!populationMethodHealthy\}/);
+  assert.match(page, /populationMethodAudit\.warnings\.length === 0 &&[\s\S]*populationMethodNeedsReviewCount === 0/);
   assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Population Method Audit|Intake Map|Copy Record IDs/);
 
   const auditCopy = pageCopy.slice(
-    pageCopy.indexOf("Population Method Audit"),
-    pageCopy.indexOf("Incoming BNL Signals", pageCopy.indexOf("Population Method Audit")),
+    pageCopy.indexOf("Population Method Audit / Intake Map"),
+    pageCopy.indexOf("Incoming BNL Signals", pageCopy.indexOf("Population Method Audit / Intake Map")),
   );
   assert.doesNotMatch(auditCopy, /fix automatically|Fix Automatically|Run Subject Consolidation|Confirm Consolidation|Consolidate Into|Create Source File|Create Dossier Update|Keep Separate|Select Different Target|merge candidates|Merge button|publish public pages|change public dossier text/i);
 });
@@ -2196,7 +2197,7 @@ test("Population Method Audit renders independently of Subject Consolidation sta
   const subjectQueueIndex = page.indexOf("Subject Consolidation Queue");
   const consolidationResultIndex = page.indexOf("consolidationResult &&");
   const subjectConditionalCloseIndex = page.indexOf("open={!populationMethodHealthy}", subjectConditionalIndex);
-  const populationAuditIndex = page.indexOf("Population Method Audit");
+  const populationAuditIndex = page.indexOf("Population Method Audit / Intake Map");
   const candidatesIndex = page.indexOf("Incoming BNL Signals", populationAuditIndex);
   const clearBranch = page.slice(subjectConditionalIndex, subjectQueueIndex);
   const fullQueueBranch = page.slice(subjectQueueIndex, subjectConditionalCloseIndex);
@@ -2205,15 +2206,14 @@ test("Population Method Audit renders independently of Subject Consolidation sta
   assert.ok(subjectQueueIndex > subjectConditionalIndex, "Subject Consolidation queue state still renders");
   assert.ok(consolidationResultIndex > subjectQueueIndex, "consolidationResult state still renders inside the queue state");
   assert.ok(populationAuditIndex > subjectConditionalCloseIndex, "Population Method Audit renders after the Subject Consolidation conditional");
-  assert.ok(candidatesIndex > populationAuditIndex, "Population Method Audit renders before the Population Review Queue section");
+  assert.ok(candidatesIndex > populationAuditIndex, "Population Method Audit renders before the BNL signal diagnostic section");
   assert.doesNotMatch(clearBranch, /Population Method Audit|Population Method:/);
   assert.doesNotMatch(fullQueueBranch, /Population Method Audit|Population Method:/);
   assertIncludesCopy(pageCopy, "Subject Consolidation: clear");
   assertIncludesCopy(pageCopy, "Subject Consolidation Queue");
   assertIncludesCopy(pageCopy, "Subject Consolidation Complete");
-  assertIncludesCopy(pageCopy, "Population Method:");
-  assertIncludesCopy(pageCopy, "healthy");
-  assertIncludesCopy(pageCopy, "needs review");
+  assertIncludesCopy(pageCopy, "Population Method Audit: clear");
+  assertIncludesCopy(pageCopy, "Population Method Audit: needs review");
   assertIncludesCopy(pageCopy, "public pages published");
   assertIncludesCopy(pageCopy, "public dossier text changed");
   assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Population Method Audit|Intake Map|Copy Record IDs/);
@@ -9094,6 +9094,47 @@ test("BNL population context endpoint is authenticated, compact, and routing-saf
   assert.match(source("src/lib/dossier-workflow-store.ts"), /Subject Consolidation/);
 
   delete process.env.BNL_API_KEY;
+});
+
+test("Dossier Control Center keeps healthy diagnostics compact and preserves default workflow sections", () => {
+  const page = source("src/app/admin/dossiers/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
+
+  assert.match(page, /open=\{!populationMethodHealthy\}/, "Population Method Audit stays collapsed when healthy");
+  assert.match(page, /populationMethodAudit\.warnings\.length === 0 &&[\s\S]*populationMethodNeedsReviewCount === 0/, "healthy audit requires no warnings or review records");
+  assert.match(page, /Population Method Audit: needs review/, "Population Method Audit surfaces when warnings exist");
+  assert.match(page, /showIncomingBnlSignals = unresolvedPopulationSignals\.length > 0/, "Incoming BNL Signals hides when every signal is filed");
+  assert.match(page, /showIncomingBnlSignals \? \([\s\S]*Incoming BNL Signals/, "Incoming BNL Signals appears for unresolved signals");
+  assert.match(page, /unresolvedPopulationSignals\.map/, "Incoming BNL Signals renders exception cards only from unresolved signals");
+  assert.doesNotMatch(page, /No unresolved BNL Signals|No BNL signals|empty BNL/i, "Incoming BNL Signals does not render an empty card wall");
+  assert.match(page, /data-compact-diagnostic-status/, "Summary includes compact diagnostic status copy");
+  assert.match(page, /bnlSignalStatusText/, "Summary has compact BNL signal status");
+  assert.match(page, /populationMethodStatusText/, "Summary has compact Population Method Audit status");
+
+  for (const label of [
+    "Candidates & Recommendation Intake",
+    "Source Files",
+    "Dossier Updates",
+    "Proposed Dossiers",
+    "Owner Review",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  assert.match(page, /optionalText\(sourceFileSummary\?\.summaryText\)[\s\S]*optionalText\(dynamicRecord\.adminSummary\)[\s\S]*optionalText\(dynamicRecord\.whyNow\)[\s\S]*optionalText\(dynamicRecord\.reason\)[\s\S]*optionalText\(dynamicRecord\.evidenceSummary\)[\s\S]*optionalText\(dynamicRecord\.recommendedNextStep\)/, "Why it matters priority order is explicit");
+  assert.match(page, /return selected \? compactUsefulSummary\(selected\) : "Needs more evidence"/, "Why it matters fallback stays concise");
+  assert.match(page, /rawEvidenceRefs\?|evidenceRefs\?|sourcePackage|relationship\[_-\]journal|private_admin|internal_controlled/, "Why it matters rejects raw JSON/evidence refs");
+  assert.match(page, /publishes\? 0 public pages|changes\? 0 public dossier text|exposes\? 0 internal aliases|raw\/private evidence/, "Why it matters rejects safety boilerplate");
+  assert.match(page, /BNL Signal Diagnostics — filed\/non-dossier details collapsed/, "Filed/already-represented BNL signals stay in collapsed diagnostics");
+  assert.match(page, /Diagnostics\/Test Artifacts — collapsed by default/, "Diagnostics/Test Artifacts remain accessible but collapsed");
+  assert.match(page, /nonDossierPopulationSignals\.length > 0/, "Non-dossier signals remain accessible only when present");
+
+  assert.doesNotMatch(source("src/app/database/[slug]/page.tsx"), /Incoming BNL Signals|Population Method Audit|rawEvidenceRefs|internal aliases/i);
+  assert.doesNotMatch(source("src/app/database/page.tsx"), /Incoming BNL Signals|Population Method Audit|rawEvidenceRefs|internal aliases/i);
+  assert.match(source("src/app/api/admin/dossiers/route.ts"), /reconcile_population_signals/);
+  assert.match(source("src/app/api/bnl/population-context/route.ts"), /export async function GET/);
+  assert.match(source("src/app/api/bnl/dossier-recommendations/route.ts"), /BNL_DOSSIER_INGEST_TOKEN|authorization/i);
+  assert.match(source("src/lib/dossier-workflow-store.ts"), /Subject Consolidation|createDossierPopulationMethodAudit|candidate_intake|active_source_file/);
 });
 
 test("Incoming BNL Signals renders filing summary, unresolved exceptions, and safe admin actions", () => {


### PR DESCRIPTION
### Motivation
- Reduce dashboard noise by collapsing diagnostic-heavy views when there is nothing actionable so admins see workflow items first.
- Keep Population Method Audit and Incoming BNL Signals accessible for debugging but avoid showing them as large panels when healthy or fully auto-filed.
- Improve the short “Why it matters” copy for candidate/recommendation rows to prefer concise, human-readable fields and avoid raw/internal data.

### Description
- Collapse/hide healthy Population Method Audit unless warnings or review-needed records exist by treating both `warnings.length` and review counts when deciding the audit’s healthy state, and surface a compact status line when healthy. (src/app/admin/dossiers/page.tsx)
- Hide the full Incoming BNL Signals DashboardCard unless unresolved signals exist; expose a compact BNL signal status in the Summary and move filed/already-represented/non-dossier details into a collapsed diagnostic section. (src/app/admin/dossiers/page.tsx)
- Add compact diagnostic status copy in the Summary that shows `BNL Signals` and `Population Method Audit` statuses when useful. (src/app/admin/dossiers/page.tsx)
- Implement `whyItMattersCopy` logic that prefers fields in this order: `sourceFileSummary.summaryText`, `adminSummary`, `whyNow`, `reason`, `evidenceSummary`, `recommendedNextStep`; filter out JSON/raw evidence refs/boilerplate and truncate long text, with fallback `Needs more evidence`. Apply this to Candidate Intake, Dossier Updates, Source Files, and recommendation rows. (src/app/admin/dossiers/page.tsx)
- Keep diagnostics accessible but non-dominant by collapsing Diagnostics/Test Artifacts and moving filed/already-represented BNL signal details into a collapsed “BNL Signal Diagnostics” area. (src/app/admin/dossiers/page.tsx)
- Tests updated/added to assert the new compact behavior, hidden/conditional rendering, and the “Why it matters” selection and filters. (tests/admin-dossiers.test.mjs)
- No public dossier text or public pages were changed, and no bot code was modified.

Files changed
- src/app/admin/dossiers/page.tsx — compact diagnostic status, conditional rendering for Incoming BNL Signals and Population Method Audit, `whyItMattersCopy` utility, and applying concise Why-it-matters copy across rows.
- tests/admin-dossiers.test.mjs — added/updated tests to cover compact diagnostics, hidden/resurfaced BNL sections, ordering/fallback/filtering of Why-it-matters, and related route/API expectations.

### Testing
- Ran unit/test suite: `node --test tests/admin-dossiers.test.mjs` — all relevant tests passed locally (test run passed after test updates).
- Type-check: `npx tsc --noEmit` — TypeScript check passed with no errors.

If you want, I can open the PR description body to match any specific internal template or address any follow-up tweaks (copy changes, microcopy for the compact status line, or smaller UX adjustments).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba2672720832182bf18c23e187ac1)