### PR TITLE
Move diagnostics into bottom "Diagnostics & Maintenance" drawer and tighten summary filtering

### DIFF
--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -298,12 +298,38 @@ function optionalText(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+const genericWhyItMattersPatterns = [
+  /review source context and decide whether to attach or convert into a bnl source file/i,
+  /review update details before attaching anywhere public/i,
+  /review(?: the)? (?:candidate|record|signal|source file|details|context)\b/i,
+  /needs one admin decision because no deterministic destination was found/i,
+  /no action needed|filed automatically|already represented/i,
+  /admin(?:-| )only|diagnostic|debug|maintenance|workflow state|intake map/i,
+  /publishes? 0 public pages|changes? 0 public dossier text|exposes? 0 internal aliases|raw\/private evidence/i,
+  /private evidence refs?|raw evidence refs?|evidence refs? preserved internally/i,
+  /source of recommendation|last updated|generatedat|copy record ids/i,
+  /candidate intake|needs population review|dossier update workspace|source file refresh|archive diagnostic artifact/i,
+  /missing info|confidence unset|status:|destination:/i,
+];
+
+function looksLikeRawStructuredText(value: string) {
+  const trimmed = value.trim();
+  if (/^[\[{]/.test(trimmed) || /[}\]]$/.test(trimmed)) return true;
+  if (/^\{?[\"']?[\w-]+[\"']?\s*[:=]/.test(trimmed)) return true;
+  if (/\b(rawEvidenceRefs?|evidenceRefs?|sourcePackage|relationship[_-]journal|private_admin|internal_controlled)\b/i.test(trimmed)) return true;
+  if (/^(ref|evidence|raw)[:#_-]/i.test(trimmed)) return true;
+  return false;
+}
+
 function isPlainUsefulSummary(value: string) {
   if (!value) return false;
-  if (/^[\[{]/.test(value) || /[}\]]$/.test(value)) return false;
-  if (/\b(rawEvidenceRefs?|evidenceRefs?|sourcePackage|relationship[_-]journal|private_admin|internal_controlled)\b/i.test(value)) return false;
-  if (/^(ref|evidence|raw)[:#_-]/i.test(value)) return false;
-  if (/publishes? 0 public pages|changes? 0 public dossier text|exposes? 0 internal aliases|raw\/private evidence/i.test(value)) return false;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length < 12) return false;
+  if (looksLikeRawStructuredText(normalized)) return false;
+  if (genericWhyItMattersPatterns.some((pattern) => pattern.test(normalized))) return false;
+  if (/^(needs (review|more info|more evidence)|admin review|required|unknown|n\/a|none|—)$/i.test(normalized)) return false;
+  const words = normalized.toLowerCase().split(/\W+/).filter(Boolean);
+  if (words.length >= 6 && new Set(words).size <= Math.ceil(words.length / 3)) return false;
   return true;
 }
 
@@ -1619,119 +1645,7 @@ export default function DossierControlCenterPage() {
         </section>
         )}
 
-          <details className="border border-border bg-background/30 p-4" open={!populationMethodHealthy}>
-            <summary className="cursor-pointer text-sm font-semibold text-foreground">
-              {populationMethodHealthy ? "Population Method Audit: clear" : "Population Method Audit: needs review"}
-              {!populationMethodHealthy ? ` — ${populationMethodAudit.warnings.length} warnings, ${populationMethodNeedsReviewCount} records need attention.` : ""}
-            </summary>
-            <div className="mt-4 space-y-5">
-              <div>
-                <p className="text-xs uppercase tracking-[0.35em] text-muted">Population Method Audit</p>
-                <h2 className="text-xl font-bold text-foreground">Population Method Audit / Intake Map</h2>
-                <p className="mt-2 text-sm text-muted">Admin-only read-only diagnostic map for how Source Files, Dossier Updates, recommendations, diagnostics, and public dossier update signals entered the system, which lane they belong in, and whether hidden records have destinations.</p>
-                {populationMethodHealthy && (
-                  <p className="mt-3 border border-accent/40 bg-accent/10 p-3 text-sm text-accent">Population Method Audit: clear. All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.</p>
-                )}
-              </div>
 
-              <section className="grid gap-3 md:grid-cols-2">
-                <div className="border border-border/70 bg-surface/60 p-4">
-                  <h3 className="font-semibold text-foreground">Intake Summary</h3>
-                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
-                    <dt>BNL recommendations</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["BNL recommendation"] + populationMethodAudit.countsByOrigin["BNL source knowledge bridge"] + populationMethodAudit.countsByOrigin["BNL dynamic candidate discovery"]}</dd>
-                    <dt>manual admin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["manual admin creation"]}</dd>
-                    <dt>public dossier update signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["public dossier update signal"]}</dd>
-                    <dt>source file refresh/archive records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["source file refresh"] + populationMethodAudit.countsByOrigin["source file archive"]}</dd>
-                    <dt>diagnostic/test artifacts</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["diagnostic/test artifact"]}</dd>
-                    <dt>unknown origin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["unknown / insufficient metadata"]}</dd>
-                  </dl>
-                </div>
-                <div className="border border-border/70 bg-surface/60 p-4">
-                  <h3 className="font-semibold text-foreground">Lane Map</h3>
-                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
-                    <dt>Active Source Files</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Active Source File"]}</dd>
-                    <dt>Candidate Intake</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Candidate Intake"]}</dd>
-                    <dt>Dossier Update Workspaces</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Dossier Update Workspace"]}</dd>
-                    <dt>Public Dossier Update Signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Public Dossier Update Signal"]}</dd>
-                    <dt>Resolved Incoming Records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Resolved Incoming Record"] + populationMethodAudit.countsByLane["Merged Source Record"]}</dd>
-                    <dt>Diagnostics</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Diagnostic/Test Artifact"]}</dd>
-                    <dt>Archived/Closed</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Archived / Closed"]}</dd>
-                    <dt>Needs Population Review</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Needs Population Review"]}</dd>
-                  </dl>
-                </div>
-              </section>
-
-              {populationMethodAudit.warnings.length > 0 && (
-                <section className="space-y-3">
-                  <h3 className="font-semibold text-foreground">Warnings / Problems</h3>
-                  {populationMethodAudit.warnings.slice(0, 8).map((warning) => (
-                    <article key={warning.id} className="border border-accent/50 bg-accent/10 p-4 text-sm">
-                      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                        <div>
-                          <p className="font-semibold text-accent">{warning.issueTitle}</p>
-                          <p className="mt-1 text-foreground">Affected subject: {warning.affectedSubject}</p>
-                        </div>
-                        <button type="button" onClick={() => navigator.clipboard?.writeText(warning.affectedIds.join(", "))} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Copy Record IDs</button>
-                      </div>
-                      <dl className="mt-3 grid gap-2 text-xs text-muted md:grid-cols-2">
-                        <div><dt>Affected IDs</dt><dd className="text-foreground">{warning.affectedIds.join(", ") || "—"}</dd></div>
-                        <div><dt>Source type</dt><dd className="text-foreground">{warning.sourceType}</dd></div>
-                        <div><dt>Current status</dt><dd className="text-foreground">{warning.currentStatus}</dd></div>
-                        <div><dt>Expected lane</dt><dd className="text-foreground">{warning.expectedLane}</dd></div>
-                        <div><dt>Detected destination</dt><dd className="text-foreground">{warning.detectedDestination ?? "—"}</dd></div>
-                        <div><dt>Recommended admin next step</dt><dd className="text-foreground">{warning.recommendedAdminNextStep}</dd></div>
-                      </dl>
-                    </article>
-                  ))}
-                </section>
-              )}
-
-              <details className="border border-border/70 bg-surface/40 p-3">
-                <summary className="cursor-pointer text-sm font-semibold text-foreground">Hidden Records With Destinations ({populationMethodAudit.hiddenWithDestinations.length})</summary>
-                <div className="mt-3 space-y-2 text-sm">
-                  {populationMethodAudit.hiddenWithDestinations.slice(0, 8).map((record) => (
-                    <div key={`hidden-destination-${record.id}`} className="border border-border/60 p-3">
-                      <p className="font-semibold text-foreground">{record.subject}</p>
-                      <p className="text-xs text-muted">{record.origin} → {record.destinationSubject ?? "destination"}</p>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {record.href && <Link href={record.href} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
-                        {record.destinationHref && <Link href={record.destinationHref} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
-                        {record.publicDossierId && <Link href={`/database/${record.publicDossierId}`} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Public Dossier Match</Link>}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </details>
-
-              {populationMethodAudit.hiddenWithoutDestination.length > 0 && (
-                <section className="border border-accent/50 bg-accent/10 p-4">
-                  <h3 className="font-semibold text-accent">Hidden Records Without Destinations</h3>
-                  <div className="mt-3 space-y-2 text-sm">
-                    {populationMethodAudit.hiddenWithoutDestination.slice(0, 8).map((record) => (
-                      <div key={`hidden-orphan-${record.id}`} className="border border-border/60 bg-background/30 p-3">
-                        <p className="font-semibold text-foreground">{record.subject}</p>
-                        <p className="text-xs text-muted">{record.origin} · {record.currentStatus} · expected lane: {record.intendedLane}</p>
-                        {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              )}
-
-              <details className="border border-border/70 bg-surface/40 p-3" open={!populationMethodHealthy}>
-                <summary className="cursor-pointer text-sm font-semibold text-foreground">Destination Workspaces ({populationMethodAudit.visibleDestinationWorkspaces.length})</summary>
-                <div className="mt-3 grid gap-2 md:grid-cols-2">
-                  {populationMethodAudit.visibleDestinationWorkspaces.slice(0, 10).map((record) => (
-                    <div key={`destination-${record.id}`} className="border border-border/60 p-3 text-sm">
-                      <p className="font-semibold text-foreground">{record.subject}</p>
-                      <p className="text-xs text-muted">{record.intendedLane} · received records: {populationMethodAudit.intakeFlows.filter((flow) => flow.destinationId === record.id).length}</p>
-                      {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
-                    </div>
-                  ))}
-                </div>
-              </details>
-            </div>
-          </details>
 
         {showIncomingBnlSignals ? (
         <DashboardCard
@@ -1823,42 +1737,7 @@ export default function DossierControlCenterPage() {
         ) : null}
 
 
-        {(filedPopulationSignals.length > 0 || nonDossierPopulationSignals.length > 0) ? (
-          <details className="border border-border/70 bg-background/20 p-4">
-            <summary className="cursor-pointer text-sm font-semibold text-foreground">BNL Signal Diagnostics — filed/non-dossier details collapsed ({filedPopulationSignals.length + nonDossierPopulationSignals.length})</summary>
-            <p className="mt-2 text-sm text-muted">Filed, already-represented, and non-dossier signal details remain available for debugging without crowding the working dashboard.</p>
-            <div className="mt-4 space-y-4">
-            <details className="border border-border/70 bg-background/20 p-4">
-              <summary className="cursor-pointer text-lg font-bold text-foreground">Filed / Already Represented ({filedPopulationSignals.length})</summary>
-              <p className="mt-2 text-sm text-muted">Audit view for signals already attached, merged, marked no-new-info, or represented elsewhere. These do not clutter the default work queue.</p>
-              <div className="mt-3 grid gap-3 lg:grid-cols-2">
-                {filedPopulationSignals.map((recommendation) => (
-                  <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-2">
-                    <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
-                    <p>{populationDestinationLabel(recommendation, candidates)}</p>
-                    <p>No action needed. Filed automatically.</p>
-                  </article>
-                ))}
-              </div>
-            </details>
-            {nonDossierPopulationSignals.length > 0 ? (
-              <details className="border border-border/70 bg-background/20 p-4">
-                <summary className="cursor-pointer text-lg font-bold text-foreground">Non-dossier Signals ({nonDossierPopulationSignals.length})</summary>
-                <p className="mt-2 text-sm text-muted">Show-state notes, broadcast memory notes, and not-population-subject items stay out of the main dossier work queue.</p>
-                <div className="mt-3 grid gap-3 lg:grid-cols-2">
-                  {nonDossierPopulationSignals.map((recommendation) => (
-                    <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
-                      <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
-                      <p>{whyItMattersCopy(recommendation)}</p>
-                      <p>Private evidence refs preserved internally; raw/private content hidden.</p>
-                    </article>
-                  ))}
-                </div>
-              </details>
-            ) : null}
-            </div>
-          </details>
-        ) : null}
+
 
         <DashboardCard
           eyebrow="Candidates & Recommendation Intake"
@@ -2200,26 +2079,7 @@ export default function DossierControlCenterPage() {
           )}
         </DashboardCard>
 
-        {(diagnosticCandidates.length > 0 || diagnosticRecommendations.length > 0) && (
-          <DashboardCard
-            eyebrow="Diagnostics/Test Artifacts"
-            title="Diagnostics/Test Artifacts"
-            aside={<StatusPill>{diagnosticCandidates.length + diagnosticRecommendations.length} hidden</StatusPill>}
-          >
-            <details className="border border-border/70 bg-background/30 p-4">
-              <summary className="cursor-pointer text-sm font-semibold text-foreground">Diagnostics/Test Artifacts — collapsed by default</summary>
-              <p className="mt-3 text-sm text-muted">These diagnostic_test_artifact records are hidden from normal Source File and Subject Consolidation workflows. They can be archived safely from their detail pages when needed.</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {diagnosticCandidates.map((candidate) => (
-                  <Link key={`diagnostic-candidate-${candidate.id}`} href={`/admin/dossiers/candidates/${candidate.id}`} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">Archive Diagnostic Artifact: {candidate.name}</Link>
-                ))}
-                {diagnosticRecommendations.map((recommendation) => (
-                  <Link key={`diagnostic-recommendation-${recommendation.id}`} href={`/admin/dossiers/recommendations/${recommendation.id}`} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">Archive Diagnostic Artifact: {recommendation.subjectName}</Link>
-                ))}
-              </div>
-            </details>
-          </DashboardCard>
-        )}
+
 
         <DashboardCard
           eyebrow="Source Files"
@@ -2373,6 +2233,203 @@ export default function DossierControlCenterPage() {
               ))}
             </div>
           )}
+        </details>
+
+        <details className="border border-border bg-surface/70 p-5">
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Diagnostics & Maintenance
+          </summary>
+          <div className="mt-4 space-y-5">
+            <p className="text-sm text-muted">
+              Diagnostic readouts, filed BNL signal details, population-method mapping,
+              and maintenance-only artifacts live here so the normal dashboard starts
+              with actionable work. This drawer is admin-only and collapsed by default.
+            </p>
+            <div className="flex flex-wrap gap-2 text-xs text-muted" data-compact-diagnostic-status>
+              {showBnlSignalStatus ? (
+                <span className="border border-border/70 bg-background/30 px-3 py-1.5">
+                  {bnlSignalStatusText}
+                </span>
+              ) : null}
+              <span className="border border-border/70 bg-background/30 px-3 py-1.5">
+                {populationMethodStatusText}
+              </span>
+            </div>
+          <details className="border border-border/70 bg-background/30 p-4" open={!populationMethodHealthy}>
+            <summary className="cursor-pointer text-sm font-semibold text-foreground">
+              {populationMethodHealthy ? "Population Method Audit: clear" : "Population Method Audit: needs review"}
+              {!populationMethodHealthy ? ` — ${populationMethodAudit.warnings.length} warnings, ${populationMethodNeedsReviewCount} records need attention.` : ""}
+            </summary>
+            <div className="mt-4 space-y-5">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-muted">Population Method Audit</p>
+                <h2 className="text-xl font-bold text-foreground">Population Method Audit / Intake Map</h2>
+                <p className="mt-2 text-sm text-muted">Admin-only read-only diagnostic map for how Source Files, Dossier Updates, recommendations, diagnostics, and public dossier update signals entered the system, which lane they belong in, and whether hidden records have destinations.</p>
+                {populationMethodHealthy && (
+                  <p className="mt-3 border border-accent/40 bg-accent/10 p-3 text-sm text-accent">Population Method Audit: clear. All resolved records have visible destinations or valid archive/diagnostic status. No orphaned intake records detected.</p>
+                )}
+              </div>
+
+              <section className="grid gap-3 md:grid-cols-2">
+                <div className="border border-border/70 bg-surface/60 p-4">
+                  <h3 className="font-semibold text-foreground">Intake Summary</h3>
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
+                    <dt>BNL recommendations</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["BNL recommendation"] + populationMethodAudit.countsByOrigin["BNL source knowledge bridge"] + populationMethodAudit.countsByOrigin["BNL dynamic candidate discovery"]}</dd>
+                    <dt>manual admin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["manual admin creation"]}</dd>
+                    <dt>public dossier update signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["public dossier update signal"]}</dd>
+                    <dt>source file refresh/archive records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["source file refresh"] + populationMethodAudit.countsByOrigin["source file archive"]}</dd>
+                    <dt>diagnostic/test artifacts</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["diagnostic/test artifact"]}</dd>
+                    <dt>unknown origin records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByOrigin["unknown / insufficient metadata"]}</dd>
+                  </dl>
+                </div>
+                <div className="border border-border/70 bg-surface/60 p-4">
+                  <h3 className="font-semibold text-foreground">Lane Map</h3>
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted">
+                    <dt>Active Source Files</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Active Source File"]}</dd>
+                    <dt>Candidate Intake</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Candidate Intake"]}</dd>
+                    <dt>Dossier Update Workspaces</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Dossier Update Workspace"]}</dd>
+                    <dt>Public Dossier Update Signals</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Public Dossier Update Signal"]}</dd>
+                    <dt>Resolved Incoming Records</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Resolved Incoming Record"] + populationMethodAudit.countsByLane["Merged Source Record"]}</dd>
+                    <dt>Diagnostics</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Diagnostic/Test Artifact"]}</dd>
+                    <dt>Archived/Closed</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Archived / Closed"]}</dd>
+                    <dt>Needs Population Review</dt><dd className="text-right text-foreground">{populationMethodAudit.countsByLane["Needs Population Review"]}</dd>
+                  </dl>
+                </div>
+              </section>
+
+              {populationMethodAudit.warnings.length > 0 && (
+                <section className="space-y-3">
+                  <h3 className="font-semibold text-foreground">Warnings / Problems</h3>
+                  {populationMethodAudit.warnings.slice(0, 8).map((warning) => (
+                    <article key={warning.id} className="border border-accent/50 bg-accent/10 p-4 text-sm">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="font-semibold text-accent">{warning.issueTitle}</p>
+                          <p className="mt-1 text-foreground">Affected subject: {warning.affectedSubject}</p>
+                        </div>
+                        <button type="button" onClick={() => navigator.clipboard?.writeText(warning.affectedIds.join(", "))} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">Copy Record IDs</button>
+                      </div>
+                      <dl className="mt-3 grid gap-2 text-xs text-muted md:grid-cols-2">
+                        <div><dt>Affected IDs</dt><dd className="text-foreground">{warning.affectedIds.join(", ") || "—"}</dd></div>
+                        <div><dt>Source type</dt><dd className="text-foreground">{warning.sourceType}</dd></div>
+                        <div><dt>Current status</dt><dd className="text-foreground">{warning.currentStatus}</dd></div>
+                        <div><dt>Expected lane</dt><dd className="text-foreground">{warning.expectedLane}</dd></div>
+                        <div><dt>Detected destination</dt><dd className="text-foreground">{warning.detectedDestination ?? "—"}</dd></div>
+                        <div><dt>Recommended admin next step</dt><dd className="text-foreground">{warning.recommendedAdminNextStep}</dd></div>
+                      </dl>
+                    </article>
+                  ))}
+                </section>
+              )}
+
+              <details className="border border-border/70 bg-surface/40 p-3">
+                <summary className="cursor-pointer text-sm font-semibold text-foreground">Hidden Records With Destinations ({populationMethodAudit.hiddenWithDestinations.length})</summary>
+                <div className="mt-3 space-y-2 text-sm">
+                  {populationMethodAudit.hiddenWithDestinations.slice(0, 8).map((record) => (
+                    <div key={`hidden-destination-${record.id}`} className="border border-border/60 p-3">
+                      <p className="font-semibold text-foreground">{record.subject}</p>
+                      <p className="text-xs text-muted">{record.origin} → {record.destinationSubject ?? "destination"}</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {record.href && <Link href={record.href} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
+                        {record.destinationHref && <Link href={record.destinationHref} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
+                        {record.publicDossierId && <Link href={`/database/${record.publicDossierId}`} className="border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Public Dossier Match</Link>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </details>
+
+              {populationMethodAudit.hiddenWithoutDestination.length > 0 && (
+                <section className="border border-accent/50 bg-accent/10 p-4">
+                  <h3 className="font-semibold text-accent">Hidden Records Without Destinations</h3>
+                  <div className="mt-3 space-y-2 text-sm">
+                    {populationMethodAudit.hiddenWithoutDestination.slice(0, 8).map((record) => (
+                      <div key={`hidden-orphan-${record.id}`} className="border border-border/60 bg-background/30 p-3">
+                        <p className="font-semibold text-foreground">{record.subject}</p>
+                        <p className="text-xs text-muted">{record.origin} · {record.currentStatus} · expected lane: {record.intendedLane}</p>
+                        {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Source Record</Link>}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              <details className="border border-border/70 bg-surface/40 p-3" open={!populationMethodHealthy}>
+                <summary className="cursor-pointer text-sm font-semibold text-foreground">Destination Workspaces ({populationMethodAudit.visibleDestinationWorkspaces.length})</summary>
+                <div className="mt-3 grid gap-2 md:grid-cols-2">
+                  {populationMethodAudit.visibleDestinationWorkspaces.slice(0, 10).map((record) => (
+                    <div key={`destination-${record.id}`} className="border border-border/60 p-3 text-sm">
+                      <p className="font-semibold text-foreground">{record.subject}</p>
+                      <p className="text-xs text-muted">{record.intendedLane} · received records: {populationMethodAudit.intakeFlows.filter((flow) => flow.destinationId === record.id).length}</p>
+                      {record.href && <Link href={record.href} className="mt-2 inline-flex border border-border px-3 py-1 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent">View Destination Workspace</Link>}
+                    </div>
+                  ))}
+                </div>
+              </details>
+            </div>
+          </details>
+
+        {(filedPopulationSignals.length > 0 || nonDossierPopulationSignals.length > 0) ? (
+          <details className="border border-border/70 bg-background/20 p-4">
+            <summary className="cursor-pointer text-sm font-semibold text-foreground">BNL Signal Diagnostics — filed/non-dossier details collapsed ({filedPopulationSignals.length + nonDossierPopulationSignals.length})</summary>
+            <p className="mt-2 text-sm text-muted">Filed, already-represented, and non-dossier signal details remain available for debugging without crowding the working dashboard.</p>
+            <div className="mt-4 space-y-4">
+            <details className="border border-border/70 bg-background/20 p-4">
+              <summary className="cursor-pointer text-lg font-bold text-foreground">Filed / Already Represented ({filedPopulationSignals.length})</summary>
+              <p className="mt-2 text-sm text-muted">Audit view for signals already attached, merged, marked no-new-info, or represented elsewhere. These do not clutter the default work queue.</p>
+              <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                {filedPopulationSignals.map((recommendation) => (
+                  <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-2">
+                    <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
+                    <p>{populationDestinationLabel(recommendation, candidates)}</p>
+                    <p>No action needed. Filed automatically.</p>
+                  </article>
+                ))}
+              </div>
+            </details>
+            {nonDossierPopulationSignals.length > 0 ? (
+              <details className="border border-border/70 bg-background/20 p-4">
+                <summary className="cursor-pointer text-lg font-bold text-foreground">Non-dossier Signals ({nonDossierPopulationSignals.length})</summary>
+                <p className="mt-2 text-sm text-muted">Show-state notes, broadcast memory notes, and not-population-subject items stay out of the main dossier work queue.</p>
+                <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                  {nonDossierPopulationSignals.map((recommendation) => (
+                    <article key={recommendation.id} className="border border-border bg-surface p-4 text-sm text-muted space-y-3">
+                      <h4 className="text-lg font-bold text-foreground">{recommendation.subjectName}</h4>
+                      <p>{whyItMattersCopy(recommendation)}</p>
+                      <p>Private evidence refs preserved internally; raw/private content hidden.</p>
+                    </article>
+                  ))}
+                </div>
+              </details>
+            ) : null}
+            </div>
+          </details>
+        ) : null}
+
+        {(diagnosticCandidates.length > 0 || diagnosticRecommendations.length > 0) ? (
+          <section className="border border-border/70 bg-background/20 p-4">
+            <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-muted">Diagnostics/Test Artifacts</p>
+                <h3 className="text-lg font-bold text-foreground">Diagnostics/Test Artifacts</h3>
+              </div>
+              <StatusPill>{diagnosticCandidates.length + diagnosticRecommendations.length} hidden</StatusPill>
+            </div>
+            <details className="border border-border/70 bg-background/30 p-4">
+              <summary className="cursor-pointer text-sm font-semibold text-foreground">Diagnostics/Test Artifacts — collapsed by default</summary>
+              <p className="mt-3 text-sm text-muted">These diagnostic_test_artifact records are hidden from normal Source File and Subject Consolidation workflows. They can be archived safely from their detail pages when needed.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {diagnosticCandidates.map((candidate) => (
+                  <Link key={`diagnostic-candidate-${candidate.id}`} href={`/admin/dossiers/candidates/${candidate.id}`} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">Archive Diagnostic Artifact: {candidate.name}</Link>
+                ))}
+                {diagnosticRecommendations.map((recommendation) => (
+                  <Link key={`diagnostic-recommendation-${recommendation.id}`} href={`/admin/dossiers/recommendations/${recommendation.id}`} className="border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-foreground hover:border-accent hover:text-accent">Archive Diagnostic Artifact: {recommendation.subjectName}</Link>
+                ))}
+              </div>
+            </details>
+          </section>
+        ) : null}
+          </div>
         </details>
 
         <div className="flex justify-center pt-4">

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -2190,25 +2190,37 @@ test("Population Method Audit renders read-only admin intake map states", () => 
   assert.doesNotMatch(auditCopy, /fix automatically|Fix Automatically|Run Subject Consolidation|Confirm Consolidation|Consolidate Into|Create Source File|Create Dossier Update|Keep Separate|Select Different Target|merge candidates|Merge button|publish public pages|change public dossier text/i);
 });
 
-test("Population Method Audit renders independently of Subject Consolidation state", () => {
+test("Population Method Audit lives in the bottom Diagnostics & Maintenance drawer", () => {
   const page = source("src/app/admin/dossiers/page.tsx");
   const pageCopy = normalizedSource("src/app/admin/dossiers/page.tsx");
   const subjectConditionalIndex = page.indexOf("isSubjectConsolidationClear && !consolidationResult");
   const subjectQueueIndex = page.indexOf("Subject Consolidation Queue");
   const consolidationResultIndex = page.indexOf("consolidationResult &&");
-  const subjectConditionalCloseIndex = page.indexOf("open={!populationMethodHealthy}", subjectConditionalIndex);
+  const sourceFilesIndex = page.indexOf('eyebrow="Source Files"');
+  const archiveIndex = page.indexOf("Archive / Dismissed / Trash", sourceFilesIndex);
+  const drawerIndex = page.indexOf("Diagnostics & Maintenance");
+  const ownerReviewIndex = page.indexOf("Owner Review", drawerIndex);
   const populationAuditIndex = page.indexOf("Population Method Audit / Intake Map");
-  const candidatesIndex = page.indexOf("Incoming BNL Signals", populationAuditIndex);
+  const bnlDiagnosticsIndex = page.indexOf("BNL Signal Diagnostics — filed/non-dossier details collapsed");
+  const diagnosticArtifactsIndex = page.indexOf("Diagnostics/Test Artifacts — collapsed by default");
   const clearBranch = page.slice(subjectConditionalIndex, subjectQueueIndex);
-  const fullQueueBranch = page.slice(subjectQueueIndex, subjectConditionalCloseIndex);
+  const fullQueueBranch = page.slice(subjectQueueIndex, drawerIndex);
+  const normalDashboardCopy = page.slice(0, drawerIndex);
 
   assert.ok(subjectConditionalIndex >= 0, "Subject Consolidation clear conditional exists");
   assert.ok(subjectQueueIndex > subjectConditionalIndex, "Subject Consolidation queue state still renders");
   assert.ok(consolidationResultIndex > subjectQueueIndex, "consolidationResult state still renders inside the queue state");
-  assert.ok(populationAuditIndex > subjectConditionalCloseIndex, "Population Method Audit renders after the Subject Consolidation conditional");
-  assert.ok(candidatesIndex > populationAuditIndex, "Population Method Audit renders before the BNL signal diagnostic section");
+  assert.ok(sourceFilesIndex > subjectQueueIndex, "normal Source Files section renders before maintenance diagnostics");
+  assert.ok(archiveIndex > sourceFilesIndex, "archive/trash stays near the bottom of the working dashboard");
+  assert.ok(drawerIndex > archiveIndex, "Diagnostics & Maintenance is a bottom drawer after normal work sections");
+  assert.ok(ownerReviewIndex > drawerIndex, "Owner Review link remains after the maintenance drawer");
+  assert.ok(populationAuditIndex > drawerIndex, "Population Method Audit content is inside the maintenance drawer");
+  assert.ok(bnlDiagnosticsIndex > drawerIndex, "BNL filed/non-dossier diagnostics are inside the maintenance drawer");
+  assert.ok(diagnosticArtifactsIndex > drawerIndex, "Diagnostic/test artifacts are inside the maintenance drawer");
   assert.doesNotMatch(clearBranch, /Population Method Audit|Population Method:/);
-  assert.doesNotMatch(fullQueueBranch, /Population Method Audit|Population Method:/);
+  assert.doesNotMatch(fullQueueBranch, /Population Method Audit \/ Intake Map|BNL Signal Diagnostics|Diagnostics\/Test Artifacts — collapsed by default/);
+  assert.doesNotMatch(normalDashboardCopy, /Population Method Audit \/ Intake Map|BNL Signal Diagnostics|Diagnostics\/Test Artifacts — collapsed by default/);
+  assert.match(page, /<details className="border border-border bg-surface\/70 p-5">\s*<summary className="cursor-pointer text-xl font-bold text-foreground">\s*Diagnostics & Maintenance/, "maintenance drawer is collapsed by default");
   assertIncludesCopy(pageCopy, "Subject Consolidation: clear");
   assertIncludesCopy(pageCopy, "Subject Consolidation Queue");
   assertIncludesCopy(pageCopy, "Subject Consolidation Complete");
@@ -9110,6 +9122,9 @@ test("Dossier Control Center keeps healthy diagnostics compact and preserves def
   assert.match(page, /data-compact-diagnostic-status/, "Summary includes compact diagnostic status copy");
   assert.match(page, /bnlSignalStatusText/, "Summary has compact BNL signal status");
   assert.match(page, /populationMethodStatusText/, "Summary has compact Population Method Audit status");
+  assert.match(page, /Diagnostics & Maintenance/, "Diagnostics and maintenance material lives in one bottom drawer");
+  assert.ok(page.indexOf("Diagnostics & Maintenance") > page.indexOf('eyebrow="Source Files"'), "Diagnostics & Maintenance renders after default work sections");
+  assert.doesNotMatch(page.slice(0, page.indexOf("Diagnostics & Maintenance")), /Population Method Audit \/ Intake Map|BNL Signal Diagnostics|Diagnostics\/Test Artifacts — collapsed by default/, "normal dashboard flow does not expose full diagnostic sections");
 
   for (const label of [
     "Candidates & Recommendation Intake",
@@ -9125,6 +9140,9 @@ test("Dossier Control Center keeps healthy diagnostics compact and preserves def
   assert.match(page, /return selected \? compactUsefulSummary\(selected\) : "Needs more evidence"/, "Why it matters fallback stays concise");
   assert.match(page, /rawEvidenceRefs\?|evidenceRefs\?|sourcePackage|relationship\[_-\]journal|private_admin|internal_controlled/, "Why it matters rejects raw JSON/evidence refs");
   assert.match(page, /publishes\? 0 public pages|changes\? 0 public dossier text|exposes\? 0 internal aliases|raw\/private evidence/, "Why it matters rejects safety boilerplate");
+  assert.match(page, /review source context and decide whether to attach or convert into a bnl source file/i, "Why it matters rejects generic workflow filler");
+  assert.match(page, /genericWhyItMattersPatterns/, "Why it matters rejects generic admin review phrases");
+  assert.doesNotMatch(pageCopy, /Review source context and decide whether to attach or convert into a BNL Source File\./, "generic workflow filler is not rendered as row copy");
   assert.match(page, /BNL Signal Diagnostics — filed\/non-dossier details collapsed/, "Filed/already-represented BNL signals stay in collapsed diagnostics");
   assert.match(page, /Diagnostics\/Test Artifacts — collapsed by default/, "Diagnostics/Test Artifacts remain accessible but collapsed");
   assert.match(page, /nonDossierPopulationSignals\.length > 0/, "Non-dossier signals remain accessible only when present");


### PR DESCRIPTION
### Motivation
- The Dossier Control Center showed too much diagnostic and workflow filler by default, which distracted from actual work items and risked exposing raw/internal diagnostics in normal admin views.
- The intent is to keep actionable work prominent while preserving diagnostics and maintenance tools accessible but collapsed and segregated from the main review flow.

### Description
- Move Population Method Audit, filed/already-represented BNL signal diagnostics, non-dossier signal details, diagnostic/test artifacts, and related maintenance/debug readouts out of the normal dashboard flow into one collapsed bottom drawer titled `Diagnostics & Maintenance` in `src/app/admin/dossiers/page.tsx`.
- Keep compact diagnostic status chips (`bnlSignalStatusText` and `populationMethodStatusText`) in the main `Summary` card so only a small status indicator appears by default.
- Strengthen `whyItMattersCopy` summary selection and filtering to reject generic workflow filler, repeated boilerplate, diagnostic/admin phrases, raw/structured JSON-like text, evidence/ref tokens, and other non-subject-specific fallback copy while preferring subject-specific fields in the requested order (`sourceFileSummary.summaryText`, `adminSummary`, `whyNow`, `reason`, `evidenceSummary`, `recommendedNextStep`).
- Remove the specific redundant row text `Review source context and decide whether to attach or convert into a BNL Source File.` from normal dashboard flows by filtering it out and adjust related UI copy so public dossier text and public pages are unchanged.
- Update tests in `tests/admin-dossiers.test.mjs` to assert the drawer placement and the absence of full diagnostic sections from the normal dashboard flow and to validate the new `whyItMattersCopy` filtering behavior.

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed (175 tests, 0 failures). 
- Ran `npx tsc --noEmit` with no type errors reported (aside from an unrelated npm env config warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2baa2a30708321b4aac15bd2936413)