### PR TITLE
BNL Source File → Proposed Dossier: assemble public‑safe drafts, add update flow, and reorganize Source File UI

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -429,6 +429,152 @@ function uniqueLabels(labels: string[]) {
   return Array.from(new Set(labels.filter(Boolean)));
 }
 
+type DossierReadinessLabel =
+  | "Ready for Proposed Dossier"
+  | "Almost Ready"
+  | "Internal Source File Only"
+  | "Needs Identity Review"
+  | "Needs More Public Evidence";
+
+type MainSourceFileAction =
+  | "add_to_source_file"
+  | "add_missing_evidence"
+  | "create_draft"
+  | "open_draft"
+  | "update_draft"
+  | "open_update_workspace";
+
+function safeCompleteText(value?: string | null) {
+  const clean = value?.replace(/\s+/g, " ").trim();
+  if (!clean) return undefined;
+  return clean.replace(/(\.\.\.|…)+$/g, "").trim();
+}
+
+function firstMeaningful(items: Array<string | undefined | null>, fallback: string) {
+  return safeCompleteText(items.find((item) => safeCompleteText(item))) ?? fallback;
+}
+
+function readableCoverageLabel(value: string) {
+  const key = value.toLowerCase();
+  if (key.includes("queue") || key.includes("submission") || key.includes("played")) return "queue evidence";
+  if (key.includes("discord") || key.includes("conversation")) return "public Discord activity";
+  if (key.includes("relationship")) return "review-only internal context";
+  if (key.includes("memory") || key.includes("broadcast")) return "BNL memory";
+  if (key.includes("entity_activity")) return "community presence";
+  if (key.includes("dossier")) return "public dossier match";
+  if (key.includes("note")) return "source notes";
+  return value
+    .replace(/_/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function uniqueReadable(items: Array<string | undefined | null>, limit = 5) {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const item of items) {
+    const clean = safeCompleteText(item);
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function inferEntityType(input: {
+  candidate: DossierCandidate;
+  activitySignals: string[];
+  musicSignals: string[];
+}) {
+  const text = [
+    input.candidate.recommendedKind,
+    input.candidate.recommendedCategory,
+    ...(input.candidate.recommendedTags ?? []),
+    ...(input.candidate.proposedTags ?? []),
+    ...input.activitySignals,
+    ...input.musicSignals,
+  ]
+    .join(" ")
+    .toLowerCase();
+  if (/sponsor|brand|partner/.test(text)) return "sponsor";
+  if (/moderator|mod\b/.test(text)) return "moderator";
+  if (/artist|music|track|song|producer|dj/.test(text)) return "artist";
+  if (/collaborator|guest|contributor/.test(text)) return "collaborator";
+  if (/supporter|donor|boost/.test(text)) return "supporter";
+  if (/lore|anomaly|character/.test(text)) return "lore/anomaly figure";
+  if (/technical|internal|system|interface/.test(text)) return "technical/internal entity";
+  if (/viewer|community|discord|chat/.test(text)) return "viewer/community member";
+  return "unknown / not enough evidence";
+}
+
+function readinessForSourceFile(input: {
+  sourceFileExists: boolean;
+  identityNeedsReview: boolean;
+  publicSafeFactCount: number;
+  activityEvidenceCount: number;
+  roleKnown: boolean;
+  missingInfoCount: number;
+  reviewOnlyEvidenceCount: number;
+}): { label: DossierReadinessLabel; reasons: string[]; blockers: string[] } {
+  const reasons: string[] = [];
+  const blockers: string[] = [];
+  if (!input.sourceFileExists) {
+    return {
+      label: "Internal Source File Only",
+      reasons: ["This record has not been added to a BNL Source File yet."],
+      blockers: ["Add it to a Source File before drafting."],
+    };
+  }
+  if (input.identityNeedsReview) blockers.push("Identity links or aliases still need review.");
+  if (input.publicSafeFactCount === 0) blockers.push("Public-safe facts have not been separated yet.");
+  if (!input.roleKnown) blockers.push("Public-safe identity / role / activity evidence is incomplete.");
+  if (input.activityEvidenceCount === 0) blockers.push("Community activity evidence is missing or only internal.");
+  if (input.reviewOnlyEvidenceCount > 0) reasons.push("Review-only evidence exists and must stay out of public copy.");
+  if (input.publicSafeFactCount > 0) reasons.push("Public-safe facts are available for admin drafting.");
+  if (input.activityEvidenceCount > 0) reasons.push("BNL has activity evidence to review.");
+
+  if (input.identityNeedsReview) return { label: "Needs Identity Review", reasons, blockers };
+  if (input.publicSafeFactCount === 0 || !input.roleKnown) {
+    return { label: "Needs More Public Evidence", reasons, blockers };
+  }
+  if (input.activityEvidenceCount === 0) {
+    return { label: "Internal Source File Only", reasons, blockers };
+  }
+  if (input.missingInfoCount > 0 || input.reviewOnlyEvidenceCount > 0) {
+    return { label: "Almost Ready", reasons, blockers };
+  }
+  return { label: "Ready for Proposed Dossier", reasons, blockers };
+}
+
+function primaryActionForSourceFile(input: {
+  sourceFileExists: boolean;
+  hasPublicDossier: boolean;
+  isExistingDossierUpdate: boolean;
+  hasDraft: boolean;
+  sourceFileChangedSinceDraft: boolean;
+  readyForDraft: boolean;
+}): MainSourceFileAction {
+  if (!input.sourceFileExists) return "add_to_source_file";
+  if (input.hasPublicDossier && !input.isExistingDossierUpdate) return "open_update_workspace";
+  if (input.hasDraft && input.sourceFileChangedSinceDraft) return "update_draft";
+  if (input.hasDraft) return "open_draft";
+  if (input.readyForDraft) return "create_draft";
+  return "add_missing_evidence";
+}
+
+function actionExplanation(action: MainSourceFileAction, readinessLabel: DossierReadinessLabel) {
+  if (action === "add_to_source_file") return "This record needs to become a BNL Source File before drafting is available.";
+  if (action === "create_draft") return "The Source File has enough public-safe dossier intelligence to create a reviewable Proposed Dossier draft.";
+  if (action === "open_draft") return "The Proposed Dossier draft is current with the Source File.";
+  if (action === "update_draft") return "The Source File has changed since the current draft was created or updated.";
+  if (action === "open_update_workspace") return "A public dossier is already linked, so this should move through the Dossier Update workspace instead of a new Proposed Dossier.";
+  return `Draft blocked: missing public-safe identity / role / activity evidence. Current readiness: ${readinessLabel}.`;
+}
+
 function sourceWarningLabels(input: {
   candidate: DossierCandidate;
   recommendations: DossierRecommendation[];
@@ -1288,8 +1434,17 @@ export default function CandidateReviewPage() {
       recommendation,
     ]),
   );
+  const draftSourceReferenceAt =
+    primaryDraft?.sourceFileDraftMetadata?.assembledAt ?? primaryDraft?.updatedAt;
   const sourceFileChangedSinceDraft = Boolean(
-    primaryDraft && (sourceMetrics?.unappliedSourceNotesCount ?? 0) > 0,
+    primaryDraft &&
+      ((sourceMetrics?.unappliedSourceNotesCount ?? 0) > 0 ||
+        (draftSourceReferenceAt &&
+          candidate?.updatedAt &&
+          Date.parse(candidate.updatedAt) > Date.parse(draftSourceReferenceAt)) ||
+        (draftSourceReferenceAt &&
+          latestRecommendationTimestamp &&
+          Date.parse(latestRecommendationTimestamp) > Date.parse(draftSourceReferenceAt))),
   );
   const nextRecommendedAction = sourceFileChangedSinceDraft
     ? "Update Draft From Source File"
@@ -1655,6 +1810,128 @@ export default function CandidateReviewPage() {
     ],
     { subjectName: candidate.name, fallback: "No review-only evidence notes recorded." },
   );
+  const rawPublicSafeFacts = uniqueReadable([
+    ...(candidate.knownFacts ?? []),
+    ...(candidate.sourceFileNotes ?? [])
+      .filter((note) => note.status === "active" && note.publicSafe === true)
+      .map((note) => note.text),
+    ...(entityActivityReadout?.publicUseCandidates ?? []),
+  ]);
+  const activitySignals = uniqueReadable([
+    ...(entityActivityReadout?.activityFrequencySummary ?? []),
+    ...(entityActivityReadout?.recentActivitySummary ?? []),
+    ...(entityActivityReadout?.communitySignals ?? []),
+    ...(entityActivityReadout?.conversationHighlights ?? []),
+    ...(sourceFileSummary?.activityFrequencySummary ?? []),
+    ...(sourceFileSummary?.recentActivitySummary ?? []),
+    ...(sourceFileSummary?.communitySignals ?? []),
+  ], 6);
+  const topicSignals = uniqueReadable([
+    ...(entityActivityReadout?.topicBreakdown ?? []),
+    ...(entityActivityReadout?.topTopicDetails ?? []),
+    ...(sourceFileSummary?.topicBreakdown ?? []),
+    ...(sourceFileSummary?.topTopicDetails ?? []),
+    ...(sourceFileSummary?.patterns ?? []),
+  ], 5);
+  const authoredVsMentioned = uniqueReadable([
+    ...(entityActivityReadout?.authoredVsMentionedSummary ?? []),
+    ...(sourceFileSummary?.authoredVsMentionedSummary ?? []),
+  ], 3);
+  const musicSignals = uniqueReadable([
+    ...(entityActivityReadout?.musicSignals ?? []),
+    ...(sourceFileSummary?.musicSignals ?? []),
+  ], 5);
+  const queueStatus = safeCompleteText(
+    entityActivityReadout?.queueSubmissionStatus ?? sourceFileSummary?.queueSubmissionStatus,
+  );
+  const queueNote = safeCompleteText(
+    entityActivityReadout?.queueSubmissionNote ?? sourceFileSummary?.queueSubmissionNote,
+  );
+  const hasConfirmedQueueFootprint = Boolean(queueStatus || queueNote);
+  const readableCoverage = uniqueReadable(
+    [
+      ...(sourceFileSummary?.sourceCoverage ?? []),
+      ...(entityActivityReadout?.sourceCoverage ?? []),
+      ...evidenceReceiptLanes,
+    ].map(readableCoverageLabel),
+    6,
+  );
+  const roleKnown = Boolean(
+    candidate.recommendedKind ||
+      candidate.recommendedCategory ||
+      rawPublicSafeFacts.some((item) => /artist|moderator|collaborator|supporter|viewer|sponsor|community|music/i.test(item)),
+  );
+  const sourceFileExists = !isCandidateIntake && !isArchivedCandidate && !isCandidateClosed(candidate);
+  const identityNeedsReview =
+    proposedIdentityLinks.length > 0 || candidate.identityReviewStatus === "needs_confirmation";
+  const readiness = readinessForSourceFile({
+    sourceFileExists,
+    identityNeedsReview,
+    publicSafeFactCount: rawPublicSafeFacts.length,
+    activityEvidenceCount: activitySignals.length + rawPublicSafeFacts.length,
+    roleKnown,
+    missingInfoCount: (candidate.missingInfo ?? []).length + (sourceFileSummary?.missingInfo ?? []).length,
+    reviewOnlyEvidenceCount: reviewOnlyNotes[0] === "No review-only evidence notes recorded." ? 0 : reviewOnlyNotes.length,
+  });
+  const readyForDraft = readiness.label === "Ready for Proposed Dossier";
+  const mainAction = primaryActionForSourceFile({
+    sourceFileExists,
+    hasPublicDossier: Boolean(candidate.existingDossierMatch),
+    isExistingDossierUpdate,
+    hasDraft: Boolean(primaryDraft),
+    sourceFileChangedSinceDraft,
+    readyForDraft,
+  });
+  const entityType = inferEntityType({ candidate, activitySignals, musicSignals });
+  const activityLevel =
+    sourceFileSummary?.substanceLevel === "strong"
+      ? "high"
+      : sourceFileSummary?.substanceLevel === "useful"
+        ? "medium"
+        : sourceFileSummary?.substanceLevel === "partial"
+          ? "low"
+          : activitySignals.length > 0
+            ? "low"
+            : "unknown";
+  const dossierIntelligenceSummary = firstMeaningful([
+    sourceFileSummary?.currentRead,
+    entityActivityReadout?.currentRead,
+    `${candidate.name} is classified as ${entityType}. Dossier readiness is ${readiness.label.toLowerCase()} based on ${rawPublicSafeFacts.length} public-safe fact${rawPublicSafeFacts.length === 1 ? "" : "s"} and ${activitySignals.length} activity signal${activitySignals.length === 1 ? "" : "s"}.`,
+  ], `${candidate.name} needs more BNL dossier intelligence before public drafting.`);
+  const whatToAddGroups = [
+    {
+      title: "Identity",
+      items: [
+        identityNeedsReview ? "Resolve proposed aliases or identity links before public drafting." : undefined,
+        !roleKnown ? "Confirm a public display name and role that can be used safely." : undefined,
+      ],
+    },
+    {
+      title: "Community role",
+      items: [
+        activitySignals.length === 0 ? "Add authored community activity or repeated public participation evidence." : undefined,
+        topicSignals.length === 0 ? "Add recurring topics or context that explains why this subject matters." : undefined,
+      ],
+    },
+    {
+      title: "Queue/music",
+      items: [
+        !hasConfirmedQueueFootprint ? "No confirmed queue submissions, played-track history, or owned music links are connected yet." : undefined,
+        musicSignals.length === 0 ? "Add owned music links only if they are confirmed and public-safe." : undefined,
+      ],
+    },
+    {
+      title: "Public-safe evidence",
+      items: [
+        rawPublicSafeFacts.length === 0 ? "Separate public-safe facts from review-only/internal evidence." : undefined,
+        reviewOnlyNotes[0] !== "No review-only evidence notes recorded." ? "Review-only/private/internal evidence cannot be used publicly yet." : undefined,
+      ],
+    },
+    {
+      title: "Dossier decision",
+      items: [actionExplanation(mainAction, readiness.label)],
+    },
+  ].map((group) => ({ ...group, items: group.items.filter(Boolean) as string[] }));
 
   return (
     <main className="pt-14 min-h-screen bg-background">
@@ -1777,8 +2054,11 @@ export default function CandidateReviewPage() {
           </div>
 
           <div className="mt-5 grid grid-cols-1 gap-3 text-xs uppercase tracking-widest lg:grid-cols-3">
-            <div className="border border-border bg-background/20 p-3">
+            <div className="border border-border bg-background/20 p-3 lg:col-span-2">
               <p className="mb-3 text-accent">Main actions</p>
+              <p className="mb-3 text-sm normal-case tracking-normal text-muted">
+                {actionExplanation(mainAction, readiness.label)}
+              </p>
               <div className="flex flex-wrap gap-3">
                 <Link
                   href="/admin/dossiers"
@@ -1786,13 +2066,25 @@ export default function CandidateReviewPage() {
                 >
                   Back to Dossier Control Center
                 </Link>
-                <a
-                  href="#add-info"
-                  className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
-                >
-                  Add to Source File
-                </a>
-                {canCreateDraft && (
+                {mainAction === "add_to_source_file" && (
+                  <button
+                    type="button"
+                    onClick={() => void candidateLifecycleAction("promoteCandidateToSourceFile")}
+                    disabled={saving || !canPromoteCandidate}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Add to Source File
+                  </button>
+                )}
+                {mainAction === "add_missing_evidence" && (
+                  <a
+                    href="#what-to-add"
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
+                  >
+                    Add Missing Evidence
+                  </a>
+                )}
+                {mainAction === "create_draft" && (
                   <button
                     type="button"
                     onClick={() => void createDraft()}
@@ -1802,7 +2094,7 @@ export default function CandidateReviewPage() {
                     Create Proposed Dossier Draft
                   </button>
                 )}
-                {primaryDraft && sourceFileChangedSinceDraft && (
+                {mainAction === "update_draft" && primaryDraft && (
                   <button
                     type="button"
                     onClick={() => void updateDraftFromSourceFile()}
@@ -1812,15 +2104,37 @@ export default function CandidateReviewPage() {
                     Update Draft From Source File
                   </button>
                 )}
-                {primaryDraft && isDraftActive(primaryDraft) && (
-                  <Link
-                    href={`/admin/dossiers/drafts/${primaryDraft.id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
+                {(mainAction === "open_draft" || mainAction === "update_draft") &&
+                  primaryDraft &&
+                  isDraftActive(primaryDraft) && (
+                    <Link
+                      href={`/admin/dossiers/drafts/${primaryDraft.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`${mainAction === "open_draft" ? "border-accent text-accent hover:bg-accent hover:text-background" : "border-border text-muted hover:border-accent hover:text-accent"} border px-4 py-2`}
+                    >
+                      Open Proposed Dossier Draft
+                    </Link>
+                  )}
+                {mainAction === "open_update_workspace" && (
+                  <button
+                    type="button"
+                    onClick={() => void candidateLifecycleAction("markCandidateAsExistingDossierUpdate")}
+                    disabled={saving || !canUpdateCandidate || !existingDossierSelection}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
                   >
-                    Open Proposed Dossier Draft
-                  </Link>
+                    Open Dossier Update Workspace
+                  </button>
+                )}
+                {!readyForDraft && !primaryDraft && sourceFileExists && mainAction !== "open_update_workspace" && (
+                  <button
+                    type="button"
+                    disabled
+                    className="border border-border px-4 py-2 text-muted opacity-60"
+                    title={actionExplanation(mainAction, readiness.label)}
+                  >
+                    Draft blocked: missing public-safe identity / role / activity evidence
+                  </button>
                 )}
               </div>
             </div>
@@ -1959,6 +2273,118 @@ export default function CandidateReviewPage() {
           </div>
         </section>
 
+        <Section title="BNL Dossier Intelligence">
+          <div className="space-y-3">
+            <p className="text-foreground">{dossierIntelligenceSummary}</p>
+            <dl className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Entity type</dt>
+                <dd className="mt-1">{entityType}</dd>
+              </div>
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Activity level</dt>
+                <dd className="mt-1">{activityLevel}</dd>
+              </div>
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Dossier decision</dt>
+                <dd className="mt-1">{readiness.label}</dd>
+              </div>
+            </dl>
+            <div>
+              <h3 className="font-semibold text-foreground">Evidence supporting dossier value</h3>
+              {meaningFirstList(
+                [
+                  ...rawPublicSafeFacts,
+                  ...activitySignals,
+                  ...musicSignals,
+                  ...(hasConfirmedQueueFootprint ? [queueStatus, queueNote] : []),
+                ],
+                "No public-safe dossier evidence has been separated yet.",
+                candidate.name,
+              )}
+            </div>
+            <div>
+              <h3 className="font-semibold text-foreground">Missing before public use</h3>
+              {meaningFirstList(
+                [...readiness.blockers, ...(sourceFileSummary?.missingInfo ?? [])],
+                "No blockers recorded beyond Owner Review.",
+                candidate.name,
+              )}
+            </div>
+          </div>
+        </Section>
+
+        <Section title="Community Activity Profile">
+          <div className="space-y-3">
+            <dl className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Recent activity</dt>
+                <dd className="mt-1">{firstMeaningful(entityActivityReadout?.recentActivitySummary ?? sourceFileSummary?.recentActivitySummary ?? [], "No recent activity summary connected yet.")}</dd>
+              </div>
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Authored or mentioned</dt>
+                <dd className="mt-1">{firstMeaningful(authoredVsMentioned, "BNL has not separated authored activity from mentions yet.")}</dd>
+              </div>
+              <div className="border border-border/60 bg-background/30 p-3">
+                <dt className="text-xs uppercase tracking-widest text-accent">Confidence</dt>
+                <dd className="mt-1">{entityActivityReadout?.confidence ?? candidate.confidence ?? "unknown"}</dd>
+              </div>
+            </dl>
+            <div>
+              <h3 className="font-semibold text-foreground">Recurring topics</h3>
+              {meaningFirstList(topicSignals, "No recurring public-safe topics connected yet.", candidate.name)}
+            </div>
+            <div>
+              <h3 className="font-semibold text-foreground">Readable source context</h3>
+              {meaningFirstList(readableCoverage, "No readable source coverage connected yet.", candidate.name)}
+            </div>
+            <p className="border border-border/60 bg-background/20 p-3">
+              Public-safe status: {rawPublicSafeFacts.length > 0 ? "public-safe facts are available for drafting" : "public-safe facts are still missing"}. Review-only status: {reviewOnlyNotes[0] === "No review-only evidence notes recorded." ? "no review-only notes recorded" : "review-only evidence exists and must stay internal"}.
+            </p>
+          </div>
+        </Section>
+
+        <Section title="Queue / Music Footprint">
+          <div className="space-y-3">
+            {hasConfirmedQueueFootprint ? (
+              <>
+                <p>{queueStatus ?? "Queue connection present."}</p>
+                {queueNote && <p>{queueNote}</p>}
+              </>
+            ) : (
+              <p>No confirmed queue footprint connected yet.</p>
+            )}
+            <div>
+              <h3 className="font-semibold text-foreground">Music connection</h3>
+              {meaningFirstList(
+                musicSignals,
+                hasConfirmedQueueFootprint
+                  ? "Queue evidence is present, but no owned public music link has been separated yet."
+                  : "Music connection is missing or unverified.",
+                candidate.name,
+              )}
+            </div>
+            <p>
+              Public-safe use: {hasConfirmedQueueFootprint || musicSignals.length > 0 ? "review the listed public-safe evidence before mentioning music or queue activity" : "do not mention queue or music activity publicly yet"}.
+            </p>
+          </div>
+        </Section>
+
+        <Section title="Dossier Readiness">
+          <div className="space-y-3">
+            <p className="text-xl font-bold text-foreground">{readiness.label}</p>
+            <div>
+              <h3 className="font-semibold text-foreground">Readiness reasons</h3>
+              {meaningFirstList(readiness.reasons, "No positive readiness reasons recorded yet.", candidate.name)}
+            </div>
+            <div>
+              <h3 className="font-semibold text-foreground">Blockers</h3>
+              {meaningFirstList(readiness.blockers, "No blockers recorded beyond Owner Review.", candidate.name)}
+            </div>
+            <p>Recommended next action: {actionExplanation(mainAction, readiness.label)}</p>
+          </div>
+        </Section>
+
         <Section title="BNL take / why this file matters">
           <p>
             {sourceFileSummary?.currentRead ??
@@ -1977,15 +2403,21 @@ export default function CandidateReviewPage() {
         <Section title="Evidence receipts / source lanes">
           <div className="space-y-3">
             <p>
-              Review-only evidence stays internal. Primary copy shows source lanes
-              and receipt counts instead of raw/private evidence refs.
+              Review-only evidence stays internal. Primary copy translates source
+              coverage into readable meaning instead of exposing raw/private refs.
             </p>
-            <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
-              {(evidenceReceiptLanes.length ? evidenceReceiptLanes : ["Review-only evidence"]).map((lane) => (
-                <StatusBadge key={lane}>{lane}</StatusBadge>
-              ))}
-            </div>
+            {meaningFirstList(readableCoverage, "No readable source coverage connected yet.", candidate.name)}
             <p>{attachedRecommendations.length} BNL Signal receipt{attachedRecommendations.length === 1 ? "" : "s"} attached.</p>
+            <details className="border border-border/60 bg-background/20 p-3">
+              <summary className="cursor-pointer font-semibold text-foreground">
+                Technical Source Coverage
+              </summary>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+                {(evidenceReceiptLanes.length ? evidenceReceiptLanes : ["Review-only evidence"]).map((lane) => (
+                  <StatusBadge key={lane}>{lane}</StatusBadge>
+                ))}
+              </div>
+            </details>
           </div>
         </Section>
 
@@ -2195,7 +2627,7 @@ export default function CandidateReviewPage() {
               }
               className="w-full max-w-xl bg-background border border-border px-3 py-2.5 text-sm normal-case tracking-normal text-foreground"
             >
-              <option value="">Choose public dossier…</option>
+              <option value="">Choose public dossier</option>
               {publicDossiers.map((dossier) => (
                 <option key={dossier.id} value={dossier.id}>
                   {dossier.name} ({dossier.id})
@@ -2245,15 +2677,30 @@ export default function CandidateReviewPage() {
           </h2>
           <p className="text-sm text-muted">
             This adds information to this subject&apos;s BNL Source File. It
-            does not directly edit the proposed dossier.
+            does not directly edit the Proposed Dossier.
           </p>
           <p className="text-sm text-muted">
-            Add to BNL Source File = add a source note, correction, evidence,
-            warning, public-safe fact, or missing-info item to this subject.
-            This source file remains one subject/entity. If this information
-            belongs to a different subject, create or wait for a separate BNL
-            recommendation.
+            This source file remains one subject/entity. If the information
+            belongs to a different person or entity, keep it out of this file
+            and create or wait for a separate BNL recommendation.
           </p>
+          <section id="what-to-add" className="border border-border/70 bg-background/20 p-4">
+            <h3 className="text-lg font-bold text-foreground">
+              What to add to this Source File
+            </h3>
+            <p className="mt-2 text-sm text-muted">
+              These gaps are generated from dossier readiness, identity review,
+              activity evidence, queue/music evidence, and public-safe facts.
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+              {whatToAddGroups.map((group) => (
+                <section key={group.title} className="border border-border/60 bg-background/30 p-3 text-sm text-muted">
+                  <h4 className="font-semibold text-foreground">{group.title}</h4>
+                  {group.items.length ? list(group.items) : <p>No gap recorded for this category.</p>}
+                </section>
+              ))}
+            </div>
+          </section>
           {hasOwnerReviewDraft && (
             <p className="border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
               This becomes an Admin Addendum for owner review. It does not
@@ -2375,7 +2822,7 @@ export default function CandidateReviewPage() {
                 defaultValue={candidate.sourceFileSummary?.summaryText ?? ""}
                 rows={3}
                 className="w-full bg-background border border-border px-3 py-2 text-sm normal-case tracking-normal text-foreground"
-                placeholder="Plain-English internal correction to BNL's current read…"
+                placeholder="Plain-English internal correction to BNL's current read."
               />
             </label>
             <label className="space-y-2 text-xs uppercase tracking-widest text-muted">

--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -854,7 +854,7 @@ function PhaseRail() {
     >
       <div className="flex flex-wrap gap-2">
         <span className="border border-accent bg-accent/10 px-3 py-2 text-accent">
-          Phase 1 — Case File / BNL Source File
+          Phase 1 — BNL Source File
         </span>
         <span className="border border-border px-3 py-2">
           Phase 2 — Proposed Dossier + BNL Edit Chat
@@ -1204,22 +1204,18 @@ export default function CandidateReviewPage() {
         (sourceFileOpenState.immediateRefresh?.ok && immediateRecommendationVisible)),
   );
   const refreshStatusLabel = sourceFileOpenState.running
-    ? "UPDATING SOURCE FILE"
-    : caseReportMissingForLatestArchive
-      ? latestRefreshRequest?.status === "pending" || latestRefreshRequest?.status === "claimed"
-        ? "CASE REPORT QUEUED"
-        : latestRefreshRequest?.status === "failed"
-          ? "CASE REPORT FAILED"
-          : "CASE REPORT MISSING"
-      : sourceFileFreshForOpen
-        ? "FILE UPDATED"
-        : "FILE NOT UPDATED";
+    ? sourceFileOpenState.immediateRefresh
+      ? "RETRYING UPDATE"
+      : "UPDATING SOURCE FILE"
+    : sourceFileFreshForOpen
+      ? "FILE UPDATED"
+      : "FILE NOT UPDATED";
   const refreshStatusDetail = sourceFileOpenState.running
     ? "BNL is updating this Source File now through the server-side immediate refresh endpoint."
     : caseReportMissingForLatestArchive
-      ? "Latest archive exists, but BNL has not generated the Case File Report yet. Refresh requests ask BNL for case-report backfill."
+      ? "Latest archive exists, but BNL has not generated the Source File report yet. Refresh requests ask BNL for report backfill."
       : sourceFileFreshForOpen
-        ? "Latest BNL enrichment is fresh for this page open."
+        ? "Source File updated for this page open."
         : "This page is not treating older BNL Source File data as current. Use FILE NOT UPDATED to retry the immediate update.";
   const refreshFailureReason =
     sourceFileOpenState.immediateRefresh?.failureReason ??
@@ -1281,7 +1277,7 @@ export default function CandidateReviewPage() {
     ? "Dossier Update"
     : isCandidateIntake
       ? "Dossier Seed"
-      : "Case File / BNL Source File";
+      : "BNL Source File";
   const closedIdentityLinks = identityLinks.filter(
     (identityLink) =>
       identityLink.status === "rejected" || identityLink.status === "retired",
@@ -1292,13 +1288,16 @@ export default function CandidateReviewPage() {
       recommendation,
     ]),
   );
-  const nextRecommendedAction = sourceMetrics?.unappliedSourceNotesCount
-    ? "Review source updates in proposed dossier"
+  const sourceFileChangedSinceDraft = Boolean(
+    primaryDraft && (sourceMetrics?.unappliedSourceNotesCount ?? 0) > 0,
+  );
+  const nextRecommendedAction = sourceFileChangedSinceDraft
+    ? "Update Draft From Source File"
     : primaryDraft
-      ? "Open Proposed Dossier"
+      ? "Open Proposed Dossier Draft"
       : candidate?.status === "needs_more_evidence"
         ? "Add missing info"
-        : "Create Proposed Dossier";
+        : "Create Proposed Dossier Draft";
 
   async function postWorkflow(body: Record<string, unknown>) {
     setSaving(true);
@@ -1391,10 +1390,29 @@ export default function CandidateReviewPage() {
         candidateId,
       });
       setNotice(
-        `Draft created: ${data.draft?.fields.name ?? "draft"}. Open Proposed Dossier in the dedicated editor.`,
+        `Draft from Source File created: ${data.draft?.fields.name ?? "draft"}. Open Proposed Dossier Draft in the dedicated editor.`,
       );
     } catch (err) {
       setNotice(err instanceof Error ? err.message : "Failed to create draft.");
+    }
+  }
+
+  async function updateDraftFromSourceFile() {
+    if (!primaryDraft || !sourceFileChangedSinceDraft) return;
+    try {
+      const data = await postWorkflow({
+        action: "updateDraftFromSourceFile",
+        draftId: primaryDraft.id,
+      });
+      setNotice(
+        `Draft from Source File updated: ${data.draft?.fields.name ?? "draft"}. Public-safe draft remains unpublished for admin and Owner Review.`,
+      );
+    } catch (err) {
+      setNotice(
+        err instanceof Error
+          ? err.message
+          : "Failed to update draft from Source File.",
+      );
     }
   }
 
@@ -1460,7 +1478,7 @@ export default function CandidateReviewPage() {
                 ? "Existing public dossier target attached. Public dossier content was not changed."
                 : action === "markCandidateAsExistingDossierUpdate"
                   ? "Workflow record moved to Dossier Updates. Public dossier content was not changed."
-                  : "Dossier Seed promoted to a Case File / BNL Source File. Public dossiers were not changed.",
+                  : "Dossier Seed promoted to a BNL Source File. Public dossiers were not changed.",
       );
     } catch (err) {
       setNotice(
@@ -1605,6 +1623,39 @@ export default function CandidateReviewPage() {
       />
     );
 
+  const evidenceReceiptLanes = uniqueLabels([
+    ...(candidate.sourceLanes ?? []),
+    ...attachedRecommendations.flatMap((recommendation) => [
+      ...(recommendation.sourceLanes ?? []),
+      ...(recommendation.sourceTypes ?? []),
+    ]),
+  ]);
+  const publicSafeFactItems = sanitizeMeaningFirstItems(
+    [
+      ...(candidate.knownFacts ?? []),
+      ...(candidate.sourceFileNotes ?? [])
+        .filter((note) => note.status === "active" && note.publicSafe === true)
+        .map((note) => note.text),
+    ],
+    { subjectName: candidate.name, fallback: "No public-safe facts separated yet." },
+  );
+  const reviewOnlyNotes = sanitizeMeaningFirstItems(
+    [
+      ...(candidate.doNotSay ?? []),
+      ...(candidate.publicSafetyNotes ?? []),
+      ...(candidate.sourceFileNotes ?? [])
+        .filter(
+          (note) =>
+            note.status === "active" &&
+            (note.publicSafe === false ||
+              note.type === "do_not_say" ||
+              note.type === "public_safety"),
+        )
+        .map((note) => note.text),
+    ],
+    { subjectName: candidate.name, fallback: "No review-only evidence notes recorded." },
+  );
+
   return (
     <main className="pt-14 min-h-screen bg-background">
       <section className="border-b border-border bg-surface/80">
@@ -1689,7 +1740,7 @@ export default function CandidateReviewPage() {
             primaryDraft && (
               <div className="mt-4 border border-accent/60 bg-accent/10 p-3 text-sm text-accent">
                 <p>
-                  This Case File / BNL Source File has new info not yet applied to the Proposed Dossier.
+                  This BNL Source File has new info not yet applied to the Proposed Dossier.
                 </p>
                 <p className="mt-2 text-xs uppercase tracking-widest">
                   Use the primary Proposed Dossier action above to apply the new
@@ -1701,7 +1752,7 @@ export default function CandidateReviewPage() {
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div>
                 <p className="text-xs uppercase tracking-widest text-accent">
-                  Case File Refresh
+                  Source File status / refresh state
                 </p>
                 <p className="text-foreground">{refreshStatusLabel}</p>
                 <p className="mt-1">{refreshStatusDetail}</p>
@@ -1748,7 +1799,17 @@ export default function CandidateReviewPage() {
                     disabled={saving}
                     className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
                   >
-                    Create Proposed Dossier
+                    Create Proposed Dossier Draft
+                  </button>
+                )}
+                {primaryDraft && sourceFileChangedSinceDraft && (
+                  <button
+                    type="button"
+                    onClick={() => void updateDraftFromSourceFile()}
+                    disabled={saving}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Update Draft From Source File
                   </button>
                 )}
                 {primaryDraft && isDraftActive(primaryDraft) && (
@@ -1758,7 +1819,7 @@ export default function CandidateReviewPage() {
                     rel="noopener noreferrer"
                     className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background"
                   >
-                    Open Proposed Dossier
+                    Open Proposed Dossier Draft
                   </Link>
                 )}
               </div>
@@ -1810,7 +1871,7 @@ export default function CandidateReviewPage() {
                     disabled={saving}
                     className="border border-border px-4 py-2 text-foreground hover:border-accent hover:text-accent disabled:opacity-50"
                   >
-                    Move Back to Case File
+                    Move Back to BNL Source File
                   </button>
                 )}
                 {canPromoteCandidate && (
@@ -1822,7 +1883,7 @@ export default function CandidateReviewPage() {
                     disabled={saving}
                     className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
                   >
-                    Promote to Case File
+                    Promote to BNL Source File
                   </button>
                 )}
               </div>
@@ -1838,7 +1899,7 @@ export default function CandidateReviewPage() {
                     }
                     disabled={saving}
                     className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
-                    title="Safe cleanup: removes this Case File from active dashboard lanes without deleting public dossiers or published data."
+                    title="Safe cleanup: removes this BNL Source File from active dashboard lanes without deleting public dossiers or published data."
                   >
                     Archive
                   </button>
@@ -1897,7 +1958,76 @@ export default function CandidateReviewPage() {
             ))}
           </div>
         </section>
-        <Section title="Identity Check">
+
+        <Section title="BNL take / why this file matters">
+          <p>
+            {sourceFileSummary?.currentRead ??
+              sourceFileReasonMeaning(candidate.reason, candidate.name)}
+          </p>
+          <p className="mt-2">
+            {sourceFileSummary?.whyTracked ??
+              sourceFileWhyNowMeaning(candidate.whyNow)}
+          </p>
+        </Section>
+
+        <Section title="Known facts">
+          {meaningFirstList(publicSafeFactItems, "No public-safe facts separated yet.", candidate.name)}
+        </Section>
+
+        <Section title="Evidence receipts / source lanes">
+          <div className="space-y-3">
+            <p>
+              Review-only evidence stays internal. Primary copy shows source lanes
+              and receipt counts instead of raw/private evidence refs.
+            </p>
+            <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+              {(evidenceReceiptLanes.length ? evidenceReceiptLanes : ["Review-only evidence"]).map((lane) => (
+                <StatusBadge key={lane}>{lane}</StatusBadge>
+              ))}
+            </div>
+            <p>{attachedRecommendations.length} BNL Signal receipt{attachedRecommendations.length === 1 ? "" : "s"} attached.</p>
+          </div>
+        </Section>
+
+        <Section title="Source notes">
+          <p>
+            {sourceNotesSummary.noteCount} saved Source File note{sourceNotesSummary.noteCount === 1 ? "" : "s"}; {sourceNotesSummary.warningCount} review-only warning{sourceNotesSummary.warningCount === 1 ? "" : "s"}.
+          </p>
+          <p className="mt-2">
+            Source notes remain internal until an admin rewrites them into a
+            Public-safe draft.
+          </p>
+        </Section>
+
+        <Section title="Missing info / open questions">
+          {meaningFirstList(
+            [
+              ...(candidate.sourceFileSummary?.openQuestions ?? []),
+              ...(candidate.missingInfo ?? []),
+              ...attachedRecommendations.flatMap((recommendation) => recommendation.missingInfo ?? []),
+            ],
+            "No open questions recorded.",
+            candidate.name,
+          )}
+        </Section>
+
+        <Section title="Public-safety notes">
+          {meaningFirstList(
+            [
+              ...(candidate.publicSafetyNotes ?? []),
+              ...attachedRecommendations.flatMap((recommendation) => recommendation.publicSafetyNotes ?? []),
+            ],
+            "No public-safety notes recorded.",
+            candidate.name,
+          )}
+        </Section>
+
+        <Section title="Do-not-say / review-only notes">
+          {meaningFirstList(reviewOnlyNotes, "No review-only evidence notes recorded.", candidate.name)}
+        </Section>
+
+
+        <Section title="Identity links / aliases">
             <div className="space-y-5">
               <p className="border border-border/70 bg-background/20 p-3">
                 Identity links are internal routing/context tools. Resolve these before
@@ -1995,7 +2125,7 @@ export default function CandidateReviewPage() {
             {/* BNL Case File Report display lives inside DossierSourceFileSummaryPanel. */}
           </>
         )}
-        <Section title="Dossier Workbench / Proposed Dossier Status">
+        <Section title="Proposed Dossier status">
           {!primaryDraft ? (
             <div className="space-y-2">
               <p>No Proposed Dossier exists yet.</p>
@@ -2015,11 +2145,20 @@ export default function CandidateReviewPage() {
               </p>
               <p>
                 Owner review blocked until admins separate public-safe language
-                from internal Case File context in the dedicated Proposed
+                from internal BNL Source File context in the dedicated Proposed
                 Dossier editor.
               </p>
             </div>
           )}
+        </Section>
+
+        <Section title="Next recommended action">
+          <p className="text-foreground">{nextRecommendedAction}</p>
+          <p className="mt-2">
+            Draft from Source File actions create or update a Public-safe draft
+            only. They do not publish, confirm aliases, merge identities, or
+            mutate public dossier pages. Owner Review remains the final approval lane.
+          </p>
         </Section>
 
         <details
@@ -2102,14 +2241,14 @@ export default function CandidateReviewPage() {
           className="border border-border bg-surface p-5 space-y-3"
         >
           <h2 className="text-2xl font-bold text-foreground">
-            Add to Case File / BNL Source File
+            Add to BNL Source File
           </h2>
           <p className="text-sm text-muted">
-            This adds information to this subject&apos;s Case File / BNL Source File. It
+            This adds information to this subject&apos;s BNL Source File. It
             does not directly edit the proposed dossier.
           </p>
           <p className="text-sm text-muted">
-            Add to Case File / BNL Source File = add a source note, correction, evidence,
+            Add to BNL Source File = add a source note, correction, evidence,
             warning, public-safe fact, or missing-info item to this subject.
             This source file remains one subject/entity. If this information
             belongs to a different subject, create or wait for a separate BNL
@@ -2213,18 +2352,12 @@ export default function CandidateReviewPage() {
 
 
 
-        <DossierSourceFileArchiveRawData latestSourceFileArchive={candidate.latestSourceFileArchive} />
-
-
-
-
-
         <details
           open={hasSavedOperatorSourceSummary}
           className="border border-border bg-surface p-5 text-sm text-muted"
         >
           <summary className="cursor-pointer text-xl font-bold text-foreground">
-            Operator Case File Summary
+            Operator Source File Summary
           </summary>
           <p className="mt-3 text-sm text-muted max-w-4xl">
             Optional internal override for the top Source File summary. Use only
@@ -2284,10 +2417,10 @@ export default function CandidateReviewPage() {
                 disabled={saving}
                 className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
               >
-                Save Operator Case File Summary
+                Save Operator Source File Summary
               </button>
               <span className="text-muted self-center">
-                Optional override only; use Add to Case File / BNL Source File for normal
+                Optional override only; use Add to BNL Source File for normal
                 source updates.
               </span>
             </div>
@@ -2448,11 +2581,13 @@ export default function CandidateReviewPage() {
             Diagnostics — collapsed by default
           </summary>
           <p className="mt-3 mb-4">
-            Diagnostics only. Not Case File claims. Raw, technical, and legacy
+            Diagnostics only. Not BNL Source File claims. Raw, technical, and legacy
             supporting fields stay here so the primary review flow remains
             concise.
           </p>
-          <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Raw Source File Data stays inside collapsed diagnostics. */}
+          <DossierSourceFileArchiveRawData latestSourceFileArchive={candidate.latestSourceFileArchive} />
+          <section className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
             <Section title="Reason">
               <p>{sourceFileReasonMeaning(candidate.reason, candidate.name)}</p>
             </Section>
@@ -2507,7 +2642,7 @@ export default function CandidateReviewPage() {
               {meaningFirstList(candidate.knownFacts, "—", candidate.name)}
             </Section>
             <Section title="Corrections / extra notes">
-              <p>Saved notes now live in Case File / BNL Source File Notes above.</p>
+              <p>Saved notes now live in BNL Source File Notes above.</p>
             </Section>
             <Section title="Missing Info">
               {meaningFirstList(candidate.missingInfo, "—", candidate.name)}

--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -760,27 +760,27 @@ export default function DossierDraftEditorPage() {
           )}
           <p className="text-sm text-muted mt-2 max-w-4xl">
             This is the curated public-facing draft. It should be
-            generated/written from reviewed Case File / BNL Source File material, not copied
+            generated/written from reviewed BNL Source File material, not copied
             wholesale from the internal working case file. The source file may
             contain unverified, internal, conflicting, source-blind, or
             private-review material; this page contains only the curated draft
             that may become public after owner review.
           </p>
           <p className="text-sm text-muted mt-2 max-w-4xl">
-            BNL will eventually generate the proposed dossier from the Case File / BNL Source File and approved sources. Admins will direct changes
+            BNL will eventually generate the proposed dossier from the BNL Source File and approved sources. Admins will direct changes
             conversationally. BNL should ask only for missing specifics. Draft
             fields are not mutated automatically when new source notes arrive.
           </p>
           <div className="mt-4">
             <PhaseRail currentPhase={currentPhase} />
-            {/* Case File / BNL Source File Summary / Source File Summary */}
+            {/* BNL Source File Summary / Source File Summary */}
           </div>
           <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-widest">
             <Link
               href={`/admin/dossiers/candidates/${draft.candidateId}`}
               className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent"
             >
-              Back to Case File / BNL Source File
+              Back to BNL Source File
             </Link>
             <Link
               href="/admin/dossiers"
@@ -838,7 +838,7 @@ export default function DossierDraftEditorPage() {
             href={`/admin/dossiers/candidates/${draft.candidateId}`}
             className="mt-4 inline-flex text-accent hover:underline"
           >
-            Open full Case File / BNL Source File
+            Open full BNL Source File
           </Link>
         </details>
         <form onSubmit={saveDraft} className="space-y-5">
@@ -849,7 +849,7 @@ export default function DossierDraftEditorPage() {
             {unappliedSourceNotes.length > 0 ? (
               <>
                 <p className="border border-accent/60 bg-accent/10 p-3 text-accent">
-                  Case File / BNL Source File has new notes since this Proposed Dossier was last
+                  BNL Source File has new notes since this Proposed Dossier was last
                   updated.
                 </p>
                 <div className="space-y-3">
@@ -895,7 +895,7 @@ export default function DossierDraftEditorPage() {
               other collaborator dossiers.”
             </p>
             <p>
-              Future BNL source packet: Case File / BNL Source File, website read model,
+              Future BNL source packet: BNL Source File, website read model,
               dossier taxonomy guide, authoring guide, tag registry,
               queue/public show context, broadcast memory references,
               R&amp;D/operator-approved notes, Discord-safe/mod-approved
@@ -1183,7 +1183,7 @@ export default function DossierDraftEditorPage() {
               href={`/admin/dossiers/candidates/${draft.candidateId}`}
               className="border border-border px-4 py-2 text-xs uppercase tracking-widest text-muted hover:border-accent hover:text-accent"
             >
-              Back to Case File / BNL Source File
+              Back to BNL Source File
             </Link>
             <Link
               href="/admin/dossiers"

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -43,6 +43,7 @@ import {
   convertRecommendationToCandidate,
   createDossierRecommendation,
   createDraftFromCandidate,
+  updateDraftFromSourceFile,
   createManualDossierCandidate,
   dismissDossierRecommendation,
   DossierMergeError,
@@ -124,6 +125,7 @@ type DossierWorkflowResponse = {
 const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "createManualCandidate",
   "createDraftFromCandidate",
+  "updateDraftFromSourceFile",
   "saveDraft",
   "submitDraftForOwnerReview",
   "denyCandidate",
@@ -1011,6 +1013,27 @@ export async function POST(req: Request) {
     if (!draft) {
       return NextResponse.json(
         { error: "Candidate not found" },
+        { status: 404 },
+      );
+    }
+
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: true, action, draft, ...payload });
+  }
+
+  if (action === "updateDraftFromSourceFile") {
+    const draftId = draftIdFromBody(body);
+    if (!draftId) {
+      return NextResponse.json(
+        { error: "draftId is required" },
+        { status: 400 },
+      );
+    }
+
+    const draft = await updateDraftFromSourceFile(draftId);
+    if (!draft) {
+      return NextResponse.json(
+        { error: "Draft not found or cannot be updated from Source File" },
         { status: 404 },
       );
     }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -4,6 +4,7 @@ import { databasePage, type DatabaseEntry } from "@/content";
 import {
   DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
   DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+  containsDossierPublicCopyJunk,
   isDossierPublicCopyPlaceholder,
   sanitizeDossierPublicCopy,
   validateDossierPublicDraftFields,
@@ -6014,11 +6015,124 @@ function cleanDraftSeedTags(values: string[] | undefined): string[] {
 function cleanDraftSeedPrimaryLink(
   link: DossierWorkflowLink | undefined,
 ): DossierWorkflowLink | undefined {
-  if (!link?.url) return undefined;
+  if (!link?.url || link.publicSafe === false) return undefined;
   const label = sanitizeDossierPublicCopy(link.label);
   return {
     ...link,
     label: label || "Featured link",
+    publicSafe: true,
+  };
+}
+
+function uniqueDraftSeedLines(values: Array<string | undefined>, limit = 6): string[] {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const value of values) {
+    const clean = cleanDraftSeedText(value);
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(clean);
+    if (lines.length >= limit) break;
+  }
+  return lines;
+}
+
+function assemblePublicSafeDraftFromSourceFile(input: {
+  candidate: DossierCandidate;
+  recommendations: DossierRecommendation[];
+  now: string;
+}): Pick<DossierDraft, "fields" | "sourceFileDraftMetadata"> {
+  const { candidate, recommendations, now } = input;
+  const publicSafeNotes = (candidate.sourceFileNotes ?? []).filter(
+    (note) => note.status === "active" && note.publicSafe === true,
+  );
+  const publicSafeFacts = uniqueDraftSeedLines([
+    ...(candidate.knownFacts ?? []),
+    ...publicSafeNotes
+      .filter((note) => note.type === "fact" || note.type === "correction")
+      .map((note) => note.text),
+    ...recommendations.flatMap((recommendation) => recommendation.publicUseCandidates ?? []),
+  ], 5);
+  const privateBoundaryCount =
+    (candidate.doNotSay ?? []).length +
+    (candidate.publicSafetyNotes ?? []).length +
+    (candidate.sourceFileNotes ?? []).filter(
+      (note) => note.status === "active" && note.publicSafe === false,
+    ).length;
+  const ownerReviewNotes = uniqueDraftSeedLines([
+    privateBoundaryCount > 0
+      ? `${privateBoundaryCount} review-only evidence note${privateBoundaryCount === 1 ? "" : "s"} must stay in admin metadata.`
+      : undefined,
+    "Owner Review should verify every public-facing claim before approval.",
+  ], 5);
+  const boundaries = uniqueDraftSeedLines([
+    ...(candidate.missingInfo ?? [])
+      .filter((item) => !containsDossierPublicCopyJunk(item) && !/owner-approved public copy|public-safe wording/i.test(item))
+      .map((item) => `Needs review before claiming: ${item}`),
+    privateBoundaryCount > 0
+      ? "Internal admin metadata exists and must not be copied into public text."
+      : undefined,
+    "Owner Review must approve this Proposed Dossier before any public use.",
+  ], 6);
+  const connection = uniqueDraftSeedLines([
+    candidate.reason,
+    candidate.whyNow,
+    ...recommendations.map((recommendation) => recommendation.reason),
+  ], 2);
+  const summary = uniqueDraftSeedLines([
+    candidate.sourceFileSummary?.summaryText,
+    candidate.evidenceSummary,
+    publicSafeFacts[0],
+  ], 1)[0];
+  const role = DOSSIER_PUBLIC_ROLE_PLACEHOLDER;
+  const notesSections = [
+    publicSafeFacts.length
+      ? `Public-safe facts:\n${publicSafeFacts.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+    connection.length
+      ? `Connection to BARCODE Network:\n${connection.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+    boundaries.length
+      ? `Boundaries / what not to claim:\n${boundaries.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+    ownerReviewNotes.length
+      ? `Owner-review notes:\n${ownerReviewNotes.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return {
+    fields: normalizeDraftFields({
+      name: cleanDraftSeedText(candidate.name) ?? candidate.name,
+      category: candidate.recommendedCategory,
+      kind: candidate.recommendedKind,
+      ecosystemLane: candidate.recommendedEcosystemLane,
+      identityAuthority: candidate.recommendedIdentityAuthority,
+      status: candidate.recommendedStatus ?? "PENDING",
+      clearance: candidate.recommendedClearance ?? "PUBLIC",
+      origin: candidate.recommendedOrigin ?? "UNVERIFIED",
+      role: role ?? DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+      summary: summary ?? DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+      notes: notesSections,
+      tags: cleanDraftSeedTags(candidate.recommendedTags),
+      proposedTags: cleanDraftSeedTags(candidate.proposedTags),
+      primaryLink: cleanDraftSeedPrimaryLink(candidate.primaryLink),
+      files: [],
+    }),
+    sourceFileDraftMetadata: {
+      sourceCandidateId: candidate.id,
+      sourceCandidateUpdatedAt: candidate.updatedAt,
+      sourceFileNoteIds: publicSafeNotes.map((note) => note.id),
+      recommendationIds: recommendations.map((recommendation) => recommendation.id),
+      assembledAt: now,
+      publicSafeDraft: true,
+      reviewOnlyEvidence: true,
+      autoConfirmedIdentityLinks: false,
+      publicPagesMutated: false,
+    },
   };
 }
 
@@ -6045,32 +6159,19 @@ export async function createDraftFromCandidate(
       return currentState;
     }
 
-    const publicSummary = cleanDraftSeedText(candidate.evidenceSummary);
-    const publicTags = cleanDraftSeedTags(candidate.recommendedTags);
-    const publicProposedTags = cleanDraftSeedTags(candidate.proposedTags);
-    const publicPrimaryLink = cleanDraftSeedPrimaryLink(candidate.primaryLink);
+    const assembledDraft = assemblePublicSafeDraftFromSourceFile({
+      candidate,
+      recommendations: currentState.recommendations.filter(
+        (recommendation) => recommendation.targetCandidateId === candidate.id,
+      ),
+      now,
+    });
 
     draft = {
       id: createDraftId(),
       candidateId: candidate.id,
       status: "draft",
-      fields: normalizeDraftFields({
-        name: candidate.name,
-        category: candidate.recommendedCategory,
-        kind: candidate.recommendedKind,
-        ecosystemLane: candidate.recommendedEcosystemLane,
-        identityAuthority: candidate.recommendedIdentityAuthority,
-        status: candidate.recommendedStatus ?? "PENDING",
-        clearance: candidate.recommendedClearance ?? "PUBLIC",
-        origin: candidate.recommendedOrigin ?? "UNVERIFIED",
-        role: DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
-        summary: publicSummary ?? DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
-        notes: "",
-        tags: publicTags,
-        proposedTags: publicProposedTags,
-        primaryLink: publicPrimaryLink,
-        files: [],
-      }),
+      ...assembledDraft,
       createdAt: now,
       updatedAt: now,
     };
@@ -6083,6 +6184,50 @@ export async function createDraftFromCandidate(
   });
 
   return draft;
+}
+
+export async function updateDraftFromSourceFile(
+  draftId: string,
+): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let updatedDraft: DossierDraft | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const draft = currentState.drafts.find((item) => item.id === draftId);
+    if (!draft || draft.status === "published" || draft.status === "owner_approved") {
+      return currentState;
+    }
+    const candidate = currentState.candidates.find(
+      (item) => item.id === draft.candidateId,
+    );
+    if (!candidate) return currentState;
+
+    const assembledDraft = assemblePublicSafeDraftFromSourceFile({
+      candidate,
+      recommendations: currentState.recommendations.filter(
+        (recommendation) => recommendation.targetCandidateId === candidate.id,
+      ),
+      now,
+    });
+
+    const drafts = currentState.drafts.map((item) => {
+      if (item.id !== draftId) return item;
+      updatedDraft = {
+        ...item,
+        ...assembledDraft,
+        updatedAt: now,
+      };
+      return updatedDraft;
+    });
+
+    return {
+      ...currentState,
+      drafts,
+      updatedAt: now,
+    };
+  });
+
+  return updatedDraft;
 }
 
 export async function saveDossierDraft(

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6081,13 +6081,40 @@ function assemblePublicSafeDraftFromSourceFile(input: {
     candidate.whyNow,
     ...recommendations.map((recommendation) => recommendation.reason),
   ], 2);
-  const summary = uniqueDraftSeedLines([
+  const activityProfile = uniqueDraftSeedLines([
+    ...recommendations.flatMap((recommendation) => recommendation.activityFrequencySummary ?? []),
+    ...recommendations.flatMap((recommendation) => recommendation.recentActivitySummary ?? []),
+    ...recommendations.flatMap((recommendation) => recommendation.communitySignals ?? []),
+    ...recommendations.flatMap((recommendation) => recommendation.conversationHighlights ?? []),
+  ], 5);
+  const confirmedQueueFootprint = uniqueDraftSeedLines([
+    ...recommendations.map((recommendation) => recommendation.queueSubmissionStatus),
+    ...recommendations.map((recommendation) => recommendation.queueSubmissionNote),
+  ], 4);
+  const musicFootprint = confirmedQueueFootprint.length > 0
+    ? uniqueDraftSeedLines([
+        ...confirmedQueueFootprint,
+        ...recommendations.flatMap((recommendation) => recommendation.musicSignals ?? []),
+      ], 5)
+    : [];
+  const dossierIntelligence = uniqueDraftSeedLines([
     candidate.sourceFileSummary?.summaryText,
     candidate.evidenceSummary,
+    activityProfile[0],
     publicSafeFacts[0],
-  ], 1)[0];
+  ], 2);
+  const summary = dossierIntelligence[0];
   const role = DOSSIER_PUBLIC_ROLE_PLACEHOLDER;
   const notesSections = [
+    dossierIntelligence.length
+      ? `BNL Dossier Intelligence:\n${dossierIntelligence.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+    activityProfile.length
+      ? `Community Activity Profile:\n${activityProfile.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
+    musicFootprint.length
+      ? `Queue / Music Footprint:\n${musicFootprint.map((item) => `- ${item}`).join("\n")}`
+      : undefined,
     publicSafeFacts.length
       ? `Public-safe facts:\n${publicSafeFacts.map((item) => `- ${item}`).join("\n")}`
       : undefined,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -357,6 +357,17 @@ export type DossierDraft = {
   id: string;
   candidateId: string;
   status: DossierDraftStatus;
+  sourceFileDraftMetadata?: {
+    sourceCandidateId: string;
+    sourceCandidateUpdatedAt?: string;
+    sourceFileNoteIds: string[];
+    recommendationIds: string[];
+    assembledAt: string;
+    publicSafeDraft: true;
+    reviewOnlyEvidence: true;
+    autoConfirmedIdentityLinks: false;
+    publicPagesMutated: false;
+  };
   fields: {
     id?: string;
     name: string;
@@ -2919,6 +2930,7 @@ export type DossierWorkflowAction =
   | "selectCandidate"
   | "requestDraft"
   | "createDraftFromCandidate"
+  | "updateDraftFromSourceFile"
   | "saveDraft"
   | "saveDraftEdit"
   | "submitDraftForOwnerReview"
@@ -2980,6 +2992,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "selectCandidate",
   "requestDraft",
   "createDraftFromCandidate",
+  "updateDraftFromSourceFile",
   "saveDraft",
   "saveDraftEdit",
   "submitDraftForOwnerReview",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -10059,6 +10059,7 @@ test("Draft from Source File creates and updates public-safe Proposed Dossier dr
   assert.equal(draft.status, "draft");
   assert.equal(draft.fields.name, "Bridge Subject");
   assert.match(draft.fields.summary, /Public-safe summary/);
+  assert.match(draft.fields.notes, /BNL Dossier Intelligence:/);
   assert.match(draft.fields.notes, /Public-safe facts:/);
   assert.match(draft.fields.notes, /Connection to BARCODE Network:/);
   assert.match(draft.fields.notes, /Boundaries \/ what not to claim:/);
@@ -10116,4 +10117,55 @@ test("Draft from Source File creates and updates public-safe Proposed Dossier dr
   const stateAfterUpdate = await store.getDossierWorkflowState();
   assert.equal(stateAfterUpdate.candidates[0].identityLinks[0].status, "proposed");
   assert.equal(databasePage.entries.some((entry) => entry.name === "Bridge Subject"), false);
+});
+
+test("Source File intelligence and dynamic main actions are readiness-driven", () => {
+  const page = source("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+
+  for (const label of [
+    "BNL Dossier Intelligence",
+    "Community Activity Profile",
+    "Queue / Music Footprint",
+    "Dossier Readiness",
+    "Technical Source Coverage",
+    "What to add to this Source File",
+    "Identity",
+    "Community role",
+    "Queue/music",
+    "Public-safe evidence",
+    "Dossier decision",
+    "Draft blocked: missing public-safe identity / role / activity evidence",
+    "No confirmed queue footprint connected yet.",
+    "Ready for Proposed Dossier",
+    "Almost Ready",
+    "Internal Source File Only",
+    "Needs Identity Review",
+    "Needs More Public Evidence",
+  ]) {
+    assertIncludesCopy(pageCopy, label);
+  }
+
+  assert.match(page, /primaryActionForSourceFile/);
+  assert.match(page, /mainAction === "add_to_source_file"[\s\S]*Add to Source File/);
+  assert.match(page, /mainAction === "create_draft"[\s\S]*Create Proposed Dossier Draft/);
+  assert.match(page, /mainAction === "open_draft" \|\| mainAction === "update_draft"/);
+  assert.match(page, /mainAction === "update_draft"[\s\S]*Update Draft From Source File/);
+  assert.match(page, /mainAction === "open_update_workspace"[\s\S]*Open Dossier Update Workspace/);
+  assert.match(page, /!readyForDraft && !primaryDraft && sourceFileExists/);
+  assert.match(page, /identityNeedsReview[\s\S]*Needs Identity Review/);
+  assert.match(page, /readableCoverageLabel/);
+  assert.match(page, /queue evidence|public Discord activity|community presence|BNL memory|review-only internal context/);
+
+  const mainActions = page.slice(page.indexOf("<p className=\"mb-3 text-accent\">Main actions</p>"), page.indexOf("<p className=\"mb-3 text-accent\">Review state</p>"));
+  assert.doesNotMatch(mainActions, /Create Proposed Dossier Draft[\s\S]*Open Proposed Dossier Draft[\s\S]*Update Draft From Source File[\s\S]*Add to Source File/);
+  assert.match(mainActions, /actionExplanation\(mainAction, readiness\.label\)/);
+
+  const technicalCoverageIndex = page.indexOf("Technical Source Coverage");
+  const dossierIntelligenceIndex = page.indexOf("BNL Dossier Intelligence");
+  assert.ok(dossierIntelligenceIndex >= 0);
+  assert.ok(technicalCoverageIndex > dossierIntelligenceIndex);
+  assert.match(page, /No confirmed queue footprint connected yet\./);
+  assert.doesNotMatch(pageCopy, /Review source context and decide whether to attach or convert into a BNL Source File/);
+  assert.doesNotMatch(pageCopy, /RELATIONSHIP_JOURNAL[\s\S]{0,200}BNL Dossier Intelligence/);
 });

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -179,7 +179,7 @@ test("proposed dossier preview sanitizes internal starter phrases before Dossier
 
 test("phase 2 draft editor stacks source summary, BNL edit panel, and dossier preview full-width", () => {
   const adminPageSource = normalizedSource("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
-  const sourceSummaryIndex = adminPageSource.indexOf("Case File / BNL Source File Summary");
+  const sourceSummaryIndex = adminPageSource.indexOf("BNL Source File Summary");
   const editPanelIndex = adminPageSource.indexOf("BNL Edit Chat panel — Coming Next", sourceSummaryIndex);
   const previewIndex = adminPageSource.indexOf("<ProposedDossierPreview form={form} candidate={candidate ?? undefined} />", editPanelIndex);
 
@@ -1293,10 +1293,10 @@ test("admin Source File page uses immediate refresh status/retry UI and preserve
   for (const label of [
     "Source File header / refresh status",
     "BNL Case File Report",
-    "Dossier Workbench / Proposed Dossier Status",
+    "Proposed Dossier status",
     "Source Notes / Admin Addendums",
     "Archive / Raw Source File Data",
-    "Identity Check",
+    "Identity links / aliases",
     "Advanced Tools",
     "Phase 4 — Owner Review",
     "Diagnostics",
@@ -1483,7 +1483,7 @@ test("dossier admin pages keep dashboard simple while detail pages retain workfl
     assertIncludesCopy(dashboard, label);
   }
   for (const removed of [
-    "Phase 1 — Case File / BNL Source File",
+    "Phase 1 — BNL Source File",
     "Phase 2 — Proposed Dossier + BNL Edit Chat",
     "Archive / History",
     "System Boundaries",
@@ -1498,10 +1498,10 @@ test("dossier admin pages keep dashboard simple while detail pages retain workfl
   assertIncludesCopy(sourceFileCopy, "Archive");
   assertIncludesCopy(sourceFileCopy, "Delete Permanently");
   assertIncludesCopy(sourceFileCopy, "Restore");
-  assertIncludesCopy(sourceFileCopy, "Promote to Case File");
+  assertIncludesCopy(sourceFileCopy, "Promote to BNL Source File");
   assertIncludesCopy(sourceFileCopy, "DELETE SOURCE FILE");
   assertIncludesCopy(sourceFileCopy, "Public dossiers and published data are not deleted");
-  assertIncludesCopy(sourceFileCopy, "Dossier Workbench / Proposed Dossier Status");
+  assertIncludesCopy(sourceFileCopy, "Proposed Dossier status");
   assertIncludesCopy(sourceFileCopy, "Create one only from reviewed, public-safe Source File material.");
 
   const draftCopy = normalizedSource(
@@ -1509,9 +1509,9 @@ test("dossier admin pages keep dashboard simple while detail pages retain workfl
   );
   assertIncludesCopy(
     draftCopy,
-    "This is the curated public-facing draft. It should be generated/written from reviewed Case File / BNL Source File material, not copied wholesale from the internal working case file.",
+    "This is the curated public-facing draft. It should be generated/written from reviewed BNL Source File material, not copied wholesale from the internal working case file.",
   );
-  assertIncludesCopy(draftCopy, "Case File / BNL Source File Summary");
+  assertIncludesCopy(draftCopy, "BNL Source File Summary");
   assertIncludesCopy(draftCopy, "Unapplied Source Notes");
 
   const ownerPage = source("src/app/admin/dossiers/owner-review/page.tsx");
@@ -1532,11 +1532,11 @@ test("dossier workflow boundary copy separates case files, drafts, owner review,
     "Internal-Only Notes",
     "Source Warnings",
     "Conflicts / Needs Review",
-    "Identity Check",
+    "Identity links / aliases",
     "Advanced Tools",
     "Do Not Say",
     "dossier question",
-    "Dossier Workbench / Proposed Dossier Status",
+    "Proposed Dossier status",
     "Review-only memory context",
     "Internal/private review required",
     "Public use not allowed until review",
@@ -1608,7 +1608,7 @@ test("dedicated draft editor route contains focused editing workflow and future 
   assert.match(page, /Already submitted to Owner Review/);
   assertIncludesCopy(
     pageCopy,
-    "BNL will eventually generate the proposed dossier from the Case File / BNL Source File and approved sources",
+    "BNL will eventually generate the proposed dossier from the BNL Source File and approved sources",
   );
   assertIncludesCopy(pageCopy, "BNL should ask only for missing specifics");
   assert.match(page, /Draft is superseded/);
@@ -1663,109 +1663,65 @@ test("admin dirty-copy warning stays outside shared public DossierPageView", () 
 });
 
 
-test("dedicated candidate review route is the BNL Source File subject hub", () => {
+test("Source File page renders organized BNL Source File workspace with collapsed diagnostics", () => {
   const routePath = "src/app/admin/dossiers/candidates/[candidateId]/page.tsx";
   assert.equal(fs.existsSync(path.join(projectRoot, routePath)), true);
   const page = source(routePath);
   const pageCopy = normalizedSource(routePath);
+
   for (const label of [
     "BNL Source File",
-    "Source strength",
-    "Current state",
-    "Recommendations",
-    "Refresh status",
-    "Case File Refresh",
+    "Source File status / refresh state",
+    "BNL take / why this file matters",
+    "Known facts",
+    "Evidence receipts / source lanes",
+    "Source notes",
+    "Missing info / open questions",
+    "Public-safety notes",
+    "Do-not-say / review-only notes",
+    "Identity links / aliases",
+    "Proposed Dossier status",
+    "Next recommended action",
+    "Diagnostics — collapsed by default",
     "UPDATING SOURCE FILE",
     "FILE UPDATED",
     "FILE NOT UPDATED",
     "RETRYING UPDATE",
-    "Last-known BNL data is not current for this page open",
-    "Source notes",
-    "Unapplied notes",
-    "Recommended next step",
-    "BNL Case File Report",
-    "Review Boundaries",
-    "owner review required",
-    "no public use until review",
-    "Add to Case File / BNL Source File",
-    "This adds information to this subject&apos;s Case File / BNL Source File. It does not directly edit the proposed dossier.",
-    "DossierSourceFileSummaryPanel",
-    "Dossier Workbench / Proposed Dossier Status",
-    "Create one only from reviewed, public-safe Source File material.",
-    "Create Proposed Dossier",
-    "Open Proposed Dossier",
-    "Save Info",
-    "Mark Needs Info",
-    "Internal working material only",
-    "not public copy",
-        "Source Notes / Admin Addendums",
-    "Diagnostics",
-    "Review Context / Possible Supporting Evidence",
-    "Public-Safe Facts Pending Owner/Admin Approval",
-    "Internal-Only Notes",
-    "Source Warnings",
-    "Conflicts / Needs Review",
-    "Identity Check",
-    "Advanced Tools",
-    "Do Not Say",
-    "dossier question",
-    "Review-only memory context",
-    "Internal/private review required",
-    "Public use not allowed until review",
-    "Owner review required",
-    "Possible connection, not confirmed identity",
-    "Dossier Update Actions",
-    "No existing public dossier match currently attached.",
-    "This internal record is a Dossier Update target, not a new dossier proposal.",
-    "Move Back to Case File",
+    "Create Proposed Dossier Draft",
+    "Open Proposed Dossier Draft",
+    "Update Draft From Source File",
+    "Draft from Source File",
+    "Public-safe draft",
+    "Review-only evidence",
+    "Owner Review remains the final approval lane",
   ]) {
     assertIncludesCopy(pageCopy, label);
   }
+
   assert.match(page, /sourceFileFreshForOpen/);
   assert.match(page, /sourceFileOpenState\.running/);
   assert.match(page, /isStaleOpenRefreshRequest/);
-  assert.doesNotMatch(pageCopy, /Persistent Source File Draft/);
-  assert.doesNotMatch(pageCopy, /Internal Operator Summary/);
-  assert.doesNotMatch(pageCopy, /Save Internal Summary/);
-  assert.match(pageCopy, /Operator Case File Summary/);
-  const workspace = page.slice(page.indexOf('<Section title="Identity Check"'));
-  assert.ok(workspace.indexOf("Identity Check") < workspace.indexOf("DossierSourceFileSummaryPanel"));
-  assert.ok(workspace.indexOf("Identity Check") < workspace.indexOf("Dossier Workbench / Proposed Dossier Status"));
-  assert.ok(
-    workspace.indexOf("DossierSourceFileSummaryPanel") < workspace.indexOf("Dossier Workbench / Proposed Dossier Status"),
-  );
-  assert.ok(workspace.indexOf("Dossier Workbench / Proposed Dossier Status") < workspace.indexOf("Add to Case File / BNL Source File"));
-  assert.ok(workspace.indexOf("Add to Case File / BNL Source File") < workspace.indexOf("Source Notes / Admin Addendums"));
-  assert.ok(workspace.indexOf("Source Notes / Admin Addendums") < workspace.indexOf("Operator Case File Summary"));
-  assert.ok(workspace.indexOf("Operator Case File Summary") < workspace.indexOf("Advanced Tools"));
-  assert.ok(workspace.indexOf("Archive / Raw Source File Data") < workspace.indexOf("Diagnostics"));
-  assert.equal((page.match(/>\s*Open Proposed Dossier\s*</g) ?? []).length, 1);
-  assert.equal((page.match(/>\s*Create Proposed Dossier\s*</g) ?? []).length, 1);
-
-  for (const noteType of [
-    "fact",
-    "correction",
-    "missing_info",
-    "public_safety",
-    "do_not_say",
-    "link_note",
-    "general_note",
-    "owner_note",
-  ]) {
-    assert.match(page, new RegExp(noteType));
-  }
-  assert.match(page, /useParams/);
-  assert.match(page, /routeParam\(params\?\.candidateId\)/);
   assert.match(page, /action: "createDraftFromCandidate"/);
+  assert.match(page, /action: "updateDraftFromSourceFile"/);
   assert.match(page, /action: "addSourceFileNote"/);
-  assert.match(page, /attachCandidateToExistingDossier/);
-  assert.match(page, /markCandidateAsExistingDossierUpdate/);
-  assert.doesNotMatch(page, />Deny<|>Deny<\/button>/);
-  assert.doesNotMatch(page, />Final Approve<|>Publish<|>Delete<|>Final Merge</);
+  assert.match(page, /<details className="border border-border bg-surface p-5 text-sm text-muted">[\s\S]*Diagnostics — collapsed by default/);
+  assert.ok(page.indexOf("Diagnostics — collapsed by default") > page.indexOf("Operator Source File Summary"));
+  assert.ok(page.indexOf("Raw Source File Data") > page.indexOf("Diagnostics — collapsed by default"));
+  assert.ok(page.indexOf('title="BNL take / why this file matters"') < page.indexOf('title="Known facts"'));
+  assert.ok(page.indexOf('title="Known facts"') < page.indexOf('title="Evidence receipts / source lanes"'));
+  assert.ok(page.indexOf('title="Evidence receipts / source lanes"') < page.indexOf('title="Source notes"'));
+  assert.ok(page.indexOf('title="Source notes"') < page.indexOf('title="Missing info / open questions"'));
+  assert.ok(page.indexOf('title="Missing info / open questions"') < page.indexOf('title="Public-safety notes"'));
+  assert.ok(page.indexOf('title="Public-safety notes"') < page.indexOf('title="Do-not-say / review-only notes"'));
+  assert.ok(page.indexOf('title="Do-not-say / review-only notes"') < page.indexOf('title="Identity links / aliases"'));
+  assert.ok(page.indexOf('title="Identity links / aliases"') < page.indexOf('title="Proposed Dossier status"'));
+  assert.ok(page.indexOf('title="Proposed Dossier status"') < page.indexOf('title="Next recommended action"'));
+  assert.doesNotMatch(pageCopy, /Review source context and decide whether to attach or convert into a BNL Source File/);
+  assert.doesNotMatch(pageCopy, /Advanced actions/);
+  assert.doesNotMatch(pageCopy, /automatic publishing|canonical profile|public identity merge/);
   assert.doesNotMatch(page, /fetch\("\/api\/bnl/);
   assert.doesNotMatch(page, /publishDraft/);
 });
-
 
 
 test("dossier public-copy guard flags internal starter and source phrases", () => {
@@ -1922,11 +1878,11 @@ test("admin Source File and recommendation pages render readable sections with c
     "Public readiness",
     "Identity certainty",
     "Recommended next step",
-    "Diagnostics only. Not Case File claims.",
+    "Diagnostics only. Not BNL Source File claims.",
     "Older BNL Review Note",
     "BNL Review Addendum",
     "Review-only context connected to this subject",
-    "Diagnostics only. Not Case File claims.",
+    "Diagnostics only. Not BNL Source File claims.",
     "warnings",
     "Recommended Next Steps",
     "Review-only",
@@ -2345,7 +2301,7 @@ test("Population Method Audit preserves existing dossier admin and public bounda
 
   assertIncludesCopy(pageCopy, "Dossier Control Center");
   assertIncludesCopy(pageCopy, "Subject Consolidation Queue");
-  assertIncludesCopy(sourceFilePage, "Case File / BNL Source File");
+  assertIncludesCopy(sourceFilePage, "BNL Source File");
   assertIncludesCopy(publicPage, "<DossierPageView dossier={databaseEntryToDossierPageViewModel(entry)} />");
   assert.doesNotMatch(publicPage + publicView, /Population Method Audit|Intake Map|internal aliases|Copy Record IDs/);
   assert.doesNotMatch(pageCopy, /publicPagesPublished: [1-9]|publicDossierTextChanged: [1-9]/);
@@ -3628,7 +3584,8 @@ test("createDraftFromCandidate keeps internal starter notes out of public draft 
   }
   assert.equal(fields.summary, publicCopyGuard.DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER);
   assert.equal(fields.role, publicCopyGuard.DOSSIER_PUBLIC_ROLE_PLACEHOLDER);
-  assert.equal(fields.notes, undefined);
+  assert.match(fields.notes ?? "", /Boundaries \/ what not to claim:/);
+  assert.match(fields.notes ?? "", /Owner-review notes:/);
   assert.deepEqual(fields.tags, ["artist"]);
   assert.deepEqual(fields.proposedTags, ["manual-review"]);
   assert.equal(fields.primaryLink.label, "Featured link");
@@ -4757,7 +4714,7 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   ]) {
     assert.match(sourceFilePage, new RegExp(group));
   }
-  assert.match(sourceFilePage, /<Section title="Identity Check">/);
+  assert.match(sourceFilePage, /<Section title="Identity links \/ aliases">/);
   assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
   assert.doesNotMatch(sourceFilePage, /identityLinks\.length > 0 &&/);
   assert.match(sourceFilePage, /No identity links pending/);
@@ -4766,12 +4723,12 @@ test("identity alias review UX is grouped, status-aware, and public-safe", () =>
   assert.match(sourceFilePage, /title: "Confirmed Identity Links",[\s\S]*links: confirmedIdentityLinks/);
   assert.match(sourceFilePage, /title: "Rejected \/ Retired Identity History",[\s\S]*links: closedIdentityLinks/);
   assert.match(sourceFilePage, /\.filter\(\(group\) => group\.links\.length > 0\)/);
-  const identityCheckStart = sourceFilePage.indexOf('<Section title="Identity Check">');
+  const identityCheckStart = sourceFilePage.indexOf('<Section title="Identity links / aliases">');
   const identityCheckEnd = sourceFilePage.indexOf('</Section>', identityCheckStart);
   const identityCheckSection = sourceFilePage.slice(identityCheckStart, identityCheckEnd);
   assert.ok(identityCheckStart >= 0);
   assert.ok(identityCheckStart < sourceFilePage.indexOf('Source Notes / Admin Addendums'));
-  assert.ok(identityCheckStart < sourceFilePage.indexOf('Proposed Dossier Status'));
+  assert.ok(identityCheckStart < sourceFilePage.indexOf('Proposed Dossier status'));
   assert.doesNotMatch(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
   assert.match(sourceFilePage, /Advanced Tools/);
   assert.doesNotMatch(identityCheckSection, /Add Identity Link/);
@@ -4991,8 +4948,8 @@ test("unapplied source notes count after draft creation without mutating draft f
   );
   assertIncludesCopy(dashboardCopy, "Needs update from Source File");
   assertIncludesCopy(dashboardCopy, "Dossier status");
-  assertIncludesCopy(sourceFileCopy, "This Case File / BNL Source File has new info not yet applied to the Proposed Dossier.");
-  assertIncludesCopy(draftCopy, "Case File / BNL Source File has new notes since this Proposed Dossier was last updated.");
+  assertIncludesCopy(sourceFileCopy, "This BNL Source File has new info not yet applied to the Proposed Dossier.");
+  assertIncludesCopy(draftCopy, "BNL Source File has new notes since this Proposed Dossier was last updated.");
   assertIncludesCopy(draftCopy, "Draft fields are not mutated automatically when new source notes arrive.");
 });
 
@@ -5644,12 +5601,12 @@ test("recommendation inbox and source note UI are present and bounded", () => {
   const sourceFilePage = source(
     "src/app/admin/dossiers/candidates/[candidateId]/page.tsx",
   );
-  assert.match(sourceFilePage, /Add to Case File \/ BNL Source File/);
-  assert.match(sourceFilePage, /This adds information to this subject&apos;s Case File \/ BNL Source File/);
+  assert.match(sourceFilePage, /Add to BNL Source File/);
+  assert.match(sourceFilePage, /This adds information to this subject&apos;s BNL Source File/);
   assert.match(sourceFilePage, /This source file[\s\S]*remains one subject\/entity/);
   assert.match(sourceFilePage, /create or wait for a separate BNL\s+recommendation/);
   assert.match(sourceFilePage, /Save Info/);
-  assert.match(sourceFilePage, /Identity Check/);
+  assert.match(sourceFilePage, /Identity links \/ aliases/);
   assert.doesNotMatch(sourceFilePage, /<Section title="Identity Link Actions">/);
   assert.doesNotMatch(sourceFilePage, /Advanced Tools: Add Identity Link Manually/);
   assert.match(sourceFilePage, /Advanced Tools/);
@@ -5659,7 +5616,7 @@ test("recommendation inbox and source note UI are present and bounded", () => {
 
   const draftPage = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   assert.match(draftPage, /Unapplied Source Notes/);
-  assert.match(draftPage, /Case File \/ BNL Source File has new notes since this Proposed Dossier was last/);
+  assert.match(draftPage, /BNL Source File has new notes since this Proposed Dossier was last/);
   assert.match(draftPage, /Do not auto-apply notes to draft fields/);
 
   const recommendationPagePath =
@@ -7665,8 +7622,8 @@ test("Source File page renders Entity Intelligence Review Console sections", () 
   assert.match(sourceFilePage, /entityReadout=\{entityActivityReadout\}/);
   assert.doesNotMatch(sourceFilePage, /DossierEntityActivityReadoutPanel readout=\{entityActivityReadout\}/);
   assert.doesNotMatch(sourceFilePage, /Persistent Source File Draft|Save Internal Summary/);
-  assert.match(sourceFilePage, /Operator Case File Summary/);
-  assert.match(sourceFilePage, /Add to Case File \/ BNL Source File/);
+  assert.match(sourceFilePage, /Operator Source File Summary/);
+  assert.match(sourceFilePage, /Add to BNL Source File/);
   assert.ok(
     sourceFilePage.indexOf("DossierSourceFileSummaryPanel") < sourceFilePage.indexOf("<form onSubmit={saveSourceFileSummary}"),
   );
@@ -7934,7 +7891,7 @@ test("Source File page renders only BNL-authored Case File Reports and keeps raw
   assert.doesNotMatch(componentSource, /Record Compactor|Duplicate Analysis|compactSummary[\s\S]{0,80}caseSummary/);
 
   const candidatePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
-  const workbenchStart = candidatePage.indexOf("Dossier Workbench / Proposed Dossier Status");
+  const workbenchStart = candidatePage.indexOf("Proposed Dossier status");
   const workbenchEnd = candidatePage.indexOf("Source Notes / Admin Addendums", workbenchStart);
   const workbench = candidatePage.slice(workbenchStart, workbenchEnd);
   assert.doesNotMatch(workbench, /reviewBlockers|missingInfo|RAW_MISSING_INFO/);
@@ -8733,14 +8690,14 @@ test("Source File workspace layout keeps advanced diagnostics below the normal r
   const normalizedPage = page.replace(/\s+/g, " ");
   const workspaceStart = page.indexOf('<section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-4">');
   const reviewStart = page.indexOf("Review Boundaries", workspaceStart);
-  const identityStart = page.indexOf('<Section title="Identity Check">', workspaceStart);
+  const identityStart = page.indexOf('<Section title="Identity links / aliases">', workspaceStart);
   const readoutStart = page.indexOf("<DossierSourceFileSummaryPanel", workspaceStart);
-  const workbenchStart = page.indexOf("Dossier Workbench / Proposed Dossier Status");
-  const addInfoStart = page.indexOf("Add to Case File / BNL Source File");
+  const workbenchStart = page.indexOf("Proposed Dossier status");
+  const addInfoStart = page.indexOf("Add to BNL Source File");
   const notesStart = page.indexOf("Source Notes / Admin Addendums");
-  const rawStart = page.indexOf("<DossierSourceFileArchiveRawData", workspaceStart);
-  const advancedStart = page.indexOf("Advanced Tools", rawStart);
+  const advancedStart = page.indexOf("Advanced Tools", notesStart);
   const diagnosticsStart = page.indexOf("Diagnostics — collapsed by default", advancedStart);
+  const rawStart = page.indexOf("<DossierSourceFileArchiveRawData", diagnosticsStart);
 
   for (const [label, index] of Object.entries({
     reviewStart,
@@ -8761,9 +8718,9 @@ test("Source File workspace layout keeps advanced diagnostics below the normal r
   assert.ok(readoutStart < workbenchStart);
   assert.ok(workbenchStart < addInfoStart);
   assert.ok(addInfoStart < notesStart);
-  assert.ok(notesStart < rawStart);
-  assert.ok(rawStart < advancedStart);
+  assert.ok(notesStart < advancedStart);
   assert.ok(advancedStart < diagnosticsStart);
+  assert.ok(diagnosticsStart < rawStart);
   assert.doesNotMatch(page.slice(0, readoutStart), /<summary[^>]*>\s*Advanced Tools|Diagnostics — collapsed by default|Advanced Tools: Add Identity Link Manually/);
   assert.equal((page.match(/Advanced Tools: Add Identity Link Manually/g) ?? []).length, 0);
   assert.equal((page.match(/Diagnostics — collapsed by default/g) ?? []).length, 1);
@@ -10008,4 +9965,155 @@ test("population context exposes reconcile destinations and diagnostics", async 
   assert.equal(context.existingPopulationRecommendations.length, 1);
   assert.equal(JSON.stringify(context).includes("private:"), false);
   delete process.env.BNL_API_KEY;
+});
+
+test("Draft from Source File creates and updates public-safe Proposed Dossier drafts without publishing or identity confirmation", async () => {
+  await resetWorkflowStore();
+  const now = new Date("2026-06-12T00:00:00.000Z").toISOString();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [
+      {
+        id: "source-bridge-candidate",
+        name: "Bridge Subject",
+        candidateType: "entity",
+        source: "manual",
+        tier: "seed",
+        score: 80,
+        whyNow: "Public BARCODE Network mention surfaced for review.",
+        reason: "Known public connection to BARCODE Network programming.",
+        evidenceSummary: "Public-safe summary of Bridge Subject.",
+        evidenceItems: [
+          {
+            id: "private-evidence-ref",
+            label: "raw-private-ref-123",
+            summary: "raw-private-ref-123 private evidence should stay internal",
+          },
+        ],
+        knownFacts: ["Bridge Subject appeared in a public BARCODE Network context."],
+        missingInfo: ["Confirm the exact public role before owner review."],
+        doNotSay: ["Do not claim private alias Internal Alias."],
+        publicSafetyNotes: ["Avoid private evidence refs in public copy."],
+        recommendedCategory: "Entity",
+        recommendedStatus: "PENDING",
+        recommendedClearance: "PUBLIC",
+        recommendedOrigin: "UNVERIFIED",
+        sourceFileNotes: [
+          {
+            id: "public-note-1",
+            candidateId: "source-bridge-candidate",
+            type: "fact",
+            text: "Public-safe source note for draft use.",
+            source: "admin_manual",
+            publicSafe: true,
+            status: "active",
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: "private-note-1",
+            candidateId: "source-bridge-candidate",
+            type: "do_not_say",
+            text: "raw-private-ref-123 and Internal Alias are review-only evidence.",
+            source: "admin_manual",
+            publicSafe: false,
+            status: "active",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        identityLinks: [
+          {
+            id: "identity-link-1",
+            candidateId: "source-bridge-candidate",
+            label: "Internal Alias",
+            normalizedLabel: "internal alias",
+            type: "alias",
+            visibility: "internal_only",
+            source: "admin_manual",
+            status: "proposed",
+            useForMatching: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        status: "suggested",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    drafts: [],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const createResponse = await authedPost({
+    action: "createDraftFromCandidate",
+    candidateId: "source-bridge-candidate",
+  });
+  assert.equal(createResponse.status, 200);
+  const createPayload = await createResponse.json();
+  const draft = createPayload.draft;
+  assert.equal(draft.status, "draft");
+  assert.equal(draft.fields.name, "Bridge Subject");
+  assert.match(draft.fields.summary, /Public-safe summary/);
+  assert.match(draft.fields.notes, /Public-safe facts:/);
+  assert.match(draft.fields.notes, /Connection to BARCODE Network:/);
+  assert.match(draft.fields.notes, /Boundaries \/ what not to claim:/);
+  assert.match(draft.fields.notes, /Owner-review notes:/);
+  assert.doesNotMatch(JSON.stringify(draft.fields), /raw-private-ref-123|Internal Alias/);
+  assert.deepEqual(draft.sourceFileDraftMetadata.publicSafeDraft, true);
+  assert.deepEqual(draft.sourceFileDraftMetadata.reviewOnlyEvidence, true);
+  assert.deepEqual(draft.sourceFileDraftMetadata.publicPagesMutated, false);
+  assert.deepEqual(draft.sourceFileDraftMetadata.autoConfirmedIdentityLinks, false);
+
+  const stateAfterCreate = await store.getDossierWorkflowState();
+  assert.equal(stateAfterCreate.drafts.length, 1);
+  assert.equal(stateAfterCreate.drafts[0].status, "draft");
+  assert.equal(stateAfterCreate.candidates[0].identityLinks[0].status, "proposed");
+  assert.equal(databasePage.entries.some((entry) => entry.name === "Bridge Subject"), false);
+
+  const later = new Date("2026-06-12T00:10:00.000Z").toISOString();
+  await store.saveDossierWorkflowState({
+    ...stateAfterCreate,
+    candidates: stateAfterCreate.candidates.map((candidate) =>
+      candidate.id === "source-bridge-candidate"
+        ? {
+            ...candidate,
+            sourceFileNotes: [
+              ...candidate.sourceFileNotes,
+              {
+                id: "public-note-2",
+                candidateId: candidate.id,
+                type: "fact",
+                text: "New public-safe fact added after draft creation.",
+                source: "admin_manual",
+                publicSafe: true,
+                status: "active",
+                createdAt: later,
+                updatedAt: later,
+              },
+            ],
+            updatedAt: later,
+          }
+        : candidate,
+    ),
+    updatedAt: later,
+  });
+
+  const updateResponse = await authedPost({
+    action: "updateDraftFromSourceFile",
+    draftId: draft.id,
+  });
+  assert.equal(updateResponse.status, 200);
+  const updatePayload = await updateResponse.json();
+  assert.match(updatePayload.draft.fields.notes, /New public-safe fact added after draft creation/);
+  assert.equal(updatePayload.draft.status, "draft");
+  assert.equal(updatePayload.draft.sourceFileDraftMetadata.publicPagesMutated, false);
+
+  const stateAfterUpdate = await store.getDossierWorkflowState();
+  assert.equal(stateAfterUpdate.candidates[0].identityLinks[0].status, "proposed");
+  assert.equal(databasePage.entries.some((entry) => entry.name === "Bridge Subject"), false);
 });


### PR DESCRIPTION
### Motivation
- Make the BNL Source File a usable internal case file and provide a clear, admin-only path to produce a curated Proposed Dossier draft without publishing or exposing raw/private evidence.
- Preserve the existing dossier workflow while ensuring drafts are public‑safe, editable, and traceable back to Source File provenance.

### Description
- Assembled public‑safe draft generation: added `assemblePublicSafeDraftFromSourceFile` and helper utilities to `src/lib/dossier-workflow-store.ts` and changed `createDraftFromCandidate` to produce a curated, public‑safe draft seeded from Source File fields and public‑safe notes instead of dumping raw source text. (file: `src/lib/dossier-workflow-store.ts`)
- Draft provenance metadata and update API: added `sourceFileDraftMetadata` to the draft shape and implemented `updateDraftFromSourceFile` in the store to refresh an existing draft from the Source File; exposed `updateDraftFromSourceFile` as a POST action in the admin workflow API at `src/app/api/admin/dossiers/route.ts`. (files: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`)
- Candidate page UI reorganization and controls: reorganized `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` into clear sections (status/refresh, BNL take, known facts, evidence lanes, source notes, missing info, public-safety notes, do‑not‑say, identity links/aliases, Proposed Dossier status, next recommended action, diagnostics collapsed), preserved and clarified refresh state labels (`UPDATING SOURCE FILE`, `RETRYING UPDATE`, `FILE UPDATED`, `FILE NOT UPDATED`), removed redundant filler copy, and added primary actions: `Create Proposed Dossier Draft`, `Open Proposed Dossier Draft`, and `Update Draft From Source File` (only creates/updates reviewable draft metadata and does not publish or mutate public pages). (file: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Workflow action list/type updates: added the new action name `updateDraftFromSourceFile` to the workflow action lists/types so the API/store and UI remain consistent. (files: `src/lib/dossier-workflow.ts`, `src/app/api/admin/dossiers/route.ts`)
- UI copy and labels tightened to use recommended language (BNL Source File, Proposed Dossier, Owner Review, public‑safe draft, review‑only evidence) and to avoid forbidden terms/actions (automatic publishing, reconcile/population queue verbiage). (file: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Kept diagnostics and raw archive data collapsed/admin-only and placed them after the primary review workbench (component `DossierSourceFileArchiveRawData` is still used but hidden behind details). (files: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)

Files changed and why:
- `src/lib/dossier-workflow.ts` — added new workflow action/type entry for `updateDraftFromSourceFile` and expanded draft shape to include provenance metadata field pointer.
- `src/lib/dossier-workflow-store.ts` — implemented `assemblePublicSafeDraftFromSourceFile`, updated `createDraftFromCandidate` to use assembled public‑safe draft, added `updateDraftFromSourceFile`, and adjusted helper sanitizers/seeders to prefer public‑safe notes/fields.
- `src/app/api/admin/dossiers/route.ts` — added handling for the new `updateDraftFromSourceFile` POST action and registered the action in the implemented set.
- `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` — reorganized the Source File page into the requested sections, preserved immediate refresh-on-open behavior, added/adjusted primary actions and conditional buttons for creating/updating/opening Proposed Dossier drafts, and tightened UI copy.
- (no public dossier publishing code or queue/payment/identity-merge logic changed). 

### Testing
- Automated tests were not executed in this edit session; these changes touch the workflow store, API routing, and page components so running the test suite and type check is required before merge.
- Recommended automated checks to run locally or in CI: `node --test tests/admin-dossiers.test.mjs` and `npx tsc --noEmit` (expectation: full admin-dossiers test suite passes and TypeScript compiles without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbde07534832199b52f3ca27203f9)