### PR TITLE
Wire Existing BNL Edit Chat Panel

### DIFF
--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -8,6 +8,7 @@ import { useParams } from "next/navigation";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
   getUnappliedSourceNotes,
+  type DossierBnlDraftRevision,
   type DossierCandidate,
   type DossierDraft,
   type DossierDuplicateGroup,
@@ -304,6 +305,7 @@ export default function DossierDraftEditorPage() {
   const [error, setError] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [bnlInstruction, setBnlInstruction] = useState("");
 
   const loadWorkflow = useCallback(
     async function loadWorkflow() {
@@ -387,6 +389,18 @@ export default function DossierDraftEditorPage() {
   );
   const publicCopyIsDirty =
     publicCopyWarnings.length > 0 || sourceMaterialNeedsPublicCopy;
+  const bnlDraftRevisions = draft?.bnlDraftRevisions ?? [];
+  const pendingBnlRevision = bnlDraftRevisions.find(
+    (revision) => revision.status === "pending",
+  );
+  const bnlEditSuggestions = [
+    "Make this less generic.",
+    "Rewrite public summary using only confirmed public-safe facts.",
+    "Explain why this is not ready for Owner Review.",
+    "Remove technical/source-lane language.",
+    "Strengthen role/category without inventing facts.",
+    "Convert review-only notes into safe missing-info questions.",
+  ];
 
   function draftFieldsFromForm() {
     if (!form) return {};
@@ -470,6 +484,66 @@ export default function DossierDraftEditorPage() {
     setNotice(
       "Final Admin Draft ready for review. Sending to owner does not publish.",
     );
+  }
+
+  async function proposeBnlRevision(instruction = bnlInstruction) {
+    if (!draft || !instruction.trim()) return;
+    try {
+      await postWorkflow({
+        action: "proposeBnlDraftRevision",
+        draftId: draft.id,
+        instruction,
+      });
+      setBnlInstruction("");
+      setNotice("BNL revision proposed for admin review. Draft fields were not overwritten.");
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to propose BNL revision.");
+    }
+  }
+
+  async function acceptBnlRevision(revision: DossierBnlDraftRevision) {
+    if (!draft) return;
+    try {
+      await postWorkflow({
+        action: "acceptBnlDraftRevision",
+        draftId: draft.id,
+        revisionId: revision.id,
+      });
+      setNotice(revision.publicSafetyResult.passed ? "BNL revision accepted into draft. Owner Review is still required." : "BNL revision failed public-safety checks and was not accepted.");
+      await loadWorkflow();
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to accept BNL revision.");
+    }
+  }
+
+  async function rejectBnlRevision(revision: DossierBnlDraftRevision) {
+    if (!draft) return;
+    try {
+      await postWorkflow({
+        action: "rejectBnlDraftRevision",
+        draftId: draft.id,
+        revisionId: revision.id,
+        reason: "Rejected from draft editor.",
+      });
+      setNotice("BNL revision rejected. Draft fields were unchanged.");
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to reject BNL revision.");
+    }
+  }
+
+  async function revertBnlRevision(revision: DossierBnlDraftRevision) {
+    if (!draft) return;
+    try {
+      await postWorkflow({
+        action: "revertBnlDraftRevision",
+        draftId: draft.id,
+        revisionId: revision.id,
+      });
+      setNotice("Draft reverted to the previous accepted draft state. Owner Review is still required.");
+      await loadWorkflow();
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to revert BNL revision.");
+    }
   }
 
   async function sendToOwnerReview() {
@@ -808,39 +882,6 @@ export default function DossierDraftEditorPage() {
             <p>No source file could be loaded for this draft.</p>
           </section>
         )}
-        <details className="border border-border bg-surface p-5 text-sm text-muted">
-          <summary className="cursor-pointer text-xl font-bold text-foreground">
-            Developer / Raw Source Audit — internal debugging only
-          </summary>
-          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-            <section>
-              <h3 className="font-bold text-foreground">Source file identifiers</h3>
-              <p>Candidate: {candidate?.name ?? draft.candidateId}</p>
-              <p>Status: {candidate?.status ?? "—"}</p>
-              <p>Source: {candidate?.source ?? "—"}</p>
-              <p>Tier/score: {candidate ? `${candidate.tier} / ${candidate.score}` : "—"}</p>
-              <p>Duplicate risk: {candidate?.duplicateRisk ?? "none"}</p>
-              <p>Source notes: {sourceNoteCount}</p>
-              <p>Unapplied source notes: {unappliedSourceNotes.length}</p>
-            </section>
-            <section>
-              <h3 className="font-bold text-foreground">Raw source fields</h3>
-              <p className="whitespace-pre-wrap">Reason: {candidate?.reason || "—"}</p>
-              <p className="whitespace-pre-wrap">Why now: {candidate?.whyNow || "—"}</p>
-              <p className="whitespace-pre-wrap">Evidence summary: {candidate?.evidenceSummary || "—"}</p>
-              <p>Known facts: {(candidate?.knownFacts ?? []).join(", ") || "—"}</p>
-              <p>Missing info: {(candidate?.missingInfo ?? []).join(", ") || "—"}</p>
-              <p>Do-not-say: {(candidate?.doNotSay ?? []).join(", ") || "—"}</p>
-              <p>Public safety notes: {(candidate?.publicSafetyNotes ?? []).join(", ") || "—"}</p>
-            </section>
-          </div>
-          <Link
-            href={`/admin/dossiers/candidates/${draft.candidateId}`}
-            className="mt-4 inline-flex text-accent hover:underline"
-          >
-            Open full BNL Source File
-          </Link>
-        </details>
         <form onSubmit={saveDraft} className="space-y-5">
           <section className="border border-border bg-surface p-5 space-y-3 text-sm text-muted">
             <h2 className="text-2xl font-bold text-foreground">
@@ -879,42 +920,144 @@ export default function DossierDraftEditorPage() {
             </p>
           </section>
 
-          <section className="border border-accent/60 bg-accent/10 p-5 text-sm text-accent space-y-3">
-            <h2 className="text-2xl font-bold">
-              BNL Edit Chat panel — Coming Next
-            </h2>
-            <p>
-              BNL edit chat comes next. This panel will help rewrite reviewed
-              source material into clean, public-safe dossier copy and revise the proposed dossier conversationally instead of
-              applying raw source notes directly.
+          <section className="border border-accent/60 bg-accent/10 p-5 text-sm text-accent space-y-4">
+            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.4em] text-accent/80 mb-2">
+                  Admin-only revision tool
+                </p>
+                <h2 className="text-2xl font-bold">
+                  BNL Edit Chat panel
+                </h2>
+              </div>
+              <span className="border border-accent/60 px-3 py-2 text-xs uppercase tracking-widest">
+                Draft revisions only
+              </span>
+            </div>
+            <p className="border border-accent/60 bg-background/30 p-3">
+              BNL can revise the Proposed Dossier draft, but cannot publish it,
+              confirm identity, expose private evidence, or change the Source
+              File record.
             </p>
-            <p>
-              This is the intended main editing flow. Example future prompts:
-              “Make this more in-universe.” “Remove that detail.” “Use this
-              chosen link.” “Ask me what you still need.” “Make this match the
-              other collaborator dossiers.”
-            </p>
-            <p>
-              Future BNL source packet: BNL Source File, website read model,
-              dossier taxonomy guide, authoring guide, tag registry,
-              queue/public show context, broadcast memory references,
-              R&amp;D/operator-approved notes, Discord-safe/mod-approved
-              context, duplicate/merge history, and existing dossier style
-              profile.
-            </p>
-            <p>
-              Future BNL output: complete proposed dossier, tags, taxonomy,
-              warnings, missing info questions, and public-safety caveats. BNL
-              must not invent facts, must ask only for missing specifics,
-              preserve dossier tone, keep community-owned identities separate
-              from BARCODE-controlled characters, and treat AI/human/unknown as
-              tags/traits, not primary organization.
-            </p>
-            <textarea
-              disabled
-              placeholder="BNL edit chat is not wired yet."
-              className={`${inputClass()} min-h-24`}
-            />
+            <label className="block space-y-2 text-xs uppercase tracking-widest">
+              <span>Request a BNL draft revision</span>
+              <textarea
+                disabled={!isEditable || saving}
+                value={bnlInstruction}
+                onChange={(event) => setBnlInstruction(event.target.value)}
+                placeholder="Ask BNL to rewrite for public dossier tone, clarify confirmed vs review-only details, shorten the summary, or explain what is missing before Owner Review."
+                className={`${inputClass()} min-h-24`}
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void proposeBnlRevision()}
+                disabled={saving || !isEditable || !bnlInstruction.trim()}
+                className="border border-accent px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+              >
+                Create Pending BNL Revision
+              </button>
+            </div>
+            {bnlDraftRevisions.length === 0 && (
+              <div className="space-y-2">
+                <h3 className="font-bold text-foreground">BNL Edit Suggestions</h3>
+                <div className="flex flex-wrap gap-2">
+                  {bnlEditSuggestions.map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => void proposeBnlRevision(suggestion)}
+                      disabled={saving || !isEditable}
+                      className="border border-accent/60 bg-background/20 px-3 py-2 text-left text-xs uppercase tracking-widest hover:bg-accent hover:text-background disabled:opacity-50"
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {pendingBnlRevision && (
+              <article className="border border-accent bg-background/30 p-4 space-y-3">
+                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h3 className="text-xl font-bold text-foreground">
+                      Pending revision preview
+                    </h3>
+                    <p>Instruction: {pendingBnlRevision.requestedInstruction}</p>
+                    <p>{pendingBnlRevision.changeSummary}</p>
+                  </div>
+                  <span className="border border-accent/60 px-3 py-2 text-xs uppercase tracking-widest">
+                    {pendingBnlRevision.publicSafetyResult.passed ? "Checks passed" : "Checks blocked"}
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-muted">
+                  {Object.entries(pendingBnlRevision.proposedChangedFields).map(([field, value]) => (
+                    <div key={field} className="border border-border/70 bg-surface p-3">
+                      <p className="font-bold text-foreground">{field}</p>
+                      <p className="whitespace-pre-wrap">{Array.isArray(value) ? value.join(", ") : typeof value === "object" && value ? JSON.stringify(value) : String(value ?? "—")}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="space-y-2">
+                  <h4 className="font-bold text-foreground">Public-safety checks</h4>
+                  {pendingBnlRevision.publicSafetyResult.checks.map((check) => (
+                    <p key={check.id} className={check.passed ? "text-muted" : "text-accent"}>
+                      {check.passed ? "✓" : "!"} {check.label}{check.message ? ` — ${check.message}` : ""}
+                    </p>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
+                  <button
+                    type="button"
+                    onClick={() => void acceptBnlRevision(pendingBnlRevision)}
+                    disabled={saving || !isEditable || !pendingBnlRevision.publicSafetyResult.passed}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Accept Revision Into Draft
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void rejectBnlRevision(pendingBnlRevision)}
+                    disabled={saving || !isEditable}
+                    className="border border-border px-4 py-2 text-muted hover:border-accent hover:text-accent disabled:opacity-50"
+                  >
+                    Reject Revision
+                  </button>
+                </div>
+              </article>
+            )}
+            <div className="space-y-2">
+              <h3 className="font-bold text-foreground">Revision history</h3>
+              {bnlDraftRevisions.length === 0 ? (
+                <p>No BNL draft revisions yet. Suggested prompts are shown above.</p>
+              ) : (
+                <div className="space-y-2">
+                  {[...bnlDraftRevisions].reverse().map((revision) => (
+                    <article key={revision.id} className="border border-border/70 bg-background/20 p-3">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="font-bold text-foreground">{revision.status} / {new Date(revision.createdAt).toLocaleString()}</p>
+                          <p>{revision.requestedInstruction}</p>
+                          <p>{revision.statusReason ?? revision.changeSummary}</p>
+                          <p className="text-xs uppercase tracking-widest text-muted">Provenance: Source File {revision.provenance.candidateId}; {revision.provenance.sourceFileNoteIds.length} source note(s). Admin-only metadata.</p>
+                        </div>
+                        {revision.status === "accepted" && (
+                          <button
+                            type="button"
+                            onClick={() => void revertBnlRevision(revision)}
+                            disabled={saving || !isEditable}
+                            className="border border-accent px-3 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                          >
+                            Revert
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              )}
+            </div>
           </section>
           <PublicCopyGuardWarning warnings={publicCopyWarnings} />
           <ThinSourcePublicCopyWarning show={sourceMaterialNeedsPublicCopy} />
@@ -1197,6 +1340,39 @@ export default function DossierDraftEditorPage() {
             publishing, tag creation, or src/content.ts mutation occurs here.
           </p>
         </form>
+        <details className="border border-border bg-surface p-5 text-sm text-muted">
+          <summary className="cursor-pointer text-xl font-bold text-foreground">
+            Diagnostics — collapsed by default / Developer / Raw Source Audit — internal debugging only
+          </summary>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <section>
+              <h3 className="font-bold text-foreground">Source file identifiers</h3>
+              <p>Candidate: {candidate?.name ?? draft.candidateId}</p>
+              <p>Status: {candidate?.status ?? "—"}</p>
+              <p>Source: {candidate?.source ?? "—"}</p>
+              <p>Tier/score: {candidate ? `${candidate.tier} / ${candidate.score}` : "—"}</p>
+              <p>Duplicate risk: {candidate?.duplicateRisk ?? "none"}</p>
+              <p>Source notes: {sourceNoteCount}</p>
+              <p>Unapplied source notes: {unappliedSourceNotes.length}</p>
+            </section>
+            <section>
+              <h3 className="font-bold text-foreground">Raw source fields</h3>
+              <p className="whitespace-pre-wrap">Reason: {candidate?.reason || "—"}</p>
+              <p className="whitespace-pre-wrap">Why now: {candidate?.whyNow || "—"}</p>
+              <p className="whitespace-pre-wrap">Evidence summary: {candidate?.evidenceSummary || "—"}</p>
+              <p>Known facts: {(candidate?.knownFacts ?? []).join(", ") || "—"}</p>
+              <p>Missing info: {(candidate?.missingInfo ?? []).join(", ") || "—"}</p>
+              <p>Do-not-say: {(candidate?.doNotSay ?? []).join(", ") || "—"}</p>
+              <p>Public safety notes: {(candidate?.publicSafetyNotes ?? []).join(", ") || "—"}</p>
+            </section>
+          </div>
+          <Link
+            href={`/admin/dossiers/candidates/${draft.candidateId}`}
+            className="mt-4 inline-flex text-accent hover:underline"
+          >
+            Open full BNL Source File
+          </Link>
+        </details>
       </section>
     </main>
   );

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -28,6 +28,7 @@ import {
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 import {
+  acceptBnlDraftRevision,
   addDossierIdentityLink,
   applyPopulationReviewRecommendationAction,
   reconcilePopulationSignals,
@@ -45,6 +46,7 @@ import {
   createDraftFromCandidate,
   updateDraftFromSourceFile,
   createManualDossierCandidate,
+  proposeBnlDraftRevision,
   dismissDossierRecommendation,
   DossierMergeError,
   DossierWorkflowInputError,
@@ -53,8 +55,10 @@ import {
   ignoreDossierRecommendation,
   recordDossierSourceFileOpen,
   sourceFileNeedsCaseReportBackfill,
+  rejectBnlDraftRevision,
   rejectDossierIdentityLink,
   requestDossierSourceFileRefresh,
+  revertBnlDraftRevision,
   retireDossierIdentityLink,
   runSubjectConsolidation,
   mergeDossierCandidates,
@@ -126,6 +130,10 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "createManualCandidate",
   "createDraftFromCandidate",
   "updateDraftFromSourceFile",
+  "proposeBnlDraftRevision",
+  "acceptBnlDraftRevision",
+  "rejectBnlDraftRevision",
+  "revertBnlDraftRevision",
   "saveDraft",
   "submitDraftForOwnerReview",
   "denyCandidate",
@@ -610,6 +618,87 @@ export async function POST(req: Request) {
           : "BNL Source File immediate update did not complete. Retry from the status button.",
         ...payload,
       });
+    }
+
+    if (action === "proposeBnlDraftRevision") {
+      const draftId = draftIdFromBody(body);
+      const instruction = typeof body.instruction === "string" ? body.instruction : "";
+      if (!draftId || !instruction.trim()) {
+        return NextResponse.json(
+          { error: "draftId and revision instruction are required" },
+          { status: 400 },
+        );
+      }
+      const revision = await proposeBnlDraftRevision({ draftId, instruction });
+      if (!revision) {
+        return NextResponse.json({ error: "Draft not found" }, { status: 404 });
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, revision, ...payload });
+    }
+
+    if (action === "acceptBnlDraftRevision") {
+      const draftId = draftIdFromBody(body);
+      const revisionId = typeof body.revisionId === "string" ? body.revisionId.trim() : "";
+      if (!draftId || !revisionId) {
+        return NextResponse.json(
+          { error: "draftId and revisionId are required" },
+          { status: 400 },
+        );
+      }
+      const draft = await acceptBnlDraftRevision({ draftId, revisionId });
+      if (!draft) {
+        return NextResponse.json(
+          { error: "Draft revision could not be accepted" },
+          { status: 400 },
+        );
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, draft, ...payload });
+    }
+
+    if (action === "rejectBnlDraftRevision") {
+      const draftId = draftIdFromBody(body);
+      const revisionId = typeof body.revisionId === "string" ? body.revisionId.trim() : "";
+      if (!draftId || !revisionId) {
+        return NextResponse.json(
+          { error: "draftId and revisionId are required" },
+          { status: 400 },
+        );
+      }
+      const revision = await rejectBnlDraftRevision({
+        draftId,
+        revisionId,
+        reason: typeof body.reason === "string" ? body.reason : undefined,
+      });
+      if (!revision) {
+        return NextResponse.json(
+          { error: "Draft revision could not be rejected" },
+          { status: 400 },
+        );
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, revision, ...payload });
+    }
+
+    if (action === "revertBnlDraftRevision") {
+      const draftId = draftIdFromBody(body);
+      const revisionId = typeof body.revisionId === "string" ? body.revisionId.trim() : "";
+      if (!draftId || !revisionId) {
+        return NextResponse.json(
+          { error: "draftId and revisionId are required" },
+          { status: 400 },
+        );
+      }
+      const draft = await revertBnlDraftRevision({ draftId, revisionId });
+      if (!draft) {
+        return NextResponse.json(
+          { error: "Draft revision could not be reverted" },
+          { status: 400 },
+        );
+      }
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, draft, ...payload });
     }
 
     if (action === "addDossierIdentityLink") {

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -17,6 +17,7 @@ import {
   type UpdateDossierSourceFileSummaryInput,
   type CreateManualDossierCandidateInput,
   type CreateExistingDossierUpdateTargetInput,
+  type DossierBnlDraftRevision,
   type DossierCandidate,
   type DossierCandidateStatus,
   type DossierIdentityLink,
@@ -739,6 +740,160 @@ function createIdentityLinkId(): string {
 
 function createDraftId(): string {
   return `dossier_draft_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createBnlDraftRevisionId(): string {
+  return `bnl_revision_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function textIncludesAny(value: string, terms: string[]): string | null {
+  const lower = value.toLowerCase();
+  return terms.find((term) => term && lower.includes(term.toLowerCase())) ?? null;
+}
+
+const SOURCE_LANE_JARGON_TERMS = [
+  "source lane",
+  "source-file",
+  "source file",
+  "review-only evidence",
+  "bnl source",
+  "ingest",
+  "candidateid",
+  "recommendationid",
+  "queue_frequency",
+  "rd_context",
+  "discord_context",
+  "broadcast_memory",
+  "website_read_model",
+];
+
+const UNSUPPORTED_QUEUE_MUSIC_TERMS = [
+  "queue regular",
+  "played on barcode radio",
+  "released music",
+  "official release",
+  "discography",
+  "producer credit",
+  "track by",
+];
+
+function publicDraftText(fields: Partial<DossierDraft["fields"]>): string {
+  return [
+    fields.name,
+    fields.role,
+    fields.summary,
+    fields.notes,
+    ...(fields.tags ?? []),
+    ...(fields.proposedTags ?? []),
+    fields.primaryLink?.label,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+}
+
+function meaningfulSentence(value: string | undefined): boolean {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) return true;
+  if (trimmed.includes("...") || trimmed.includes("…")) return false;
+  return /[.!?)]$/.test(trimmed) || trimmed.length < 72;
+}
+
+function evaluateBnlDraftRevisionSafety(input: {
+  candidate: DossierCandidate | undefined;
+  draft: DossierDraft;
+  proposedFields: Partial<DossierDraft["fields"]>;
+}): DossierBnlDraftRevision["publicSafetyResult"] {
+  const mergedFields = normalizeDraftFields({
+    ...input.draft.fields,
+    ...input.proposedFields,
+  });
+  const text = publicDraftText(mergedFields);
+  const rawEvidenceTerms = [
+    ...(input.candidate?.evidenceItems ?? []).flatMap((item) => [
+      item.id,
+      item.label,
+      item.publicSafe === false ? item.summary : "",
+    ]),
+    ...(input.candidate?.sourceFileNotes ?? [])
+      .filter((note) => note.publicSafe === false || note.type === "do_not_say")
+      .flatMap((note) => [note.id, note.text]),
+    ...(input.candidate?.doNotSay ?? []),
+  ].filter(Boolean);
+  const internalAliases = (input.candidate?.identityLinks ?? [])
+    .filter((link) => link.visibility === "internal_only" || link.status !== "confirmed" || !link.useInPublicDossier)
+    .map((link) => link.label)
+    .filter(Boolean);
+  const publicWarnings = validateDossierPublicDraftFields(mergedFields);
+  const checks = [
+    { id: "no_raw_private_evidence", label: "No raw/private evidence refs", blocker: textIncludesAny(text, rawEvidenceTerms) },
+    { id: "no_internal_aliases", label: "No internal aliases", blocker: textIncludesAny(text, internalAliases) },
+    { id: "no_source_lane_jargon", label: "No source-lane jargon in public copy", blocker: textIncludesAny(text, SOURCE_LANE_JARGON_TERMS) },
+    { id: "no_mid_sentence_cutoff", label: "No ellipsis or mid-sentence cutoff", blocker: [mergedFields.role, mergedFields.summary, mergedFields.notes].every(meaningfulSentence) ? null : "ellipsis or cutoff" },
+    { id: "no_unsupported_queue_music_claims", label: "No unsupported queue/music claims", blocker: textIncludesAny(text, UNSUPPORTED_QUEUE_MUSIC_TERMS) },
+    { id: "no_identity_confirmation", label: "No identity confirmation if identity review is unresolved", blocker: input.candidate?.identityReviewStatus === "needs_confirmation" && /\b(confirmed identity|verified identity|same person|merged alias)\b/i.test(text) ? "identity confirmation" : null },
+    { id: "no_review_only_public_claim", label: "No public claim from review-only evidence", blocker: publicWarnings[0]?.message ?? null },
+    { id: "no_publish_action", label: "No publish action", blocker: /\b(publish|published|make public now|go live)\b/i.test(text) ? "publish language" : null },
+  ];
+  const resultChecks = checks.map((check) => ({
+    id: check.id,
+    label: check.label,
+    passed: !check.blocker,
+    message: check.blocker ? `${check.label} blocked: ${check.blocker}.` : undefined,
+  }));
+  return { passed: resultChecks.every((check) => check.passed), checks: resultChecks };
+}
+
+function concisePublicSentence(value: string | undefined, fallback: string): string {
+  const sanitized = sanitizeDossierPublicCopy(value ?? "");
+  const first = sanitized.split(/(?<=[.!?])\s+/)[0]?.trim();
+  return first || fallback;
+}
+
+function buildBnlProposedDraftFields(input: {
+  draft: DossierDraft;
+  candidate: DossierCandidate | undefined;
+  instruction: string;
+}): Partial<DossierDraft["fields"]> {
+  const fields = input.draft.fields;
+  const confirmedFacts = [
+    ...(input.candidate?.knownFacts ?? []),
+    ...(input.candidate?.sourceFileNotes ?? [])
+      .filter((note) => note.publicSafe === true && note.type !== "do_not_say")
+      .map((note) => note.text),
+  ].map(sanitizeDossierPublicCopy).filter(Boolean);
+  const safeFact = confirmedFacts[0] ?? concisePublicSentence(input.candidate?.evidenceSummary, "Public-safe BARCODE Network context is still being prepared for owner review.");
+  const missingInfo = (input.candidate?.missingInfo ?? []).map(sanitizeDossierPublicCopy).filter(Boolean);
+  const instruction = input.instruction.toLowerCase();
+  const currentSummary = concisePublicSentence(fields.summary, safeFact);
+  const currentRole = concisePublicSentence(fields.role, "Subject pending public role confirmation");
+  const proposed: Partial<DossierDraft["fields"]> = {};
+
+  if (instruction.includes("role") || instruction.includes("category")) {
+    proposed.role = currentRole.replace(/^(possible|maybe)\s+/i, "").trim();
+    proposed.category = fields.category ?? input.candidate?.recommendedCategory;
+  }
+  if (instruction.includes("missing") || instruction.includes("owner review")) {
+    proposed.notes = [
+      "Owner Review needs public-safe confirmation before this dossier can move forward.",
+      ...(missingInfo.length ? missingInfo.map((item) => `Missing info question: ${item}`) : ["Missing info question: Confirm the exact public role and any public-safe connection that can be shown."]),
+    ].join("\n");
+  } else if (instruction.includes("technical") || instruction.includes("source-lane")) {
+    proposed.notes = sanitizeDossierPublicCopy(fields.notes ?? "") || "Internal source details have been converted into public-facing review notes.";
+  } else if (instruction.includes("shorten")) {
+    proposed.summary = currentSummary.length > 180 ? `${currentSummary.slice(0, 177).replace(/\s+\S*$/, "")}.` : currentSummary;
+  } else {
+    proposed.summary = `${fields.name} is represented here with public-safe BARCODE Network context: ${safeFact}`;
+    proposed.notes = missingInfo.length
+      ? `Owner Review should confirm: ${missingInfo.join("; ")}.`
+      : sanitizeDossierPublicCopy(fields.notes ?? "") || "Owner Review should confirm the final public wording before this dossier is eligible for publishing.";
+  }
+  if (instruction.includes("less generic") && proposed.summary) {
+    proposed.summary = proposed.summary.replace("public-safe BARCODE Network context", "reviewed BARCODE Network context");
+  }
+  if (!proposed.role && (instruction.includes("tone") || instruction.includes("public") || instruction.includes("generic"))) {
+    proposed.role = currentRole;
+  }
+  return normalizeDraftFields({ ...fields, ...proposed });
 }
 
 export async function getDossierWorkflowState(): Promise<DossierWorkflowState> {
@@ -6254,6 +6409,201 @@ export async function updateDraftFromSourceFile(
     };
   });
 
+  return updatedDraft;
+}
+
+export async function proposeBnlDraftRevision(input: {
+  draftId: string;
+  instruction: string;
+}): Promise<DossierBnlDraftRevision | null> {
+  const instruction = input.instruction.trim();
+  if (!instruction) {
+    throw new DossierWorkflowInputError(
+      "BNL draft revision requires an instruction",
+      400,
+      "missing_bnl_revision_instruction",
+    );
+  }
+  const now = new Date().toISOString();
+  let createdRevision: DossierBnlDraftRevision | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const draft = currentState.drafts.find((item) => item.id === input.draftId);
+    if (!draft || draft.status === "published") return currentState;
+    const candidate = currentState.candidates.find(
+      (item) => item.id === draft.candidateId,
+    );
+    const proposedFields = buildBnlProposedDraftFields({
+      draft,
+      candidate,
+      instruction,
+    });
+    const safety = evaluateBnlDraftRevisionSafety({
+      candidate,
+      draft,
+      proposedFields,
+    });
+    createdRevision = {
+      id: createBnlDraftRevisionId(),
+      draftId: draft.id,
+      createdAt: now,
+      updatedAt: now,
+      requestedInstruction: instruction,
+      previousDraftSnapshot: normalizeDraftFields(draft.fields),
+      proposedChangedFields: proposedFields,
+      changeSummary: safety.passed
+        ? "BNL proposed a public-safe draft revision for admin review. Draft fields were not overwritten."
+        : "BNL proposed a revision, but public-safety checks found blockers. Draft fields were not overwritten.",
+      publicSafetyResult: safety,
+      provenance: {
+        candidateId: draft.candidateId,
+        sourceFileNoteIds: (candidate?.sourceFileNotes ?? []).map((note) => note.id),
+        recommendationIds: draft.sourceFileDraftMetadata?.recommendationIds ?? [],
+        sourceFileDraftMetadata: draft.sourceFileDraftMetadata,
+        adminOnly: true,
+      },
+      status: "pending",
+    };
+
+    return {
+      ...currentState,
+      drafts: currentState.drafts.map((item) =>
+        item.id === draft.id
+          ? {
+              ...item,
+              bnlDraftRevisions: [
+                ...(item.bnlDraftRevisions ?? []),
+                createdRevision as DossierBnlDraftRevision,
+              ],
+              updatedAt: now,
+            }
+          : item,
+      ),
+      updatedAt: now,
+    };
+  });
+
+  return createdRevision;
+}
+
+export async function acceptBnlDraftRevision(input: {
+  draftId: string;
+  revisionId: string;
+}): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let updatedDraft: DossierDraft | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    const draft = currentState.drafts.find((item) => item.id === input.draftId);
+    if (!draft || draft.status === "published") return currentState;
+    const candidate = currentState.candidates.find((item) => item.id === draft.candidateId);
+    const revision = (draft.bnlDraftRevisions ?? []).find((item) => item.id === input.revisionId);
+    if (!revision || revision.status !== "pending") return currentState;
+    const safety = evaluateBnlDraftRevisionSafety({
+      candidate,
+      draft,
+      proposedFields: revision.proposedChangedFields,
+    });
+    const nextRevision: DossierBnlDraftRevision = {
+      ...revision,
+      publicSafetyResult: safety,
+      status: safety.passed ? "accepted" : "rejected",
+      statusReason: safety.passed
+        ? "Accepted by admin into Proposed Dossier draft."
+        : "Rejected because public-safety checks failed before acceptance.",
+      acceptedAt: safety.passed ? now : undefined,
+      rejectedAt: safety.passed ? undefined : now,
+      updatedAt: now,
+    };
+    updatedDraft = {
+      ...draft,
+      fields: safety.passed
+        ? normalizeDraftFields({
+            ...draft.fields,
+            ...revision.proposedChangedFields,
+          })
+        : draft.fields,
+      bnlDraftRevisions: (draft.bnlDraftRevisions ?? []).map((item) =>
+        item.id === revision.id ? nextRevision : item,
+      ),
+      updatedAt: now,
+    };
+    return {
+      ...currentState,
+      drafts: currentState.drafts.map((item) =>
+        item.id === draft.id ? (updatedDraft as DossierDraft) : item,
+      ),
+      updatedAt: now,
+    };
+  });
+
+  return updatedDraft;
+}
+
+export async function rejectBnlDraftRevision(input: {
+  draftId: string;
+  revisionId: string;
+  reason?: string;
+}): Promise<DossierBnlDraftRevision | null> {
+  const now = new Date().toISOString();
+  let rejectedRevision: DossierBnlDraftRevision | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const drafts = currentState.drafts.map((draft) => {
+      if (draft.id !== input.draftId) return draft;
+      const revisions = (draft.bnlDraftRevisions ?? []).map((revision) => {
+        if (revision.id !== input.revisionId || revision.status !== "pending") return revision;
+        rejectedRevision = {
+          ...revision,
+          status: "rejected",
+          statusReason: input.reason?.trim() || "Rejected by admin.",
+          rejectedAt: now,
+          updatedAt: now,
+        };
+        return rejectedRevision;
+      });
+      return { ...draft, bnlDraftRevisions: revisions, updatedAt: now };
+    });
+    if (!rejectedRevision) return currentState;
+    return { ...currentState, drafts, updatedAt: now };
+  });
+  return rejectedRevision;
+}
+
+export async function revertBnlDraftRevision(input: {
+  draftId: string;
+  revisionId: string;
+}): Promise<DossierDraft | null> {
+  const now = new Date().toISOString();
+  let updatedDraft: DossierDraft | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const draft = currentState.drafts.find((item) => item.id === input.draftId);
+    if (!draft || draft.status === "published") return currentState;
+    const revision = (draft.bnlDraftRevisions ?? []).find((item) => item.id === input.revisionId);
+    if (!revision || revision.status !== "accepted") return currentState;
+    updatedDraft = {
+      ...draft,
+      fields: normalizeDraftFields(revision.previousDraftSnapshot),
+      bnlDraftRevisions: (draft.bnlDraftRevisions ?? []).map((item) =>
+        item.id === revision.id
+          ? {
+              ...item,
+              status: "reverted",
+              statusReason: "Reverted by admin to the previous accepted draft state.",
+              revertedAt: now,
+              updatedAt: now,
+            }
+          : item,
+      ),
+      updatedAt: now,
+    };
+    return {
+      ...currentState,
+      drafts: currentState.drafts.map((item) =>
+        item.id === draft.id ? (updatedDraft as DossierDraft) : item,
+      ),
+      updatedAt: now,
+    };
+  });
   return updatedDraft;
 }
 

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -353,10 +353,47 @@ export type DossierCandidate = {
   updatedAt: string;
 };
 
+
+export type DossierBnlDraftRevisionStatus =
+  | "pending"
+  | "accepted"
+  | "rejected"
+  | "reverted";
+
+export type DossierBnlDraftRevisionPublicSafetyResult = {
+  passed: boolean;
+  checks: Array<{ id: string; label: string; passed: boolean; message?: string }>;
+};
+
+export type DossierBnlDraftRevision = {
+  id: string;
+  draftId: string;
+  createdAt: string;
+  updatedAt: string;
+  requestedInstruction: string;
+  previousDraftSnapshot: DossierDraft["fields"];
+  proposedChangedFields: Partial<DossierDraft["fields"]>;
+  changeSummary: string;
+  publicSafetyResult: DossierBnlDraftRevisionPublicSafetyResult;
+  provenance: {
+    candidateId: string;
+    sourceFileNoteIds: string[];
+    recommendationIds: string[];
+    sourceFileDraftMetadata?: DossierDraft["sourceFileDraftMetadata"];
+    adminOnly: true;
+  };
+  status: DossierBnlDraftRevisionStatus;
+  statusReason?: string;
+  acceptedAt?: string;
+  rejectedAt?: string;
+  revertedAt?: string;
+};
+
 export type DossierDraft = {
   id: string;
   candidateId: string;
   status: DossierDraftStatus;
+  bnlDraftRevisions?: DossierBnlDraftRevision[];
   sourceFileDraftMetadata?: {
     sourceCandidateId: string;
     sourceCandidateUpdatedAt?: string;
@@ -2931,6 +2968,10 @@ export type DossierWorkflowAction =
   | "requestDraft"
   | "createDraftFromCandidate"
   | "updateDraftFromSourceFile"
+  | "proposeBnlDraftRevision"
+  | "acceptBnlDraftRevision"
+  | "rejectBnlDraftRevision"
+  | "revertBnlDraftRevision"
   | "saveDraft"
   | "saveDraftEdit"
   | "submitDraftForOwnerReview"
@@ -2993,6 +3034,10 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "requestDraft",
   "createDraftFromCandidate",
   "updateDraftFromSourceFile",
+  "proposeBnlDraftRevision",
+  "acceptBnlDraftRevision",
+  "rejectBnlDraftRevision",
+  "revertBnlDraftRevision",
   "saveDraft",
   "saveDraftEdit",
   "submitDraftForOwnerReview",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -180,7 +180,7 @@ test("proposed dossier preview sanitizes internal starter phrases before Dossier
 test("phase 2 draft editor stacks source summary, BNL edit panel, and dossier preview full-width", () => {
   const adminPageSource = normalizedSource("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
   const sourceSummaryIndex = adminPageSource.indexOf("BNL Source File Summary");
-  const editPanelIndex = adminPageSource.indexOf("BNL Edit Chat panel — Coming Next", sourceSummaryIndex);
+  const editPanelIndex = adminPageSource.indexOf("BNL Edit Chat panel", sourceSummaryIndex);
   const previewIndex = adminPageSource.indexOf("<ProposedDossierPreview form={form} candidate={candidate ?? undefined} />", editPanelIndex);
 
   assert.notEqual(sourceSummaryIndex, -1);
@@ -1565,7 +1565,7 @@ test("admin dossier page has minimal loading and auth-required states", () => {
   assert.match(page, /MinimalDossierAdminState/);
 });
 
-test("dedicated draft editor route contains focused editing workflow and future BNL boundary", () => {
+test("dedicated draft editor route contains focused editing workflow and wired BNL boundary", () => {
   const routePath = "src/app/admin/dossiers/drafts/[draftId]/page.tsx";
   assert.equal(fs.existsSync(path.join(projectRoot, routePath)), true);
   const page = source(routePath);
@@ -1574,7 +1574,7 @@ test("dedicated draft editor route contains focused editing workflow and future 
     "Proposed Dossier + BNL Edit Chat",
     "BNL Source File",
     "Proposed Dossier Preview",
-    "BNL Edit Chat panel — Coming Next",
+    "BNL Edit Chat panel",
     "Open Advanced Manual Edit",
     "fallback/manual override",
     "Save Proposed Dossier",
@@ -1583,8 +1583,9 @@ test("dedicated draft editor route contains focused editing workflow and future 
     "Send to Owner Review",
     "Return to Editing",
     "Sending to owner does not publish",
-    "BNL edit chat comes next",
-    "revise the proposed dossier conversationally",
+    "BNL can revise the Proposed Dossier draft, but cannot publish it, confirm identity, expose private evidence, or change the Source File record.",
+    "BNL Edit Suggestions",
+    "Create Pending BNL Revision",
     "manual override",
     "category",
     "kind",
@@ -10168,4 +10169,282 @@ test("Source File intelligence and dynamic main actions are readiness-driven", (
   assert.match(page, /No confirmed queue footprint connected yet\./);
   assert.doesNotMatch(pageCopy, /Review source context and decide whether to attach or convert into a BNL Source File/);
   assert.doesNotMatch(pageCopy, /RELATIONSHIP_JOURNAL[\s\S]{0,200}BNL Dossier Intelligence/);
+});
+
+test("BNL Edit Chat is wired in the existing draft panel with suggestions and collapsed admin diagnostics", () => {
+  const page = source("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
+  const pageCopy = normalizedSource("src/app/admin/dossiers/drafts/[draftId]/page.tsx");
+  assert.equal((page.match(/BNL Edit Chat panel/g) ?? []).length, 1);
+  assert.doesNotMatch(page, /BNL Edit Chat panel — Coming Next|BNL edit chat is not wired yet/);
+  for (const suggestion of [
+    "Make this less generic.",
+    "Rewrite public summary using only confirmed public-safe facts.",
+    "Explain why this is not ready for Owner Review.",
+    "Remove technical/source-lane language.",
+    "Strengthen role/category without inventing facts.",
+    "Convert review-only notes into safe missing-info questions.",
+  ]) {
+    assertIncludesCopy(pageCopy, suggestion);
+  }
+  assert.ok(page.indexOf("BNL Edit Chat panel") < page.indexOf("<ProposedDossierPreview"));
+  assert.ok(page.indexOf("Revision history") < page.indexOf("Diagnostics — collapsed by default"));
+  assertIncludesCopy(pageCopy, "Admin-only revision tool");
+  assertIncludesCopy(pageCopy, "Draft revisions only");
+});
+
+test("BNL draft revisions preview, accept, reject, revert, and preserve owner/source/public boundaries", async () => {
+  await resetWorkflowStore();
+  const now = new Date("2026-06-12T01:00:00.000Z").toISOString();
+  const candidate = {
+    id: "bnl-revision-candidate",
+    name: "Revision Subject",
+    candidateType: "entity",
+    source: "manual",
+    tier: "draft_ready",
+    score: 90,
+    reason: "Public-safe fixture reason.",
+    whyNow: "Admin wants public-safe copy.",
+    evidenceSummary: "Revision Subject appeared in public BARCODE Network context.",
+    evidenceItems: [
+      {
+        id: "raw-private-evidence-ref",
+        label: "raw-private-ref-999",
+        summary: "Private evidence receipt with raw-private-ref-999.",
+        publicSafe: false,
+      },
+    ],
+    knownFacts: ["Revision Subject appeared in public BARCODE Network context."],
+    missingInfo: ["Confirm final public role before owner review."],
+    doNotSay: ["Private Alias"],
+    publicSafetyNotes: ["Do not expose private evidence."],
+    identityReviewStatus: "needs_confirmation",
+    identityLinks: [
+      {
+        id: "private-alias-link",
+        candidateId: "bnl-revision-candidate",
+        label: "Private Alias",
+        normalizedLabel: "private alias",
+        type: "alias",
+        visibility: "internal_only",
+        source: "admin_manual",
+        status: "proposed",
+        useForMatching: false,
+        useInPublicDossier: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    sourceFileNotes: [
+      {
+        id: "safe-note",
+        candidateId: "bnl-revision-candidate",
+        type: "fact",
+        text: "Public-safe source note for Revision Subject.",
+        source: "admin_manual",
+        publicSafe: true,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "private-note",
+        candidateId: "bnl-revision-candidate",
+        type: "do_not_say",
+        text: "Private Alias and raw-private-ref-999 are private evidence.",
+        source: "admin_manual",
+        publicSafe: false,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    status: "draft_ready",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const draft = {
+    id: "bnl-revision-draft",
+    candidateId: candidate.id,
+    status: "draft",
+    fields: {
+      name: "Revision Subject",
+      category: "Entity",
+      kind: "lore_node",
+      ecosystemLane: "network_entity",
+      identityAuthority: "review_required",
+      status: "PENDING",
+      clearance: "PUBLIC",
+      origin: "UNVERIFIED",
+      role: "Public role pending.",
+      summary: "Original summary stays until accepted.",
+      notes: "Original notes.",
+      tags: ["review"],
+      proposedTags: [],
+      files: [],
+    },
+    sourceFileDraftMetadata: {
+      sourceCandidateId: candidate.id,
+      sourceFileNoteIds: ["safe-note", "private-note"],
+      recommendationIds: ["rec-1"],
+      assembledAt: now,
+      publicSafeDraft: true,
+      reviewOnlyEvidence: true,
+      autoConfirmedIdentityLinks: false,
+      publicPagesMutated: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [candidate],
+    drafts: [draft],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const proposed = await (await authedPost({
+    action: "proposeBnlDraftRevision",
+    draftId: draft.id,
+    instruction: "Rewrite public summary using only confirmed public-safe facts.",
+  })).json();
+  assert.equal(proposed.revision.status, "pending");
+  assert.equal(proposed.revision.publicSafetyResult.passed, true);
+  assert.match(proposed.revision.changeSummary, /not overwritten/);
+  assert.equal(proposed.drafts[0].fields.summary, "Original summary stays until accepted.");
+  assert.equal(proposed.drafts[0].status, "draft");
+  assert.equal(proposed.drafts[0].sourceFileDraftMetadata.publicPagesMutated, false);
+  assert.equal(proposed.candidates[0].sourceFileNotes[1].text, "Private Alias and raw-private-ref-999 are private evidence.");
+
+  const accepted = await (await authedPost({
+    action: "acceptBnlDraftRevision",
+    draftId: draft.id,
+    revisionId: proposed.revision.id,
+  })).json();
+  assert.notEqual(accepted.draft.fields.summary, "Original summary stays until accepted.");
+  assert.equal(accepted.draft.status, "draft");
+  assert.equal(accepted.ownerReviewQueue.waitingCount, 0);
+  assert.equal(databasePage.entries.some((entry) => entry.name === "Revision Subject"), false);
+
+  const acceptedSummary = accepted.draft.fields.summary;
+  const rejectCandidateState = await store.getDossierWorkflowState();
+  const second = await (await authedPost({
+    action: "proposeBnlDraftRevision",
+    draftId: draft.id,
+    instruction: "Explain why this is not ready for Owner Review.",
+  })).json();
+  const rejected = await (await authedPost({
+    action: "rejectBnlDraftRevision",
+    draftId: draft.id,
+    revisionId: second.revision.id,
+  })).json();
+  assert.equal(rejected.revision.status, "rejected");
+  assert.equal(rejected.drafts[0].fields.summary, acceptedSummary);
+  assert.deepEqual(rejected.candidates[0].sourceFileNotes, rejectCandidateState.candidates[0].sourceFileNotes);
+
+  const reverted = await (await authedPost({
+    action: "revertBnlDraftRevision",
+    draftId: draft.id,
+    revisionId: proposed.revision.id,
+  })).json();
+  assert.equal(reverted.draft.fields.summary, "Original summary stays until accepted.");
+  assert.equal(reverted.draft.bnlDraftRevisions.find((revision) => revision.id === proposed.revision.id).status, "reverted");
+  assert.equal(reverted.draft.status, "draft");
+});
+
+test("BNL revision safety blocks private aliases, raw evidence, queue/music claims, cutoffs, and publish/identity language", async () => {
+  await resetWorkflowStore();
+  const now = new Date("2026-06-12T02:00:00.000Z").toISOString();
+  const candidate = {
+    id: "bnl-block-candidate",
+    name: "Block Subject",
+    candidateType: "entity",
+    source: "manual",
+    tier: "draft_ready",
+    score: 90,
+    reason: "Safe reason.",
+    evidenceSummary: "Safe evidence.",
+    evidenceItems: [{ id: "raw-block-ref", label: "raw-block-ref", summary: "raw-block-ref private", publicSafe: false }],
+    knownFacts: ["Block Subject has one public-safe fact."],
+    missingInfo: [],
+    doNotSay: ["Hidden Alias"],
+    publicSafetyNotes: [],
+    identityReviewStatus: "needs_confirmation",
+    identityLinks: [{
+      id: "hidden-alias-link",
+      candidateId: "bnl-block-candidate",
+      label: "Hidden Alias",
+      normalizedLabel: "hidden alias",
+      type: "alias",
+      visibility: "internal_only",
+      source: "admin_manual",
+      status: "proposed",
+      createdAt: now,
+      updatedAt: now,
+    }],
+    sourceFileNotes: [],
+    status: "draft_ready",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [candidate],
+    drafts: [{
+      id: "bnl-block-draft",
+      candidateId: candidate.id,
+      status: "draft",
+      fields: {
+        name: "Block Subject",
+        category: "Entity",
+        kind: "lore_node",
+        ecosystemLane: "network_entity",
+        identityAuthority: "review_required",
+        status: "PENDING",
+        clearance: "PUBLIC",
+        origin: "UNVERIFIED",
+        role: "Hidden Alias confirmed identity raw-block-ref source lane queue regular published...",
+        summary: "Block Subject was played on BARCODE Radio as an official release...",
+        notes: "This should publish now from review-only evidence.",
+        tags: ["review"],
+        proposedTags: [],
+        files: [],
+      },
+      createdAt: now,
+      updatedAt: now,
+    }],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+
+  const proposed = await (await authedPost({
+    action: "proposeBnlDraftRevision",
+    draftId: "bnl-block-draft",
+    instruction: "Shorten the summary.",
+  })).json();
+  const failedChecks = proposed.revision.publicSafetyResult.checks.filter((check) => !check.passed).map((check) => check.id);
+  assert.equal(proposed.revision.status, "pending");
+  for (const id of [
+    "no_raw_private_evidence",
+    "no_internal_aliases",
+    "no_source_lane_jargon",
+    "no_mid_sentence_cutoff",
+    "no_unsupported_queue_music_claims",
+    "no_identity_confirmation",
+    "no_publish_action",
+  ]) {
+    assert.ok(failedChecks.includes(id), `${id} should fail`);
+  }
+  const accepted = await (await authedPost({
+    action: "acceptBnlDraftRevision",
+    draftId: "bnl-block-draft",
+    revisionId: proposed.revision.id,
+  })).json();
+  assert.equal(accepted.draft.bnlDraftRevisions[0].status, "rejected");
+  assert.match(accepted.draft.fields.summary, /official release/);
+  assert.equal(accepted.ownerReviewQueue.waitingCount, 0);
 });


### PR DESCRIPTION
### Motivation
- Replace the placeholder "BNL Edit Chat panel — Coming Next" with an in-place admin-only revision workflow so admins can request BNL-assisted draft revisions without publishing or mutating Source File truth. 
- Keep public/owner/source safety boundaries explicit so BNL suggestions create reviewable revisions (pending/accepted/rejected/reverted) rather than overwriting draft fields or publishing content. 
- Provide a minimal, auditable revision model with provenance and lightweight public-safety checks to block raw/private evidence, internal aliases, source-lane jargon, unsupported queue/music claims, mid-sentence cutoffs, publish/identity language, and review-only claims. 

### Description
- Wired the existing panel UI at `src/app/admin/dossiers/drafts/[draftId]/page.tsx` by replacing the disabled placeholder with: an admin-only instruction textarea, suggested prompts, `Create Pending BNL Revision` action, pending revision preview (proposed fields + change summary), public-safety checks, accept/reject controls, a revision history list, and a revert control; the raw diagnostics drawer was moved to a collapsed diagnostics section below the normal flow. 
- Added revision types and data model (`DossierBnlDraftRevision`, status/result shapes) in `src/lib/dossier-workflow.ts` and attached `bnlDraftRevisions` to `DossierDraft`. 
- Implemented store-side revision lifecycle functions in `src/lib/dossier-workflow-store.ts`: `proposeBnlDraftRevision`, `acceptBnlDraftRevision`, `rejectBnlDraftRevision`, and `revertBnlDraftRevision`, plus helper logic to build proposed public-safe fields and `evaluateBnlDraftRevisionSafety` checks; acceptance runs safety re-checks and only applies accepted revisions to draft fields. 
- Exposed new admin-only workflow actions through the existing admin API `src/app/api/admin/dossiers/route.ts` (`proposeBnlDraftRevision`, `acceptBnlDraftRevision`, `rejectBnlDraftRevision`, `revertBnlDraftRevision`) reusing the same POST endpoint and auth gating. 
- Added client-side wiring to call those actions, show previews and checks, and perform accept/reject/revert from the same panel in `src/app/admin/dossiers/drafts/[draftId]/page.tsx`. 
- Updated tests in `tests/admin-dossiers.test.mjs` to cover the wired panel, suggestions, creation of pending revisions (no immediate overwrite), accept/reject/revert behavior, public/owner/source boundaries, and safety blockers. 
- Files changed: `src/app/admin/dossiers/drafts/[draftId]/page.tsx`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`, and `tests/admin-dossiers.test.mjs`.

### Testing
- Ran the full admin dossier unit suite with `node --test tests/admin-dossiers.test.mjs` and observed all tests for the modified behaviors pass (tests completed successfully). 
- Type-checked the code with `npx tsc --noEmit` which completed without type errors. 
- Ran `npm run lint` which surfaced pre-existing unrelated lint issues elsewhere in the repo (archived queue pages and some hook/state warnings) and did not block this scoped change; lint failures are unrelated to the BNL wiring. 
- The UI wiring was exercised via the test fixtures (no browser automation required), and all new API/store flows behaved as expected in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c7c9500a08321951297f86082ccfe)