### PR TITLE
Dossier Taxonomy Expansion + Classification Blueprint

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -34,6 +34,7 @@ import {
   sourceFileReasonMeaning,
   sourceFileWhyNowMeaning,
 } from "@/lib/dossier-source-memory-meaning";
+import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
 
 type WorkflowPayload = {
   candidates: DossierCandidate[];
@@ -1882,6 +1883,10 @@ export default function CandidateReviewPage() {
     sourceFileChangedSinceDraft,
     readyForDraft,
   });
+  const blueprint = createDossierDraftBlueprint({
+    candidate,
+    recommendations: attachedRecommendations,
+  });
   const entityType = inferEntityType({ candidate, activitySignals, musicSignals });
   const activityLevel =
     sourceFileSummary?.substanceLevel === "strong"
@@ -2553,6 +2558,7 @@ export default function CandidateReviewPage() {
                   ? "existing dossier update"
                   : "active source file"
               }
+              blueprint={blueprint}
             />
             {/* BNL Case File Report display lives inside DossierSourceFileSummaryPanel. */}
           </>

--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -21,7 +21,9 @@ import {
   type DossierDraftFieldWarning,
 } from "@/lib/dossier-public-copy-guard";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
+import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
 import {
+  DOSSIER_CATEGORY_OPTIONS,
   DOSSIER_ECOSYSTEM_LANE_OPTIONS,
   DOSSIER_IDENTITY_AUTHORITY_OPTIONS,
   DOSSIER_KIND_OPTIONS,
@@ -53,14 +55,7 @@ type DraftForm = {
   selectedBy: "operator" | "subject" | "legacy";
 };
 
-const categoryOptions = [
-  "",
-  "Entity",
-  "Personnel",
-  "Sponsor",
-  "Interface",
-  "Production",
-];
+const categoryOptions = ["", ...DOSSIER_CATEGORY_OPTIONS];
 const statusOptions = [
   "",
   "ACTIVE",
@@ -368,6 +363,9 @@ export default function DossierDraftEditorPage() {
     ? getUnappliedSourceNotes({ candidate: candidate ?? {}, draft })
     : [];
   const sourceNoteCount = candidate?.sourceFileNotes?.length ?? 0;
+  const blueprint = candidate
+    ? createDossierDraftBlueprint({ candidate, recommendations: [], publicDossiers: [] })
+    : null;
   const sourceFileSummary = candidate
     ? createDossierSourceFileSummary({
         candidate,
@@ -798,7 +796,15 @@ export default function DossierDraftEditorPage() {
       </section>
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-6">
         {sourceFileSummary && (
-          <DossierSourceFileSummaryPanel summary={sourceFileSummary} />
+          <DossierSourceFileSummaryPanel
+            summary={sourceFileSummary}
+            subjectName={candidate?.name}
+            sourceFileNotes={candidate?.sourceFileNotes ?? []}
+            latestSourceFileArchive={candidate?.latestSourceFileArchive}
+            currentLane={candidate?.status}
+            sourceFileTargetStatus="proposed dossier source"
+            blueprint={blueprint ?? undefined}
+          />
         )}
         {!sourceFileSummary && (
           <section className="border border-border bg-surface p-5 text-sm text-muted">
@@ -807,6 +813,30 @@ export default function DossierDraftEditorPage() {
             </h2>
             <p>No source file could be loaded for this draft.</p>
           </section>
+        )}
+
+        {blueprint && (
+          <details className="border border-border bg-surface p-5 text-sm text-muted">
+            <summary className="cursor-pointer text-xl font-bold text-foreground">
+              Related Dossier Blueprint — admin-only
+            </summary>
+            <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <section className="border border-border/60 bg-background/30 p-3">
+                <h3 className="font-bold text-foreground">Classification</h3>
+                <p>{blueprint.classification.category} / {blueprint.classification.kind} / {blueprint.classification.ecosystemLane}</p>
+                <p>Identity authority: {blueprint.classification.identityAuthority}</p>
+                <p>Confidence: {blueprint.classification.confidence}</p>
+              </section>
+              <section className="border border-border/60 bg-background/30 p-3">
+                <h3 className="font-bold text-foreground">Readiness</h3>
+                <p>{blueprint.readiness.label} ({blueprint.readiness.score}/100)</p>
+                <p>{blueprint.readiness.recommendedNextAction}</p>
+              </section>
+            </div>
+            <p className="mt-3 text-xs uppercase tracking-widest text-accent">
+              Blueprint material is not public dossier prose and is not displayed in the public preview text fields.
+            </p>
+          </details>
         )}
         <details className="border border-border bg-surface p-5 text-sm text-muted">
           <summary className="cursor-pointer text-xl font-bold text-foreground">

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -420,6 +420,8 @@ const DOSSIER_RULES = [
   "Public-page-visible dossiers are not automatic broadcast memory.",
   "Public-page-visible dossiers are not automatic dossier seeds.",
   "Queue-derived artists are still not dossier records unless manually promoted through a future approved workflow.",
+  "Artist, Collaborator, and Community are first-class public categories and must not collapse into Personnel by default.",
+  "Personnel is reserved for official/formal BARCODE staff, operator, moderator, admin, or personnel roles.",
   "Research classifier dossier seeds are not public dossiers until a future approved site workflow publishes them.",
   "BNL should classify dossiers in order: category, kind, ecosystem lane, identity authority, then tags.",
   "AI, human, hybrid, and unknown nature are tags/traits, not primary dossier organization.",
@@ -444,6 +446,10 @@ function inferPublicDossierKind(entry: DatabaseEntry): PublicDossierKind {
   if (name === "discord community") return "interface";
   if (name === "auxchord" || name === "tiktok live") return "platform";
   if (name.includes("bnl-01")) return "system";
+  if (category === "artist") return "artist";
+  if (category === "collaborator") return "collaborator";
+  if (category === "community") return "community_member";
+  if (category === "personnel") return "moderator";
   if (category === "production") return "program";
   if (category === "interface") return "interface";
   if (category === "sponsor") return "sponsor_character";

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -8,6 +8,7 @@ import type {
   DossierSourceFileCaseReportV1,
   DossierSourceFileNote,
 } from "@/lib/dossier-workflow";
+import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
 import {
   formatDossierSummaryBadge,
   type DossierSourceFileSummary,
@@ -572,6 +573,78 @@ export function DossierSourceFileArchiveRawData({ latestSourceFileArchive }: { l
   );
 }
 
+
+function BlueprintList({ items, empty = "—" }: { items?: string[]; empty?: string }) {
+  const safeItems = (items ?? []).filter(Boolean);
+  if (!safeItems.length) return <p className="text-muted">{empty}</p>;
+  return (
+    <ul className="list-disc space-y-1 pl-5 text-foreground">
+      {safeItems.slice(0, 6).map((item, index) => (
+        <li key={`${index}-${item.slice(0, 24)}`}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint }) {
+  return (
+    <Section
+      title="Dossier Blueprint"
+      tone="caution"
+      helper="Classification and readiness foundation only. This is not public dossier prose and does not confirm identities or merge aliases."
+    >
+      <div className="space-y-4">
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <SnapshotItem label="Category" value={blueprint.classification.category} />
+          <SnapshotItem label="Kind" value={blueprint.classification.kind} />
+          <SnapshotItem label="Ecosystem lane" value={blueprint.classification.ecosystemLane} />
+          <SnapshotItem label="Identity authority" value={blueprint.classification.identityAuthority} />
+          <SnapshotItem label="Confidence" value={blueprint.classification.confidence} />
+          <SnapshotItem label="Future prefix" value={`${blueprint.classification.recommendedDesignationPrefix}-###`} />
+          <SnapshotItem label="Readiness" value={`${blueprint.readiness.label} (${blueprint.readiness.score}/100)`} />
+          <SnapshotItem label="Evidence counts" value={`${blueprint.evidenceCounts.publicSafeFacts} public-safe / ${blueprint.evidenceCounts.reviewOnlyItems} review-only`} />
+        </dl>
+        <section className="border border-border/50 bg-background/30 p-3">
+          <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended next action</h4>
+          <p className="text-foreground">{blueprint.readiness.recommendedNextAction}</p>
+        </section>
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Why this classification</h4>
+            <BlueprintList items={blueprint.classification.reasons} />
+          </section>
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Blockers / missing info</h4>
+            <BlueprintList items={[...blueprint.readiness.blockers, ...blueprint.missingInfoQuestions]} empty="No blockers recorded." />
+          </section>
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Suggested tags</h4>
+            <BlueprintList items={blueprint.suggestedTags.tags.map((item) => `${item.tag} (${item.confidence})`)} />
+          </section>
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Proposed tags</h4>
+            <BlueprintList items={blueprint.suggestedTags.proposedTags.map((item) => `${item.tag} — ${item.reason}`)} empty="No new/proposed tags." />
+          </section>
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Public-safe ingredients</h4>
+            <BlueprintList items={blueprint.safeSummaryIngredients} empty="No public-safe summary ingredients yet." />
+          </section>
+          <section className="border border-border/50 bg-background/30 p-3">
+            <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Queue / music footprint</h4>
+            <p className="text-foreground">{blueprint.queueMusicFootprintStatus}</p>
+          </section>
+        </div>
+        <details className="border border-border/50 bg-background/20 p-3 text-xs text-muted">
+          <summary className="cursor-pointer font-semibold text-foreground">Technical provenance</summary>
+          <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap">
+            {JSON.stringify(blueprint.adminOnlyProvenance, null, 2)}
+          </pre>
+        </details>
+      </div>
+    </Section>
+  );
+}
+
 function formatSnapshotDate(value?: string) {
   if (!value) return "—";
   const parsed = new Date(value);
@@ -617,6 +690,7 @@ export function DossierSourceFileSummaryPanel({
   latestRecommendationTimestamp,
   sourceFileTargetStatus,
   latestSourceFileArchive,
+  blueprint,
 }: {
   summary: DossierSourceFileSummary;
   entityReadout?: DossierEntityActivityReadout | null;
@@ -628,6 +702,7 @@ export function DossierSourceFileSummaryPanel({
   latestRecommendationTimestamp?: string;
   sourceFileTargetStatus?: string;
   latestSourceFileArchive?: DossierSourceFileArchiveMetadata;
+  blueprint?: DossierDraftBlueprint;
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
@@ -680,6 +755,8 @@ export function DossierSourceFileSummaryPanel({
           Summary badge: {formatDossierSummaryBadge(summary.summarySource)}.
         </p>
       </Section>
+
+      {blueprint && <DossierBlueprintView blueprint={blueprint} />}
 
       {hasArchiveDiagnostics && (
         <Section title="Archive ingest diagnostics" helper="Admin-only preservation check. These fields are safe booleans and path labels, not raw archive secrets.">

--- a/src/content.ts
+++ b/src/content.ts
@@ -284,6 +284,7 @@ export type DossierEcosystemLane =
   | "community_mod"
   | "radio_support"
   | "technical_operator"
+  | "artist"
   | "collaborator"
   | "community_member"
   | "radio_regular"
@@ -291,6 +292,7 @@ export type DossierEcosystemLane =
   | "radio_entity"
   | "infrastructure"
   | "production"
+  | "external_platform"
   | "unknown";
 
 export type PublicDossierKind =
@@ -311,7 +313,8 @@ export type PublicDossierKind =
   | "collaborator"
   | "community_member"
   | "radio_regular"
-  | "radio_entity";
+  | "radio_entity"
+  | "unknown";
 
 export type PublicDossierLifecycle =
   | "active"
@@ -377,7 +380,7 @@ export type DatabaseEntry = {
   id: string;
   name: string;
   image: string;
-  category: "Entity" | "Personnel" | "Sponsor" | "Interface" | "Production";
+  category: "Entity" | "Personnel" | "Artist" | "Collaborator" | "Community" | "Sponsor" | "Interface" | "Production";
   status: "ACTIVE" | "INACTIVE" | "ARCHIVED" | "PENDING" | "UNKNOWN";
   clearance: "PUBLIC" | "INTERNAL" | "RESTRICTED";
   role: string;
@@ -403,8 +406,8 @@ export type DatabaseEntry = {
 };
 
 // Designation prefixes:
-//   EN-### = Entity | PE-### = Personnel | SP-### = Sponsor | IF-### = Interface | PD-### = Production
-// Categories: Entity | Personnel | Sponsor | Interface | Production
+//   EN-### = Entity | PE-### = Personnel | AR-### = Artist | CO-### = Collaborator | CM-### = Community | SP-### = Sponsor | IF-### = Interface | PD-### = Production
+// Categories: Entity | Personnel | Artist | Collaborator | Community | Sponsor | Interface | Production
 // Statuses:   ACTIVE | INACTIVE | ARCHIVED | PENDING | UNKNOWN
 // Clearance:  PUBLIC | INTERNAL | RESTRICTED
 // Origin:     KNOWN | UNKNOWN | UNVERIFIED | WITHHELD

--- a/src/lib/dossier-authoring-guide.ts
+++ b/src/lib/dossier-authoring-guide.ts
@@ -10,13 +10,13 @@ export const dossierAuthoringGuide = {
     "Terminal Readout: generated route/query/status/category/origin lines",
   ],
   fieldGuide: {
-    id: "Stable dossier designation using the current prefix pattern, such as EN-###, PE-###, SP-###, IF-###, or PD-###.",
+    id: "Stable dossier designation using the current prefix pattern, such as EN-###, PE-###, AR-###, CO-###, CM-###, SP-###, IF-###, or PD-###.",
     name: "Public display name for the person, entity, production, interface, sponsor, or anomaly.",
     category:
-      "Pick the structural record type first: Entity, Personnel, Sponsor, Interface, or Production.",
+      "Pick the structural record type first: Entity, Personnel, Artist, Collaborator, Community, Sponsor, Interface, or Production. Personnel is not the human catch-all; artists, collaborators, and active community members stay first-class categories when their evidence supports those routes.",
     kind: "Pick the dossier form after category, using the taxonomy guide; keep legacy values compatible and use expanded values such as core_entity, network_operator, network_staff, moderator, or radio_entity where appropriate.",
     ecosystemLane:
-      "Pick where the subject sits in the BARCODE ecosystem, such as core_team, network_operator, community_mod, infrastructure, production, or unknown.",
+      "Pick where the subject sits in the BARCODE ecosystem, such as core_team, network_operator, community_mod, artist, collaborator, community_member, infrastructure, production, external_platform, or unknown.",
     identityAuthority:
       "Pick who controls or owns the identity: barcode_controlled, community_owned, external_system, sponsor_controlled, or mixed_or_unclear. This is about authority/control, not AI/human nature.",
     status:
@@ -68,7 +68,7 @@ export const dossierAuthoringGuide = {
     "Use existing page structure.",
     "Classify in order: category, kind, ecosystem lane, identity authority, then tags.",
     "Do not use AI, human, hybrid, or unknown nature as the primary organization; those are tags/traits only.",
-    "Separate BARCODE-controlled characters/entities such as Sheila or Cliff from community-owned mods and helpers.",
+    "Separate BARCODE-controlled characters/entities such as Sheila or Cliff from community-owned mods and helpers, and do not collapse artists, collaborators, or active community members into Personnel by default.",
     "Match current dossier tone and length.",
     "Use public-page-safe facts only.",
     "Preserve clearance/status/origin uncertainty.",

--- a/src/lib/dossier-classification.ts
+++ b/src/lib/dossier-classification.ts
@@ -1,0 +1,636 @@
+import { databasePage, type DatabaseEntry } from "@/content";
+import {
+  buildDossierTagRegistry,
+  resolveDossierTagCanonical,
+  type DossierTagRegistryItem,
+} from "@/lib/dossier-tags";
+import {
+  DOSSIER_CATEGORY_PREFIXES,
+  type DossierCategory,
+  type DossierCandidate,
+  type DossierCandidateType,
+  type DossierRecommendation,
+  type DossierSourceFileNote,
+  type DossierWorkflowLink,
+} from "@/lib/dossier-workflow";
+import type {
+  DossierEcosystemLane,
+  DossierIdentityAuthority,
+  PublicDossierKind,
+} from "@/content";
+
+export type DossierClassificationConfidence = "low" | "medium" | "high";
+
+export type DossierClassificationAlternate = {
+  category: DossierCategory;
+  kind: PublicDossierKind;
+  ecosystemLane: DossierEcosystemLane;
+  identityAuthority: DossierIdentityAuthority;
+  reason: string;
+};
+
+export type DossierClassificationResult = {
+  category: DossierCategory;
+  kind: PublicDossierKind;
+  ecosystemLane: DossierEcosystemLane;
+  identityAuthority: DossierIdentityAuthority;
+  confidence: DossierClassificationConfidence;
+  reasons: string[];
+  blockers: string[];
+  alternatePossibilities: DossierClassificationAlternate[];
+  recommendedDesignationPrefix: string;
+};
+
+export type DossierTagSuggestion = {
+  tag: string;
+  confidence: DossierClassificationConfidence;
+  reason: string;
+  registrySource: DossierTagRegistryItem["source"] | "candidate";
+};
+
+export type DossierRejectedTagCandidate = {
+  tag: string;
+  reason: string;
+};
+
+export type DossierTagSuggestionResult = {
+  tags: DossierTagSuggestion[];
+  proposedTags: DossierTagSuggestion[];
+  rejectedTagCandidates: DossierRejectedTagCandidate[];
+};
+
+export type DossierEvidenceDistillation = {
+  publicSafe: {
+    confirmedPublicFacts: string[];
+    publicRoleHints: string[];
+    publicCommunityActivity: string[];
+    publicLinks: DossierWorkflowLink[];
+    publicQueueMusicEvidence: string[];
+  };
+  reviewOnly: {
+    internalNotes: string[];
+    sourceBlindMemory: string[];
+    internalAliases: string[];
+    privateAdminEvidence: string[];
+    uncertainIdentityLinks: string[];
+    inferredRoleClaims: string[];
+    unsupportedQueueMusicClaims: string[];
+  };
+  missing: string[];
+};
+
+export type DossierReadinessLabel =
+  | "Ready for Proposed Dossier"
+  | "Almost Ready"
+  | "Internal Source File Only"
+  | "Needs Identity Review"
+  | "Needs More Public Evidence"
+  | "Not Dossier Material Yet";
+
+export type DossierReadinessResult = {
+  label: DossierReadinessLabel;
+  score: number;
+  reasons: string[];
+  blockers: string[];
+  recommendedNextAction: string;
+};
+
+export type DossierDraftBlueprint = {
+  version: "1.0";
+  subjectName: string;
+  classification: DossierClassificationResult;
+  suggestedTags: DossierTagSuggestionResult;
+  publicSafeFacts: DossierEvidenceDistillation["publicSafe"];
+  safeRoleDirection: string;
+  safeSummaryIngredients: string[];
+  safeNotesIngredients: string[];
+  linkRecommendations: DossierWorkflowLink[];
+  queueMusicFootprintStatus: string;
+  communityActivitySummary: string[];
+  missingInfoQuestions: string[];
+  ownerReviewWarnings: string[];
+  readiness: DossierReadinessResult;
+  adminOnlyProvenance: {
+    candidateId: string;
+    sourceLanes: string[];
+    recommendationIds: string[];
+    reviewOnlyEvidence: DossierEvidenceDistillation["reviewOnly"];
+  };
+  sourceFileReferences: string[];
+  evidenceCounts: {
+    publicSafeFacts: number;
+    reviewOnlyItems: number;
+    missingItems: number;
+    recommendations: number;
+    sourceNotes: number;
+    identityLinks: number;
+  };
+  styleReferencesToUseLater: string[];
+};
+
+type ClassificationInput = {
+  candidate: DossierCandidate;
+  recommendations?: DossierRecommendation[];
+  publicDossiers?: DatabaseEntry[];
+};
+
+type EvidenceInput = ClassificationInput;
+
+type CandidateRoute = {
+  category: DossierCategory;
+  kind: PublicDossierKind;
+  ecosystemLane: DossierEcosystemLane;
+  identityAuthority: DossierIdentityAuthority;
+  reason: string;
+};
+
+export const DOSSIER_CANDIDATE_TYPE_ROUTES = {
+  artist: {
+    category: "Artist",
+    kind: "artist",
+    ecosystemLane: "artist",
+    identityAuthority: "community_owned",
+    reason: "Candidate type identifies music/performance relevance.",
+  },
+  collaborator: {
+    category: "Collaborator",
+    kind: "collaborator",
+    ecosystemLane: "collaborator",
+    identityAuthority: "community_owned",
+    reason: "Candidate type identifies direct creative or project contribution.",
+  },
+  community_member: {
+    category: "Community",
+    kind: "community_member",
+    ecosystemLane: "community_member",
+    identityAuthority: "community_owned",
+    reason: "Candidate type identifies recurring community presence.",
+  },
+  personnel: {
+    category: "Personnel",
+    kind: "moderator",
+    ecosystemLane: "community_mod",
+    identityAuthority: "community_owned",
+    reason: "Candidate type identifies an official/formal BARCODE role.",
+  },
+  entity: {
+    category: "Entity",
+    kind: "core_entity",
+    ecosystemLane: "core_team",
+    identityAuthority: "barcode_controlled",
+    reason: "Candidate type identifies BARCODE-created or entity-like subject.",
+  },
+  production: {
+    category: "Production",
+    kind: "program",
+    ecosystemLane: "production",
+    identityAuthority: "barcode_controlled",
+    reason: "Candidate type identifies produced BARCODE output.",
+  },
+  interface: {
+    category: "Interface",
+    kind: "interface",
+    ecosystemLane: "infrastructure",
+    identityAuthority: "external_system",
+    reason: "Candidate type identifies access surface or platform layer.",
+  },
+  sponsor: {
+    category: "Sponsor",
+    kind: "sponsor_character",
+    ecosystemLane: "sponsor",
+    identityAuthority: "sponsor_controlled",
+    reason: "Candidate type identifies sponsor or commercial-partner context.",
+  },
+  story_arc: {
+    category: "Production",
+    kind: "story_arc",
+    ecosystemLane: "production",
+    identityAuthority: "barcode_controlled",
+    reason: "Candidate type identifies narrative or campaign production.",
+  },
+  unknown: {
+    category: "Community",
+    kind: "unknown",
+    ecosystemLane: "unknown",
+    identityAuthority: "mixed_or_unclear",
+    reason: "Candidate type is unknown; classification needs evidence review.",
+  },
+} as const satisfies Record<DossierCandidateType, CandidateRoute>;
+
+const ROLE_HINTS = {
+  artist: /\b(artist|rapper|singer|producer|performer|band|song|track|music|submission|submitted|submitter|auxchord|album|release)\b/i,
+  collaborator: /\b(collaborator|contributor|playlist|graphic|graphics|designer|feature|segment|creative asset|event|initiative|production help|built|made for barcode|radio function)\b/i,
+  community: /\b(community|viewer|chat|regular|supporter|fan|presence|participant|recurring|discord member|radio regular)\b/i,
+  personnel: /\b(moderator|mod\b|admin|operator|staff|official|formal role|manager|core team)\b/i,
+  entity: /\b(entity|anomaly|character|barcode-created|network-controlled|ai|system character|persona|lore)\b/i,
+  interface: /\b(interface|platform|discord|website|tool|surface|integration|submission tool|access)\b/i,
+  production: /\b(show|program|episode|segment|arc|campaign|album|broadcast format|release)\b/i,
+  sponsor: /\b(sponsor|brand|commercial|partner|ad-world|advertiser)\b/i,
+};
+
+function cleanText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function uniqueStrings(values: Array<string | undefined | null>, limit = 12): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values) {
+    const clean = cleanText(value);
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+    if (output.length >= limit) break;
+  }
+  return output;
+}
+
+function combinedEvidenceText(input: ClassificationInput) {
+  const candidate = input.candidate;
+  return uniqueStrings([
+    candidate.name,
+    candidate.candidateType,
+    candidate.recommendedCategory,
+    candidate.recommendedKind,
+    candidate.recommendedEcosystemLane,
+    candidate.recommendedIdentityAuthority,
+    candidate.reason,
+    candidate.whyNow,
+    candidate.evidenceSummary,
+    candidate.sourceFileSummary?.summaryText,
+    candidate.sourceFileSummary?.knownContext?.join(" "),
+    ...(candidate.knownFacts ?? []),
+    ...(candidate.recommendedTags ?? []),
+    ...(candidate.proposedTags ?? []),
+    ...(candidate.sourceLanes ?? []),
+    ...(candidate.sourceFileNotes ?? []).map((note) => note.text),
+    ...(input.recommendations ?? []).flatMap((recommendation) => [
+      recommendation.recommendedCategory,
+      recommendation.recommendedKind,
+      recommendation.reason,
+      recommendation.adminSummary,
+      recommendation.evidenceSummary,
+      recommendation.queueSubmissionStatus,
+      recommendation.queueSubmissionNote,
+      ...(recommendation.musicSignals ?? []),
+      ...(recommendation.communitySignals ?? []),
+      ...(recommendation.activityFrequencySummary ?? []),
+      ...(recommendation.recentActivitySummary ?? []),
+      ...(recommendation.sourceLanes ?? []),
+    ]),
+  ], 80).join(" \n");
+}
+
+function routeFromRecommendedFields(candidate: DossierCandidate): CandidateRoute | undefined {
+  if (!candidate.recommendedCategory && !candidate.recommendedKind) return undefined;
+  const base = DOSSIER_CANDIDATE_TYPE_ROUTES[candidate.candidateType];
+  const kind = candidate.recommendedKind ?? base.kind;
+  let category = candidate.recommendedCategory ?? base.category;
+  let ecosystemLane = candidate.recommendedEcosystemLane ?? base.ecosystemLane;
+  let identityAuthority = candidate.recommendedIdentityAuthority ?? base.identityAuthority;
+
+  if (kind === "artist") {
+    category = "Artist";
+    ecosystemLane = "artist";
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "community_owned";
+  }
+  if (kind === "collaborator") {
+    category = "Collaborator";
+    ecosystemLane = "collaborator";
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "community_owned";
+  }
+  if (kind === "community_member" || kind === "radio_regular") {
+    category = "Community";
+    ecosystemLane = kind;
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "community_owned";
+  }
+  if (kind === "moderator") {
+    category = "Personnel";
+    ecosystemLane = candidate.recommendedEcosystemLane ?? "community_mod";
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "community_owned";
+  }
+  if (kind === "network_operator" || kind === "network_staff" || kind === "core_entity" || kind === "radio_entity") {
+    category = "Entity";
+    ecosystemLane = kind === "core_entity" ? "core_team" : kind;
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "barcode_controlled";
+  }
+  if (kind === "platform" || kind === "interface" || kind === "system") {
+    category = "Interface";
+    ecosystemLane = candidate.recommendedEcosystemLane ?? "infrastructure";
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "external_system";
+  }
+  if (kind === "program" || kind === "story_arc") {
+    category = "Production";
+    ecosystemLane = "production";
+    identityAuthority = candidate.recommendedIdentityAuthority ?? "barcode_controlled";
+  }
+
+  return { category, kind, ecosystemLane, identityAuthority, reason: "Existing recommended taxonomy fields were normalized." };
+}
+
+export function routeDossierCandidateType(candidateType: DossierCandidateType): CandidateRoute {
+  return DOSSIER_CANDIDATE_TYPE_ROUTES[candidateType];
+}
+
+export function classifyDossierSourceFileSubject(input: ClassificationInput): DossierClassificationResult {
+  const candidate = input.candidate;
+  const text = combinedEvidenceText(input);
+  const reasons: string[] = [];
+  const blockers: string[] = [];
+  const alternates: DossierClassificationAlternate[] = [];
+  const explicitRoute = routeFromRecommendedFields(candidate);
+  let route: CandidateRoute = explicitRoute ?? DOSSIER_CANDIDATE_TYPE_ROUTES[candidate.candidateType];
+  reasons.push(explicitRoute?.reason ?? route.reason);
+
+  const hintMatches = Object.entries(ROLE_HINTS)
+    .filter(([, pattern]) => pattern.test(text))
+    .map(([key]) => key);
+
+  const setRoute = (next: CandidateRoute, reason: string) => {
+    if (route.category !== next.category || route.kind !== next.kind) {
+      alternates.push({
+        category: route.category,
+        kind: route.kind,
+        ecosystemLane: route.ecosystemLane,
+        identityAuthority: route.identityAuthority,
+        reason: `Alternate before evidence override: ${route.reason}`,
+      });
+    }
+    route = next;
+    reasons.push(reason);
+  };
+
+  if (!explicitRoute) {
+    const typeLocked = ["artist", "collaborator", "community_member", "personnel", "entity", "production", "interface", "sponsor", "story_arc"].includes(candidate.candidateType);
+    if (!typeLocked && ROLE_HINTS.entity.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.entity, "Evidence mentions BARCODE-created/entity-like or lore/system subject.");
+    else if (!typeLocked && ROLE_HINTS.sponsor.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.sponsor, "Evidence mentions sponsor/commercial relationship.");
+    else if (!typeLocked && ROLE_HINTS.interface.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.interface, "Evidence mentions platform/interface/access surface.");
+    else if (!typeLocked && ROLE_HINTS.production.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.production, "Evidence mentions produced BARCODE output.");
+    else if (candidate.candidateType === "unknown" && ROLE_HINTS.personnel.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.personnel, "Evidence mentions formal moderator/staff/admin role.");
+    else if (candidate.candidateType === "unknown" && ROLE_HINTS.artist.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.artist, "Evidence mentions music, artist, or submission footprint.");
+    else if (candidate.candidateType === "unknown" && ROLE_HINTS.collaborator.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.collaborator, "Evidence mentions direct BARCODE project contribution.");
+    else if (candidate.candidateType === "unknown" && ROLE_HINTS.community.test(text)) setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.community_member, "Evidence mentions recurring community participation.");
+  }
+
+  if (candidate.candidateType === "artist" && route.category === "Personnel") {
+    setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.artist, "Artist candidate must not collapse into generic Personnel without stronger formal-role evidence.");
+  }
+  if (candidate.candidateType === "collaborator" && route.category === "Personnel") {
+    setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.collaborator, "Collaborator candidate must not collapse into generic Personnel without stronger formal-role evidence.");
+  }
+  if (candidate.candidateType === "community_member" && route.category === "Personnel" && !/moderator|admin|staff|official/i.test(text)) {
+    setRoute(DOSSIER_CANDIDATE_TYPE_ROUTES.community_member, "Community candidate stays Community when formal-role evidence is absent.");
+  }
+
+  if (candidate.identityReviewStatus === "needs_confirmation") blockers.push("Identity links require review before public drafting.");
+  if ((candidate.identityLinks ?? []).some((link) => link.status === "proposed")) blockers.push("Proposed identity links are not confirmed.");
+  if (!candidate.name.trim()) blockers.push("Public display name is missing.");
+  if (route.kind === "unknown" || route.ecosystemLane === "unknown") blockers.push("Subject type still needs operator classification.");
+
+  const confidence: DossierClassificationConfidence = blockers.length > 0 || route.kind === "unknown"
+    ? "low"
+    : explicitRoute || hintMatches.length > 0 || candidate.candidateType !== "unknown"
+      ? "medium"
+      : "low";
+
+  const alternateKeys = new Set(alternates.map((item) => `${item.category}/${item.kind}`));
+  for (const hint of hintMatches) {
+    const hintedRoute = hint === "community" ? DOSSIER_CANDIDATE_TYPE_ROUTES.community_member : DOSSIER_CANDIDATE_TYPE_ROUTES[hint as DossierCandidateType] ?? undefined;
+    if (!hintedRoute) continue;
+    const key = `${hintedRoute.category}/${hintedRoute.kind}`;
+    if (key === `${route.category}/${route.kind}` || alternateKeys.has(key)) continue;
+    alternates.push({ ...hintedRoute, reason: `Evidence also contains ${hint} signals.` });
+    alternateKeys.add(key);
+  }
+
+  return {
+    category: route.category,
+    kind: route.kind,
+    ecosystemLane: route.ecosystemLane,
+    identityAuthority: route.identityAuthority,
+    confidence,
+    reasons: uniqueStrings(reasons, 8),
+    blockers: uniqueStrings(blockers, 8),
+    alternatePossibilities: alternates.slice(0, 4),
+    recommendedDesignationPrefix: DOSSIER_CATEGORY_PREFIXES[route.category],
+  };
+}
+
+function registryItemFor(tag: string, registryItems: DossierTagRegistryItem[]) {
+  const canonical = resolveDossierTagCanonical(tag) ?? tag.toLowerCase();
+  return registryItems.find((item) => item.tag.toLowerCase() === canonical || item.canonical.toLowerCase() === canonical);
+}
+
+export function suggestDossierTags(input: ClassificationInput & { classification?: DossierClassificationResult }): DossierTagSuggestionResult {
+  const classification = input.classification ?? classifyDossierSourceFileSubject(input);
+  const registry = buildDossierTagRegistry(input.publicDossiers ?? databasePage.entries);
+  const confirmed = new Map<string, DossierTagSuggestion>();
+  const proposed = new Map<string, DossierTagSuggestion>();
+  const rejected: DossierRejectedTagCandidate[] = [];
+
+  const addTag = (tag: string, reason: string, confidence: DossierClassificationConfidence = "medium") => {
+    const item = registryItemFor(tag, registry.items);
+    if (!item) {
+      const clean = tag.toLowerCase().replace(/\s+/g, "-");
+      if (["human", "ai", "hybrid", "unknown-nature"].includes(clean)) {
+        rejected.push({ tag: clean, reason: "Nature tags are traits only and are not inferred from taxonomy classification." });
+        return;
+      }
+      proposed.set(clean, { tag: clean, confidence: "low", reason: `${reason} Registry entry does not exist yet.`, registrySource: "candidate" });
+      return;
+    }
+    confirmed.set(item.tag, { tag: item.tag, confidence, reason, registrySource: item.source });
+  };
+
+  addTag(classification.kind === "community_member" ? "member" : classification.kind, "Suggested from dossier kind.");
+  if (classification.category === "Artist") addTag("artist", "Artist category maps to the existing artist tag.", "high");
+  if (classification.category === "Collaborator") addTag("collaborator", "Collaborator category maps to the existing collaborator tag.", "high");
+  if (classification.category === "Community") addTag("community", "Community category maps to existing community tag.", "high");
+  if (classification.kind === "radio_regular") addTag("radio", "Radio regular kind maps to the existing radio tag.");
+  if (classification.kind === "moderator") addTag("mod", "Moderator kind maps to the existing mod tag.", "high");
+  if (classification.category === "Production") addTag("producer", "Production records use existing production-oriented tag when applicable.");
+  if (classification.category === "Interface") addTag("systems", "Interface records use existing systems tag when applicable.");
+  if (classification.category === "Sponsor") addTag("sponsor", "Sponsor category maps to existing sponsor tag.", "high");
+  if (classification.category === "Entity") addTag("core", "Entity records can reuse core/entity-oriented registry tags when applicable.");
+
+  for (const tag of input.candidate.recommendedTags ?? []) addTag(tag, "Existing candidate recommendation reused when present in registry.");
+  for (const tag of input.candidate.proposedTags ?? []) {
+    const item = registryItemFor(tag, registry.items);
+    if (item) addTag(item.tag, "Candidate proposed tag already exists in registry, so it is safe to suggest.");
+    else proposed.set(tag, { tag, confidence: "low", reason: "Candidate proposed tag is not in the registry yet.", registrySource: "candidate" });
+  }
+
+  return {
+    tags: Array.from(confirmed.values()).slice(0, 8),
+    proposedTags: Array.from(proposed.values()).slice(0, 8),
+    rejectedTagCandidates: rejected,
+  };
+}
+
+function publicSafeNotes(notes: DossierSourceFileNote[] = []) {
+  return notes.filter((note) => note.status === "active" && note.publicSafe === true);
+}
+
+function reviewOnlyNotes(notes: DossierSourceFileNote[] = []) {
+  return notes.filter((note) => note.status === "active" && note.publicSafe === false);
+}
+
+export function distillDossierEvidence(input: EvidenceInput): DossierEvidenceDistillation {
+  const candidate = input.candidate;
+  const recommendations = input.recommendations ?? [];
+  const safeNotes = publicSafeNotes(candidate.sourceFileNotes);
+  const unsafeNotes = reviewOnlyNotes(candidate.sourceFileNotes);
+  const publicLinks = [candidate.primaryLink].filter((link): link is DossierWorkflowLink => Boolean(link?.url && link.publicSafe !== false));
+  const queueEvidence = uniqueStrings([
+    ...recommendations.map((recommendation) => recommendation.queueSubmissionStatus),
+    ...recommendations.map((recommendation) => recommendation.queueSubmissionNote),
+  ], 6);
+  const publicQueueMusicEvidence = queueEvidence.length
+    ? uniqueStrings([...queueEvidence, ...recommendations.flatMap((recommendation) => recommendation.musicSignals ?? [])], 8)
+    : [];
+  const unsupportedMusic = queueEvidence.length
+    ? []
+    : uniqueStrings(recommendations.flatMap((recommendation) => recommendation.musicSignals ?? []), 6);
+  const publicActivity = uniqueStrings([
+    ...recommendations.flatMap((recommendation) => recommendation.communitySignals ?? []),
+    ...recommendations.flatMap((recommendation) => recommendation.activityFrequencySummary ?? []),
+    ...recommendations.flatMap((recommendation) => recommendation.recentActivitySummary ?? []),
+  ], 8);
+  const publicRoleHints = uniqueStrings([
+    candidate.recommendedKind,
+    candidate.recommendedCategory,
+    ...safeNotes.filter((note) => note.type === "fact" || note.type === "correction").map((note) => note.text),
+  ], 8);
+  const missing = uniqueStrings([
+    ...(candidate.missingInfo ?? []),
+    candidate.name ? undefined : "public display name",
+    candidate.recommendedKind || candidate.recommendedCategory ? undefined : "role confirmation",
+    publicLinks.length ? undefined : "public links",
+    publicQueueMusicEvidence.length ? undefined : "owned music links or queue/submission history, if this is an artist/music dossier",
+    candidate.identityReviewStatus === "needs_confirmation" ? "identity review" : undefined,
+    "owner approval",
+  ], 12);
+
+  return {
+    publicSafe: {
+      confirmedPublicFacts: uniqueStrings([
+        ...(candidate.knownFacts ?? []),
+        ...safeNotes.map((note) => note.text),
+        ...recommendations.flatMap((recommendation) => recommendation.publicUseCandidates ?? []),
+      ], 10),
+      publicRoleHints,
+      publicCommunityActivity: publicActivity,
+      publicLinks,
+      publicQueueMusicEvidence,
+    },
+    reviewOnly: {
+      internalNotes: uniqueStrings([...(candidate.doNotSay ?? []), ...(candidate.publicSafetyNotes ?? []), ...unsafeNotes.map((note) => note.text)], 10),
+      sourceBlindMemory: uniqueStrings(recommendations.flatMap((recommendation) => recommendation.conversationHighlights ?? []), 6),
+      internalAliases: uniqueStrings((candidate.identityLinks ?? []).filter((link) => link.visibility === "internal_only").map((link) => link.label), 8),
+      privateAdminEvidence: uniqueStrings([candidate.evidenceSummary, candidate.reason, candidate.whyNow], 8),
+      uncertainIdentityLinks: uniqueStrings((candidate.identityLinks ?? []).filter((link) => link.status !== "confirmed").map((link) => link.label), 8),
+      inferredRoleClaims: uniqueStrings([candidate.sourceFileSummary?.summaryText], 4),
+      unsupportedQueueMusicClaims: unsupportedMusic,
+    },
+    missing,
+  };
+}
+
+export function evaluateDossierReadiness(input: {
+  classification: DossierClassificationResult;
+  evidence: DossierEvidenceDistillation;
+  candidate: DossierCandidate;
+}): DossierReadinessResult {
+  const reasons: string[] = [];
+  const blockers = [...input.classification.blockers];
+  let score = input.classification.confidence === "high" ? 70 : input.classification.confidence === "medium" ? 55 : 30;
+  const publicFactCount = input.evidence.publicSafe.confirmedPublicFacts.length + input.evidence.publicSafe.publicRoleHints.length;
+  const activityCount = input.evidence.publicSafe.publicCommunityActivity.length + input.evidence.publicSafe.publicQueueMusicEvidence.length;
+  const reviewOnlyCount = Object.values(input.evidence.reviewOnly).reduce((sum, items) => sum + items.length, 0);
+
+  if (publicFactCount > 0) { score += 15; reasons.push("Public-safe facts or role hints are available."); }
+  else blockers.push("Public-safe facts have not been separated yet.");
+  if (activityCount > 0) { score += 10; reasons.push("Activity, community, or queue/music evidence is available for review."); }
+  if (input.evidence.publicSafe.publicLinks.length > 0) { score += 5; reasons.push("At least one public-safe link is available."); }
+  if (reviewOnlyCount > 0) { score -= 10; reasons.push("Review-only evidence exists and must stay admin-only."); }
+  if (input.evidence.missing.length > 0) score -= Math.min(20, input.evidence.missing.length * 3);
+  if (input.candidate.identityReviewStatus === "needs_confirmation" || input.evidence.reviewOnly.uncertainIdentityLinks.length > 0) blockers.push("Identity links need review; no alias should be auto-confirmed or auto-merged.");
+  score = Math.max(0, Math.min(100, score));
+
+  let label: DossierReadinessLabel = "Almost Ready";
+  let recommendedNextAction = "Review the blueprint, fill missing facts, and keep owner review required.";
+  if (blockers.some((item) => /identity/i.test(item))) {
+    label = "Needs Identity Review";
+    recommendedNextAction = "Resolve identity/alias review before drafting public copy.";
+  } else if (publicFactCount === 0) {
+    label = "Needs More Public Evidence";
+    recommendedNextAction = "Add public-safe facts, role confirmation, or public links before drafting.";
+  } else if (score >= 75 && blockers.length === 0) {
+    label = "Ready for Proposed Dossier";
+    recommendedNextAction = "Use this blueprint as structured input for a later BNL Proposed Dossier draft.";
+  } else if (score < 35) {
+    label = input.candidate.status === "candidate_intake" ? "Not Dossier Material Yet" : "Internal Source File Only";
+    recommendedNextAction = "Keep this as an internal Source File until more public evidence exists.";
+  }
+
+  return { label, score, reasons: uniqueStrings(reasons, 8), blockers: uniqueStrings(blockers, 10), recommendedNextAction };
+}
+
+export function createDossierDraftBlueprint(input: ClassificationInput): DossierDraftBlueprint {
+  const publicDossiers = input.publicDossiers ?? databasePage.entries;
+  const classification = classifyDossierSourceFileSubject({ ...input, publicDossiers });
+  const suggestedTags = suggestDossierTags({ ...input, publicDossiers, classification });
+  const evidence = distillDossierEvidence(input);
+  const readiness = evaluateDossierReadiness({ classification, evidence, candidate: input.candidate });
+  const reviewOnlyCount = Object.values(evidence.reviewOnly).reduce((sum, items) => sum + items.length, 0);
+  const publicFacts = evidence.publicSafe.confirmedPublicFacts;
+  const roleDirection = `${classification.category} / ${classification.kind} / ${classification.ecosystemLane}; keep identity authority as ${classification.identityAuthority}.`;
+
+  return {
+    version: "1.0",
+    subjectName: input.candidate.name,
+    classification,
+    suggestedTags,
+    publicSafeFacts: evidence.publicSafe,
+    safeRoleDirection: roleDirection,
+    safeSummaryIngredients: uniqueStrings([...publicFacts, ...evidence.publicSafe.publicRoleHints, ...evidence.publicSafe.publicCommunityActivity], 8),
+    safeNotesIngredients: uniqueStrings([...evidence.publicSafe.publicQueueMusicEvidence, ...evidence.publicSafe.publicCommunityActivity], 8),
+    linkRecommendations: evidence.publicSafe.publicLinks,
+    queueMusicFootprintStatus: evidence.publicSafe.publicQueueMusicEvidence.length
+      ? "Connected queue/music footprint is present and may be reviewed."
+      : "No queue/music footprint should be claimed until connected evidence is added.",
+    communityActivitySummary: evidence.publicSafe.publicCommunityActivity,
+    missingInfoQuestions: evidence.missing,
+    ownerReviewWarnings: uniqueStrings([
+      "Owner Review remains required before any public use.",
+      reviewOnlyCount > 0 ? "Review-only evidence exists and must stay out of public dossier prose." : undefined,
+      input.candidate.identityReviewStatus === "needs_confirmation" ? "Identity links are not confirmed." : undefined,
+    ], 8),
+    readiness,
+    adminOnlyProvenance: {
+      candidateId: input.candidate.id,
+      sourceLanes: uniqueStrings([...(input.candidate.sourceLanes ?? []), ...(input.recommendations ?? []).flatMap((recommendation) => recommendation.sourceLanes ?? [])], 12),
+      recommendationIds: (input.recommendations ?? []).map((recommendation) => recommendation.id),
+      reviewOnlyEvidence: evidence.reviewOnly,
+    },
+    sourceFileReferences: uniqueStrings([
+      input.candidate.latestSourceFileArchiveId,
+      ...(input.candidate.sourceFileArchiveIds ?? []),
+      ...(input.recommendations ?? []).map((recommendation) => recommendation.id),
+    ], 20),
+    evidenceCounts: {
+      publicSafeFacts: publicFacts.length,
+      reviewOnlyItems: reviewOnlyCount,
+      missingItems: evidence.missing.length,
+      recommendations: (input.recommendations ?? []).length,
+      sourceNotes: (input.candidate.sourceFileNotes ?? []).length,
+      identityLinks: (input.candidate.identityLinks ?? []).length,
+    },
+    styleReferencesToUseLater: publicDossiers
+      .filter((entry) => entry.category === classification.category || entry.kind === classification.kind)
+      .slice(0, 3)
+      .map((entry) => `${entry.id} ${entry.name}`),
+  };
+}

--- a/src/lib/dossier-taxonomy.ts
+++ b/src/lib/dossier-taxonomy.ts
@@ -3,6 +3,18 @@ import type {
   DossierIdentityAuthority,
   PublicDossierKind,
 } from "@/content";
+import type { DossierCategory } from "@/lib/dossier-workflow";
+
+export const DOSSIER_CATEGORY_OPTIONS = [
+  "Entity",
+  "Personnel",
+  "Artist",
+  "Collaborator",
+  "Community",
+  "Sponsor",
+  "Interface",
+  "Production",
+] as const satisfies readonly DossierCategory[];
 
 export const DOSSIER_IDENTITY_AUTHORITY_OPTIONS = [
   "barcode_controlled",
@@ -19,6 +31,7 @@ export const DOSSIER_ECOSYSTEM_LANE_OPTIONS = [
   "community_mod",
   "radio_support",
   "technical_operator",
+  "artist",
   "collaborator",
   "community_member",
   "radio_regular",
@@ -26,6 +39,7 @@ export const DOSSIER_ECOSYSTEM_LANE_OPTIONS = [
   "radio_entity",
   "infrastructure",
   "production",
+  "external_platform",
   "unknown",
 ] as const satisfies readonly DossierEcosystemLane[];
 
@@ -48,6 +62,7 @@ export const DOSSIER_KIND_OPTIONS = [
   "community_member",
   "radio_regular",
   "radio_entity",
+  "unknown",
 ] as const satisfies readonly PublicDossierKind[];
 
 export const DOSSIER_KIND_GUIDE = {
@@ -74,6 +89,7 @@ export const DOSSIER_KIND_GUIDE = {
   community_member: "Recurring or active community member dossier form.",
   radio_regular: "Recurring BARCODE Radio participant dossier form.",
   radio_entity: "BARCODE Radio-created entity/anomaly such as Studio Rats.",
+  unknown: "Unclassified dossier form pending operator review.",
 } as const satisfies Record<PublicDossierKind, string>;
 
 export const DOSSIER_TAXONOMY_GUIDE = {
@@ -88,7 +104,13 @@ export const DOSSIER_TAXONOMY_GUIDE = {
   categoryGuide: {
     Entity: "BARCODE entities, characters, anomalies, and entity-like systems.",
     Personnel:
-      "Community-owned people, personas, moderators, collaborators, or operators represented as personnel records.",
+      "Official BARCODE staff, operators, moderators, admin roles, or known personnel where the formal role matters more than general community activity.",
+    Artist:
+      "Music artists, performers, submitters, producers, rappers, singers, bands, or music identities whose main relevance is music, submissions, releases, or performance.",
+    Collaborator:
+      "People or identities directly contributing to BARCODE projects, creative assets, playlists, features, production, events, graphics, radio segments, tech, or special initiatives.",
+    Community:
+      "Active community members, recurring viewers, supporters, chat regulars, fan/support identities, and people whose dossier value is participation/presence rather than formal staff, music, or direct collaboration.",
     Sponsor: "Sponsor or commercial-relationship records.",
     Interface:
       "Platforms, community surfaces, submission surfaces, and other interaction layers.",
@@ -103,6 +125,7 @@ export const DOSSIER_TAXONOMY_GUIDE = {
     community_mod: "Community-owned moderators/helpers.",
     radio_support: "Support roles around BARCODE Radio.",
     technical_operator: "Site, bot, or infrastructure helpers.",
+    artist: "Artists, performers, submitters, producers, or music identities.",
     collaborator: "Musical or creative collaborators.",
     community_member: "Recurring/active BARCODE Network members.",
     radio_regular: "Recurring BARCODE Radio participants.",
@@ -110,6 +133,7 @@ export const DOSSIER_TAXONOMY_GUIDE = {
     radio_entity: "BARCODE Radio-created entities/anomalies like Studio Rats.",
     infrastructure: "Platforms, interfaces, systems, and tools.",
     production: "Shows, albums, arcs, and programs.",
+    external_platform: "Third-party or external platform surfaces.",
     unknown: "Not classified yet.",
   } satisfies Record<DossierEcosystemLane, string>,
   identityAuthorityGuide: {

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -9,6 +9,7 @@ import {
   sanitizeDossierPublicCopy,
   validateDossierPublicDraftFields,
 } from "@/lib/dossier-public-copy-guard";
+import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
 import {
   scoreManualDossierCandidate,
   type CreateDossierRecommendationInput,
@@ -1499,8 +1500,10 @@ function candidateTypeFromRecommendation(
     "recommendedCategory" | "recommendedKind"
   >,
 ): DossierCandidate["candidateType"] {
-  if (recommendation.recommendedKind === "artist") return "artist";
-  if (recommendation.recommendedKind === "community_member") {
+  if (recommendation.recommendedKind === "artist" || recommendation.recommendedCategory === "Artist") return "artist";
+  if (recommendation.recommendedKind === "collaborator" || recommendation.recommendedCategory === "Collaborator") return "collaborator";
+  if (recommendation.recommendedKind === "moderator") return "personnel";
+  if (recommendation.recommendedKind === "community_member" || recommendation.recommendedKind === "radio_regular" || recommendation.recommendedCategory === "Community") {
     return "community_member";
   }
   if (recommendation.recommendedCategory === "Production") return "production";
@@ -5384,8 +5387,10 @@ export function archiveDossierRecommendation(
 function candidateTypeFromPublicDossierEntry(
   entry: DatabaseEntry,
 ): DossierCandidate["candidateType"] {
-  if (entry.kind === "artist") return "artist";
-  if (entry.kind === "community_member" || entry.category === "Personnel") {
+  if (entry.kind === "artist" || entry.category === "Artist") return "artist";
+  if (entry.kind === "collaborator" || entry.category === "Collaborator") return "collaborator";
+  if (entry.kind === "moderator" || entry.category === "Personnel") return "personnel";
+  if (entry.kind === "community_member" || entry.kind === "radio_regular" || entry.category === "Community") {
     return "community_member";
   }
   if (entry.category === "Production") return "production";
@@ -6045,107 +6050,61 @@ function assemblePublicSafeDraftFromSourceFile(input: {
   now: string;
 }): Pick<DossierDraft, "fields" | "sourceFileDraftMetadata"> {
   const { candidate, recommendations, now } = input;
+  const blueprint = createDossierDraftBlueprint({ candidate, recommendations });
   const publicSafeNotes = (candidate.sourceFileNotes ?? []).filter(
     (note) => note.status === "active" && note.publicSafe === true,
   );
   const publicSafeFacts = uniqueDraftSeedLines([
-    ...(candidate.knownFacts ?? []),
-    ...publicSafeNotes
-      .filter((note) => note.type === "fact" || note.type === "correction")
-      .map((note) => note.text),
-    ...recommendations.flatMap((recommendation) => recommendation.publicUseCandidates ?? []),
+    ...blueprint.publicSafeFacts.confirmedPublicFacts,
+    ...blueprint.publicSafeFacts.publicRoleHints,
   ], 5);
-  const privateBoundaryCount =
-    (candidate.doNotSay ?? []).length +
-    (candidate.publicSafetyNotes ?? []).length +
-    (candidate.sourceFileNotes ?? []).filter(
-      (note) => note.status === "active" && note.publicSafe === false,
-    ).length;
-  const ownerReviewNotes = uniqueDraftSeedLines([
-    privateBoundaryCount > 0
-      ? `${privateBoundaryCount} review-only evidence note${privateBoundaryCount === 1 ? "" : "s"} must stay in admin metadata.`
+  const readinessNote = `Dossier Blueprint readiness: ${blueprint.readiness.label}. ${blueprint.readiness.recommendedNextAction}`;
+  const boundaryLines = uniqueDraftSeedLines([
+    readinessNote,
+    blueprint.evidenceCounts.reviewOnlyItems > 0
+      ? "Admin-only evidence exists and must not be copied into public text."
       : undefined,
-    "Owner Review should verify every public-facing claim before approval.",
-  ], 5);
-  const boundaries = uniqueDraftSeedLines([
-    ...(candidate.missingInfo ?? [])
-      .filter((item) => !containsDossierPublicCopyJunk(item) && !/owner-approved public copy|public-safe wording/i.test(item))
+    ...blueprint.missingInfoQuestions
+      .filter((item) => !/owner-approved public copy|public-safe wording/i.test(item))
       .map((item) => `Needs review before claiming: ${item}`),
-    privateBoundaryCount > 0
-      ? "Internal admin metadata exists and must not be copied into public text."
-      : undefined,
-    "Owner Review must approve this Proposed Dossier before any public use.",
-  ], 6);
-  const connection = uniqueDraftSeedLines([
-    candidate.reason,
-    candidate.whyNow,
-    ...recommendations.map((recommendation) => recommendation.reason),
-  ], 2);
-  const activityProfile = uniqueDraftSeedLines([
-    ...recommendations.flatMap((recommendation) => recommendation.activityFrequencySummary ?? []),
-    ...recommendations.flatMap((recommendation) => recommendation.recentActivitySummary ?? []),
-    ...recommendations.flatMap((recommendation) => recommendation.communitySignals ?? []),
-    ...recommendations.flatMap((recommendation) => recommendation.conversationHighlights ?? []),
-  ], 5);
-  const confirmedQueueFootprint = uniqueDraftSeedLines([
-    ...recommendations.map((recommendation) => recommendation.queueSubmissionStatus),
-    ...recommendations.map((recommendation) => recommendation.queueSubmissionNote),
-  ], 4);
-  const musicFootprint = confirmedQueueFootprint.length > 0
-    ? uniqueDraftSeedLines([
-        ...confirmedQueueFootprint,
-        ...recommendations.flatMap((recommendation) => recommendation.musicSignals ?? []),
-      ], 5)
-    : [];
+  ], 8);
   const dossierIntelligence = uniqueDraftSeedLines([
     candidate.sourceFileSummary?.summaryText,
     candidate.evidenceSummary,
-    activityProfile[0],
-    publicSafeFacts[0],
-  ], 2);
-  const summary = dossierIntelligence[0];
-  const role = DOSSIER_PUBLIC_ROLE_PLACEHOLDER;
-  const notesSections = [
-    dossierIntelligence.length
-      ? `BNL Dossier Intelligence:\n${dossierIntelligence.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    activityProfile.length
-      ? `Community Activity Profile:\n${activityProfile.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    musicFootprint.length
-      ? `Queue / Music Footprint:\n${musicFootprint.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    publicSafeFacts.length
-      ? `Public-safe facts:\n${publicSafeFacts.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    connection.length
-      ? `Connection to BARCODE Network:\n${connection.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    boundaries.length
-      ? `Boundaries / what not to claim:\n${boundaries.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-    ownerReviewNotes.length
-      ? `Owner-review notes:\n${ownerReviewNotes.map((item) => `- ${item}`).join("\n")}`
-      : undefined,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
+  ], 2).filter((item) => !/starter note|starter evidence/i.test(item));
+  const connection = uniqueDraftSeedLines([candidate.reason, candidate.whyNow], 2);
+  const publicFactSection = uniqueDraftSeedLines(publicSafeFacts, 5);
+  const ownerReviewLines = uniqueDraftSeedLines([
+    "Owner Review must approve this Proposed Dossier before any public use.",
+    ...blueprint.ownerReviewWarnings.map((item) => item.replace(/Review-only evidence/gi, "Admin-only evidence")),
+  ], 8);
+  const ownerReviewNotes = [
+    dossierIntelligence.length ? `BNL Dossier Intelligence:\n${dossierIntelligence.map((item) => `- ${item}`).join("\n")}` : undefined,
+    publicFactSection.length ? `Public-safe facts:\n${publicFactSection.map((item) => `- ${item}`).join("\n")}` : undefined,
+    connection.length ? `Connection to BARCODE Network:\n${connection.map((item) => `- ${item}`).join("\n")}` : undefined,
+    boundaryLines.length ? `Boundaries / what not to claim:\n${boundaryLines.map((item) => `- ${item}`).join("\n")}` : undefined,
+    ownerReviewLines.length ? `Owner-review notes:\n${ownerReviewLines.map((item) => `- ${item}`).join("\n")}` : undefined,
+  ].filter(Boolean).join("\n\n");
+  const proposedTags = uniqueDraftSeedLines([
+    ...blueprint.suggestedTags.proposedTags.map((tag) => tag.tag),
+    ...(candidate.proposedTags ?? []),
+  ], 12);
 
   return {
     fields: normalizeDraftFields({
       name: cleanDraftSeedText(candidate.name) ?? candidate.name,
-      category: candidate.recommendedCategory,
-      kind: candidate.recommendedKind,
-      ecosystemLane: candidate.recommendedEcosystemLane,
-      identityAuthority: candidate.recommendedIdentityAuthority,
+      category: candidate.recommendedCategory ?? blueprint.classification.category,
+      kind: candidate.recommendedKind ?? blueprint.classification.kind,
+      ecosystemLane: candidate.recommendedEcosystemLane ?? blueprint.classification.ecosystemLane,
+      identityAuthority: candidate.recommendedIdentityAuthority ?? blueprint.classification.identityAuthority,
       status: candidate.recommendedStatus ?? "PENDING",
       clearance: candidate.recommendedClearance ?? "PUBLIC",
       origin: candidate.recommendedOrigin ?? "UNVERIFIED",
-      role: role ?? DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
-      summary: summary ?? DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
-      notes: notesSections,
-      tags: cleanDraftSeedTags(candidate.recommendedTags),
-      proposedTags: cleanDraftSeedTags(candidate.proposedTags),
+      role: DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
+      summary: dossierIntelligence[0] ?? DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
+      notes: ownerReviewNotes,
+      tags: cleanDraftSeedTags(blueprint.suggestedTags.tags.map((tag) => tag.tag)),
+      proposedTags: cleanDraftSeedTags(proposedTags),
       primaryLink: cleanDraftSeedPrimaryLink(candidate.primaryLink),
       files: [],
     }),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -17,7 +17,9 @@ export type DossierCandidateSource =
 
 export type DossierCandidateType =
   | "artist"
+  | "collaborator"
   | "community_member"
+  | "personnel"
   | "entity"
   | "production"
   | "interface"
@@ -82,9 +84,24 @@ export type DossierDraftStatus =
 export type DossierCategory =
   | "Entity"
   | "Personnel"
+  | "Artist"
+  | "Collaborator"
+  | "Community"
   | "Sponsor"
   | "Interface"
   | "Production";
+
+export const DOSSIER_CATEGORY_PREFIXES = {
+  Entity: "EN",
+  Personnel: "PE",
+  Artist: "AR",
+  Collaborator: "CO",
+  Community: "CM",
+  Sponsor: "SP",
+  Interface: "IF",
+  Production: "PD",
+} as const satisfies Record<DossierCategory, string>;
+
 export type DossierPublicStatus =
   | "ACTIVE"
   | "INACTIVE"
@@ -3258,6 +3275,7 @@ export const DOSSIER_WORKFLOW_RULES = [
   "Drafting requires operator selection.",
   "Proposed tags are proposal-only until an operator or site content update creates them.",
   "AI/human/unknown nature tags do not organize dossiers; category, kind, ecosystem lane, and identity authority come first.",
+  "Artist, Collaborator, and Community are first-class categories; Personnel is reserved for official/formal BARCODE roles and is not the person catch-all.",
   "Sheila/Cliff-style Network characters are BARCODE-controlled records, while mods are community-owned identities.",
   "Loose intake, strict drafting/publishing: BNL discoveries enter Candidate Intake first, active Source Files require admin promotion, and drafting/publishing require evidence, duplicate checks, public-safety review, and owner approval.",
 ] as const;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -63,6 +63,8 @@ const sourceSummaryPanelComponent = require("../src/components/DossierSourceFile
 const actionableBrief = require("../src/lib/dossier-source-file-actionable-brief.ts");
 const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
+const dossierTaxonomy = require("../src/lib/dossier-taxonomy.ts");
+const dossierClassification = require("../src/lib/dossier-classification.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -78,6 +80,184 @@ function assertIncludesCopy(text, expected) {
     `Expected normalized source to include: ${expected}`,
   );
 }
+
+
+test("Dossier taxonomy expansion supports first-class artist, collaborator, and community routing", () => {
+  assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Artist"));
+  assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Collaborator"));
+  assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Community"));
+  assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Personnel"));
+  assert.equal(workflow.DOSSIER_CATEGORY_PREFIXES.Artist, "AR");
+  assert.equal(workflow.DOSSIER_CATEGORY_PREFIXES.Collaborator, "CO");
+  assert.equal(workflow.DOSSIER_CATEGORY_PREFIXES.Community, "CM");
+  assert.equal(databasePage.entries[0].id.startsWith("EN-") || databasePage.entries[0].id.startsWith("PE-") || databasePage.entries[0].id.startsWith("PD-") || databasePage.entries[0].id.startsWith("IF-") || databasePage.entries[0].id.startsWith("SP-"), true);
+
+  assert.deepEqual(dossierClassification.routeDossierCandidateType("artist"), {
+    category: "Artist",
+    kind: "artist",
+    ecosystemLane: "artist",
+    identityAuthority: "community_owned",
+    reason: "Candidate type identifies music/performance relevance.",
+  });
+  assert.equal(dossierClassification.routeDossierCandidateType("collaborator").category, "Collaborator");
+  assert.equal(dossierClassification.routeDossierCandidateType("community_member").category, "Community");
+  assert.equal(dossierClassification.routeDossierCandidateType("personnel").category, "Personnel");
+});
+
+test("Dossier classification blueprint separates category, evidence, readiness, and admin-only identity data", () => {
+  const now = "2026-06-12T00:00:00.000Z";
+  const base = {
+    id: "classification-fixture",
+    name: "Fixture Subject",
+    source: "manual",
+    tier: "review_candidate",
+    score: 50,
+    whyNow: "Fixture review.",
+    reason: "Fixture reason.",
+    evidenceSummary: "Fixture public-safe summary.",
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const classify = (candidate) => dossierClassification.createDossierDraftBlueprint({
+    candidate: { ...base, ...candidate },
+    recommendations: candidate.recommendations ?? [],
+  });
+
+  const artist = classify({
+    candidateType: "artist",
+    evidenceSummary: "Rapper submitted music through Auxchord.",
+    knownFacts: ["Public music submission evidence exists."],
+    recommendedTags: ["artist"],
+    identityReviewStatus: "not_required",
+  });
+  assert.equal(artist.classification.category, "Artist");
+  assert.equal(artist.classification.kind, "artist");
+  assert.equal(artist.classification.ecosystemLane, "artist");
+  assert.equal(artist.classification.identityAuthority, "community_owned");
+  assert.notEqual(artist.classification.category, "Personnel");
+  assert.ok(artist.classification.reasons.length > 0);
+  assert.ok(Array.isArray(artist.classification.blockers));
+  assert.ok(Array.isArray(artist.classification.alternatePossibilities));
+  assert.equal(artist.suggestedTags.tags.some((tag) => tag.tag === "artist"), true);
+
+  const collaborator = classify({
+    candidateType: "collaborator",
+    evidenceSummary: "Made a BARCODE playlist and contributes a planned radio segment.",
+    knownFacts: ["Public playlist contribution was approved."],
+  });
+  assert.equal(collaborator.classification.category, "Collaborator");
+  assert.equal(collaborator.classification.kind, "collaborator");
+  assert.notEqual(collaborator.classification.category, "Personnel");
+
+  const community = classify({
+    candidateType: "community_member",
+    evidenceSummary: "Recurring chat regular with strong community presence.",
+    knownFacts: ["Public community presence is visible."],
+  });
+  assert.equal(community.classification.category, "Community");
+  assert.equal(community.classification.kind, "community_member");
+  assert.notEqual(community.classification.category, "Personnel");
+
+  const moderator = classify({
+    candidateType: "personnel",
+    evidenceSummary: "Official Discord moderator role.",
+    recommendedKind: "moderator",
+    knownFacts: ["Public moderator role confirmed."],
+  });
+  assert.equal(moderator.classification.category, "Personnel");
+  assert.equal(moderator.classification.kind, "moderator");
+
+  const entity = classify({
+    candidateType: "entity",
+    evidenceSummary: "BARCODE-created network operator character.",
+    recommendedKind: "network_operator",
+    knownFacts: ["BARCODE-created entity record."],
+  });
+  assert.equal(entity.classification.category, "Entity");
+  assert.equal(entity.classification.identityAuthority, "barcode_controlled");
+
+  const uncertain = dossierClassification.createDossierDraftBlueprint({
+    candidate: {
+      ...base,
+      candidateType: "artist",
+      evidenceSummary: "Possible artist with unverified private alias and music rumor.",
+      proposedTags: ["new-uncertain-tag"],
+      identityReviewStatus: "needs_confirmation",
+      identityLinks: [{
+        id: "alias-1",
+        candidateId: base.id,
+        label: "Internal Alias",
+        normalizedLabel: "internal alias",
+        type: "alias",
+        visibility: "internal_only",
+        source: "admin_manual",
+        status: "proposed",
+        useInPublicDossier: false,
+        createdAt: now,
+        updatedAt: now,
+      }],
+      sourceFileNotes: [{
+        id: "review-note",
+        candidateId: base.id,
+        type: "do_not_say",
+        text: "Private admin-only alias evidence.",
+        source: "admin_manual",
+        status: "active",
+        publicSafe: false,
+        createdAt: now,
+        updatedAt: now,
+      }],
+    },
+    recommendations: [{
+      id: "rec-1",
+      type: "new_subject",
+      subjectName: base.name,
+      status: "new",
+      reason: "Music rumor only.",
+      sourceLanes: ["broadcast_memory"],
+      musicSignals: ["Rumored track mention without connected queue record."],
+      createdAt: now,
+      updatedAt: now,
+    }],
+  });
+  assert.equal(uncertain.suggestedTags.proposedTags.some((tag) => tag.tag === "new-uncertain-tag"), true);
+  assert.equal(uncertain.publicSafeFacts.publicQueueMusicEvidence.length, 0);
+  assert.match(uncertain.queueMusicFootprintStatus, /No queue\/music footprint/);
+  assert.ok(uncertain.adminOnlyProvenance.reviewOnlyEvidence.internalAliases.includes("Internal Alias"));
+  assert.ok(uncertain.adminOnlyProvenance.reviewOnlyEvidence.internalNotes.some((item) => /Private admin-only/.test(item)));
+  assert.equal(uncertain.readiness.label, "Needs Identity Review");
+  assert.match(uncertain.readiness.recommendedNextAction, /identity\/alias review/i);
+  assert.ok(uncertain.ownerReviewWarnings.some((item) => /Owner Review remains required/.test(item)));
+  assert.equal(uncertain.classification.blockers.some((item) => /Identity/.test(item)), true);
+});
+
+test("Dossier blueprint generation does not mutate Source File truth or public dossier content", () => {
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const candidate = {
+    id: "mutation-fixture",
+    name: "Mutation Fixture",
+    candidateType: "community_member",
+    source: "manual",
+    tier: "review_candidate",
+    score: 45,
+    whyNow: "Community activity review.",
+    reason: "Recurring viewer.",
+    evidenceSummary: "Recurring viewer with public chat presence.",
+    knownFacts: ["Public chat presence is visible."],
+    identityReviewStatus: "needs_confirmation",
+    identityLinks: [],
+    status: "active_source_file",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    updatedAt: "2026-06-12T00:00:00.000Z",
+  };
+  const beforeCandidate = JSON.stringify(candidate);
+  const blueprint = dossierClassification.createDossierDraftBlueprint({ candidate, recommendations: [] });
+  assert.equal(JSON.stringify(candidate), beforeCandidate);
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  assert.equal(blueprint.classification.category, "Community");
+  assert.equal(blueprint.adminOnlyProvenance.reviewOnlyEvidence.uncertainIdentityLinks.length, 0);
+});
 
 test("public database dossiers render through shared dossier page view", () => {
   const publicPageSource = normalizedSource("src/app/database/[slug]/page.tsx");


### PR DESCRIPTION
### Motivation
- The top-level dossier category space was collapsing diverse subjects into `Personnel`, causing poor routing and weak draft foundations for artists, collaborators, and community members.
- Provide a deterministic, testable foundation so Source Files can be classified (category/kind/ecosystemLane/identityAuthority) and produce an admin-only, non-public blueprint for later BNL draft generation.
- Preserve public-safety and existing public entries: no auto-confirmation of identities, no alias auto-merges, and no publishing changes in this PR.

### Description
- Add a new classification module `src/lib/dossier-classification.ts` that implements deterministic candidate-type routing, role-hint matching, tag suggestion, evidence distillation (public-safe vs review-only), readiness scoring, and a structured `DossierDraftBlueprint` output used for later BNL draft generation.
- Expand shared types and taxonomy: add top-level categories `Artist`, `Collaborator`, `Community`; add ecosystem lanes `artist` and `external_platform`; add `unknown` kind compatibility; and introduce `DOSSIER_CATEGORY_PREFIXES` for future designation prefix recommendations (AR/CO/CM/etc.). (files: `src/content.ts`, `src/lib/dossier-workflow.ts`, `src/lib/dossier-taxonomy.ts`)
- Wire blueprint generation into workflow/draft assembly while preserving owner-review gates and public-safety placeholders: `assemblePublicSafeDraftFromSourceFile` now uses the blueprint to seed draft fields but keeps internal review-only items out of public copy and sets `autoConfirmedIdentityLinks: false` and `publicPagesMutated: false`. (file: `src/lib/dossier-workflow-store.ts`)
- Surface the blueprint in admin UI only: added `Dossier Blueprint` admin view in `DossierSourceFileSummaryPanel` and a collapsed admin-only blueprint panel on the Proposed Dossier edit page; blueprint provenance is collapsed and clearly marked as admin-only. (files: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/drafts/[draftId]/page.tsx`)
- Update BNL read-model taxonomy guidance and mappings to treat `Artist`, `Collaborator`, and `Community` as first-class categories instead of defaulting to `Personnel`. (file: `src/app/api/bnl/read-model/route.ts`)
- Update the dossier authoring guide to reflect expanded categories and prefix guidance and to reiterate that `Personnel` is reserved for formal BARCODE roles. (file: `src/lib/dossier-authoring-guide.ts`)
- Tests: extend `tests/admin-dossiers.test.mjs` to validate the new categories, prefix mapping, classification outputs (category/kind/ecosystemLane/identityAuthority), tag suggestion behavior, evidence separation, readiness labeling, and that blueprints do not mutate public/source truth. (file: `tests/admin-dossiers.test.mjs`)
- Intentionally left public dossier pages/entries, the bot repo, BNL draft generation, BNL Edit Chat, auto-merge/auto-confirm behaviors, and closed PR #208 branch content untouched.

### Testing
- Ran the full dossier test suite: `node --test tests/admin-dossiers.test.mjs` — all tests passed locally (final run: 180 tests, 0 failures).
- Type-check: `npx tsc --noEmit` — completed without errors.
- Lint: `npx eslint src/lib/dossier-classification.ts src/components/DossierSourceFileSummaryPanel.tsx src/app/admin/dossiers/candidates/[candidateId]/page.tsx src/app/admin/dossiers/drafts/[draftId]/page.tsx` — completed with no errors and two pre-existing warnings in the candidate page (react-hooks/exhaustive-deps / unused var) that were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c8e7e62a48321a4f09b948a1b9039)