### PR TITLE
Dossier Style Packet + Draft Contract and Validation (site-side)

### DIFF
--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/dossier-public-copy-guard";
 import { createDossierSourceFileSummary } from "@/lib/dossier-source-file-summary";
 import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
+import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
 import {
   DOSSIER_CATEGORY_OPTIONS,
   DOSSIER_ECOSYSTEM_LANE_OPTIONS,
@@ -366,6 +367,7 @@ export default function DossierDraftEditorPage() {
   const blueprint = candidate
     ? createDossierDraftBlueprint({ candidate, recommendations: [], publicDossiers: [] })
     : null;
+  const stylePacket = useMemo(() => buildDossierStylePacket(), []);
   const sourceFileSummary = candidate
     ? createDossierSourceFileSummary({
         candidate,
@@ -818,8 +820,30 @@ export default function DossierDraftEditorPage() {
         {blueprint && (
           <details className="border border-border bg-surface p-5 text-sm text-muted">
             <summary className="cursor-pointer text-xl font-bold text-foreground">
-              Related Dossier Blueprint — admin-only
+              Draft Contract / Style Reference — admin-only
             </summary>
+            <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+              <section className="border border-border/60 bg-background/30 p-3">
+                <h3 className="font-bold text-foreground">Structured contract</h3>
+                <p>{DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS.length} required fields. Future BNL output must return fields, not a blob.</p>
+              </section>
+              <section className="border border-border/60 bg-background/30 p-3">
+                <h3 className="font-bold text-foreground">Style packet</h3>
+                <p>{stylePacket.representativePublicDossierExamples.length} representative public examples loaded from site content.</p>
+              </section>
+              <section className="border border-border/60 bg-background/30 p-3">
+                <h3 className="font-bold text-foreground">Review boundary</h3>
+                <p>Owner Review remains required; style data is not public dossier text.</p>
+              </section>
+            </div>
+            <details className="mt-4 border border-border/60 bg-background/20 p-3 text-xs">
+              <summary className="cursor-pointer font-semibold text-foreground">Collapsed style packet boundaries</summary>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {[...stylePacket.publicSafetyRules, ...stylePacket.sourceBoundaryRules].map((rule) => (
+                  <li key={rule}>{rule}</li>
+                ))}
+              </ul>
+            </details>
             <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
               <section className="border border-border/60 bg-background/30 p-3">
                 <h3 className="font-bold text-foreground">Classification</h3>

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -9,6 +9,7 @@ import type {
   DossierSourceFileNote,
 } from "@/lib/dossier-workflow";
 import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
+import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
 import {
   formatDossierSummaryBadge,
   type DossierSourceFileSummary,
@@ -587,6 +588,10 @@ function BlueprintList({ items, empty = "—" }: { items?: string[]; empty?: str
 }
 
 function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint }) {
+  const stylePacket = buildDossierStylePacket();
+  const missingCoverage = stylePacket.categorySpecificExamples
+    .filter((item) => item.coverage === "missing")
+    .map((item) => item.category);
   return (
     <Section
       title="Dossier Blueprint"
@@ -607,6 +612,24 @@ function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint 
         <section className="border border-border/50 bg-background/30 p-3">
           <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended next action</h4>
           <p className="text-foreground">{blueprint.readiness.recommendedNextAction}</p>
+        </section>
+        <section className="border border-border/50 bg-background/30 p-3">
+          <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Style Packet / Draft Contract</h4>
+          <p className="text-foreground">Available for future BNL authoring. Draft Blueprint exists and can pair with the site-owned style packet and structured draft contract.</p>
+          <p className="mt-1 text-xs uppercase tracking-widest text-muted">Required fields: {DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS.length} · Public examples: {stylePacket.representativePublicDossierExamples.length} · Missing category examples: {missingCoverage.length ? missingCoverage.join(", ") : "none"}</p>
+          <details className="mt-3 border border-border/50 bg-background/20 p-2 text-xs text-muted">
+            <summary className="cursor-pointer font-semibold text-foreground">Collapsed style reference</summary>
+            <div className="mt-2 grid grid-cols-1 gap-2 md:grid-cols-2">
+              <div>
+                <p className="font-semibold text-foreground">Owner Review rules</p>
+                <BlueprintList items={stylePacket.ownerReviewRules} />
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">Source boundary rules</p>
+                <BlueprintList items={stylePacket.sourceBoundaryRules} />
+              </div>
+            </div>
+          </details>
         </section>
         <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <section className="border border-border/50 bg-background/30 p-3">

--- a/src/lib/dossier-style-packet.ts
+++ b/src/lib/dossier-style-packet.ts
@@ -1,0 +1,457 @@
+import {
+  databasePage,
+  type DatabaseEntry,
+  type DossierEcosystemLane,
+  type DossierIdentityAuthority,
+  type PublicDossierKind,
+} from "@/content";
+import { dossierAuthoringGuide } from "@/lib/dossier-authoring-guide";
+import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
+import { buildDossierTagRegistry } from "@/lib/dossier-tags";
+import {
+  DOSSIER_CATEGORY_OPTIONS,
+  DOSSIER_ECOSYSTEM_LANE_OPTIONS,
+  DOSSIER_IDENTITY_AUTHORITY_OPTIONS,
+  DOSSIER_KIND_OPTIONS,
+  DOSSIER_TAXONOMY_GUIDE,
+} from "@/lib/dossier-taxonomy";
+import type {
+  DossierCandidate,
+  DossierCategory,
+  DossierClearance,
+  DossierOrigin,
+  DossierPublicStatus,
+  DossierWorkflowLink,
+} from "@/lib/dossier-workflow";
+
+export type DossierDraftContractOutput = {
+  name: string;
+  category: DossierCategory;
+  kind: PublicDossierKind;
+  ecosystemLane: DossierEcosystemLane;
+  identityAuthority: DossierIdentityAuthority;
+  status: DossierPublicStatus;
+  clearance: DossierClearance;
+  origin: DossierOrigin;
+  role: string;
+  summary: string;
+  notes: string;
+  tags: string[];
+  proposedTags: string[];
+  primaryLink?: DossierWorkflowLink | null;
+  links: DossierWorkflowLink[];
+  files: [];
+  missingInfoQuestions: string[];
+  ownerReviewWarnings: string[];
+  publicSafetyWarnings: string[];
+  unsupportedClaimsRejected: string[];
+  sourceUsageSummary: string;
+};
+
+export const DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS = [
+  "name",
+  "category",
+  "kind",
+  "ecosystemLane",
+  "identityAuthority",
+  "status",
+  "clearance",
+  "origin",
+  "role",
+  "summary",
+  "notes",
+  "tags",
+  "proposedTags",
+  "primaryLink",
+  "links",
+  "files",
+  "missingInfoQuestions",
+  "ownerReviewWarnings",
+  "publicSafetyWarnings",
+  "unsupportedClaimsRejected",
+  "sourceUsageSummary",
+] as const satisfies readonly (keyof DossierDraftContractOutput)[];
+
+export const DOSSIER_DRAFT_CONTRACT = {
+  version: "1.0",
+  outputMode: "structured_fields_only",
+  requiredFields: DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS,
+  rules: [
+    "Return structured fields only; do not return one blob of public copy.",
+    "role must be a short public role line.",
+    "summary must be one compact public-facing dossier paragraph.",
+    "notes must be one or two short contextual public-safe sentences.",
+    "tags must prefer existing tag registry entries.",
+    "proposedTags may contain uncertain or new suggestions only.",
+    "missingInfoQuestions, ownerReviewWarnings, and publicSafetyWarnings are admin/review fields, not public dossier prose.",
+    "sourceUsageSummary is admin-only provenance, not public dossier prose.",
+  ],
+} as const;
+
+export const DOSSIER_FORBIDDEN_PUBLIC_COPY_PATTERNS = [
+  "BNL Dossier Intelligence",
+  "Community Activity Profile",
+  "Queue / Music Footprint",
+  "Activity frequency",
+  "Review only evidence count",
+  "Most recent observed evidence",
+  "sourceFileSummary",
+  "memory_tiers",
+  "relationship_state",
+  "rd_context",
+  "queue_frequency",
+  "source lane",
+  "evidence id",
+  "recommendation id",
+] as const;
+
+const FORBIDDEN_REGEXES = [
+  /BNL Dossier Intelligence/i,
+  /Community Activity Profile/i,
+  /Queue\s*\/\s*Music Footprint/i,
+  /Activity frequency/i,
+  /Review only evidence count/i,
+  /Most recent observed evidence/i,
+  /sourceFileSummary/i,
+  /memory_tiers/i,
+  /relationship_state/i,
+  /rd_context/i,
+  /queue_frequency/i,
+  /source lanes?/i,
+  /evidence id/i,
+  /recommendation id/i,
+  /\b(?:public_discord|broadcast_memory|queue_context|website_dossier|admin_manual|owner_manual|mod_manual)\b/i,
+  /\b(?:evidence|recommendation|candidate|source|target)[-_ ]?id\s*[:=]?\s*[a-z0-9:_-]{6,}\b/i,
+  /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z\b/,
+  /\b\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\b/,
+  /\b(?:\d+\s*)?(?:activity|message|submission|evidence|observation)s?\s+count\b/i,
+  /\{\s*"?[a-z0-9_]+"?\s*:/i,
+  /\[[\s\n]*\{\s*"?[a-z0-9_]+"?\s*:/i,
+  /\.\.\.\s*$/,
+  /[,;:]\s*$/,
+  /\b(?:published|publish-ready|ready to publish|live on the site|public page has been created)\b/i,
+];
+
+const QUEUE_CLAIM_REGEX = /\b(?:queue|submission|submitted|track|song|artist|music|Auxchord)\b/i;
+const IDENTITY_CONFIRMED_REGEX = /\b(?:confirmed identity|same person|identity confirmed|alias confirmed|verified alias)\b/i;
+
+export type DossierStylePacketPublicExample = Pick<
+  DatabaseEntry,
+  | "id"
+  | "name"
+  | "category"
+  | "kind"
+  | "ecosystemLane"
+  | "identityAuthority"
+  | "status"
+  | "clearance"
+  | "origin"
+  | "role"
+  | "summary"
+  | "notes"
+  | "tags"
+  | "primaryLink"
+  | "links"
+  | "files"
+>;
+
+export type DossierStylePacketCategoryCoverage = {
+  category: DossierCategory;
+  definition: string;
+  examples: DossierStylePacketPublicExample[];
+  coverage: "available" | "missing";
+};
+
+export type DossierStylePacket = {
+  version: "1.0";
+  generatedAt: string;
+  publicDossierFieldModel: typeof dossierAuthoringGuide.fieldGuide;
+  requiredOutputShape: typeof DOSSIER_DRAFT_CONTRACT;
+  taxonomyGuide: typeof DOSSIER_TAXONOMY_GUIDE;
+  tagRegistryGuidance: ReturnType<typeof buildDossierTagRegistry>;
+  authoringGuideSummary: {
+    purpose: string;
+    pageStructure: readonly string[];
+    toneGuide: typeof dossierAuthoringGuide.toneGuide;
+    lengthGuide: typeof dossierAuthoringGuide.lengthGuide;
+    draftingRules: readonly string[];
+  };
+  representativePublicDossierExamples: DossierStylePacketPublicExample[];
+  categorySpecificExamples: DossierStylePacketCategoryCoverage[];
+  goodRoleLineExamples: string[];
+  goodSummaryExamples: string[];
+  goodNotesExamples: string[];
+  forbiddenPublicCopyPatterns: readonly string[];
+  publicSafetyRules: string[];
+  ownerReviewRules: string[];
+  sourceBoundaryRules: string[];
+  draftBlueprintInputExpectations: string[];
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function publicExample(entry: DatabaseEntry): DossierStylePacketPublicExample {
+  return {
+    id: entry.id,
+    name: entry.name,
+    category: entry.category,
+    kind: entry.kind,
+    ecosystemLane: entry.ecosystemLane,
+    identityAuthority: entry.identityAuthority,
+    status: entry.status,
+    clearance: entry.clearance,
+    origin: entry.origin,
+    role: entry.role,
+    summary: entry.summary,
+    notes: entry.notes,
+    tags: [...entry.tags],
+    primaryLink: entry.primaryLink,
+    links: entry.links,
+    files: entry.files,
+  };
+}
+
+function representativeExamples(entries: DatabaseEntry[]) {
+  const examples: DossierStylePacketPublicExample[] = [];
+  for (const category of DOSSIER_CATEGORY_OPTIONS) {
+    const entry = entries.find((item) => item.category === category);
+    if (entry) examples.push(publicExample(entry));
+  }
+  return examples;
+}
+
+export function buildDossierStylePacket(input: {
+  publicDossiers?: DatabaseEntry[];
+  generatedAt?: string;
+} = {}): DossierStylePacket {
+  const publicDossiers = input.publicDossiers ?? databasePage.entries;
+  const categorySpecificExamples = DOSSIER_CATEGORY_OPTIONS.map((category) => {
+    const examples = publicDossiers
+      .filter((entry) => entry.category === category)
+      .slice(0, 3)
+      .map(publicExample);
+    return {
+      category,
+      definition: DOSSIER_TAXONOMY_GUIDE.categoryGuide[category],
+      examples,
+      coverage: examples.length ? ("available" as const) : ("missing" as const),
+    };
+  });
+  const examples = representativeExamples(publicDossiers);
+
+  return {
+    version: "1.0",
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    publicDossierFieldModel: dossierAuthoringGuide.fieldGuide,
+    requiredOutputShape: DOSSIER_DRAFT_CONTRACT,
+    taxonomyGuide: DOSSIER_TAXONOMY_GUIDE,
+    tagRegistryGuidance: buildDossierTagRegistry(publicDossiers),
+    authoringGuideSummary: {
+      purpose: dossierAuthoringGuide.purpose,
+      pageStructure: dossierAuthoringGuide.pageStructure,
+      toneGuide: dossierAuthoringGuide.toneGuide,
+      lengthGuide: dossierAuthoringGuide.lengthGuide,
+      draftingRules: dossierAuthoringGuide.draftingRules,
+    },
+    representativePublicDossierExamples: examples,
+    categorySpecificExamples,
+    goodRoleLineExamples: examples.map((entry) => entry.role).filter(Boolean).slice(0, 8),
+    goodSummaryExamples: examples.map((entry) => entry.summary).filter(Boolean).slice(0, 8),
+    goodNotesExamples: examples.map((entry) => entry.notes).filter(Boolean).slice(0, 8),
+    forbiddenPublicCopyPatterns: DOSSIER_FORBIDDEN_PUBLIC_COPY_PATTERNS,
+    publicSafetyRules: [
+      "Public fields may use only public-safe facts and selected public links.",
+      "Review-only evidence, internal aliases, raw evidence IDs, source lane names, and diagnostics must stay out of public prose.",
+      "Do not claim queue/music participation unless connected public-safe evidence supports it.",
+      "Do not confirm identity, merge aliases, or imply publication from draft generation.",
+    ],
+    ownerReviewRules: [
+      "Owner Review remains required before public use.",
+      "Generated draft fields are proposed admin material only.",
+      "Packet generation must not publish, approve, or mutate public dossier pages.",
+    ],
+    sourceBoundaryRules: [
+      "Source File truth is read-only input for this packet.",
+      "Draft Blueprint adminOnlyProvenance remains review-only.",
+      "missingInfoQuestions, warnings, unsupportedClaimsRejected, and sourceUsageSummary are admin-only fields.",
+    ],
+    draftBlueprintInputExpectations: [
+      "Use DossierDraftBlueprint classification for category, kind, ecosystemLane, and identityAuthority direction.",
+      "Use safeSummaryIngredients and safeNotesIngredients as ingredients, not prose to dump verbatim.",
+      "Keep adminOnlyProvenance and reviewOnlyEvidence out of public fields.",
+      "Keep Owner Review warnings attached to review fields, not public dossier copy.",
+    ],
+  };
+}
+
+export type DossierDraftContractValidationIssue = {
+  field: string;
+  code: string;
+  message: string;
+};
+
+export type DossierDraftContractValidationResult = {
+  ok: boolean;
+  issues: DossierDraftContractValidationIssue[];
+};
+
+function textFields(draft: Partial<DossierDraftContractOutput>) {
+  return [
+    ["name", draft.name],
+    ["role", draft.role],
+    ["summary", draft.summary],
+    ["notes", draft.notes],
+  ] as const;
+}
+
+function addIssue(
+  issues: DossierDraftContractValidationIssue[],
+  field: string,
+  code: string,
+  message: string,
+) {
+  issues.push({ field, code, message });
+}
+
+function validatePublicText(
+  issues: DossierDraftContractValidationIssue[],
+  field: string,
+  value: string | undefined,
+  options: DossierDraftContractValidationOptions,
+) {
+  const text = value?.trim() ?? "";
+  if (!text) return;
+  for (const pattern of FORBIDDEN_REGEXES) {
+    if (pattern.test(text)) addIssue(issues, field, "forbidden_public_pattern", `${field} contains internal/source-file or unsafe public text.`);
+  }
+  for (const alias of options.internalAliases ?? []) {
+    if (alias.trim() && text.toLowerCase().includes(alias.trim().toLowerCase())) {
+      addIssue(issues, field, "internal_alias_exposed", `${field} exposes an internal alias.`);
+    }
+  }
+  if (!options.queueMusicEvidenceAllowed && QUEUE_CLAIM_REGEX.test(text)) {
+    addIssue(issues, field, "unsupported_queue_music_claim", `${field} includes unsupported queue/music claims.`);
+  }
+  if (!options.identityConfirmed && IDENTITY_CONFIRMED_REGEX.test(text)) {
+    addIssue(issues, field, "identity_confirmation_blocked", `${field} confirms identity without confirmation.`);
+  }
+}
+
+function isPublicSafeUrl(url: string) {
+  if (url.startsWith("/")) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+export type DossierDraftContractValidationOptions = {
+  internalAliases?: string[];
+  identityConfirmed?: boolean;
+  queueMusicEvidenceAllowed?: boolean;
+  existingTags?: string[];
+};
+
+export function validateDossierDraftContractOutput(
+  draft: Partial<DossierDraftContractOutput>,
+  options: DossierDraftContractValidationOptions = {},
+): DossierDraftContractValidationResult {
+  const issues: DossierDraftContractValidationIssue[] = [];
+  for (const field of DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS) {
+    if (!(field in draft)) addIssue(issues, field, "missing_required_field", `${field} is required.`);
+  }
+  if (draft.category && !DOSSIER_CATEGORY_OPTIONS.includes(draft.category)) addIssue(issues, "category", "invalid_category", "category must be an expanded dossier category.");
+  if (draft.kind && !DOSSIER_KIND_OPTIONS.includes(draft.kind)) addIssue(issues, "kind", "invalid_kind", "kind is not allowed.");
+  if (draft.ecosystemLane && !DOSSIER_ECOSYSTEM_LANE_OPTIONS.includes(draft.ecosystemLane)) addIssue(issues, "ecosystemLane", "invalid_ecosystem_lane", "ecosystemLane is not allowed.");
+  if (draft.identityAuthority && !DOSSIER_IDENTITY_AUTHORITY_OPTIONS.includes(draft.identityAuthority)) addIssue(issues, "identityAuthority", "invalid_identity_authority", "identityAuthority is not allowed.");
+  if (draft.status && !["ACTIVE", "INACTIVE", "ARCHIVED", "PENDING", "UNKNOWN"].includes(draft.status)) addIssue(issues, "status", "invalid_status", "status is not allowed.");
+  if (draft.clearance && !["PUBLIC", "INTERNAL", "RESTRICTED"].includes(draft.clearance)) addIssue(issues, "clearance", "invalid_clearance", "clearance is not allowed.");
+  if (draft.origin && !["KNOWN", "UNKNOWN", "UNVERIFIED", "WITHHELD"].includes(draft.origin)) addIssue(issues, "origin", "invalid_origin", "origin is not allowed.");
+
+  if (draft.role && (draft.role.length < 2 || draft.role.length > 80 || /[\n\r]/.test(draft.role))) addIssue(issues, "role", "role_length", "role must be a short public role line.");
+  if (!draft.summary?.trim()) addIssue(issues, "summary", "summary_required", "summary must not be empty.");
+  if (draft.summary && (draft.summary.length > 800 || draft.summary.split(/\n+/).length > 1)) addIssue(issues, "summary", "summary_shape", "summary must be one compact paragraph, not a source-file dump.");
+  if (draft.notes && (draft.notes.length > 360 || draft.notes.split(/[.!?]+/).filter((part) => part.trim()).length > 2)) addIssue(issues, "notes", "notes_shape", "notes must be one or two short public-safe sentences.");
+
+  for (const [field, value] of textFields(draft)) validatePublicText(issues, field, value, options);
+
+  const registry = new Set((options.existingTags ?? buildDossierTagRegistry(databasePage.entries).items.map((item) => item.canonical)).map((tag) => tag.toLowerCase()));
+  const tags = draft.tags ?? [];
+  const proposedTags = draft.proposedTags ?? [];
+  const proposedLower = new Set(proposedTags.map((tag) => tag.toLowerCase()));
+  for (const tag of tags) {
+    if (!/^[a-z0-9][a-z0-9 -]{1,32}$/i.test(tag) || tag.split(/\s+/).length > 3) addIssue(issues, "tags", "wild_tag", "tags must not be one-off junk or diagnostics.");
+    if (!registry.has(tag.toLowerCase())) addIssue(issues, "tags", "unregistered_confirmed_tag", "confirmed tags must prefer existing registry entries; place uncertain/new tags in proposedTags.");
+    validatePublicText(issues, "tags", tag, options);
+  }
+  for (const tag of proposedTags) {
+    if (tags.map((item) => item.toLowerCase()).includes(tag.toLowerCase())) addIssue(issues, "proposedTags", "tag_not_separated", "proposedTags must be separated from confirmed tags.");
+    validatePublicText(issues, "proposedTags", tag, options);
+  }
+  for (const tag of tags) {
+    if (proposedLower.has(tag.toLowerCase())) addIssue(issues, "tags", "tag_not_separated", "confirmed tags must not duplicate proposedTags.");
+  }
+
+  for (const [field, links] of [["primaryLink", draft.primaryLink ? [draft.primaryLink] : []], ["links", draft.links ?? []]] as const) {
+    for (const link of links) {
+      if (link && (!link.publicSafe || !isPublicSafeUrl(link.url))) addIssue(issues, field, "unsafe_link", "links must be public-safe http(s) or site-relative URLs.");
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+export type FutureBnlDossierAuthoringPacket = {
+  sourceFileSubject: {
+    candidateId: string;
+    name: string;
+    status: DossierCandidate["status"];
+  };
+  draftBlueprint: DossierDraftBlueprint;
+  stylePacket: DossierStylePacket;
+  publicSafeInputs: DossierDraftBlueprint["publicSafeFacts"];
+  reviewOnlyBoundaries: {
+    adminOnlyProvenance: DossierDraftBlueprint["adminOnlyProvenance"];
+    ownerReviewWarnings: string[];
+    sourceBoundaryRules: string[];
+  };
+  requiredOutputContract: typeof DOSSIER_DRAFT_CONTRACT;
+  validationRules: {
+    forbiddenPublicCopyPatterns: readonly string[];
+    requiredFields: typeof DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS;
+    publicSafetyRules: string[];
+  };
+};
+
+export function createFutureBnlDossierAuthoringPacket(input: {
+  sourceFileSubject: DossierCandidate;
+  draftBlueprint: DossierDraftBlueprint;
+  stylePacket?: DossierStylePacket;
+}): FutureBnlDossierAuthoringPacket {
+  const stylePacket = input.stylePacket ?? buildDossierStylePacket();
+  return {
+    sourceFileSubject: {
+      candidateId: input.sourceFileSubject.id,
+      name: input.sourceFileSubject.name,
+      status: input.sourceFileSubject.status,
+    },
+    draftBlueprint: clone(input.draftBlueprint),
+    stylePacket: clone(stylePacket),
+    publicSafeInputs: clone(input.draftBlueprint.publicSafeFacts),
+    reviewOnlyBoundaries: {
+      adminOnlyProvenance: clone(input.draftBlueprint.adminOnlyProvenance),
+      ownerReviewWarnings: [...input.draftBlueprint.ownerReviewWarnings, "Owner Review remains required before any public dossier publication."],
+      sourceBoundaryRules: [...stylePacket.sourceBoundaryRules],
+    },
+    requiredOutputContract: DOSSIER_DRAFT_CONTRACT,
+    validationRules: {
+      forbiddenPublicCopyPatterns: DOSSIER_FORBIDDEN_PUBLIC_COPY_PATTERNS,
+      requiredFields: DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS,
+      publicSafetyRules: [...stylePacket.publicSafetyRules],
+    },
+  };
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -65,6 +65,7 @@ const publicCopyGuard = require("../src/lib/dossier-public-copy-guard.ts");
 const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
 const dossierTaxonomy = require("../src/lib/dossier-taxonomy.ts");
 const dossierClassification = require("../src/lib/dossier-classification.ts");
+const dossierStylePacket = require("../src/lib/dossier-style-packet.ts");
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
@@ -257,6 +258,184 @@ test("Dossier blueprint generation does not mutate Source File truth or public d
   assert.equal(JSON.stringify(databasePage.entries), beforePublic);
   assert.equal(blueprint.classification.category, "Community");
   assert.equal(blueprint.adminOnlyProvenance.reviewOnlyEvidence.uncertainIdentityLinks.length, 0);
+});
+
+
+
+test("Dossier Style Packet builds site-owned examples, taxonomy, tags, and authoring rules", () => {
+  const packet = dossierStylePacket.buildDossierStylePacket({ generatedAt: "2026-06-12T00:00:00.000Z" });
+
+  assert.equal(packet.version, "1.0");
+  assert.equal(packet.generatedAt, "2026-06-12T00:00:00.000Z");
+  assert.ok(packet.representativePublicDossierExamples.length >= 5);
+  assert.ok(packet.representativePublicDossierExamples.some((entry) => entry.category === "Entity"));
+  assert.ok(packet.representativePublicDossierExamples.some((entry) => entry.category === "Personnel"));
+  assert.ok(packet.representativePublicDossierExamples.some((entry) => entry.category === "Sponsor"));
+  assert.ok(packet.representativePublicDossierExamples.some((entry) => entry.category === "Interface"));
+  assert.ok(packet.representativePublicDossierExamples.some((entry) => entry.category === "Production"));
+  assert.deepEqual(packet.taxonomyGuide.categoryGuide.Artist.includes("Music artists"), true);
+  assert.ok(packet.categorySpecificExamples.some((item) => item.category === "Artist"));
+  assert.ok(packet.categorySpecificExamples.some((item) => item.coverage === "missing"));
+  assert.ok(packet.categorySpecificExamples.filter((item) => item.coverage === "missing").every((item) => item.examples.length === 0));
+  assert.ok(packet.tagRegistryGuidance.items.some((item) => item.tag === "artist"));
+  assert.ok(packet.authoringGuideSummary.draftingRules.some((rule) => /Classify in order/.test(rule)));
+  assert.ok(packet.goodRoleLineExamples.includes("Host / Artist"));
+  assert.ok(packet.goodSummaryExamples.some((summary) => /BARCODE Radio/.test(summary)));
+  assert.ok(packet.goodNotesExamples.length > 0);
+  assert.ok(packet.forbiddenPublicCopyPatterns.includes("sourceFileSummary"));
+});
+
+test("Dossier Draft Contract exposes required structured output fields", () => {
+  const required = dossierStylePacket.DOSSIER_DRAFT_CONTRACT.requiredFields;
+  for (const field of [
+    "name",
+    "category",
+    "kind",
+    "ecosystemLane",
+    "identityAuthority",
+    "status",
+    "clearance",
+    "origin",
+    "role",
+    "summary",
+    "notes",
+    "tags",
+    "proposedTags",
+    "primaryLink",
+    "links",
+    "files",
+    "missingInfoQuestions",
+    "ownerReviewWarnings",
+    "publicSafetyWarnings",
+    "unsupportedClaimsRejected",
+    "sourceUsageSummary",
+  ]) {
+    assert.ok(required.includes(field), `missing ${field}`);
+  }
+  assert.equal(dossierStylePacket.DOSSIER_DRAFT_CONTRACT.outputMode, "structured_fields_only");
+});
+
+function cleanContractDraft(overrides = {}) {
+  return {
+    name: "Clean Fixture",
+    category: "Community",
+    kind: "community_member",
+    ecosystemLane: "community_member",
+    identityAuthority: "community_owned",
+    status: "PENDING",
+    clearance: "PUBLIC",
+    origin: "UNVERIFIED",
+    role: "Community Member",
+    summary: "Clean Fixture is a recurring BARCODE community presence with public-safe participation signals ready for operator review.",
+    notes: "Owner review is still required before this proposed dossier can be used publicly.",
+    tags: ["community"],
+    proposedTags: ["fixture-regular"],
+    primaryLink: null,
+    links: [{ label: "BARCODE", url: "https://barcode-network.com", type: "website", selectedBy: "operator", publicSafe: true }],
+    files: [],
+    missingInfoQuestions: ["Confirm preferred public role line."],
+    ownerReviewWarnings: ["Owner Review remains required."],
+    publicSafetyWarnings: [],
+    unsupportedClaimsRejected: [],
+    sourceUsageSummary: "Used public-safe source ingredients only.",
+    ...overrides,
+  };
+}
+
+test("Dossier Draft Contract validation accepts a clean dossier-style draft", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft(), {
+    queueMusicEvidenceAllowed: false,
+    identityConfirmed: false,
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.issues));
+});
+
+test("Dossier Draft Contract validation rejects internal reports and source-file diagnostics in public fields", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft({
+    summary: "BNL Dossier Intelligence: Community Activity Profile sourceFileSummary memory_tiers relationship_state.",
+    notes: "Review only evidence count: 5. Most recent observed evidence: recommendation id rec_123456.",
+  }));
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => issue.code === "forbidden_public_pattern"));
+});
+
+test("Dossier Draft Contract validation rejects source lanes, raw IDs, timestamps, activity diagnostics, and JSON dumps", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft({
+    role: "Community Member",
+    summary: `source lane rd_context evidence id evidence_abc123 2026-06-12T00:00:00.000Z activity count {"sourceFileSummary":true}`,
+    notes: "public_discord source lane and recommendation id recommendation_fixture_123456.",
+  }));
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.filter((issue) => issue.code === "forbidden_public_pattern").length >= 2);
+});
+
+test("Dossier Draft Contract validation rejects unsupported queue/music claims", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft({
+    category: "Community",
+    kind: "community_member",
+    ecosystemLane: "community_member",
+    summary: "Clean Fixture submitted songs through the queue and is an Auxchord artist without connected evidence.",
+  }), { queueMusicEvidenceAllowed: false });
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => issue.code === "unsupported_queue_music_claim"));
+});
+
+test("Dossier Draft Contract validation rejects internal aliases and separates proposed tags", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft({
+    summary: "Clean Fixture is also Private Alias Alpha in internal notes.",
+    tags: ["community", "new-uncertain-tag"],
+    proposedTags: ["new-uncertain-tag"],
+  }), { internalAliases: ["Private Alias Alpha"] });
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => issue.code === "internal_alias_exposed"));
+  assert.ok(result.issues.some((issue) => issue.code === "tag_not_separated"));
+  assert.ok(result.issues.some((issue) => issue.code === "unregistered_confirmed_tag"));
+});
+
+test("Dossier Draft Contract validation blocks identity confirmation and publishing language", () => {
+  const result = dossierStylePacket.validateDossierDraftContractOutput(cleanContractDraft({
+    summary: "Clean Fixture has confirmed identity and the public page has been created.",
+  }), { identityConfirmed: false });
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => issue.code === "identity_confirmation_blocked"));
+  assert.ok(result.issues.some((issue) => issue.code === "forbidden_public_pattern"));
+});
+
+test("Style Packet + Blueprint bridge produces a future BNL authoring packet without mutation or publishing", () => {
+  const beforePublic = JSON.stringify(databasePage.entries);
+  const candidate = {
+    id: "bridge-fixture",
+    name: "Bridge Fixture",
+    candidateType: "community_member",
+    source: "manual",
+    tier: "review_candidate",
+    score: 45,
+    whyNow: "Bridge test.",
+    reason: "Recurring public-safe community presence.",
+    evidenceSummary: "Recurring public chat presence.",
+    knownFacts: ["Public chat presence is visible."],
+    status: "active_source_file",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    updatedAt: "2026-06-12T00:00:00.000Z",
+  };
+  const beforeCandidate = JSON.stringify(candidate);
+  const blueprint = dossierClassification.createDossierDraftBlueprint({ candidate, recommendations: [] });
+  const beforeBlueprint = JSON.stringify(blueprint);
+  const packet = dossierStylePacket.createFutureBnlDossierAuthoringPacket({
+    sourceFileSubject: candidate,
+    draftBlueprint: blueprint,
+    stylePacket: dossierStylePacket.buildDossierStylePacket({ generatedAt: "2026-06-12T00:00:00.000Z" }),
+  });
+
+  assert.equal(packet.sourceFileSubject.candidateId, "bridge-fixture");
+  assert.equal(packet.requiredOutputContract.outputMode, "structured_fields_only");
+  assert.ok(packet.validationRules.requiredFields.includes("sourceUsageSummary"));
+  assert.ok(packet.reviewOnlyBoundaries.ownerReviewWarnings.some((warning) => /Owner Review remains required/.test(warning)));
+  assert.equal(JSON.stringify(candidate), beforeCandidate);
+  assert.equal(JSON.stringify(blueprint), beforeBlueprint);
+  assert.equal(JSON.stringify(databasePage.entries), beforePublic);
+  assert.equal(packet.draftBlueprint.readiness.label !== "Owner Approved", true);
+  assert.equal(packet.draftBlueprint.readiness.recommendedNextAction.includes("publish"), false);
 });
 
 test("public database dossiers render through shared dossier page view", () => {


### PR DESCRIPTION
### Motivation
- Provide a site-owned, machine-readable Dossier Style Packet and a strict Dossier Draft Contract so future BNL generation receives clear, public-safe instructions and field rules. 
- Ensure the packet is built from existing site truth (public dossiers, taxonomy, tag registry, authoring guide) rather than duplicating or inventing facts. 
- Enforce safe public-output boundaries via validation so generated drafts cannot leak internal source-file diagnostics, raw IDs/timestamps, internal aliases, or publishing/identity-confirmation language. 
- Surface availability to admins on Source File and Proposed Dossier pages without publishing or exposing admin-only provenance to public pages. 

### Description
- Added a new site helper `src/lib/dossier-style-packet.ts` that: defines the `DossierDraftContract` and required output shape, builds a `DossierStylePacket` from `databasePage.entries`, `dossier-taxonomy`, `dossier-tags`, and `dossier-authoring-guide`, exposes `validateDossierDraftContractOutput`, and provides `createFutureBnlDossierAuthoringPacket` to bridge a `DossierDraftBlueprint` with style/validation context. 
- Implemented strict validation rules including required fields, allowed taxonomy/kind/lanes/authorities, role/summary/notes shape limits, forbidden public-copy regexes, queue/music claim blocking, internal-alias detection, tag registry hygiene, and safe-link checks via `validateDossierDraftContractOutput` and helper options (`internalAliases`, `identityConfirmed`, `queueMusicEvidenceAllowed`). 
- Admin UI: added compact, collapsed admin-only references to the style packet / draft contract in `src/components/DossierSourceFileSummaryPanel.tsx` and `src/app/admin/dossiers/drafts/[draftId]/page.tsx` to indicate availability and keep full packet details collapsed (no giant JSON dumped into the normal view). 
- Tests: extended `tests/admin-dossiers.test.mjs` to cover style-packet construction, category-specific coverage reporting, contract field exposure, positive and negative validation cases (forbidden patterns, raw IDs/timestamps/JSON dumps, queue/music claims, internal aliases, proposed-vs-confirmed tag separation), the Style Packet + Blueprint bridge, and non-mutation/no-publish guarantees. 
- Safety scope: did not add any public/admin/BNL-facing HTTP route; packet and bridge remain site-side helpers only; no BNL calls, no owner-approval/publish actions, no auto-confirmation or alias merging. 

### Testing
- Ran `node --test tests/admin-dossiers.test.mjs` and all tests passed (new tests included); full run succeeded. 
- Ran `npx tsc --noEmit` and TypeScript type-check passed. 
- Confirmed admin UI changes are lightweight (collapsed references) and do not expose admin-only provenance as public dossier copy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c9e3e50b88321a0528fe097eca0ad)