### PR TITLE
Add footer legal and contact links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -114,9 +114,19 @@ export function Footer() {
 
         {/* Bottom bar */}
         <div className="mt-8 sm:mt-12 pt-4 sm:pt-6 border-t border-border flex flex-col sm:flex-row justify-between items-center gap-2 sm:gap-4">
-          <p className="text-xs text-muted tracking-widest uppercase">
-            &copy; {currentYear} BARCODE Network. All rights reserved.
-          </p>
+          <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4">
+            <p className="text-xs text-muted tracking-widest uppercase">
+              &copy; {currentYear} BARCODE Network. All rights reserved.
+            </p>
+            <nav aria-label="Footer legal links" className="flex items-center gap-3">
+              <Link href="/legal" className="text-xs text-muted hover:text-accent tracking-widest uppercase transition-colors">
+                Legal / Privacy
+              </Link>
+              <Link href="/contact" className="text-xs text-muted hover:text-accent tracking-widest uppercase transition-colors">
+                Contact
+              </Link>
+            </nav>
+          </div>
           <p className="text-xs text-muted/50 tracking-wider font-mono animate-flicker">
             SYS.BUILD // v2.0.0 // PHASE_02
           </p>


### PR DESCRIPTION
### Motivation
- Add direct access to legal/privacy and contact pages from the footer bottom bar without changing existing layout or links.

### Description
- Modified `src/components/Footer.tsx` to add `Legal / Privacy` (href `/legal`) and `Contact` (href `/contact`) links to the bottom footer area next to the copyright and system build text while preserving all existing footer columns and links.

### Testing
- Ran `npm run check` which failed due to pre-existing lint/test issues outside this footer change, and ran `npm run test:queue` which passed 122 tests and reported 3 failing dossier/read-model assertions that are unrelated to the footer edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcdfbc3788321aefd7e965a1bfa37)