### PR TITLE
Require legal acceptance for public queue submissions

### DIFF
--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { detectQueueSourceType } from "@/lib/queue-types";
+import { PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT, PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION, PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION, PUBLIC_QUEUE_LEGAL_TERMS_VERSION, detectQueueSourceType } from "@/lib/queue-types";
 import { getPublicQueueSnapshot, getRadioQueueState, isTrackPersistedInSessionQueue, normalizeQueueSourceKey, requestPriorityUpgradePlaceholder, submitRadioTrack, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry } from "@/lib/queue-types";
 
@@ -45,6 +45,23 @@ function validateUploadMimeType(value: unknown): string {
 
 function cleanBodyText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+
+function validateLegalAcceptance(body: Record<string, unknown>) {
+  if (body.acceptedLegal !== true) throw new Error("Legal acceptance is required before submitting to the queue.");
+  if (cleanBodyText(body.termsVersion) !== PUBLIC_QUEUE_LEGAL_TERMS_VERSION) throw new Error("Legal terms version mismatch. Refresh the queue and try again.");
+  if (cleanBodyText(body.privacyVersion) !== PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION) throw new Error("Privacy policy version mismatch. Refresh the queue and try again.");
+  if (cleanBodyText(body.queueTermsVersion) !== PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION) throw new Error("Queue terms version mismatch. Refresh the queue and try again.");
+  if (cleanBodyText(body.acceptedCheckboxText) !== PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT) throw new Error("Legal acceptance text mismatch. Refresh the queue and try again.");
+  return {
+    acceptedAt: new Date().toISOString(),
+    termsVersion: PUBLIC_QUEUE_LEGAL_TERMS_VERSION,
+    privacyVersion: PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION,
+    queueTermsVersion: PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION,
+    acceptedCheckboxText: PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT,
+    source: "public_queue_form" as const,
+  };
 }
 
 function parseBodyDuration(value: unknown): number | null {
@@ -147,6 +164,12 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
   const contactEmail = cleanBodyText(body.contactEmail).slice(0, 200);
   const submitterToken = cleanBodyText(body.submitterToken).slice(0, 120);
   const sessionId = cleanBodyText(body.sessionId);
+  let legalAcceptance;
+  try {
+    legalAcceptance = validateLegalAcceptance(body);
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Legal acceptance is required before submitting to the queue." }, { status: 400 });
+  }
   const active = await getPublicQueueSnapshot();
 
   if (!sessionId) return NextResponse.json({ error: "Session sync required. Refresh the queue and try again.", code: "session_sync_required" }, { status: 409 });
@@ -186,6 +209,7 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
       collaboratorNames,
       contactEmail,
       submitterToken,
+      legalAcceptance,
     });
     if (!(await isTrackPersistedInSessionQueue(track.id, active.session.sessionId))) {
       return NextResponse.json({ error: QUEUE_ACCEPTANCE_UNCONFIRMED_MESSAGE, code: "queue_acceptance_unconfirmed" }, { status: 500 });
@@ -199,7 +223,7 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
   if (await hasDuplicateLinkSubmission(link)) return duplicateResponse();
 
   const sourceType = detectQueueSourceType(link);
-  const track = await submitRadioTrack({ artist, title, link, sourceType, note, submitterArtistName: artist, tiktokHandle, collaboratorNames, contactEmail, submitterToken });
+  const track = await submitRadioTrack({ artist, title, link, sourceType, note, submitterArtistName: artist, tiktokHandle, collaboratorNames, contactEmail, submitterToken, legalAcceptance });
   if (!(await isTrackPersistedInSessionQueue(track.id, active.session.sessionId))) {
     return NextResponse.json({ error: QUEUE_ACCEPTANCE_UNCONFIRMED_MESSAGE, code: "queue_acceptance_unconfirmed" }, { status: 500 });
   }

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -5,7 +5,7 @@ import { upload } from "@vercel/blob/client";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { buildQueueTimingDisplay, priorityDisplayFromImpact, queueTimingInputFromPublicSnapshot } from "@/lib/queue-timing-display";
-import { formatRuntime } from "@/lib/queue-types";
+import { PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT, PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION, PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION, PUBLIC_QUEUE_LEGAL_TERMS_VERSION, formatRuntime } from "@/lib/queue-types";
 import type { QueuePublicSnapshot, QueuePublicStatus, QueuePublicTrack } from "@/lib/queue-types";
 
 type Mode = "link" | "upload";
@@ -134,6 +134,8 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
   const [readState, setReadState] = useState<ReadState>("idle");
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [acceptedLegal, setAcceptedLegal] = useState(false);
+  const [legalError, setLegalError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [transmissionState, setTransmissionState] = useState<TransmissionState>("idle");
   const [warpData, setWarpData] = useState<WarpData | null>(null);
@@ -366,6 +368,11 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
     }
     finalSubmitIntent.current = false;
     setError(null);
+    setLegalError(null);
+    if (!acceptedLegal) {
+      setLegalError("You must agree to the BARCODE Network Terms, Queue Submission Terms, and Privacy Policy before submitting.");
+      return;
+    }
     setSubmitting(true);
     try {
       const refreshedBeforeSubmit = await loadStatus();
@@ -373,7 +380,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
       if (!latestSessionId) throw new Error(SESSION_SYNC_REQUIRED_MESSAGE);
       const visibleSessionId = session?.sessionId ?? sessionId;
       if (visibleSessionId && latestSessionId !== visibleSessionId) throw new Error(SESSION_CHANGED_MESSAGE);
-      const body: Record<string, string | number> = {
+      const body: Record<string, string | number | boolean> = {
         mode,
         artist: artist.trim(),
         title: title.trim(),
@@ -381,6 +388,11 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
         collaboratorNames: collaboratorNames.trim(),
         contactEmail: contactEmail.trim(),
         submitterToken,
+        acceptedLegal: true,
+        termsVersion: PUBLIC_QUEUE_LEGAL_TERMS_VERSION,
+        privacyVersion: PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION,
+        queueTermsVersion: PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION,
+        acceptedCheckboxText: PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT,
       };
       body.sessionId = latestSessionId;
       if (note.trim()) body.note = note.trim();
@@ -604,6 +616,16 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
             <div className="grid gap-3 text-xs sm:grid-cols-2">
               <button type="button" onClick={() => setRouteChoice("free")} aria-pressed={selectedRoute === "free"} className={`cursor-pointer border p-4 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${selectedRoute === "free" ? "border-accent bg-accent/10 text-foreground shadow-[0_0_24px_rgba(255,0,0,0.16)]" : "border-border bg-background/40 text-muted hover:border-accent/45"}`}><span className="text-sm font-bold text-foreground">Free queue</span><span className="mt-2 block">No payment required.</span><span className="mt-3 block text-muted">{timingSummary.submitNowFreeEstimate ? `If you submit now: ${timingSummary.submitNowFreeEstimate.songsAhead} ${timingSummary.submitNowFreeEstimate.songsAhead === 1 ? "song" : "songs"} ahead · ${timingSummary.submitNowFreeEstimate.label}.` : `If you submit now, you’ll enter around position #${estimatedPosition} in the free queue. Estimated wait may shift during the show.`}</span></button>
               {priorityCheckoutAvailable ? <button type="button" onClick={() => setRouteChoice("priority")} aria-pressed={selectedRoute === "priority"} className={`cursor-pointer border p-4 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ffaa00]/60 ${selectedRoute === "priority" ? "border-[#ffaa00] bg-[#ffaa00]/10 text-foreground shadow-[0_0_24px_rgba(255,170,0,0.2)]" : "border-[#ffaa00]/40 bg-background/40 text-muted hover:border-[#ffaa00]/70"}`}><span className="text-sm font-bold text-[#ffaa00]">{PRIORITY_SIGNAL_LABEL}</span><span className="mt-2 block">Paid skip after payment clears.</span><span className="mt-3 block text-[#ffaa00]">{formatPrice(priorityPriceCents, priorityCurrency)}</span>{submitPriorityImpact && <div className="mt-3 grid grid-cols-2 gap-2 border border-[#ffaa00]/25 bg-[#ffaa00]/5 p-2"><div><span className="block text-[10px] uppercase tracking-widest text-muted">Free queue</span><span className="font-bold text-foreground">{submitPriorityImpact.freeLabel}</span></div><div><span className="block text-[10px] uppercase tracking-widest text-muted">Priority Signal</span><span className="font-bold text-[#ffaa00]">{submitPriorityImpact.priorityLabel}</span></div></div>}<span className="mt-2 block text-muted">Moves your track closer to the front. Does not interrupt the song currently playing.</span></button> : priorityPaymentsAvailable && <div className="border border-[#ffaa00]/30 bg-background/40 p-4 text-left text-muted"><span className="text-sm font-bold text-[#ffaa00]/70">{PRIORITY_SIGNAL_LABEL}</span><span className="mt-2 block">{PRIORITY_DEPTH_UNAVAILABLE_MESSAGE}</span><span className="mt-3 block text-[#ffaa00]/70">{formatPrice(priorityPriceCents, priorityCurrency)}</span></div>}
+            </div>
+            <div className="border border-border bg-background/40 p-3 text-xs text-muted">
+              <label className="flex items-start gap-3">
+                <input type="checkbox" checked={acceptedLegal} onChange={(event) => { setAcceptedLegal(event.target.checked); if (event.target.checked) setLegalError(null); }} className="mt-1 h-4 w-4 accent-accent" aria-describedby="queue-legal-helper queue-legal-error" />
+                <span>
+                  I agree to the BARCODE Network <a href="/legal#terms" className="text-accent underline underline-offset-2" target="_blank" rel="noreferrer">Terms</a>, <a href="/legal#queue-submission" className="text-accent underline underline-offset-2" target="_blank" rel="noreferrer">Queue Submission Terms</a>, and <a href="/legal#privacy" className="text-accent underline underline-offset-2" target="_blank" rel="noreferrer">Privacy Policy</a>. I confirm I am 13+ and, if under 18, have parent/guardian permission. I confirm I have the rights to submit this track, and I understand uploads are temporary and may be used for BARCODE Radio/live show-related playback, clips, recaps, platform replays, and related BARCODE Network features as described in the terms.
+                </span>
+              </label>
+              <p id="queue-legal-helper" className="mt-2 text-[11px] text-muted">Raw uploaded MP3/WAV files are temporary and are not intended to be stored permanently. See Queue Submission Terms for upload retention and usage details.</p>
+              {legalError && <p id="queue-legal-error" className="mt-2 text-[11px] font-bold text-accent" role="alert">{legalError}</p>}
             </div>
             <div className="grid gap-2 text-xs sm:grid-cols-2">
               {submitterStatus && <div className="border border-accent/40 bg-accent/5 p-2 text-muted"><p className="font-bold text-accent">Your submissions: {submitterStatus.used} / {submitterStatus.limit}</p><p>Remaining: {submitterStatus.remaining}</p>{submitterStatus.cooldownRemainingSeconds > 0 && <p className="text-accent">Cooldown: {formatCooldown(submitterStatus.cooldownRemainingSeconds)}</p>}</div>}

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -15,6 +15,21 @@ export type PriorityUpgradeSource = "admin" | "public_placeholder" | "future_pay
 export type SponsorBreakMode = "mid_show";
 export type SponsorBreakStatus = "not_due" | "due" | "running" | "completed" | "skipped";
 
+export const PUBLIC_QUEUE_LEGAL_TERMS_VERSION = "1.0";
+export const PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION = "1.0";
+export const PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION = "1.0";
+export const PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT = "I agree to the BARCODE Network Terms, Queue Submission Terms, and Privacy Policy. I confirm I am 13+ and, if under 18, have parent/guardian permission. I confirm I have the rights to submit this track, and I understand uploads are temporary and may be used for BARCODE Radio/live show-related playback, clips, recaps, platform replays, and related BARCODE Network features as described in the terms.";
+
+
+export interface QueueLegalAcceptance {
+  acceptedAt: string;
+  termsVersion: string;
+  privacyVersion: string;
+  queueTermsVersion: string;
+  acceptedCheckboxText: string;
+  source: "public_queue_form";
+}
+
 export interface QueueEntry {
   id: string;
   artist: string;
@@ -77,6 +92,7 @@ export interface QueueEntry {
   priorityPausedAt?: string | null;
   priorityResumedAt?: string | null;
   priorityQueueOrderAt?: string | null;
+  legalAcceptance?: QueueLegalAcceptance | null;
   isTestTrack?: boolean;
 }
 

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -16,6 +16,7 @@ import {
 import type {
   QueueDurationSource,
   QueueEntry,
+  QueueLegalAcceptance,
   QueueLane,
   QueueNonPriorityLane,
   QueuePublicSnapshot,
@@ -1113,6 +1114,7 @@ export async function createQueueTrack(input: {
   providerTitle?: string | null;
   detectedDurationSeconds?: number | null;
   durationSource?: QueueDurationSource;
+  legalAcceptance?: QueueLegalAcceptance;
 }): Promise<QueueEntry> {
   const sourceType = input.sourceType ?? (input.fileUrl ? "upload" : detectQueueSourceType(input.link ?? ""));
   const submittedArtistName = input.artist.trim();
@@ -1191,6 +1193,7 @@ export async function createQueueTrack(input: {
     priorityResumedAt: null,
     priorityQueueOrderAt: null,
     stagedAsFallbackForLane: null,
+    legalAcceptance: input.legalAcceptance ?? null,
     isTestTrack: false,
   });
 }

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1525,6 +1525,17 @@ test("wheel ceremony spin and stale confirm errors do not mutate queue", async (
 
 const queueApi = require("../src/app/api/queue/route.ts");
 const uploadApi = require("../src/app/api/queue/upload/route.ts");
+const queueTypes = require("../src/lib/queue-types.ts");
+
+function legalAcceptanceBody() {
+  return {
+    acceptedLegal: true,
+    termsVersion: queueTypes.PUBLIC_QUEUE_LEGAL_TERMS_VERSION,
+    privacyVersion: queueTypes.PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION,
+    queueTermsVersion: queueTypes.PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION,
+    acceptedCheckboxText: queueTypes.PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT,
+  };
+}
 
 function jsonOf(response) {
   return response.json();
@@ -1538,6 +1549,7 @@ test("public POST rejects missing sessionId", async () => {
     title: "Session Track",
     tiktokHandle: "@sessionartist",
     link: "https://example.com/session-required",
+    ...legalAcceptanceBody(),
   });
   const payload = await jsonOf(response);
   assert.equal(response.status, 409);
@@ -1556,10 +1568,27 @@ test("public POST rejects stale sessionId", async () => {
     title: "Stale Track",
     tiktokHandle: "@staleartist",
     link: "https://example.com/stale-track",
+    ...legalAcceptanceBody(),
   });
   const payload = await jsonOf(response);
   assert.equal(response.status, 409);
   assert.equal(payload.code, "stale_session");
+});
+
+
+test("public POST rejects missing legal acceptance", async () => {
+  const sessionId = await freshOpenSession("legal required");
+  const response = await queueApi.submitTrackFromBody({
+    sessionId,
+    mode: "link",
+    artist: "Legal Artist",
+    title: "Legal Track",
+    tiktokHandle: "@legalartist",
+    link: "https://example.com/legal-track",
+  });
+  const payload = await jsonOf(response);
+  assert.equal(response.status, 400);
+  assert.equal(payload.error, "Legal acceptance is required before submitting to the queue.");
 });
 
 test("public POST accepts current active sessionId", async () => {
@@ -1571,6 +1600,7 @@ test("public POST accepts current active sessionId", async () => {
     title: "Current Track",
     tiktokHandle: "@currentartist",
     link: "https://example.com/current-track",
+    ...legalAcceptanceBody(),
   });
   const payload = await jsonOf(response);
   assert.equal(response.status, 201);
@@ -1587,6 +1617,7 @@ test("public POST remains rejected while submissions are closed", async () => {
     title: "Closed Track",
     tiktokHandle: "@closedartist",
     link: "https://example.com/closed-track",
+    ...legalAcceptanceBody(),
   });
   const payload = await jsonOf(response);
   assert.equal(response.status, 409);


### PR DESCRIPTION
### Motivation
- Ensure public queue submissions include an explicit legal acceptance tied to the existing BARCODE Legal Center and capture that acceptance privately with versioning and the exact checkbox text. 
- Prevent submissions that do not explicitly acknowledge Terms, Queue Submission Terms, and Privacy Policy while preserving public-safe snapshots and read models. 

### Description
- Add shared constants and types for public queue legal acceptance and the exact checkbox text in `src/lib/queue-types.ts`. 
- Persist a private `legalAcceptance` object on created queue entries by extending `createQueueTrack` and `QueueEntry` in `src/lib/queue.ts`. 
- Require and validate legal acceptance (boolean, versions, and exact checkbox text) in the public queue API and store the acceptance on accepted entries in `src/app/api/queue/route.ts`. 
- Add a required unchecked checkbox UI to the public submission form, block submission until checked with an inline error, and send the acceptance fields to the API in `src/components/RadioQueueForm.tsx`. 
- Update queue tests to include the new acceptance payload and add a test asserting missing legal acceptance is rejected in `tests/queue-playback.test.mjs`. 

Files changed: `src/lib/queue-types.ts`, `src/lib/queue.ts`, `src/app/api/queue/route.ts`, `src/components/RadioQueueForm.tsx`, `tests/queue-playback.test.mjs`.

### Testing
- Ran type-check: `npx tsc --noEmit` and it succeeded. 
- Linted the modified files with `npx eslint` for the changed files and targeted lint run completed for those files. 
- Ran `npm run test:queue` (queue-related tests); queue submission tests were updated and the queue tests passed; the full test command still reports unrelated BNL/dossier read-model assertions failing. 
- Ran the project-wide check `npm run check` which failed due to pre-existing unrelated lint/JSX issues in archived pages and other components outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd2718de8832195e6bcd8f3d048ea)