### PR TITLE
Add backend cleanup for BARCODE-hosted MP3/WAV queue uploads

### DIFF
--- a/src/app/api/admin/queue/cleanup-uploads/route.ts
+++ b/src/app/api/admin/queue/cleanup-uploads/route.ts
@@ -1,0 +1,17 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { COOKIE_NAME, verifyAdminToken } from "@/lib/auth";
+import { cleanupExpiredQueueUploads } from "@/lib/queue";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+async function assertAdmin(): Promise<boolean> {
+  const token = (await cookies()).get(COOKIE_NAME)?.value;
+  return token ? verifyAdminToken(token) : false;
+}
+
+export async function POST() {
+  if (!(await assertAdmin())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  return NextResponse.json(await cleanupExpiredQueueUploads());
+}

--- a/src/app/api/admin/queue/cleanup-uploads/route.ts
+++ b/src/app/api/admin/queue/cleanup-uploads/route.ts
@@ -11,6 +11,17 @@ async function assertAdmin(): Promise<boolean> {
   return token ? verifyAdminToken(token) : false;
 }
 
+function isAuthorizedCronRequest(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorizedCronRequest(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  return NextResponse.json(await cleanupExpiredQueueUploads());
+}
+
 export async function POST() {
   if (!(await assertAdmin())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   return NextResponse.json(await cleanupExpiredQueueUploads());

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -14,6 +14,7 @@ export type PriorityUpgradeStatus = "none" | "requested" | "manual" | "checkout_
 export type PriorityUpgradeSource = "admin" | "public_placeholder" | "future_payment" | "stripe";
 export type SponsorBreakMode = "mid_show";
 export type SponsorBreakStatus = "not_due" | "due" | "running" | "completed" | "skipped";
+export type UploadedFileDeletionStatus = "pending" | "deleted" | "error";
 
 export const PUBLIC_QUEUE_LEGAL_TERMS_VERSION = "1.0";
 export const PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION = "1.0";
@@ -67,6 +68,10 @@ export interface QueueEntry {
   fileName?: string | null;
   fileSize?: number | null;
   mimeType?: string | null;
+  uploadedFileDeleteAfter?: string | null;
+  uploadedFileDeletedAt?: string | null;
+  uploadedFileDeletionStatus?: UploadedFileDeletionStatus | null;
+  uploadedFileDeletionError?: string | null;
   sourceType?: QueueSourceType;
   detectedDurationSeconds?: number | null;
   estimatedDurationSeconds?: number;

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1264,13 +1264,19 @@ function isTrackActiveForPlayback(session: QueueSession, id: string): boolean {
   return session.loadedTrackId === id || session.loadedTrack?.id === id || session.nextInLineTrackId === id || session.nextInLineTrack?.id === id;
 }
 
-function updateEntryInSession(session: QueueSession, id: string, update: (entry: QueueEntry) => QueueEntry): void {
-  session.queue = session.queue.map((entry) => entry.id === id ? update(entry) : entry);
-  session.completed = session.completed.map((entry) => entry.id === id ? update(entry) : entry);
-  session.removed = session.removed.map((entry) => entry.id === id ? update(entry) : entry);
-  session.spotlight = session.spotlight.map((entry) => entry.id === id ? update(entry) : entry);
-  if (session.nextInLineTrack?.id === id) session.nextInLineTrack = update(session.nextInLineTrack);
-  if (session.loadedTrack?.id === id) session.loadedTrack = update(session.loadedTrack);
+function updateEntriesInSession(session: QueueSession, shouldUpdate: (entry: QueueEntry) => boolean, update: (entry: QueueEntry) => QueueEntry): void {
+  session.queue = session.queue.map((entry) => shouldUpdate(entry) ? update(entry) : entry);
+  session.completed = session.completed.map((entry) => shouldUpdate(entry) ? update(entry) : entry);
+  session.removed = session.removed.map((entry) => shouldUpdate(entry) ? update(entry) : entry);
+  session.spotlight = session.spotlight.map((entry) => shouldUpdate(entry) ? update(entry) : entry);
+  if (session.nextInLineTrack && shouldUpdate(session.nextInLineTrack)) session.nextInLineTrack = update(session.nextInLineTrack);
+  if (session.loadedTrack && shouldUpdate(session.loadedTrack)) session.loadedTrack = update(session.loadedTrack);
+}
+
+function updateMatchingEntriesInStore(store: QueueStore, candidate: { id: string; fileUrl: string }, update: (entry: QueueEntry) => QueueEntry): void {
+  for (const session of store.sessions) {
+    updateEntriesInSession(session, (entry) => entry.id === candidate.id || entry.fileUrl === candidate.fileUrl, update);
+  }
 }
 
 export async function cleanupExpiredQueueUploads(options: { now?: Date; deleteBlob?: (url: string) => Promise<void> } = {}): Promise<QueueUploadCleanupResult> {
@@ -1283,30 +1289,50 @@ export async function cleanupExpiredQueueUploads(options: { now?: Date; deleteBl
   const result: QueueUploadCleanupResult = { scanned: 0, deleted: 0, skippedActive: 0, failed: 0 };
   let changed = false;
 
+  const candidates = new Map<string, { id: string; fileUrl: string; active: boolean }>();
+  const candidatesByTrackId = new Map<string, { id: string; fileUrl: string; active: boolean }>();
+
   for (const session of store.sessions) {
     const entries = [session.loadedTrack, session.nextInLineTrack, ...session.queue, ...session.completed, ...session.removed, ...session.spotlight].filter((entry): entry is QueueEntry => Boolean(entry));
     for (const entry of entries) {
       const normalized = normalizeEntry(entry);
-      if (!isUploadedAudioEntry(normalized) || normalized.uploadedFileDeletionStatus === "deleted" || !normalized.uploadedFileDeleteAfter) continue;
+      if (!isUploadedAudioEntry(normalized) || normalized.uploadedFileDeletionStatus === "deleted" || !normalized.uploadedFileDeleteAfter || !normalized.fileUrl) continue;
       const due = new Date(normalized.uploadedFileDeleteAfter).getTime();
       if (!Number.isFinite(due) || due > now.getTime()) continue;
-      result.scanned += 1;
-      if (isTrackActiveForPlayback(session, normalized.id)) {
-        result.skippedActive += 1;
+      const key = normalized.fileUrl;
+      const existing = candidates.get(key) ?? candidatesByTrackId.get(normalized.id);
+      const active = isTrackActiveForPlayback(session, normalized.id);
+      if (existing) {
+        existing.active = existing.active || active;
+        candidatesByTrackId.set(normalized.id, existing);
         continue;
       }
-      try {
-        await deleteBlob(normalized.fileUrl ?? "");
-        const deletedAt = now.toISOString();
-        updateEntryInSession(session, normalized.id, (item) => normalizeEntry({ ...item, uploadedFileDeletedAt: deletedAt, uploadedFileDeletionStatus: "deleted", uploadedFileDeletionError: null }));
-        result.deleted += 1;
-        changed = true;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Upload deletion failed.";
-        updateEntryInSession(session, normalized.id, (item) => normalizeEntry({ ...item, uploadedFileDeletionStatus: "error", uploadedFileDeletionError: message.slice(0, 500) }));
-        result.failed += 1;
-        changed = true;
-      }
+      const candidate = { id: normalized.id, fileUrl: normalized.fileUrl, active };
+      candidates.set(key, candidate);
+      candidatesByTrackId.set(normalized.id, candidate);
+    }
+  }
+
+  for (const candidate of candidates.values()) {
+    result.scanned += 1;
+    if (candidate.active) {
+      result.skippedActive += 1;
+      continue;
+    }
+    try {
+      await deleteBlob(candidate.fileUrl);
+      const deletedAt = now.toISOString();
+      updateMatchingEntriesInStore(store, candidate, (item) => normalizeEntry({ ...item, uploadedFileDeletedAt: deletedAt, uploadedFileDeletionStatus: "deleted", uploadedFileDeletionError: null }));
+      result.deleted += 1;
+      changed = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Upload deletion failed.";
+      updateMatchingEntriesInStore(store, candidate, (item) => {
+        const current = normalizeEntry(item);
+        return current.uploadedFileDeletionStatus === "deleted" ? current : normalizeEntry({ ...current, uploadedFileDeletionStatus: "error", uploadedFileDeletionError: message.slice(0, 500) });
+      });
+      result.failed += 1;
+      changed = true;
     }
   }
 

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -41,6 +41,9 @@ const DEFAULT_PRIORITY_UPGRADE_INSTRUCTIONS = "Priority Signal Upgrade is being 
 const DEFAULT_PRIORITY_UPGRADE_PRICE_CENTS = 1000;
 const DEFAULT_PRIORITY_UPGRADE_CURRENCY = "usd";
 const PRE_SHOW_ROUTING_DELAY_MS = (20 * 60 + 15) * 1000;
+const UPLOADED_FILE_RETENTION_MS = 24 * 60 * 60 * 1000;
+const BARCODE_QUEUE_UPLOAD_HOST_SUFFIX = ".private.blob.vercel-storage.com";
+const BARCODE_QUEUE_UPLOAD_PATH_PREFIX = "/barcode-radio-queue/";
 
 type QueueAdminAction = "pullNext" | "pullWheelChosen" | "pullFreeTransmission" | "startShow" | "addWheelSpinOwed" | "load" | "finish" | "remove" | "priority" | "regular" | "wheel" | "moveBack" | "spotlight" | "removeSpotlight" | "restoreRegular" | "restorePriority" | "markPriorityManual" | "markPriorityRequested" | "markPriorityCheckoutPending" | "resolvePaidPriority" | "pausePriority" | "resumePriority" | "addSimulationFreeTrack" | "addSimulationPaidPriority" | "addSimulationCheckoutPending" | "addSimulationPaymentFailed" | "addSimulationHeldPriority" | "clearSimulationTracks";
 
@@ -663,6 +666,29 @@ function normalizePriorityUpgradeSource(source: unknown): QueueEntry["priorityUp
   return null;
 }
 
+function isBarcodeQueueUploadUrl(value?: string | null): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" && parsed.hostname.endsWith(BARCODE_QUEUE_UPLOAD_HOST_SUFFIX) && parsed.pathname.startsWith(BARCODE_QUEUE_UPLOAD_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
+function isUploadedAudioEntry(entry: Pick<QueueEntry, "sourceType" | "fileUrl" | "mimeType">): boolean {
+  const mime = entry.mimeType?.toLowerCase() ?? "";
+  return entry.sourceType === "upload" && isBarcodeQueueUploadUrl(entry.fileUrl) && ["audio/mpeg", "audio/mp3", "audio/wav", "audio/wave", "audio/x-wav"].includes(mime);
+}
+
+function uploadedFileDeleteAfterFor(entry: QueueEntry, sourceType: QueueSourceType): string | null {
+  if (!isUploadedAudioEntry({ ...entry, sourceType })) return null;
+  if (typeof entry.uploadedFileDeleteAfter === "string" && entry.uploadedFileDeleteAfter) return entry.uploadedFileDeleteAfter;
+  const created = new Date(entry.createdAt).getTime();
+  const base = Number.isFinite(created) ? created : Date.now();
+  return new Date(base + UPLOADED_FILE_RETENTION_MS).toISOString();
+}
+
 function normalizeEntry(entry: QueueEntry): QueueEntry {
   const { priorityOverlayDisplacedAt: legacyDisplacedFromNextInLineAt, ...entryWithoutLegacyMarker } = entry as QueueEntry & { priorityOverlayDisplacedAt?: string | null };
   const submittedArtistName = entry.submittedArtistName ?? entry.artist;
@@ -689,6 +715,10 @@ function normalizeEntry(entry: QueueEntry): QueueEntry {
     detectedDurationSeconds,
     durationIsEstimate: detectedDurationSeconds === null,
     durationSource,
+    uploadedFileDeleteAfter: uploadedFileDeleteAfterFor(entry, sourceType),
+    uploadedFileDeletedAt: entry.uploadedFileDeletedAt ?? null,
+    uploadedFileDeletionStatus: entry.uploadedFileDeletionStatus === "deleted" || entry.uploadedFileDeletionStatus === "error" || entry.uploadedFileDeletionStatus === "pending" ? entry.uploadedFileDeletionStatus : (uploadedFileDeleteAfterFor(entry, sourceType) ? "pending" : null),
+    uploadedFileDeletionError: entry.uploadedFileDeletionError ?? null,
     note: entry.note ?? null,
     priorityUpgradeRequested: entry.priorityUpgradeRequested === true,
     priorityUpgradeStatus,
@@ -1168,6 +1198,10 @@ export async function createQueueTrack(input: {
     fileName: input.fileName ?? null,
     fileSize: input.fileSize ?? null,
     mimeType: input.mimeType ?? null,
+    uploadedFileDeleteAfter: sourceType === "upload" && isUploadedAudioEntry({ sourceType, fileUrl: input.fileUrl ?? null, mimeType: input.mimeType ?? null }) ? new Date(Date.now() + UPLOADED_FILE_RETENTION_MS).toISOString() : null,
+    uploadedFileDeletedAt: null,
+    uploadedFileDeletionStatus: null,
+    uploadedFileDeletionError: null,
     sourceType,
     detectedDurationSeconds,
     estimatedDurationSeconds: detectedDurationSeconds ?? INTERNAL_BUFFER_DURATION_SECONDS,
@@ -1216,6 +1250,68 @@ export async function submitRadioTrack(input: Parameters<typeof createQueueTrack
   pullNextInLine(session);
   await writeStore(replaceSession(store, session));
   return track;
+}
+
+
+export interface QueueUploadCleanupResult {
+  scanned: number;
+  deleted: number;
+  skippedActive: number;
+  failed: number;
+}
+
+function isTrackActiveForPlayback(session: QueueSession, id: string): boolean {
+  return session.loadedTrackId === id || session.loadedTrack?.id === id || session.nextInLineTrackId === id || session.nextInLineTrack?.id === id;
+}
+
+function updateEntryInSession(session: QueueSession, id: string, update: (entry: QueueEntry) => QueueEntry): void {
+  session.queue = session.queue.map((entry) => entry.id === id ? update(entry) : entry);
+  session.completed = session.completed.map((entry) => entry.id === id ? update(entry) : entry);
+  session.removed = session.removed.map((entry) => entry.id === id ? update(entry) : entry);
+  session.spotlight = session.spotlight.map((entry) => entry.id === id ? update(entry) : entry);
+  if (session.nextInLineTrack?.id === id) session.nextInLineTrack = update(session.nextInLineTrack);
+  if (session.loadedTrack?.id === id) session.loadedTrack = update(session.loadedTrack);
+}
+
+export async function cleanupExpiredQueueUploads(options: { now?: Date; deleteBlob?: (url: string) => Promise<void> } = {}): Promise<QueueUploadCleanupResult> {
+  const now = options.now ?? new Date();
+  const deleteBlob = options.deleteBlob ?? (async (url: string) => {
+    const { del } = await import("@vercel/blob");
+    await del(url);
+  });
+  const store = await readStore();
+  const result: QueueUploadCleanupResult = { scanned: 0, deleted: 0, skippedActive: 0, failed: 0 };
+  let changed = false;
+
+  for (const session of store.sessions) {
+    const entries = [session.loadedTrack, session.nextInLineTrack, ...session.queue, ...session.completed, ...session.removed, ...session.spotlight].filter((entry): entry is QueueEntry => Boolean(entry));
+    for (const entry of entries) {
+      const normalized = normalizeEntry(entry);
+      if (!isUploadedAudioEntry(normalized) || normalized.uploadedFileDeletionStatus === "deleted" || !normalized.uploadedFileDeleteAfter) continue;
+      const due = new Date(normalized.uploadedFileDeleteAfter).getTime();
+      if (!Number.isFinite(due) || due > now.getTime()) continue;
+      result.scanned += 1;
+      if (isTrackActiveForPlayback(session, normalized.id)) {
+        result.skippedActive += 1;
+        continue;
+      }
+      try {
+        await deleteBlob(normalized.fileUrl ?? "");
+        const deletedAt = now.toISOString();
+        updateEntryInSession(session, normalized.id, (item) => normalizeEntry({ ...item, uploadedFileDeletedAt: deletedAt, uploadedFileDeletionStatus: "deleted", uploadedFileDeletionError: null }));
+        result.deleted += 1;
+        changed = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Upload deletion failed.";
+        updateEntryInSession(session, normalized.id, (item) => normalizeEntry({ ...item, uploadedFileDeletionStatus: "error", uploadedFileDeletionError: message.slice(0, 500) }));
+        result.failed += 1;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) await writeStore(store);
+  return result;
 }
 
 export async function isTrackPersistedInSessionQueue(trackId: string, sessionId?: string): Promise<boolean> {

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -59,6 +59,10 @@ const forbiddenKeys = [
   "fileName",
   "fileSize",
   "mimeType",
+  "uploadedFileDeleteAfter",
+  "uploadedFileDeletedAt",
+  "uploadedFileDeletionStatus",
+  "uploadedFileDeletionError",
   "suspiciousFlags",
   "adminNote",
   "discordUserId",
@@ -669,10 +673,31 @@ test("BNL read model excludes simulation/test tracks from all public semantic su
 test("BNL read model excludes private queue/payment/upload keys", async () => {
   await freshReadModelSession();
   await addTrack("Private Fields", { artist: "Private Artist", stripeSessionId: "cs_private_test" });
+  await queue.addToQueue({
+    artist: "Private Upload Artist",
+    title: "Private Upload Track",
+    tiktokHandle: "@privateuploadartist",
+    link: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/bnl-private-upload.mp3",
+    fileUrl: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/bnl-private-upload.mp3",
+    fileName: "bnl-private-upload.mp3",
+    fileSize: 123456,
+    mimeType: "audio/mpeg",
+    uploadedFileDeleteAfter: new Date(Date.UTC(2026, 0, 2)).toISOString(),
+    uploadedFileDeletedAt: null,
+    uploadedFileDeletionStatus: "pending",
+    uploadedFileDeletionError: null,
+    sourceType: "upload",
+    tier: "free",
+    lane: "regular",
+    amount: 0,
+    stripeSessionId: null,
+    createdAt: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+  });
 
   const model = await modelJson();
   assert.deepEqual(findForbiddenKeys(model), []);
   assert.deepEqual(findForbiddenStringValues(model), []);
+  assert.equal(JSON.stringify(model).includes("private.blob.vercel-storage.com"), false);
 });
 
 test("BNL read model keeps normal queue items out of broadcast memory candidates", async () => {

--- a/tests/queue-cleanup-route.test.mjs
+++ b/tests/queue-cleanup-route.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+// Keep queue tests isolated to the in-memory store instead of any configured Redis.
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, "src", request.slice(2));
+    if (fs.existsSync(resolved)) return resolved;
+    if (fs.existsSync(`${resolved}.ts`)) return `${resolved}.ts`;
+    if (fs.existsSync(`${resolved}.tsx`)) return `${resolved}.tsx`;
+    return resolved;
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+Module._extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+const require = createRequire(import.meta.url);
+const cleanupRoute = require("../src/app/api/admin/queue/cleanup-uploads/route.ts");
+
+test("scheduled upload cleanup rejects requests without CRON_SECRET", async () => {
+  const original = process.env.CRON_SECRET;
+  delete process.env.CRON_SECRET;
+  try {
+    const response = await cleanupRoute.GET(new Request("https://example.test/api/admin/queue/cleanup-uploads"));
+    assert.equal(response.status, 401);
+  } finally {
+    if (original === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = original;
+  }
+});
+
+test("scheduled upload cleanup rejects incorrect bearer token", async () => {
+  const original = process.env.CRON_SECRET;
+  process.env.CRON_SECRET = "test-cron-secret";
+  try {
+    const response = await cleanupRoute.GET(new Request("https://example.test/api/admin/queue/cleanup-uploads", {
+      headers: { authorization: "Bearer wrong-secret" },
+    }));
+    assert.equal(response.status, 401);
+  } finally {
+    if (original === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = original;
+  }
+});
+
+test("scheduled upload cleanup accepts CRON_SECRET bearer token and runs cleanup", async () => {
+  const original = process.env.CRON_SECRET;
+  process.env.CRON_SECRET = "test-cron-secret";
+  try {
+    const response = await cleanupRoute.GET(new Request("https://example.test/api/admin/queue/cleanup-uploads", {
+      headers: { authorization: "Bearer test-cron-secret" },
+    }));
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { scanned: 0, deleted: 0, skippedActive: 0, failed: 0 });
+  } finally {
+    if (original === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = original;
+  }
+});

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1794,3 +1794,45 @@ test("cleanup deletes expired BARCODE upload files idempotently without removing
   assert.ok(link, "link-only queue record should remain");
   assert.equal(link.uploadedFileDeletionStatus, null);
 });
+
+test("cleanup processes duplicate uploaded track appearances only once per run", async () => {
+  await freshOpenSession("duplicate upload cleanup", { showStarted: false });
+  const oldCreatedAt = new Date(Date.UTC(2026, 0, 1)).toISOString();
+  const uploadUrl = "https://store.private.blob.vercel-storage.com/barcode-radio-queue/duplicate-upload.mp3";
+  const upload = await queue.addToQueue({
+    artist: "Duplicate Upload Artist",
+    title: "Duplicate Upload Track",
+    tiktokHandle: "@duplicateuploadartist",
+    link: uploadUrl,
+    fileUrl: uploadUrl,
+    fileName: "duplicate-upload.mp3",
+    fileSize: 777,
+    mimeType: "audio/mpeg",
+    sourceType: "upload",
+    tier: "free",
+    lane: "regular",
+    amount: 0,
+    stripeSessionId: null,
+    createdAt: oldCreatedAt,
+  });
+  await queue.updateRadioTrack(upload.id, "spotlight");
+
+  const deleted = [];
+  const result = await queue.cleanupExpiredQueueUploads({
+    now: new Date(Date.UTC(2026, 0, 3)),
+    deleteBlob: async (url) => {
+      deleted.push(url);
+      if (deleted.length > 1) throw new Error("duplicate delete should not run");
+    },
+  });
+  const state = await queue.getRadioQueueState();
+  const queued = state.queue.find((entry) => entry.id === upload.id);
+  const spotlight = state.spotlight.find((entry) => entry.id === upload.id);
+
+  assert.deepEqual(result, { scanned: 1, deleted: 1, skippedActive: 0, failed: 0 });
+  assert.deepEqual(deleted, [uploadUrl]);
+  assert.equal(queued.uploadedFileDeletionStatus, "deleted");
+  assert.equal(spotlight.uploadedFileDeletionStatus, "deleted");
+  assert.equal(queued.uploadedFileDeletionError, null);
+  assert.equal(spotlight.uploadedFileDeletionError, null);
+});

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1673,3 +1673,124 @@ test("upload submission without detected duration stays internal estimate and no
   assert.equal(track.durationIsEstimate, true);
   assert.equal(track.durationSource, "internal_estimate");
 });
+
+test("uploaded MP3/WAV queue entries get private deletion metadata about 24 hours after creation", async () => {
+  const created = new Date(Date.UTC(2026, 0, 2, 3, 4, 5));
+  await freshOpenSession("upload deletion metadata", { showStarted: false });
+
+  const track = await withFakeNow(created, () => queue.submitRadioTrack({
+    artist: "Upload Artist",
+    title: "Upload Track",
+    tiktokHandle: "@uploadartistmetadata",
+    link: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/upload-track.mp3",
+    fileUrl: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/upload-track.mp3",
+    fileName: "upload-track.mp3",
+    fileSize: 1234,
+    mimeType: "audio/mpeg",
+    sourceType: "upload",
+  }));
+
+  assert.equal(track.uploadedFileDeletionStatus, "pending");
+  assert.equal(track.uploadedFileDeletedAt, null);
+  assert.equal(new Date(track.uploadedFileDeleteAfter).getTime(), created.getTime() + 24 * 60 * 60 * 1000);
+});
+
+test("link-only submissions do not get raw upload deletion metadata", async () => {
+  await freshOpenSession("link deletion metadata", { showStarted: false });
+  const track = await submitTrack("Link Only Metadata");
+
+  assert.equal(track.uploadedFileDeleteAfter, null);
+  assert.equal(track.uploadedFileDeletedAt, null);
+  assert.equal(track.uploadedFileDeletionStatus, null);
+});
+
+test("public queue snapshots omit raw upload URLs and deletion metadata", async () => {
+  await freshOpenSession("public upload privacy", { showStarted: false });
+  await queue.addToQueue({
+    artist: "Public Upload Artist",
+    title: "Public Upload Track",
+    tiktokHandle: "@publicuploadprivacy",
+    link: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/public-upload.wav",
+    fileUrl: "https://store.private.blob.vercel-storage.com/barcode-radio-queue/public-upload.wav",
+    fileName: "public-upload.wav",
+    fileSize: 4567,
+    mimeType: "audio/wav",
+    sourceType: "upload",
+    tier: "free",
+    lane: "regular",
+    amount: 0,
+    stripeSessionId: null,
+    createdAt: new Date(Date.UTC(2026, 0, 10)).toISOString(),
+  });
+
+  const json = JSON.stringify(await queue.getPublicQueueSnapshot());
+  assert.equal(json.includes("private.blob.vercel-storage.com"), false);
+  assert.equal(json.includes("uploadedFileDeleteAfter"), false);
+  assert.equal(json.includes("uploadedFileDeletedAt"), false);
+  assert.equal(json.includes("uploadedFileDeletionStatus"), false);
+});
+
+test("cleanup deletes expired BARCODE upload files idempotently without removing records or metadata", async () => {
+  await freshOpenSession("upload cleanup", { showStarted: false });
+  const oldCreatedAt = new Date(Date.UTC(2026, 0, 1)).toISOString();
+  const uploadUrl = "https://store.private.blob.vercel-storage.com/barcode-radio-queue/expired-upload.mp3";
+  const externalUrl = "https://example.com/external.mp3";
+  const legalAcceptance = {
+    acceptedAt: oldCreatedAt,
+    termsVersion: "1.0",
+    privacyVersion: "1.0",
+    queueTermsVersion: "1.0",
+    acceptedCheckboxText: "test acceptance text",
+    source: "public_queue_form",
+  };
+  const upload = await queue.addToQueue({
+    artist: "Cleanup Upload Artist",
+    title: "Cleanup Upload Track",
+    tiktokHandle: "@cleanupuploadartist",
+    link: uploadUrl,
+    fileUrl: uploadUrl,
+    fileName: "expired-upload.mp3",
+    fileSize: 999,
+    mimeType: "audio/mpeg",
+    sourceType: "upload",
+    tier: "free",
+    lane: "regular",
+    amount: 0,
+    stripeSessionId: "cs_preserved",
+    priorityUpgradePaymentId: "pi_preserved",
+    createdAt: oldCreatedAt,
+    legalAcceptance,
+  });
+  const linkOnly = await queue.addToQueue({
+    artist: "Cleanup Link Artist",
+    title: "Cleanup Link Track",
+    tiktokHandle: "@cleanuplinkartist",
+    link: externalUrl,
+    tier: "free",
+    lane: "regular",
+    amount: 0,
+    stripeSessionId: null,
+    sourceType: "link",
+    createdAt: oldCreatedAt,
+  });
+  const deleted = [];
+
+  const first = await queue.cleanupExpiredQueueUploads({ now: new Date(Date.UTC(2026, 0, 3)), deleteBlob: async (url) => { deleted.push(url); } });
+  const second = await queue.cleanupExpiredQueueUploads({ now: new Date(Date.UTC(2026, 0, 3, 1)), deleteBlob: async (url) => { deleted.push(url); } });
+  const state = await queue.getRadioQueueState();
+  const cleaned = state.queue.find((entry) => entry.id === upload.id);
+  const link = state.queue.find((entry) => entry.id === linkOnly.id);
+
+  assert.deepEqual(first, { scanned: 1, deleted: 1, skippedActive: 0, failed: 0 });
+  assert.deepEqual(second, { scanned: 0, deleted: 0, skippedActive: 0, failed: 0 });
+  assert.deepEqual(deleted, [uploadUrl]);
+  assert.ok(cleaned, "upload queue record should remain");
+  assert.equal(cleaned.uploadedFileDeletionStatus, "deleted");
+  assert.equal(cleaned.uploadedFileDeletedAt, new Date(Date.UTC(2026, 0, 3)).toISOString());
+  assert.equal(cleaned.legalAcceptance.acceptedAt, legalAcceptance.acceptedAt);
+  assert.equal(cleaned.priorityUpgradePaymentId, "pi_preserved");
+  assert.equal(cleaned.stripeSessionId, "cs_preserved");
+  assert.equal(cleaned.createdAt, oldCreatedAt);
+  assert.ok(link, "link-only queue record should remain");
+  assert.equal(link.uploadedFileDeletionStatus, null);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/queue/reset",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/admin/queue/cleanup-uploads",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
### Motivation

- Ensure raw audio files uploaded to BARCODE-controlled storage are not retained indefinitely by adding a 24‑hour retention policy and a safe, idempotent server-side cleanup process. 

### Description

- Add private upload deletion metadata fields to the queue model: `uploadedFileDeleteAfter`, `uploadedFileDeletedAt`, `uploadedFileDeletionStatus`, and optional `uploadedFileDeletionError`. (types added in `src/lib/queue-types.ts`).
- Detect BARCODE-hosted private upload URLs and set `uploadedFileDeleteAfter` ~24 hours after track creation for MP3/WAV uploads while leaving link-only submissions untouched. (helpers + initialization added in `src/lib/queue.ts`).
- Implement `cleanupExpiredQueueUploads` in `src/lib/queue.ts` which: identifies expired BARCODE upload files, skips entries currently needed for active playback, deletes blobs via Vercel Blob (`@vercel/blob`) when configured, marks deletion metadata idempotently, and preserves all queue records and related metadata. 
- Add an admin-protected route `/api/admin/queue/cleanup-uploads` that invokes the cleanup using the existing admin cookie/auth pattern (new file `src/app/api/admin/queue/cleanup-uploads/route.ts`).
- Add tests covering: upload metadata assignment after submission, exclusion of link-only submissions, public snapshot privacy (no raw upload URLs or deletion metadata), idempotent cleanup behavior, and BNL read-model exclusions for upload/privacy fields (changes in `tests/queue-playback.test.mjs` and `tests/bnl-read-model.test.mjs`).
- Files changed: `src/lib/queue-types.ts`, `src/lib/queue.ts`, `src/app/api/admin/queue/cleanup-uploads/route.ts`, `tests/queue-playback.test.mjs`, `tests/bnl-read-model.test.mjs`.

### Testing

- Ran TypeScript check: `npx tsc --noEmit` (passed).
- Ran queue tests: `node --test tests/queue-playback.test.mjs` (all new/related queue tests passed; overall queue tests passed).
- Ran combined read-model tests: `node --test tests/queue-playback.test.mjs tests/bnl-read-model.test.mjs` where the new upload/cleanup tests and BNL private-field checks passed but the command reported unrelated pre-existing dossier/read-model expectations failing (these failures are outside the scope of this PR).
- Lint: `npm run lint` surfaced unrelated existing UI/archive lint errors; no new lint failures were introduced by the backend cleanup code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd5cdc10c8321b35be4ed01cdbd43)