### PR TITLE
Add BNL dossier draft request contract and request/receive flow

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1476,7 +1476,14 @@ export default function CandidateReviewPage() {
         error?: string;
         immediateRefresh?: ImmediateRefreshResult;
         message?: string;
-        bnlDraft?: { status: string; message?: string };
+        bnlDraft?: {
+          status: string;
+          message?: string;
+          validation?: { issues?: string[]; warnings?: string[] };
+        };
+        draftStored?: boolean;
+        storedDraft?: DossierDraft;
+        existingDraft?: DossierDraft;
       };
       if (!response.ok)
         throw new Error(
@@ -1562,12 +1569,18 @@ export default function CandidateReviewPage() {
         candidateId,
         ...(primaryDraft ? { draftId: primaryDraft.id } : {}),
       });
+      const validationIssues = data.bnlDraft?.validation?.issues ?? [];
+      const validationWarnings = data.bnlDraft?.validation?.warnings ?? [];
       setNotice(
         data.bnlDraft?.status === "not_connected"
           ? "BNL draft generator not connected yet. The site prepared the safe Source File packet but did not author dossier copy."
-          : data.draft
-            ? `BNL-authored Proposed Dossier draft stored: ${data.draft.fields.name}.`
-            : (data.bnlDraft?.message ?? "BNL draft request did not return a stored draft."),
+          : data.bnlDraft?.status === "failed"
+            ? (data.bnlDraft.message ?? "BNL draft generator failed. No draft was stored.")
+            : data.bnlDraft?.status === "received" && !data.draftStored
+              ? `BNL returned draft output, but validation failed and no draft was stored.${validationIssues.length ? ` Issues: ${validationIssues.join("; ")}` : ""}${validationWarnings.length ? ` Warnings: ${validationWarnings.join("; ")}` : ""}`
+              : data.draftStored && data.storedDraft
+                ? `BNL-authored Proposed Dossier draft stored: ${data.storedDraft.fields.name}.`
+                : (data.bnlDraft?.message ?? "BNL draft request did not return a stored draft."),
       );
     } catch (err) {
       setNotice(err instanceof Error ? err.message : "Failed to request BNL draft.");

--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1476,6 +1476,7 @@ export default function CandidateReviewPage() {
         error?: string;
         immediateRefresh?: ImmediateRefreshResult;
         message?: string;
+        bnlDraft?: { status: string; message?: string };
       };
       if (!response.ok)
         throw new Error(
@@ -1550,6 +1551,26 @@ export default function CandidateReviewPage() {
       );
     } catch (err) {
       setNotice(err instanceof Error ? err.message : "Failed to create draft.");
+    }
+  }
+
+  async function requestBnlDraft() {
+    if (!candidate) return;
+    try {
+      const data = await postWorkflow({
+        action: "requestBnlDraftFromCandidate",
+        candidateId,
+        ...(primaryDraft ? { draftId: primaryDraft.id } : {}),
+      });
+      setNotice(
+        data.bnlDraft?.status === "not_connected"
+          ? "BNL draft generator not connected yet. The site prepared the safe Source File packet but did not author dossier copy."
+          : data.draft
+            ? `BNL-authored Proposed Dossier draft stored: ${data.draft.fields.name}.`
+            : (data.bnlDraft?.message ?? "BNL draft request did not return a stored draft."),
+      );
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "Failed to request BNL draft.");
     }
   }
 
@@ -2097,6 +2118,16 @@ export default function CandidateReviewPage() {
                     className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
                   >
                     Create Proposed Dossier Draft
+                  </button>
+                )}
+                {(mainAction === "create_draft" || mainAction === "update_draft" || mainAction === "open_draft") && candidate && (
+                  <button
+                    type="button"
+                    onClick={() => void requestBnlDraft()}
+                    disabled={saving}
+                    className="border border-accent px-4 py-2 text-accent hover:bg-accent hover:text-background disabled:opacity-50"
+                  >
+                    Request BNL Draft
                   </button>
                 )}
                 {mainAction === "update_draft" && primaryDraft && (

--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -767,9 +767,7 @@ export default function DossierDraftEditorPage() {
             that may become public after owner review.
           </p>
           <p className="text-sm text-muted mt-2 max-w-4xl">
-            BNL will eventually generate the proposed dossier from the BNL Source File and approved sources. Admins will direct changes
-            conversationally. BNL should ask only for missing specifics. Draft
-            fields are not mutated automatically when new source notes arrive.
+            BNL will eventually generate the proposed dossier from the BNL Source File and approved sources; when connected, BNL authors generated proposed dossier drafts from the Source File packet. The site owns packet construction, validation, storage, editing, and review gates; manual drafts remain placeholder scaffolds. BNL should ask only for missing specifics. Draft fields are not mutated automatically when new source notes arrive.
           </p>
           <div className="mt-4">
             <PhaseRail currentPhase={currentPhase} />

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -43,6 +43,7 @@ import {
   convertRecommendationToCandidate,
   createDossierRecommendation,
   createDraftFromCandidate,
+  requestBnlDraftFromCandidate,
   updateDraftFromSourceFile,
   createManualDossierCandidate,
   dismissDossierRecommendation,
@@ -126,6 +127,7 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "createManualCandidate",
   "createDraftFromCandidate",
   "updateDraftFromSourceFile",
+  "requestBnlDraftFromCandidate",
   "saveDraft",
   "submitDraftForOwnerReview",
   "denyCandidate",
@@ -1019,6 +1021,17 @@ export async function POST(req: Request) {
 
     const payload = await workflowPayload();
     return NextResponse.json({ ok: true, action, draft, ...payload });
+  }
+
+  if (action === "requestBnlDraftFromCandidate") {
+    const candidateId = candidateIdFromBody(body);
+    if (!candidateId) {
+      return NextResponse.json({ error: "candidateId is required" }, { status: 400 });
+    }
+    const draftId = draftIdFromBody(body) || undefined;
+    const { result, draft } = await requestBnlDraftFromCandidate(candidateId, draftId);
+    const payload = await workflowPayload();
+    return NextResponse.json({ ok: result.status !== "failed", action, bnlDraft: result, draft, ...payload });
   }
 
   if (action === "updateDraftFromSourceFile") {

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -1029,9 +1029,17 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "candidateId is required" }, { status: 400 });
     }
     const draftId = draftIdFromBody(body) || undefined;
-    const { result, draft } = await requestBnlDraftFromCandidate(candidateId, draftId);
+    const bnlDraftRequest = await requestBnlDraftFromCandidate(candidateId, draftId);
     const payload = await workflowPayload();
-    return NextResponse.json({ ok: result.status !== "failed", action, bnlDraft: result, draft, ...payload });
+    return NextResponse.json({
+      ok: bnlDraftRequest.result.status !== "failed",
+      action,
+      bnlDraft: bnlDraftRequest.result,
+      draftStored: bnlDraftRequest.draftStored,
+      storedDraft: bnlDraftRequest.storedDraft,
+      existingDraft: bnlDraftRequest.existingDraft,
+      ...payload,
+    });
   }
 
   if (action === "updateDraftFromSourceFile") {

--- a/src/lib/bnl-dossier-draft.ts
+++ b/src/lib/bnl-dossier-draft.ts
@@ -44,6 +44,11 @@ export type BnlDossierDraftRequestPacket = {
     sourceLanes: string[];
   };
   currentDraft?: DossierDraft["fields"];
+  safeClassification: {
+    category: DossierDraft["fields"]["category"];
+    kind: DossierDraft["fields"]["kind"];
+    ecosystemLane: DossierDraft["fields"]["ecosystemLane"];
+  };
   stylePacket: ReturnType<typeof buildDossierStylePacket>;
   fieldRequirements: string[];
   forbiddenPublicCopyPatterns: readonly string[];
@@ -146,6 +151,12 @@ export function buildBnlDossierDraftRequestPacket(input: {
       ),
     },
     ...(currentDraft ? { currentDraft: currentDraft.fields } : {}),
+    safeClassification: {
+      category: candidate.recommendedCategory ?? blueprint.classification.category,
+      kind: candidate.recommendedKind ?? blueprint.classification.kind,
+      ecosystemLane:
+        candidate.recommendedEcosystemLane ?? blueprint.classification.ecosystemLane,
+    },
     stylePacket,
     fieldRequirements: [...DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS],
     forbiddenPublicCopyPatterns: stylePacket.forbiddenPublicCopyPatterns,
@@ -154,8 +165,42 @@ export function buildBnlDossierDraftRequestPacket(input: {
   };
 }
 
+export type BnlDossierDraftValidationContext = {
+  packet?: BnlDossierDraftRequestPacket;
+};
+
+const QUEUE_MUSIC_EVIDENCE_REGEX =
+  /\b(?:artist|music|musician|producer|song|track|album|release|submission|submitted|queue|auxchord|radio|performance|performer|dj)\b/i;
+
+const PAYMENT_PRIORITY_REGEX =
+  /\b(?:stripe|payment|paid|checkout|priority\s+signal|priority|tier|invoice|receipt|purchase)\b/i;
+
+function packetAllowsQueueMusicEvidence(
+  packet?: BnlDossierDraftRequestPacket,
+): boolean {
+  if (!packet) return false;
+  const safeText = [
+    ...packet.publicSafeFacts,
+    ...packet.publicSafeNotes.map((note) => note.text),
+  ].join("\n");
+  if (QUEUE_MUSIC_EVIDENCE_REGEX.test(safeText)) return true;
+
+  if (
+    packet.safeClassification.category === "Artist" ||
+    packet.safeClassification.kind === "artist" ||
+    packet.safeClassification.ecosystemLane === "artist"
+  ) {
+    return true;
+  }
+
+  return packet.sourceUsageSummary.sourceLanes.some((lane) =>
+    /^queue_context$/i.test(lane),
+  );
+}
+
 export function validateBnlDossierDraftResponse(
   response: BnlDossierDraftResponse,
+  context: BnlDossierDraftValidationContext = {},
 ): BnlDossierDraftValidationResult {
   const issues: string[] = [];
   const warnings: string[] = [];
@@ -188,7 +233,9 @@ export function validateBnlDossierDraftResponse(
     if (!Array.isArray(response[field])) issues.push(`${field} must be an array`);
   }
   if (Array.isArray(response.files) && response.files.length > 0) issues.push("files must be empty unless safely supported");
-  const contract = validateDossierDraftContractOutput(response);
+  const contract = validateDossierDraftContractOutput(response, {
+    queueMusicEvidenceAllowed: packetAllowsQueueMusicEvidence(context.packet),
+  });
   for (const issue of contract.issues) issues.push(`${issue.field}: ${issue.message}`);
   for (const warning of validateDossierPublicDraftFields({
     ...response,
@@ -202,6 +249,9 @@ export function validateBnlDossierDraftResponse(
     notes: response.notes,
   })) {
     if (typeof value === "string" && containsDossierPublicCopyJunk(value)) issues.push(`${field} contains forbidden internal/source copy`);
+    if (typeof value === "string" && PAYMENT_PRIORITY_REGEX.test(value)) {
+      issues.push(`${field} contains unsupported payment/Priority Signal copy`);
+    }
   }
   return { valid: issues.length === 0, issues, warnings };
 }
@@ -245,7 +295,7 @@ export async function requestBnlDossierDraft(input: {
       status: "received",
       packet: input.packet,
       response,
-      validation: validateBnlDossierDraftResponse(response),
+      validation: validateBnlDossierDraftResponse(response, { packet: input.packet }),
     };
   } catch (error) {
     return {

--- a/src/lib/bnl-dossier-draft.ts
+++ b/src/lib/bnl-dossier-draft.ts
@@ -1,0 +1,262 @@
+import {
+  buildDossierStylePacket,
+  DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS,
+  validateDossierDraftContractOutput,
+  type DossierDraftContractOutput,
+} from "@/lib/dossier-style-packet";
+import {
+  containsDossierPublicCopyJunk,
+  validateDossierPublicDraftFields,
+} from "@/lib/dossier-public-copy-guard";
+import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
+import type {
+  DossierCandidate,
+  DossierDraft,
+  DossierRecommendation,
+  DossierSourceFileNote,
+} from "@/lib/dossier-workflow";
+
+export type BnlDossierDraftRequestPacket = {
+  version: "1.0";
+  requestType: "bnl_proposed_dossier_draft";
+  candidate: {
+    sourceFileId: string;
+    subjectName: string;
+    sourceCandidateUpdatedAt?: string;
+  };
+  sourceFileSummary: DossierCandidate["sourceFileSummary"] | null;
+  publicSafeFacts: string[];
+  publicSafeNotes: Array<
+    Pick<DossierSourceFileNote, "id" | "type" | "text" | "source" | "updatedAt">
+  >;
+  reviewOnlyWarnings: string[];
+  doNotSayNotes: string[];
+  missingInfo: string[];
+  identityAliasStatus: {
+    publicSafeIdentityLabels: string[];
+    internalAliasCount: number;
+    needsConfirmation: boolean;
+    status: DossierCandidate["identityReviewStatus"];
+  };
+  sourceUsageSummary: {
+    sourceFileNoteIds: string[];
+    recommendationIds: string[];
+    sourceLanes: string[];
+  };
+  currentDraft?: DossierDraft["fields"];
+  stylePacket: ReturnType<typeof buildDossierStylePacket>;
+  fieldRequirements: string[];
+  forbiddenPublicCopyPatterns: readonly string[];
+  ownerReviewRules: string[];
+  sourceBoundaryRules: string[];
+};
+
+export type BnlDossierDraftResponse = DossierDraftContractOutput;
+
+export type BnlDossierDraftValidationResult = {
+  valid: boolean;
+  issues: string[];
+  warnings: string[];
+};
+
+export type BnlDossierDraftGeneratorResult =
+  | { status: "not_connected"; message: string; packet: BnlDossierDraftRequestPacket }
+  | { status: "failed"; message: string; packet: BnlDossierDraftRequestPacket }
+  | {
+      status: "received";
+      packet: BnlDossierDraftRequestPacket;
+      response: BnlDossierDraftResponse;
+      validation: BnlDossierDraftValidationResult;
+    };
+
+function cleanList(values: Array<string | undefined>): string[] {
+  return [
+    ...new Set(
+      values
+        .map((value) => value?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+}
+
+export function buildBnlDossierDraftRequestPacket(input: {
+  candidate: DossierCandidate;
+  recommendations: DossierRecommendation[];
+  currentDraft?: DossierDraft | null;
+}): BnlDossierDraftRequestPacket {
+  const { candidate, recommendations, currentDraft } = input;
+  const blueprint = createDossierDraftBlueprint({ candidate, recommendations });
+  const stylePacket = buildDossierStylePacket();
+  const publicSafeNotes = (candidate.sourceFileNotes ?? []).filter(
+    (note) => note.status === "active" && note.publicSafe === true,
+  );
+  const publicSafeIdentityLabels = (candidate.identityLinks ?? [])
+    .filter(
+      (link) =>
+        link.status === "confirmed" &&
+        link.visibility === "public_safe" &&
+        link.useInPublicDossier,
+    )
+    .map((link) => link.label);
+  const internalAliasCount = (candidate.identityLinks ?? []).filter(
+    (link) => link.visibility === "internal_only" || !link.useInPublicDossier,
+  ).length;
+
+  return {
+    version: "1.0",
+    requestType: "bnl_proposed_dossier_draft",
+    candidate: {
+      sourceFileId: candidate.id,
+      subjectName: candidate.name,
+      sourceCandidateUpdatedAt: candidate.updatedAt,
+    },
+    sourceFileSummary: candidate.sourceFileSummary ?? null,
+    publicSafeFacts: cleanList([
+      ...(candidate.knownFacts ?? []),
+      ...blueprint.publicSafeFacts.confirmedPublicFacts,
+      ...blueprint.publicSafeFacts.publicRoleHints,
+    ]),
+    publicSafeNotes: publicSafeNotes.map(({ id, type, text, source, updatedAt }) => ({
+      id,
+      type,
+      text,
+      source,
+      updatedAt,
+    })),
+    reviewOnlyWarnings: cleanList([
+      ...blueprint.ownerReviewWarnings,
+      ...(candidate.publicSafetyNotes ?? []),
+    ]),
+    doNotSayNotes: cleanList([
+      ...(candidate.doNotSay ?? []),
+      ...blueprint.adminOnlyProvenance.reviewOnlyEvidence.internalNotes,
+    ]),
+    missingInfo: cleanList([...(candidate.missingInfo ?? []), ...blueprint.missingInfoQuestions]),
+    identityAliasStatus: {
+      publicSafeIdentityLabels,
+      internalAliasCount,
+      needsConfirmation: candidate.identityReviewStatus === "needs_confirmation",
+      status: candidate.identityReviewStatus,
+    },
+    sourceUsageSummary: {
+      sourceFileNoteIds: publicSafeNotes.map((note) => note.id),
+      recommendationIds: recommendations.map((recommendation) => recommendation.id),
+      sourceLanes: cleanList(
+        recommendations.flatMap((recommendation) => recommendation.sourceLanes),
+      ),
+    },
+    ...(currentDraft ? { currentDraft: currentDraft.fields } : {}),
+    stylePacket,
+    fieldRequirements: [...DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS],
+    forbiddenPublicCopyPatterns: stylePacket.forbiddenPublicCopyPatterns,
+    ownerReviewRules: stylePacket.ownerReviewRules,
+    sourceBoundaryRules: stylePacket.sourceBoundaryRules,
+  };
+}
+
+export function validateBnlDossierDraftResponse(
+  response: BnlDossierDraftResponse,
+): BnlDossierDraftValidationResult {
+  const issues: string[] = [];
+  const warnings: string[] = [];
+  for (const field of [
+    "name",
+    "category",
+    "kind",
+    "ecosystemLane",
+    "identityAuthority",
+    "status",
+    "clearance",
+    "origin",
+    "role",
+    "summary",
+    "notes",
+    "sourceUsageSummary",
+  ] as const) {
+    if (typeof response[field] !== "string" || !response[field].trim()) issues.push(`${field} is required`);
+  }
+  for (const field of [
+    "tags",
+    "proposedTags",
+    "links",
+    "files",
+    "missingInfoQuestions",
+    "ownerReviewWarnings",
+    "publicSafetyWarnings",
+    "unsupportedClaimsRejected",
+  ] as const) {
+    if (!Array.isArray(response[field])) issues.push(`${field} must be an array`);
+  }
+  if (Array.isArray(response.files) && response.files.length > 0) issues.push("files must be empty unless safely supported");
+  const contract = validateDossierDraftContractOutput(response);
+  for (const issue of contract.issues) issues.push(`${issue.field}: ${issue.message}`);
+  for (const warning of validateDossierPublicDraftFields({
+    ...response,
+    primaryLink: response.primaryLink ?? undefined,
+  })) {
+    warnings.push(warning.message);
+  }
+  for (const [field, value] of Object.entries({
+    role: response.role,
+    summary: response.summary,
+    notes: response.notes,
+  })) {
+    if (typeof value === "string" && containsDossierPublicCopyJunk(value)) issues.push(`${field} contains forbidden internal/source copy`);
+  }
+  return { valid: issues.length === 0, issues, warnings };
+}
+
+export async function requestBnlDossierDraft(input: {
+  packet: BnlDossierDraftRequestPacket;
+  timeoutMs?: number;
+}): Promise<BnlDossierDraftGeneratorResult> {
+  const url = process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL?.trim();
+  const token = process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN?.trim();
+  if (!url || !token) {
+    return {
+      status: "not_connected",
+      message: "BNL draft generator not connected yet.",
+      packet: input.packet,
+    };
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? 30_000);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-BNL-DOSSIER-DRAFT-TOKEN": token,
+      },
+      body: JSON.stringify(input.packet),
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok || !body) {
+      return {
+        status: "failed",
+        message: `BNL draft generator returned HTTP ${res.status}.`,
+        packet: input.packet,
+      };
+    }
+    const response = (body.draft ?? body) as BnlDossierDraftResponse;
+    return {
+      status: "received",
+      packet: input.packet,
+      response,
+      validation: validateBnlDossierDraftResponse(response),
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      message:
+        error instanceof Error
+          ? error.message
+          : "BNL draft generator request failed.",
+      packet: input.packet,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6220,10 +6220,17 @@ export async function updateDraftFromSourceFile(
   return updatedDraft;
 }
 
+export type RequestBnlDraftFromCandidateResult = {
+  result: BnlDossierDraftGeneratorResult;
+  draftStored: boolean;
+  storedDraft?: DossierDraft;
+  existingDraft?: DossierDraft;
+};
+
 export async function requestBnlDraftFromCandidate(
   candidateId: string,
   draftId?: string,
-): Promise<{ result: BnlDossierDraftGeneratorResult; draft: DossierDraft | null }> {
+): Promise<RequestBnlDraftFromCandidateResult> {
   const now = new Date().toISOString();
   const state = await getDossierWorkflowState();
   const candidate = state.candidates.find((item) => item.id === candidateId);
@@ -6237,7 +6244,11 @@ export async function requestBnlDraftFromCandidate(
   const packet = buildBnlDossierDraftRequestPacket({ candidate, recommendations, currentDraft });
   const result = await requestBnlDossierDraft({ packet });
   if (result.status !== "received" || !result.validation.valid) {
-    return { result, draft: currentDraft };
+    return {
+      result,
+      draftStored: false,
+      ...(currentDraft ? { existingDraft: currentDraft } : {}),
+    };
   }
 
   let savedDraft: DossierDraft | null = null;
@@ -6270,7 +6281,12 @@ export async function requestBnlDraftFromCandidate(
     savedDraft = { id: createDraftId(), candidateId: candidate.id, status: "draft", fields, sourceFileDraftMetadata: metadata, createdAt: now, updatedAt: now };
     return { ...currentState, drafts: [savedDraft, ...currentState.drafts], updatedAt: now };
   });
-  return { result, draft: savedDraft };
+  return {
+    result,
+    draftStored: Boolean(savedDraft),
+    ...(savedDraft ? { storedDraft: savedDraft } : {}),
+    ...(currentDraft ? { existingDraft: currentDraft } : {}),
+  };
 }
 
 export async function saveDossierDraft(

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -4,12 +4,12 @@ import { databasePage, type DatabaseEntry } from "@/content";
 import {
   DOSSIER_PUBLIC_ROLE_PLACEHOLDER,
   DOSSIER_PUBLIC_SUMMARY_PLACEHOLDER,
-  containsDossierPublicCopyJunk,
   isDossierPublicCopyPlaceholder,
   sanitizeDossierPublicCopy,
   validateDossierPublicDraftFields,
 } from "@/lib/dossier-public-copy-guard";
 import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
+import { buildBnlDossierDraftRequestPacket, requestBnlDossierDraft, type BnlDossierDraftGeneratorResult } from "@/lib/bnl-dossier-draft";
 import {
   scoreManualDossierCandidate,
   type CreateDossierRecommendationInput,
@@ -6114,6 +6114,10 @@ function assemblePublicSafeDraftFromSourceFile(input: {
       sourceFileNoteIds: publicSafeNotes.map((note) => note.id),
       recommendationIds: recommendations.map((recommendation) => recommendation.id),
       assembledAt: now,
+      generatedBy: "manual_placeholder",
+      generatedAt: now,
+      validationIssues: [],
+      validationWarnings: ["Manual placeholder scaffold; BNL did not author this draft."],
       publicSafeDraft: true,
       reviewOnlyEvidence: true,
       autoConfirmedIdentityLinks: false,
@@ -6214,6 +6218,59 @@ export async function updateDraftFromSourceFile(
   });
 
   return updatedDraft;
+}
+
+export async function requestBnlDraftFromCandidate(
+  candidateId: string,
+  draftId?: string,
+): Promise<{ result: BnlDossierDraftGeneratorResult; draft: DossierDraft | null }> {
+  const now = new Date().toISOString();
+  const state = await getDossierWorkflowState();
+  const candidate = state.candidates.find((item) => item.id === candidateId);
+  if (!candidate) throw new Error("Candidate not found");
+  const currentDraft = draftId
+    ? state.drafts.find((draft) => draft.id === draftId) ?? null
+    : state.drafts.find((draft) => draft.candidateId === candidateId && draft.status !== "published" && draft.status !== "denied") ?? null;
+  const recommendations = state.recommendations.filter(
+    (recommendation) => recommendation.targetCandidateId === candidate.id,
+  );
+  const packet = buildBnlDossierDraftRequestPacket({ candidate, recommendations, currentDraft });
+  const result = await requestBnlDossierDraft({ packet });
+  if (result.status !== "received" || !result.validation.valid) {
+    return { result, draft: currentDraft };
+  }
+
+  let savedDraft: DossierDraft | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    const latestCandidate = currentState.candidates.find((item) => item.id === candidateId) ?? candidate;
+    const metadata: DossierDraft["sourceFileDraftMetadata"] = {
+      sourceCandidateId: candidate.id,
+      sourceCandidateUpdatedAt: latestCandidate.updatedAt,
+      sourceFileNoteIds: packet.sourceUsageSummary.sourceFileNoteIds,
+      recommendationIds: packet.sourceUsageSummary.recommendationIds,
+      assembledAt: now,
+      generatedBy: "BNL",
+      generatedAt: now,
+      publicSafeDraft: true,
+      reviewOnlyEvidence: true,
+      autoConfirmedIdentityLinks: false,
+      publicPagesMutated: false,
+      validationIssues: result.validation.issues,
+      validationWarnings: result.validation.warnings,
+    };
+    const fields = normalizeDraftFields({ ...result.response, primaryLink: result.response.primaryLink ?? undefined, files: [] });
+    if (currentDraft) {
+      const drafts = currentState.drafts.map((draft) => {
+        if (draft.id !== currentDraft.id) return draft;
+        savedDraft = { ...draft, fields, sourceFileDraftMetadata: metadata, updatedAt: now };
+        return savedDraft;
+      });
+      return { ...currentState, drafts, updatedAt: now };
+    }
+    savedDraft = { id: createDraftId(), candidateId: candidate.id, status: "draft", fields, sourceFileDraftMetadata: metadata, createdAt: now, updatedAt: now };
+    return { ...currentState, drafts: [savedDraft, ...currentState.drafts], updatedAt: now };
+  });
+  return { result, draft: savedDraft };
 }
 
 export async function saveDossierDraft(

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6220,6 +6220,36 @@ export async function updateDraftFromSourceFile(
   return updatedDraft;
 }
 
+function isBnlDraftOverwriteEligible(
+  draft: DossierDraft | undefined,
+  candidateId: string,
+): draft is DossierDraft {
+  return Boolean(
+    draft &&
+      draft.candidateId === candidateId &&
+      (draft.status === "draft" || draft.status === "owner_changes_requested"),
+  );
+}
+
+function resolveEligibleBnlDraft(input: {
+  drafts: DossierDraft[];
+  candidateId: string;
+  draftId?: string;
+}): { draft: DossierDraft | null; invalidDraft?: DossierDraft | null } {
+  if (input.draftId) {
+    const providedDraft = input.drafts.find((draft) => draft.id === input.draftId);
+    return isBnlDraftOverwriteEligible(providedDraft, input.candidateId)
+      ? { draft: providedDraft }
+      : { draft: null, invalidDraft: providedDraft ?? null };
+  }
+  return {
+    draft:
+      input.drafts.find((draft) =>
+        isBnlDraftOverwriteEligible(draft, input.candidateId),
+      ) ?? null,
+  };
+}
+
 export type RequestBnlDraftFromCandidateResult = {
   result: BnlDossierDraftGeneratorResult;
   draftStored: boolean;
@@ -6235,13 +6265,37 @@ export async function requestBnlDraftFromCandidate(
   const state = await getDossierWorkflowState();
   const candidate = state.candidates.find((item) => item.id === candidateId);
   if (!candidate) throw new Error("Candidate not found");
-  const currentDraft = draftId
-    ? state.drafts.find((draft) => draft.id === draftId) ?? null
-    : state.drafts.find((draft) => draft.candidateId === candidateId && draft.status !== "published" && draft.status !== "denied") ?? null;
   const recommendations = state.recommendations.filter(
     (recommendation) => recommendation.targetCandidateId === candidate.id,
   );
-  const packet = buildBnlDossierDraftRequestPacket({ candidate, recommendations, currentDraft });
+  const { draft: currentDraft, invalidDraft } = resolveEligibleBnlDraft({
+    drafts: state.drafts,
+    candidateId,
+    draftId,
+  });
+  const packet = buildBnlDossierDraftRequestPacket({
+    candidate,
+    recommendations,
+    currentDraft,
+  });
+
+  if (draftId && invalidDraft !== undefined) {
+    return {
+      result: {
+        status: "failed",
+        message:
+          invalidDraft === null
+            ? "BNL draft request cannot update a missing draft."
+            : "BNL draft request can only update active editable drafts for the same candidate.",
+        packet,
+      },
+      draftStored: false,
+      ...(invalidDraft && invalidDraft.candidateId === candidateId
+        ? { existingDraft: invalidDraft }
+        : {}),
+    };
+  }
+
   const result = await requestBnlDossierDraft({ packet });
   if (result.status !== "received" || !result.validation.valid) {
     return {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -380,6 +380,10 @@ export type DossierDraft = {
     sourceFileNoteIds: string[];
     recommendationIds: string[];
     assembledAt: string;
+    generatedBy?: "BNL" | "manual_placeholder";
+    generatedAt?: string;
+    validationIssues?: string[];
+    validationWarnings?: string[];
     publicSafeDraft: true;
     reviewOnlyEvidence: true;
     autoConfirmedIdentityLinks: false;
@@ -2948,6 +2952,7 @@ export type DossierWorkflowAction =
   | "requestDraft"
   | "createDraftFromCandidate"
   | "updateDraftFromSourceFile"
+  | "requestBnlDraftFromCandidate"
   | "saveDraft"
   | "saveDraftEdit"
   | "submitDraftForOwnerReview"
@@ -3010,6 +3015,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "requestDraft",
   "createDraftFromCandidate",
   "updateDraftFromSourceFile",
+  "requestBnlDraftFromCandidate",
   "saveDraft",
   "saveDraftEdit",
   "submitDraftForOwnerReview",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -66,6 +66,75 @@ const dossierPageViewModel = require("../src/lib/dossier-page-view-model.ts");
 const dossierTaxonomy = require("../src/lib/dossier-taxonomy.ts");
 const dossierClassification = require("../src/lib/dossier-classification.ts");
 const dossierStylePacket = require("../src/lib/dossier-style-packet.ts");
+const bnlDossierDraft = require("../src/lib/bnl-dossier-draft.ts");
+
+
+test("BNL dossier draft packet keeps internal aliases out and declares site/BNL ownership boundaries", () => {
+  const now = "2026-06-14T00:00:00.000Z";
+  const candidate = {
+    id: "candidate_bnl_packet",
+    name: "Packet Subject",
+    candidateType: "artist",
+    source: "bnl_source_file_enrichment",
+    tier: "draft_ready",
+    score: 80,
+    whyNow: "Public-safe context is ready for BNL drafting.",
+    reason: "Source File has reviewed facts.",
+    evidenceSummary: "Public-safe BARCODE context.",
+    knownFacts: ["Public-safe fixture fact."],
+    doNotSay: ["Do not mention private handle."],
+    missingInfo: ["Confirm preferred public link."],
+    publicSafetyNotes: ["Keep raw source lanes out of public copy."],
+    sourceFileNotes: [
+      { id: "note_public", candidateId: "candidate_bnl_packet", type: "fact", text: "Public-safe note.", source: "admin_manual", status: "active", publicSafe: true, createdAt: now, updatedAt: now },
+      { id: "note_private", candidateId: "candidate_bnl_packet", type: "do_not_say", text: "Internal only.", source: "admin_manual", status: "active", publicSafe: false, createdAt: now, updatedAt: now },
+    ],
+    identityLinks: [
+      { id: "identity_internal", candidateId: "candidate_bnl_packet", label: "PrivateAlias", normalizedLabel: "privatealias", type: "alias", visibility: "internal_only", status: "confirmed", source: "admin_manual", useForMatching: true, useInPublicDossier: false, createdAt: now, updatedAt: now },
+      { id: "identity_public", candidateId: "candidate_bnl_packet", label: "Public Name", normalizedLabel: "public name", type: "public_persona", visibility: "public_safe", status: "confirmed", source: "owner_confirmed", useForMatching: true, useInPublicDossier: true, createdAt: now, updatedAt: now },
+    ],
+    identityReviewStatus: "needs_confirmation",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const packet = bnlDossierDraft.buildBnlDossierDraftRequestPacket({ candidate, recommendations: [] });
+  assert.equal(packet.requestType, "bnl_proposed_dossier_draft");
+  assert.equal(packet.candidate.sourceFileId, candidate.id);
+  assert.deepEqual(packet.sourceUsageSummary.sourceFileNoteIds, ["note_public"]);
+  assert.equal(packet.identityAliasStatus.internalAliasCount, 1);
+  assert.deepEqual(packet.identityAliasStatus.publicSafeIdentityLabels, ["Public Name"]);
+  assert.equal(JSON.stringify(packet).includes("PrivateAlias"), false);
+  assert.ok(packet.ownerReviewRules.some((rule) => /Owner Review/.test(rule)));
+  assert.ok(packet.sourceBoundaryRules.some((rule) => /Source File/.test(rule)));
+});
+
+test("BNL dossier draft response validation blocks public source/debug copy", () => {
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse({
+    name: "Packet Subject",
+    category: "Artist",
+    kind: "artist",
+    ecosystemLane: "artist",
+    identityAuthority: "community_owned",
+    status: "PENDING",
+    clearance: "PUBLIC",
+    origin: "UNVERIFIED",
+    role: "source file candidateId: candidate_bnl_packet",
+    summary: "Clean summary.",
+    notes: "Clean notes.",
+    tags: ["music"],
+    proposedTags: [],
+    primaryLink: null,
+    links: [],
+    files: [],
+    missingInfoQuestions: [],
+    ownerReviewWarnings: [],
+    publicSafetyWarnings: [],
+    unsupportedClaimsRejected: [],
+    sourceUsageSummary: "Used public-safe notes only.",
+  });
+  assert.equal(validation.valid, false);
+  assert.ok(validation.issues.some((issue) => /role/.test(issue)));
+});
 
 function source(relativePath) {
   return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -152,6 +152,97 @@ function assertIncludesCopy(text, expected) {
 }
 
 
+
+test("BNL draft validation accepts artist/music language with public-safe packet support", () => {
+  const now = "2026-06-14T00:00:00.000Z";
+  const packet = bnlDossierDraft.buildBnlDossierDraftRequestPacket({
+    candidate: {
+      id: "candidate_music_supported",
+      name: "Music Supported",
+      candidateType: "artist",
+      source: "manual",
+      tier: "draft_ready",
+      score: 80,
+      whyNow: "Public-safe artist context is ready.",
+      reason: "Artist has public music context.",
+      evidenceSummary: "Artist has public-safe music context.",
+      knownFacts: ["Public-safe artist and music evidence is available."],
+      recommendedCategory: "Artist",
+      recommendedKind: "artist",
+      recommendedEcosystemLane: "artist",
+      status: "active_source_file",
+      createdAt: now,
+      updatedAt: now,
+    },
+    recommendations: [],
+  });
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      category: "Artist",
+      kind: "artist",
+      ecosystemLane: "artist",
+      role: "Artist",
+      summary: "Music Supported is an artist with public-safe music context ready for owner review.",
+      tags: ["artist"],
+    }),
+    { packet },
+  );
+  assert.equal(validation.valid, true, JSON.stringify(validation.issues));
+});
+
+test("BNL draft validation rejects artist/music language without public-safe packet support", () => {
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      role: "Artist",
+      summary: "Unsupported Fixture is an artist with music context.",
+    }),
+  );
+  assert.equal(validation.valid, false);
+  assert.ok(
+    validation.issues.some((issue) => /unsupported queue\/music claims/i.test(issue)),
+  );
+});
+
+test("BNL draft validation still rejects Priority and payment language", () => {
+  const now = "2026-06-14T00:00:00.000Z";
+  const packet = bnlDossierDraft.buildBnlDossierDraftRequestPacket({
+    candidate: {
+      id: "candidate_payment_blocked",
+      name: "Payment Blocked",
+      candidateType: "artist",
+      source: "manual",
+      tier: "draft_ready",
+      score: 80,
+      whyNow: "Public-safe artist context is ready.",
+      reason: "Artist has public music context.",
+      evidenceSummary: "Artist has public-safe music context.",
+      knownFacts: ["Public-safe artist music evidence is available."],
+      recommendedCategory: "Artist",
+      recommendedKind: "artist",
+      recommendedEcosystemLane: "artist",
+      status: "active_source_file",
+      createdAt: now,
+      updatedAt: now,
+    },
+    recommendations: [],
+  });
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      category: "Artist",
+      kind: "artist",
+      ecosystemLane: "artist",
+      role: "Artist",
+      summary: "Payment Blocked is an artist with Priority Signal checkout momentum.",
+      tags: ["artist"],
+    }),
+    { packet },
+  );
+  assert.equal(validation.valid, false);
+  assert.ok(
+    validation.issues.some((issue) => /payment\/Priority Signal/i.test(issue)),
+  );
+});
+
 test("Dossier taxonomy expansion supports first-class artist, collaborator, and community routing", () => {
   assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Artist"));
   assert.ok(dossierTaxonomy.DOSSIER_CATEGORY_OPTIONS.includes("Collaborator"));
@@ -4057,6 +4148,139 @@ test("valid BNL draft response reports a stored BNL-authored draft", async () =>
     assert.equal(payload.storedDraft.fields.name, "Valid BNL Draft");
     assert.equal(payload.storedDraft.sourceFileDraftMetadata.generatedBy, "BNL");
     assert.equal(payload.storedDraft.sourceFileDraftMetadata.publicPagesMutated, false);
+    assert.equal(payload.drafts.length, 1);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  }
+});
+
+
+test("BNL draft request rejects a draft from another candidate without mutation", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+  const originalFetch = global.fetch;
+  let fetchCalled = false;
+  try {
+    const first = await (
+      await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "BNL Owner A" } })
+    ).json();
+    const second = await (
+      await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "BNL Owner B" } })
+    ).json();
+    const secondDraft = await (
+      await authedPost({ action: "createDraftFromCandidate", candidateId: second.candidate.id })
+    ).json();
+    global.fetch = async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({ draft: cleanContractDraft() }), { status: 200 });
+    };
+
+    const response = await authedPost({
+      action: "requestBnlDraftFromCandidate",
+      candidateId: first.candidate.id,
+      draftId: secondDraft.draft.id,
+    });
+    const payload = await response.json();
+    assert.equal(payload.bnlDraft.status, "failed");
+    assert.equal(payload.draftStored, false);
+    assert.equal(payload.storedDraft, undefined);
+    assert.equal(fetchCalled, false);
+    assert.equal(payload.drafts.length, 1);
+    assert.equal(payload.drafts[0].candidateId, second.candidate.id);
+    assert.equal(payload.drafts[0].sourceFileDraftMetadata.generatedBy, "manual_placeholder");
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  }
+});
+
+test("BNL draft request rejects non-editable same-candidate draft statuses without mutation", async () => {
+  for (const status of ["ready_for_owner_review", "owner_approved", "published", "denied", "superseded"]) {
+    await resetWorkflowStore();
+    process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+    process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+    const originalFetch = global.fetch;
+    let fetchCalled = false;
+    try {
+      const created = await (
+        await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: `BNL Status ${status}` } })
+      ).json();
+      const draftPayload = await (
+        await authedPost({ action: "createDraftFromCandidate", candidateId: created.candidate.id })
+      ).json();
+      const currentState = await store.getDossierWorkflowState();
+      await store.saveDossierWorkflowState({
+        ...currentState,
+        drafts: currentState.drafts.map((draft) =>
+          draft.id === draftPayload.draft.id ? { ...draft, status } : draft,
+        ),
+      });
+      global.fetch = async () => {
+        fetchCalled = true;
+        return new Response(JSON.stringify({ draft: cleanContractDraft() }), { status: 200 });
+      };
+
+      const response = await authedPost({
+        action: "requestBnlDraftFromCandidate",
+        candidateId: created.candidate.id,
+        draftId: draftPayload.draft.id,
+      });
+      const payload = await response.json();
+      assert.equal(payload.bnlDraft.status, "failed", status);
+      assert.equal(payload.draftStored, false, status);
+      assert.equal(payload.storedDraft, undefined, status);
+      assert.equal(fetchCalled, false, status);
+      assert.equal(payload.drafts[0].status, status);
+      assert.equal(payload.drafts[0].sourceFileDraftMetadata.generatedBy, "manual_placeholder");
+    } finally {
+      global.fetch = originalFetch;
+      delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+      delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+    }
+  }
+});
+
+test("BNL draft request updates an eligible same-candidate draft", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+  const originalFetch = global.fetch;
+  try {
+    const created = await (
+      await authedPost({ action: "createManualCandidate", input: manualCandidateInput })
+    ).json();
+    const draftPayload = await (
+      await authedPost({ action: "createDraftFromCandidate", candidateId: created.candidate.id })
+    ).json();
+    const currentState = await store.getDossierWorkflowState();
+    await store.saveDossierWorkflowState({
+      ...currentState,
+      drafts: currentState.drafts.map((draft) =>
+        draft.id === draftPayload.draft.id
+          ? { ...draft, status: "owner_changes_requested" }
+          : draft,
+      ),
+    });
+    global.fetch = async () =>
+      new Response(
+        JSON.stringify({ draft: cleanContractDraft({ name: "Updated Eligible BNL Draft" }) }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const response = await authedPost({
+      action: "requestBnlDraftFromCandidate",
+      candidateId: created.candidate.id,
+      draftId: draftPayload.draft.id,
+    });
+    const payload = await response.json();
+    assert.equal(payload.draftStored, true);
+    assert.equal(payload.storedDraft.id, draftPayload.draft.id);
+    assert.equal(payload.storedDraft.fields.name, "Updated Eligible BNL Draft");
+    assert.equal(payload.storedDraft.sourceFileDraftMetadata.generatedBy, "BNL");
     assert.equal(payload.drafts.length, 1);
   } finally {
     global.fetch = originalFetch;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -3957,6 +3957,114 @@ test("createDraftFromCandidate creates one workflow draft from candidate recomme
   assert.equal(payload.drafts.length, 1);
 });
 
+
+test("BNL draft request not-connected response does not create or report a stored draft", async () => {
+  await resetWorkflowStore();
+  delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+  delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  const created = await (
+    await authedPost({ action: "createManualCandidate", input: manualCandidateInput })
+  ).json();
+
+  const response = await authedPost({
+    action: "requestBnlDraftFromCandidate",
+    candidateId: created.candidate.id,
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.bnlDraft.status, "not_connected");
+  assert.equal(payload.draftStored, false);
+  assert.equal(payload.storedDraft, undefined);
+  assert.equal(payload.draft, undefined);
+  assert.equal(payload.drafts.length, 0);
+});
+
+test("invalid BNL draft response reports validation issues without a stored-draft success", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+  const originalFetch = global.fetch;
+  try {
+    const created = await (
+      await authedPost({ action: "createManualCandidate", input: manualCandidateInput })
+    ).json();
+    const existingDraftPayload = await (
+      await authedPost({
+        action: "createDraftFromCandidate",
+        candidateId: created.candidate.id,
+      })
+    ).json();
+
+    global.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          draft: cleanContractDraft({
+            name: "Invalid BNL Draft",
+            role: "source file candidateId: candidate_invalid_bnl",
+          }),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const response = await authedPost({
+      action: "requestBnlDraftFromCandidate",
+      candidateId: created.candidate.id,
+      draftId: existingDraftPayload.draft.id,
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.bnlDraft.status, "received");
+    assert.equal(payload.draftStored, false);
+    assert.equal(payload.storedDraft, undefined);
+    assert.equal(payload.draft, undefined);
+    assert.equal(payload.existingDraft.id, existingDraftPayload.draft.id);
+    assert.ok(payload.bnlDraft.validation.issues.some((issue) => /role/.test(issue)));
+    assert.equal(payload.drafts.length, 1);
+    assert.equal(payload.drafts[0].sourceFileDraftMetadata.generatedBy, "manual_placeholder");
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  }
+});
+
+test("valid BNL draft response reports a stored BNL-authored draft", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+  const originalFetch = global.fetch;
+  try {
+    const created = await (
+      await authedPost({ action: "createManualCandidate", input: manualCandidateInput })
+    ).json();
+    global.fetch = async (url, options = {}) => {
+      assert.equal(String(url), process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL);
+      assert.equal(options.headers["X-BNL-DOSSIER-DRAFT-TOKEN"], "test-draft-token");
+      return new Response(
+        JSON.stringify({ draft: cleanContractDraft({ name: "Valid BNL Draft" }) }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+
+    const response = await authedPost({
+      action: "requestBnlDraftFromCandidate",
+      candidateId: created.candidate.id,
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.bnlDraft.status, "received");
+    assert.equal(payload.draftStored, true);
+    assert.equal(payload.storedDraft.fields.name, "Valid BNL Draft");
+    assert.equal(payload.storedDraft.sourceFileDraftMetadata.generatedBy, "BNL");
+    assert.equal(payload.storedDraft.sourceFileDraftMetadata.publicPagesMutated, false);
+    assert.equal(payload.drafts.length, 1);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  }
+});
+
 test("createDraftFromCandidate keeps internal starter notes out of public draft fields", async () => {
   await resetWorkflowStore();
   const input = {


### PR DESCRIPTION
### Motivation
- Provide a site-side, safety-first contract and workflow so the site can prepare a safe Source File packet for BNL, request a BNL-authored Proposed Dossier draft, validate the structured response, and store it as a Proposed Dossier without the site becoming the author. 
- Preserve existing manual draft scaffolds while preventing any site-authored public dossier copy or automatic identity/public mutations. 

### Description
- Added a typed BNL request/response/validation client in `src/lib/bnl-dossier-draft.ts` that builds the safe packet (candidate id, subject name, Source File summary, public-safe facts, public-safe notes, review-only warnings, do-not-say notes, missing info, identity alias status without exposing internal aliases, source usage, current draft context, Dossier Style Packet, field requirements, forbidden public-copy patterns, owner review rules, and source boundary rules) and validates BNL structured output against the existing Draft Contract and public-copy guard. 
- Persisted BNL metadata and storage rules by extending draft metadata with `generatedBy`, `generatedAt`, `validationIssues`, and `validationWarnings`, and wired saving of validated BNL responses as Proposed Dossier drafts in `src/lib/dossier-workflow-store.ts`. 
- Exposed a site action and API lane `requestBnlDraftFromCandidate` in `src/app/api/admin/dossiers/route.ts` and added a UI control in `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` to request the BNL draft while returning a truthful `not_connected` state if the BNL endpoint/token are not configured. 
- Kept manual draft creation intact but labelled scaffolds as `manual_placeholder` and added clarifying copy in `src/app/admin/dossiers/drafts/[draftId]/page.tsx` so editors see ownership and boundary rules; added narrow tests in `tests/admin-dossiers.test.mjs` covering packet construction, alias non-exposure, ownership boundary phrasing, and response validation. 
- Files changed: `src/lib/bnl-dossier-draft.ts` (new), `src/lib/dossier-workflow-store.ts` (BNL request/save flow + manual placeholder metadata), `src/lib/dossier-workflow.ts` (types + action), `src/app/api/admin/dossiers/route.ts` (API action), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (UI/button/notice), `src/app/admin/dossiers/drafts/[draftId]/page.tsx` (copy update), and `tests/admin-dossiers.test.mjs` (added tests). 

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` and it succeeded. 
- Ran the dossier unit test subset with `node --test tests/admin-dossiers.test.mjs` and the new/modified tests passed. 
- Ran lint via `npm run lint`; existing unrelated lint issues in archived/public components caused failures but no new dossier-specific lint errors were introduced. 
- Ran `npm test` which failed because this repo does not define a top-level `test` script; the focused tests above were used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dfdb5471c8321bbd3c64de3ab452a)