### PR TITLE
Validate BNL draft evidence usage and prevent unsafe draft storage

### DIFF
--- a/src/lib/bnl-dossier-draft.ts
+++ b/src/lib/bnl-dossier-draft.ts
@@ -167,13 +167,37 @@ export function buildBnlDossierDraftRequestPacket(input: {
 
 export type BnlDossierDraftValidationContext = {
   packet?: BnlDossierDraftRequestPacket;
+  response?: BnlDossierDraftResponse;
 };
 
 const QUEUE_MUSIC_EVIDENCE_REGEX =
   /\b(?:artist|music|musician|producer|song|track|album|release|submission|submitted|queue|auxchord|radio|performance|performer|dj)\b/i;
 
 const PAYMENT_PRIORITY_REGEX =
-  /\b(?:stripe|payment|paid|checkout|priority\s+signal|priority|tier|invoice|receipt|purchase)\b/i;
+  /\b(?:stripe|payment|paid|checkout|priority\s+signal|priority|tier|invoice|receipt|purchase|customer)\b/i;
+
+const BNL_PUBLIC_SAFE_EVIDENCE_SOURCE_REGEX =
+  /\b(?:active public-safe broadcast memory|public-safe broadcast memory summar(?:y|ies)|public-safe structured entity evidence summar(?:y|ies)|public-safe entity intelligence facts?|site public read-model context)\b/i;
+
+const BNL_SUBJECT_MATCHED_PUBLIC_CONTEXT_REGEX =
+  /\b(?:official public dossier authority|matching current public dossier context)\b/i;
+
+const UNSAFE_SOURCE_USAGE_REGEX =
+  /\b(?:private|source-blind|review-only|internal|admin-only|payment|priority|stripe|checkout|customer)\b/i;
+
+const PUBLIC_NOTES_REVIEW_WARNING_REGEX =
+  /\b(?:Owner Review|Admin-only|review-only|must not be copied into public text|not public|source-blind|missing info|needs review before claiming)\b/i;
+
+function normalizeSupportText(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 function packetAllowsQueueMusicEvidence(
   packet?: BnlDossierDraftRequestPacket,
@@ -194,8 +218,20 @@ function packetAllowsQueueMusicEvidence(
   }
 
   return packet.sourceUsageSummary.sourceLanes.some((lane) =>
-    /^queue_context$/i.test(lane),
+    /^(?:queue_context|music|artist|radio|broadcast_memory)$/i.test(lane),
   );
+}
+
+function responseAllowsQueueMusicEvidence(
+  response?: BnlDossierDraftResponse,
+  packet?: BnlDossierDraftRequestPacket,
+): boolean {
+  const sourceUsage = response?.sourceUsageSummary?.trim() ?? "";
+  if (!sourceUsage || UNSAFE_SOURCE_USAGE_REGEX.test(sourceUsage)) return false;
+  if (BNL_PUBLIC_SAFE_EVIDENCE_SOURCE_REGEX.test(sourceUsage)) return true;
+  if (!BNL_SUBJECT_MATCHED_PUBLIC_CONTEXT_REGEX.test(sourceUsage)) return false;
+  const subject = normalizeSupportText(packet?.candidate.subjectName ?? response?.name ?? "");
+  return Boolean(subject && normalizeSupportText(sourceUsage).includes(subject));
 }
 
 export function validateBnlDossierDraftResponse(
@@ -233,8 +269,17 @@ export function validateBnlDossierDraftResponse(
     if (!Array.isArray(response[field])) issues.push(`${field} must be an array`);
   }
   if (Array.isArray(response.files) && response.files.length > 0) issues.push("files must be empty unless safely supported");
+  const queueMusicEvidenceAllowed =
+    packetAllowsQueueMusicEvidence(context.packet) ||
+    responseAllowsQueueMusicEvidence(context.response ?? response, context.packet);
+  if (PAYMENT_PRIORITY_REGEX.test(response.sourceUsageSummary)) {
+    issues.push("sourceUsageSummary contains payment/Priority/Stripe/checkout/customer language");
+  }
+  if (/\b(?:private|source-blind|review-only|internal|admin-only)\b/i.test(response.sourceUsageSummary)) {
+    warnings.push("sourceUsageSummary references non-public provenance and cannot authorize public queue/music claims.");
+  }
   const contract = validateDossierDraftContractOutput(response, {
-    queueMusicEvidenceAllowed: packetAllowsQueueMusicEvidence(context.packet),
+    queueMusicEvidenceAllowed,
   });
   for (const issue of contract.issues) issues.push(`${issue.field}: ${issue.message}`);
   for (const warning of validateDossierPublicDraftFields({
@@ -249,6 +294,9 @@ export function validateBnlDossierDraftResponse(
     notes: response.notes,
   })) {
     if (typeof value === "string" && containsDossierPublicCopyJunk(value)) issues.push(`${field} contains forbidden internal/source copy`);
+    if (field === "notes" && typeof value === "string" && PUBLIC_NOTES_REVIEW_WARNING_REGEX.test(value)) {
+      issues.push("notes contains review-only/admin warning text that belongs in metadata");
+    }
     if (typeof value === "string" && PAYMENT_PRIORITY_REGEX.test(value)) {
       issues.push(`${field} contains unsupported payment/Priority Signal copy`);
     }

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -6253,7 +6253,7 @@ function resolveEligibleBnlDraft(input: {
 export type RequestBnlDraftFromCandidateResult = {
   result: BnlDossierDraftGeneratorResult;
   draftStored: boolean;
-  storedDraft?: DossierDraft;
+  storedDraft: DossierDraft | null;
   existingDraft?: DossierDraft;
 };
 
@@ -6290,6 +6290,7 @@ export async function requestBnlDraftFromCandidate(
         packet,
       },
       draftStored: false,
+      storedDraft: null,
       ...(invalidDraft && invalidDraft.candidateId === candidateId
         ? { existingDraft: invalidDraft }
         : {}),
@@ -6301,6 +6302,7 @@ export async function requestBnlDraftFromCandidate(
     return {
       result,
       draftStored: false,
+      storedDraft: null,
       ...(currentDraft ? { existingDraft: currentDraft } : {}),
     };
   }
@@ -6338,7 +6340,7 @@ export async function requestBnlDraftFromCandidate(
   return {
     result,
     draftStored: Boolean(savedDraft),
-    ...(savedDraft ? { storedDraft: savedDraft } : {}),
+    storedDraft: savedDraft,
     ...(currentDraft ? { existingDraft: currentDraft } : {}),
   };
 }

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -203,6 +203,93 @@ test("BNL draft validation rejects artist/music language without public-safe pac
   );
 });
 
+test("BNL draft validation accepts music role when BNL source usage cites approved public-safe evidence", () => {
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      name: "Evidence Supported Artist",
+      role: "Music artist",
+      summary: "Evidence Supported Artist is a music artist with public-safe broadcast context.",
+      sourceUsageSummary: "Used 1 public-safe entity intelligence fact for Evidence Supported Artist.",
+    }),
+  );
+  assert.equal(validation.valid, true, JSON.stringify(validation.issues));
+});
+
+test("BNL draft validation rejects payment source usage as music support", () => {
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      name: "Payment Source Artist",
+      role: "Music artist",
+      summary: "Payment Source Artist is a music artist with public-safe broadcast context.",
+      sourceUsageSummary: "Used 1 Stripe checkout customer priority signal.",
+    }),
+  );
+  assert.equal(validation.valid, false);
+  assert.ok(validation.issues.some((issue) => /payment|unsupported queue\/music/i.test(issue)));
+});
+
+test("BNL draft validation blocks review-only warning language in public notes", () => {
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      notes: "Owner Review required. Admin-only evidence exists and must not be copied into public text.",
+      ownerReviewWarnings: ["Owner Review required. Admin-only evidence exists."],
+    }),
+  );
+  assert.equal(validation.valid, false);
+  assert.ok(validation.issues.some((issue) => /notes/.test(issue)));
+});
+
+test("BNL draft validation does not let style examples authorize unrelated music claims", () => {
+  const packet = {
+    candidate: { subjectName: "Unrelated Examples" },
+    publicSafeFacts: ["Public-safe community context only."],
+    publicSafeNotes: [],
+    sourceUsageSummary: { sourceLanes: [] },
+    safeClassification: { category: "Community", kind: "community_member", ecosystemLane: "community_member" },
+  };
+  const validation = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      name: "Unrelated Examples",
+      role: "Music artist",
+      summary: "Unrelated Examples is a music artist.",
+      sourceUsageSummary: "Used representative public dossier examples for tone only.",
+    }),
+    { packet },
+  );
+  assert.equal(validation.valid, false);
+});
+
+test("BNL draft validation requires official public dossier authority to match the subject", () => {
+  const packet = {
+    candidate: { subjectName: "Subject Match" },
+    publicSafeFacts: ["Public-safe community context only."],
+    publicSafeNotes: [],
+    sourceUsageSummary: { sourceLanes: [] },
+    safeClassification: { category: "Community", kind: "community_member", ecosystemLane: "community_member" },
+  };
+  const mismatched = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      name: "Subject Match",
+      role: "Music artist",
+      summary: "Subject Match is a music artist.",
+      sourceUsageSummary: "Used official public dossier authority for Other Artist.",
+    }),
+    { packet },
+  );
+  assert.equal(mismatched.valid, false);
+
+  const matched = bnlDossierDraft.validateBnlDossierDraftResponse(
+    cleanContractDraft({
+      name: "Subject Match",
+      role: "Music artist",
+      summary: "Subject Match is a music artist.",
+      sourceUsageSummary: "Used official public dossier authority for Subject Match.",
+    }),
+    { packet },
+  );
+  assert.equal(matched.valid, true, JSON.stringify(matched.issues));
+});
+
 test("BNL draft validation still rejects Priority and payment language", () => {
   const now = "2026-06-14T00:00:00.000Z";
   const packet = bnlDossierDraft.buildBnlDossierDraftRequestPacket({
@@ -487,7 +574,7 @@ function cleanContractDraft(overrides = {}) {
     origin: "UNVERIFIED",
     role: "Community Member",
     summary: "Clean Fixture is a recurring BARCODE community presence with public-safe participation signals ready for operator review.",
-    notes: "Owner review is still required before this proposed dossier can be used publicly.",
+    notes: "Public-safe context is ready for a concise dossier preview.",
     tags: ["community"],
     proposedTags: ["fixture-regular"],
     primaryLink: null,
@@ -4065,7 +4152,7 @@ test("BNL draft request not-connected response does not create or report a store
   const payload = await response.json();
   assert.equal(payload.bnlDraft.status, "not_connected");
   assert.equal(payload.draftStored, false);
-  assert.equal(payload.storedDraft, undefined);
+  assert.equal(payload.storedDraft, null);
   assert.equal(payload.draft, undefined);
   assert.equal(payload.drafts.length, 0);
 });
@@ -4106,7 +4193,7 @@ test("invalid BNL draft response reports validation issues without a stored-draf
     const payload = await response.json();
     assert.equal(payload.bnlDraft.status, "received");
     assert.equal(payload.draftStored, false);
-    assert.equal(payload.storedDraft, undefined);
+    assert.equal(payload.storedDraft, null);
     assert.equal(payload.draft, undefined);
     assert.equal(payload.existingDraft.id, existingDraftPayload.draft.id);
     assert.ok(payload.bnlDraft.validation.issues.some((issue) => /role/.test(issue)));
@@ -4186,7 +4273,7 @@ test("BNL draft request rejects a draft from another candidate without mutation"
     const payload = await response.json();
     assert.equal(payload.bnlDraft.status, "failed");
     assert.equal(payload.draftStored, false);
-    assert.equal(payload.storedDraft, undefined);
+    assert.equal(payload.storedDraft, null);
     assert.equal(fetchCalled, false);
     assert.equal(payload.drafts.length, 1);
     assert.equal(payload.drafts[0].candidateId, second.candidate.id);
@@ -4232,7 +4319,7 @@ test("BNL draft request rejects non-editable same-candidate draft statuses witho
       const payload = await response.json();
       assert.equal(payload.bnlDraft.status, "failed", status);
       assert.equal(payload.draftStored, false, status);
-      assert.equal(payload.storedDraft, undefined, status);
+      assert.equal(payload.storedDraft, null, status);
       assert.equal(fetchCalled, false, status);
       assert.equal(payload.drafts[0].status, status);
       assert.equal(payload.drafts[0].sourceFileDraftMetadata.generatedBy, "manual_placeholder");


### PR DESCRIPTION
### Motivation

- Support BNL PR #280 by letting the site validate BNL-generated proposed dossier drafts using both the original packet and the BNL response's stated source-usage/provenance, so public-safe queue/music/artist claims can be authorized when backed by approved evidence.
- Prevent unsafe or admin-only wording from leaking into public `notes` and avoid returning stale stored-draft successes when BNL output fails validation or write-target checks.

### Description

- Add response-aware evidence validation to `src/lib/bnl-dossier-draft.ts` by introducing new source-usage regex checks and `responseAllowsQueueMusicEvidence()` so queue/music/artist claims are allowed when the original packet or the BNL response references approved public-safe sources (active/public-safe broadcast memory, public-safe entity intelligence facts, public read-model context, or matching official public dossier authority), while blocking payment/priority and private/review-only provenance as support.
- Add a `PUBLIC_NOTES_REVIEW_WARNING_REGEX` to reject review-only/admin-warning language in public `notes` so those warnings remain metadata instead of becoming public prose.
- Keep the existing packet-based checks and extend the allowed source lane patterns to include common BNL lane names (e.g., `music`, `artist`, `radio`, `broadcast_memory`).
- Update `src/lib/dossier-workflow-store.ts` to never return a spurious stored-draft on validation failure by returning `storedDraft: null` when BNL validation or write-target checks fail, and keep BNL writes limited to same-candidate editable drafts via the existing `isBnlDraftOverwriteEligible` gate.
- Add and update unit tests in `tests/admin-dossiers.test.mjs` to cover: accepted music/artist claims when BNL response cites approved public-safe evidence, rejection when unsupported, rejection of payment/Stripe/checkout language as evidence, blocking review-only/admin-note text from public `notes`, preventing style-example text from authorizing subject-specific music claims, subject-matching requirements for official public-dossier authority, and ensuring failed validation/write-targets return `draftStored: false` with `storedDraft: null` and do not mutate other-candidate or non-editable drafts.

### Testing

- Ran `npx tsc --noEmit` successfully to verify type-check.
- Ran the full dossier tests with `node --test tests/admin-dossiers.test.mjs` and all tests passed (205 tests, 0 failures) after the updates.
- Ran `npm run lint`; lint failed on unrelated, pre-existing files (archived queue pages and several UI components) and these failures were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e1e95e2748321b6b3612543da38ba)