### PR TITLE
Persist BNL draft provenance and surface admin-only evidence details

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1239,6 +1239,10 @@ export default function CandidateReviewPage() {
   );
   const primaryDraft =
     linkedDrafts.find((draft) => isDraftActive(draft)) ?? linkedDrafts[0];
+  const newestBnlDraft = [...linkedDrafts]
+    .filter((draft) => draft.sourceFileDraftMetadata?.generatedBy === "BNL")
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  const newestBnlProvenance = newestBnlDraft?.sourceFileDraftMetadata?.bnlDraftProvenance;
   const sourceNotes = [...(candidate?.sourceFileNotes ?? [])].sort(
     (a, b) =>
       (a.status === "active" ? -1 : 1) - (b.status === "active" ? -1 : 1) ||
@@ -2630,6 +2634,29 @@ export default function CandidateReviewPage() {
                 from internal BNL Source File context in the dedicated Proposed
                 Dossier editor.
               </p>
+              {newestBnlDraft && (
+                <div className="mt-3 border border-border/70 bg-background/20 p-3 space-y-1">
+                  <p>BNL Draft Metadata: {newestBnlProvenance ? "Stored" : "Not stored"}</p>
+                  <p>
+                    Resolver evidence:{" "}
+                    {(newestBnlProvenance?.resolverSummary ?? []).length > 0
+                      ? "Detected"
+                      : "Not detected"}
+                  </p>
+                  <p>
+                    Validation:{" "}
+                    {(newestBnlProvenance?.validationIssues ?? newestBnlDraft.sourceFileDraftMetadata?.validationIssues ?? []).length > 0
+                      ? "Issues found"
+                      : "Passed"}
+                  </p>
+                  <Link
+                    href={`/admin/dossiers/drafts/${newestBnlDraft.id}`}
+                    className="inline-flex text-accent hover:underline"
+                  >
+                    Open BNL draft evidence details
+                  </Link>
+                </div>
+              )}
             </div>
           )}
         </Section>

--- a/src/app/admin/dossiers/drafts/[draftId]/page.tsx
+++ b/src/app/admin/dossiers/drafts/[draftId]/page.tsx
@@ -228,6 +228,105 @@ function PublicCopyGuardWarning({
   );
 }
 
+
+function ProvenanceList({
+  items,
+  empty,
+}: {
+  items?: string[];
+  empty: string;
+}) {
+  const cleanItems = (items ?? []).filter(Boolean);
+  if (cleanItems.length === 0) {
+    return <p className="text-sm text-muted">{empty}</p>;
+  }
+  return (
+    <ul className="list-disc space-y-1 pl-5 text-sm text-muted">
+      {cleanItems.map((item) => (
+        <li key={item} className="whitespace-pre-wrap">{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function BnlDraftProvenancePanel({ draft }: { draft: DossierDraft }) {
+  const provenance = draft.sourceFileDraftMetadata?.bnlDraftProvenance;
+  const validationItems = [
+    ...(provenance?.validationIssues ?? draft.sourceFileDraftMetadata?.validationIssues ?? []).map(
+      (item) => `Issue: ${item}`,
+    ),
+    ...(provenance?.validationWarnings ?? draft.sourceFileDraftMetadata?.validationWarnings ?? []).map(
+      (item) => `Warning: ${item}`,
+    ),
+  ];
+  return (
+    <section className="border border-border bg-surface p-5 space-y-4 text-sm text-muted">
+      <div>
+        <p className="text-xs uppercase tracking-[0.4em] text-muted mb-2">
+          Admin-only provenance
+        </p>
+        <h2 className="text-2xl font-bold text-foreground">
+          BNL Draft Evidence + Review Notes
+        </h2>
+        <p>
+          This section is stored admin review metadata from BNL. It is not public
+          dossier copy and is not rendered by public dossier pages.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Source Usage</h3>
+          <p className="whitespace-pre-wrap">
+            {provenance?.sourceUsageSummary || "No source usage summary was stored for this draft."}
+          </p>
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Subject Memory Resolver</h3>
+          <ProvenanceList
+            items={provenance?.resolverSummary}
+            empty="No resolver metadata stored for this draft."
+          />
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Owner Review Warnings</h3>
+          <ProvenanceList
+            items={provenance?.ownerReviewWarnings}
+            empty="No owner review warnings were reported."
+          />
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Missing Info</h3>
+          <ProvenanceList
+            items={provenance?.missingInfoQuestions}
+            empty="No missing info was reported."
+          />
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Public Safety Notes</h3>
+          <ProvenanceList
+            items={provenance?.publicSafetyWarnings}
+            empty="No public safety notes were reported."
+          />
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3">
+          <h3 className="font-bold text-foreground">Unsupported / Rejected Claims</h3>
+          <ProvenanceList
+            items={provenance?.unsupportedClaimsRejected}
+            empty="No unsupported claims were reported."
+          />
+        </section>
+        <section className="border border-border/70 bg-background/20 p-3 lg:col-span-2">
+          <h3 className="font-bold text-foreground">Validation</h3>
+          <ProvenanceList
+            items={validationItems}
+            empty="No validation issues or warnings were stored."
+          />
+        </section>
+      </div>
+    </section>
+  );
+}
+
 function ProposedDossierPreview({
   form,
 }: {
@@ -974,6 +1073,7 @@ export default function DossierDraftEditorPage() {
             form={form}
             candidate={candidate ?? undefined}
           />
+          <BnlDraftProvenancePanel draft={draft} />
           <details className="border border-border bg-surface p-5 space-y-4">
             <summary className="cursor-pointer text-xl font-bold text-foreground">
               Open Advanced Manual Edit — Manual Override

--- a/src/lib/bnl-dossier-draft.ts
+++ b/src/lib/bnl-dossier-draft.ts
@@ -165,6 +165,20 @@ export function buildBnlDossierDraftRequestPacket(input: {
   };
 }
 
+
+const RESOLVER_PROVENANCE_REGEX =
+  /\b(?:BNL subject memory resolver scanned|subject memory resolver|memory needing review|memory without public-safe provenance|public-safe subject memory resolver items|resolver scanned|resolver items)\b/i;
+
+export function extractBnlDraftResolverSummary(response: Partial<BnlDossierDraftResponse>): string[] {
+  return cleanList([
+    response.sourceUsageSummary,
+    ...(response.ownerReviewWarnings ?? []),
+    ...(response.unsupportedClaimsRejected ?? []),
+    ...(response.publicSafetyWarnings ?? []),
+    ...(response.missingInfoQuestions ?? []),
+  ]).filter((line) => RESOLVER_PROVENANCE_REGEX.test(line));
+}
+
 export type BnlDossierDraftValidationContext = {
   packet?: BnlDossierDraftRequestPacket;
   response?: BnlDossierDraftResponse;

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -9,7 +9,7 @@ import {
   validateDossierPublicDraftFields,
 } from "@/lib/dossier-public-copy-guard";
 import { createDossierDraftBlueprint } from "@/lib/dossier-classification";
-import { buildBnlDossierDraftRequestPacket, requestBnlDossierDraft, type BnlDossierDraftGeneratorResult } from "@/lib/bnl-dossier-draft";
+import { buildBnlDossierDraftRequestPacket, extractBnlDraftResolverSummary, requestBnlDossierDraft, type BnlDossierDraftGeneratorResult } from "@/lib/bnl-dossier-draft";
 import {
   scoreManualDossierCandidate,
   type CreateDossierRecommendationInput,
@@ -6118,6 +6118,19 @@ function assemblePublicSafeDraftFromSourceFile(input: {
       generatedAt: now,
       validationIssues: [],
       validationWarnings: ["Manual placeholder scaffold; BNL did not author this draft."],
+      bnlDraftProvenance: {
+        missingInfoQuestions: [],
+        ownerReviewWarnings: [],
+        publicSafetyWarnings: [],
+        unsupportedClaimsRejected: [],
+        validationIssues: [],
+        validationWarnings: ["Manual placeholder scaffold; BNL did not author this draft."],
+        generatedBy: "manual_placeholder",
+        generatedAt: now,
+        responseStatus: "not_connected",
+        draftStored: true,
+        resolverSummary: [],
+      },
       publicSafeDraft: true,
       reviewOnlyEvidence: true,
       autoConfirmedIdentityLinks: false,
@@ -6324,6 +6337,20 @@ export async function requestBnlDraftFromCandidate(
       publicPagesMutated: false,
       validationIssues: result.validation.issues,
       validationWarnings: result.validation.warnings,
+      bnlDraftProvenance: {
+        sourceUsageSummary: result.response.sourceUsageSummary,
+        missingInfoQuestions: result.response.missingInfoQuestions ?? [],
+        ownerReviewWarnings: result.response.ownerReviewWarnings ?? [],
+        publicSafetyWarnings: result.response.publicSafetyWarnings ?? [],
+        unsupportedClaimsRejected: result.response.unsupportedClaimsRejected ?? [],
+        validationIssues: result.validation.issues,
+        validationWarnings: result.validation.warnings,
+        generatedBy: "BNL",
+        generatedAt: now,
+        responseStatus: result.status,
+        draftStored: true,
+        resolverSummary: extractBnlDraftResolverSummary(result.response),
+      },
     };
     const fields = normalizeDraftFields({ ...result.response, primaryLink: result.response.primaryLink ?? undefined, files: [] });
     if (currentDraft) {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -384,6 +384,20 @@ export type DossierDraft = {
     generatedAt?: string;
     validationIssues?: string[];
     validationWarnings?: string[];
+    bnlDraftProvenance?: {
+      sourceUsageSummary?: string;
+      missingInfoQuestions: string[];
+      ownerReviewWarnings: string[];
+      publicSafetyWarnings: string[];
+      unsupportedClaimsRejected: string[];
+      validationIssues: string[];
+      validationWarnings: string[];
+      generatedBy: "BNL" | "manual_placeholder";
+      generatedAt?: string;
+      responseStatus?: "received" | "failed" | "not_connected";
+      draftStored?: boolean;
+      resolverSummary?: string[];
+    };
     publicSafeDraft: true;
     reviewOnlyEvidence: true;
     autoConfirmedIdentityLinks: false;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -4206,6 +4206,75 @@ test("invalid BNL draft response reports validation issues without a stored-draf
   }
 });
 
+test("BNL draft provenance metadata is persisted for admin review only", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";
+  process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN = "test-draft-token";
+  const originalFetch = global.fetch;
+  try {
+    const created = await (
+      await authedPost({ action: "createManualCandidate", input: { ...manualCandidateInput, name: "Crow" } })
+    ).json();
+    const resolverLine = "BNL subject memory resolver scanned 14 candidate memories for Crow.";
+    global.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          draft: cleanContractDraft({
+            name: "Crow",
+            sourceUsageSummary: `Used public-safe source ingredients only. ${resolverLine}`,
+            missingInfoQuestions: ["Confirm Crow's preferred public role line."],
+            ownerReviewWarnings: [
+              "Owner Review remains required.",
+              "BNL memory needing review was used only for owner-review metadata, not public copy.",
+            ],
+            publicSafetyWarnings: ["Keep source-blind memories out of public prose."],
+            unsupportedClaimsRejected: [
+              "Rejected claim: Crow founded a secret venue because it lacked public-safe provenance.",
+              "Used 2 public-safe subject memory resolver items.",
+            ],
+          }),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    const response = await authedPost({
+      action: "requestBnlDraftFromCandidate",
+      candidateId: created.candidate.id,
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.draftStored, true);
+    const provenance = payload.storedDraft.sourceFileDraftMetadata.bnlDraftProvenance;
+    assert.equal(provenance.generatedBy, "BNL");
+    assert.equal(provenance.responseStatus, "received");
+    assert.equal(provenance.draftStored, true);
+    assert.match(provenance.sourceUsageSummary, /Used public-safe source ingredients only/);
+    assert.deepEqual(provenance.missingInfoQuestions, ["Confirm Crow's preferred public role line."]);
+    assert.ok(provenance.ownerReviewWarnings.some((item) => /Owner Review remains required/.test(item)));
+    assert.deepEqual(provenance.publicSafetyWarnings, ["Keep source-blind memories out of public prose."]);
+    assert.ok(provenance.unsupportedClaimsRejected.some((item) => /Rejected claim/.test(item)));
+    assert.ok(provenance.resolverSummary.some((item) => item.includes("BNL subject memory resolver scanned")));
+    assert.ok(provenance.resolverSummary.some((item) => item.includes("memory needing review")));
+    assert.ok(provenance.resolverSummary.some((item) => item.includes("public-safe subject memory resolver items")));
+    assert.deepEqual(provenance.validationIssues, []);
+    assert.deepEqual(provenance.validationWarnings, []);
+
+    const publicFieldsJson = JSON.stringify(payload.storedDraft.fields);
+    assert.doesNotMatch(publicFieldsJson, /BNL subject memory resolver scanned|Owner Review remains required|Rejected claim|source-blind memories/);
+
+    const adminPayload = await (await authedGet()).json();
+    const storedAdminDraft = adminPayload.drafts.find((draft) => draft.id === payload.storedDraft.id);
+    assert.match(storedAdminDraft.sourceFileDraftMetadata.bnlDraftProvenance.sourceUsageSummary, /Used public-safe source ingredients only/);
+
+    const publicReadModelPayload = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+    assert.doesNotMatch(JSON.stringify(publicReadModelPayload), /BNL subject memory resolver scanned|Rejected claim|source-blind memories|bnlDraftProvenance/);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL;
+    delete process.env.BNL_DOSSIER_DRAFT_GENERATOR_TOKEN;
+  }
+});
+
 test("valid BNL draft response reports a stored BNL-authored draft", async () => {
   await resetWorkflowStore();
   process.env.BNL_DOSSIER_DRAFT_GENERATOR_URL = "https://bnl.example.test/internal/dossiers/draft";


### PR DESCRIPTION
### Motivation
- Preserve rich BNL response metadata (source usage, missing-info prompts, owner-review warnings, safety notes, rejected claims, validation context, and resolver provenance) so admins can inspect what BNL used, rejected, or flagged after the transient BNL response is gone.
- Capture whether the new subject-memory resolver contributed to a draft so admins can audit resolver scans and review-needed memory handling without moving responsibility to the bot.
- Keep public-safety boundaries by storing this data as admin-only provenance separate from public draft fields.

### Description
- Add an optional `bnlDraftProvenance` object to `DossierDraft.sourceFileDraftMetadata` that stores `sourceUsageSummary`, `missingInfoQuestions`, `ownerReviewWarnings`, `publicSafetyWarnings`, `unsupportedClaimsRejected`, `validationIssues`, `validationWarnings`, `generatedBy`, `generatedAt`, `responseStatus`, `draftStored`, and `resolverSummary` (no raw private memory or tokens are persisted). (files changed: `src/lib/dossier-workflow.ts`)
- Implement `extractBnlDraftResolverSummary` with a resolver-provenance regex and use it to extract resolver-related lines from BNL response arrays/summary so resolver evidence is persisted. (files changed: `src/lib/bnl-dossier-draft.ts`)
- Persist `bnlDraftProvenance` for both manual placeholder scaffolds and successful BNL responses in the store, preserving existing validation behavior and writing provenance only to admin metadata while normalizing `fields` for public draft copy. (files changed: `src/lib/dossier-workflow-store.ts`)
- Add an admin-only UI panel `BNL Draft Evidence + Review Notes` on the draft editor that displays stored provenance subsections and empty states, and add a compact provenance summary for the newest BNL draft on the Source File page with a link to the draft details. (files changed: `src/app/admin/dossiers/drafts/[draftId]/page.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Add/extend tests to assert provenance is persisted for admin endpoints, resolver lines are extracted into `resolverSummary`, public `fields` remain free of admin/reviewer text, and public read-models do not expose `bnlDraftProvenance`. (files changed: `tests/admin-dossiers.test.mjs`)

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran the full dossier test file with `node --test tests/admin-dossiers.test.mjs` and all tests passed (206 tests; `pass 206`, `fail 0`).
- Ran `npm run lint` which surfaced pre-existing unrelated lint errors in archived and other files (errors/warnings remain outside the scope of this PR); new changes did not introduce additional lint failures beyond existing warnings in admin candidate UI files.

Files changed and why: `src/lib/dossier-workflow.ts` (data model: added `bnlDraftProvenance`), `src/lib/bnl-dossier-draft.ts` (resolver extraction helper and regex), `src/lib/dossier-workflow-store.ts` (persist provenance on BNL/manual drafts), `src/app/admin/dossiers/drafts/[draftId]/page.tsx` (admin-only provenance UI panel), `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` (compact provenance summary and link), and `tests/admin-dossiers.test.mjs` (tests asserting provenance persistence, resolver extraction, and public boundary enforcement).

Commit: `55ffb4bc6745a23acadd5610f2066314a3addff5`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e31ed1b688321b4633d0d5c972a10)