### PR TITLE
Show BNL analyst reads in Source Files

### DIFF
--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -7,6 +7,7 @@ import type {
   DossierSourceFileArchiveMetadata,
   DossierSourceFileCaseReportV1,
   DossierSourceFileNote,
+  DossierSubjectAnalystReadV1,
 } from "@/lib/dossier-workflow";
 import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
 import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
@@ -145,6 +146,48 @@ function normalizeCaseReport(
   return undefined;
 }
 
+function hasAnalystReadShape(value: unknown): value is DossierSubjectAnalystReadV1 {
+  const read = asRecord(value);
+  if (!read) return false;
+  return [
+    "subjectName",
+    "internalRead",
+    "likelySubjectType",
+    "confidence",
+    "publicDraftPosture",
+    "strongestSignals",
+    "publicReadyClaims",
+    "sourceFileReviewClaims",
+    "reviewNeededClaims",
+    "sourceBlindInsights",
+    "privateOrInternalExclusions",
+    "doNotSayPublicly",
+    "missingInfoQuestions",
+    "recommendedAdminActions",
+    "draftIngredients",
+    "sourceFileIngredients",
+    "provenanceSummary",
+  ].some((key) => read[key] !== undefined);
+}
+
+export function normalizeSubjectAnalystReadV1(
+  latestSourceFileArchive?: DossierSourceFileArchiveMetadata,
+): DossierSubjectAnalystReadV1 | undefined {
+  for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
+    const brief = asRecord(candidate.sourceFileBriefV2);
+    const report = asRecord(candidate.sourceFileCaseReportV1);
+    const nestedReport = asRecord(brief?.sourceFileCaseReportV1);
+    const match = [
+      candidate.subjectAnalystReadV1,
+      report?.subjectAnalystReadV1,
+      nestedReport?.subjectAnalystReadV1,
+      brief?.subjectAnalystReadV1,
+    ].find(hasAnalystReadShape);
+    if (match) return match;
+  }
+  return undefined;
+}
+
 function normalizeInterimBrief(latestSourceFileArchive?: DossierSourceFileArchiveMetadata) {
   for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
     const brief = asRecord(candidate.sourceFileBriefV2);
@@ -273,7 +316,7 @@ function SubjectIntelligenceBriefView({
   const snapshot: Array<[string, unknown]> = [
     ["Approved authored items", valueByKeys(activity, ["totalApprovedPublicAuthoredItems", "approvedPublicAuthoredItems", "totalApprovedAuthoredItems"])],
     ["Public mentions", valueByKeys(activity, ["totalPublicMentions", "publicMentions"])],
-    ["Review-only evidence", valueByKeys(activity, ["reviewOnlyEvidenceCount", "reviewOnlyCount"])],
+    ["Admin-review evidence", valueByKeys(activity, ["reviewOnlyEvidenceCount", "reviewOnlyCount"])],
     ["Evidence scanned", valueByKeys(activity, ["totalEvidenceScanned", "evidenceScanned", "totalScanned"])],
     ["Latest observed", valueByKeys(activity, ["latestObserved", "latestObservedAt", "latestActivityAt"])],
     ["Activity level", valueByKeys(activity, ["activityLevel", "level"])],
@@ -290,7 +333,7 @@ function SubjectIntelligenceBriefView({
   const adminActions = listValues(brief.recommendedAdminActions);
 
   return (
-    <Section title="BNL Subject Intelligence Brief" tone="review" helper="Primary review-only BNL readout. Use this as admin context, not public copy.">
+    <Section title="BNL Subject Intelligence Brief" tone="review" helper="Primary Admin-review BNL readout. Use this as admin context, not public copy.">
       <div className="space-y-4">
         <section className="border border-accent/60 bg-background/30 p-4">
           <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Subject Read</h4>
@@ -355,7 +398,7 @@ function SubjectIntelligenceBriefView({
         </section>
 
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">Music / Link Signals</h4><SignalList value={brief.musicAndLinkSignals} /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Relationship / Context Signals</h4><p className="mb-3 text-xs text-muted">Review-only unless separately confirmed.</p><SignalList value={brief.relationshipSignals} /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Relationship / Context Signals</h4><p className="mb-3 text-xs text-muted">Admin-review unless separately confirmed.</p><SignalList value={brief.relationshipSignals} /></section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">Queue / Submission Read</h4><BriefParagraphs value={brief.queueSubmissionRead} /></section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">What To Add To This Source File</h4><div className="grid grid-cols-1 gap-3 lg:grid-cols-2"><div><h5 className="mb-2 text-xs uppercase tracking-widest text-accent">Source file gaps</h5><SignalList value={sourceFileGaps} empty="No source file gaps recorded." /></div><div><h5 className="mb-2 text-xs uppercase tracking-widest text-accent">Recommended admin actions</h5><SignalList value={adminActions} empty="No recommended admin actions recorded." /></div></div></section>
         <section className="border border-accent/60 bg-accent/10 p-3"><h4 className="mb-3 text-xs font-bold uppercase tracking-widest text-foreground">Do Not Say Publicly Yet</h4><SignalList value={brief.doNotSayPubliclyYet} empty="No do-not-say items recorded." /></section>
@@ -423,6 +466,61 @@ function ReportSectionView({ title, value }: { title: string; value: unknown }) 
   );
 }
 
+
+function AnalystList({ value, empty }: { value: unknown; empty: string }) {
+  const items = stringItems(value);
+  if (!items.length) return <p className="text-muted">{empty}</p>;
+  return (
+    <ul className="list-disc space-y-2 pl-5 text-foreground">
+      {items.map((item, index) => <li key={`${index}-${item.slice(0, 24)}`}>{item}</li>)}
+    </ul>
+  );
+}
+
+function BnlAnalystReadPanel({
+  analystRead,
+  refreshedAt,
+}: {
+  analystRead?: DossierSubjectAnalystReadV1;
+  refreshedAt?: string;
+}) {
+  if (!analystRead) {
+    return (
+      <Section title="BNL Analyst Read" tone="review" helper="Internal Source File intelligence. Not public dossier copy.">
+        <p className="text-foreground">No BNL analyst read stored yet. Refresh this Source File after bot PR #284 is deployed.</p>
+      </Section>
+    );
+  }
+  const reviewClaims = stringItems(analystRead.reviewNeededClaims).length
+    ? analystRead.reviewNeededClaims
+    : analystRead.sourceFileReviewClaims;
+  const withheldContext = [
+    ...stringItems(analystRead.sourceBlindInsights).map((item) => `Source-blind: ${item}`),
+    ...stringItems(analystRead.privateOrInternalExclusions).map((item) => `Private/internal withheld: ${item}`),
+    ...stringItems(analystRead.doNotSayPublicly).map((item) => `Do not say publicly: ${item}`),
+  ];
+  return (
+    <Section title="BNL Analyst Read" tone="review" helper="Internal Source File intelligence. Not public dossier copy.">
+      <div className="space-y-4">
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <SnapshotItem label="Subject type" value={scalarLabel(analystRead.likelySubjectType)} />
+          <SnapshotItem label="Confidence" value={scalarLabel(analystRead.confidence)} />
+          <SnapshotItem label="Public draft posture" value={scalarLabel(analystRead.publicDraftPosture)} />
+          <SnapshotItem label="Last refreshed" value={formatSnapshotDate(refreshedAt)} />
+        </dl>
+        <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Internal Read</h4><BriefParagraphs value={analystRead.internalRead} /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Public-Ready Claims</h4><AnalystList value={analystRead.publicReadyClaims} empty="No public-ready claims yet." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Review-Needed Claims</h4><AnalystList value={reviewClaims} empty="No review-needed claims reported." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Source-Blind / Withheld Context</h4><AnalystList value={withheldContext} empty="No source-blind insights reported." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Missing Confirmations</h4><AnalystList value={analystRead.missingInfoQuestions} empty="No missing confirmations reported." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended Admin Actions</h4><AnalystList value={analystRead.recommendedAdminActions} empty="No recommended admin actions reported." /></section>
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Provenance Summary</h4><AnalystList value={analystRead.provenanceSummary} empty="No provenance summary reported." /></section>
+      </div>
+    </Section>
+  );
+}
+
 function CaseReportView({ report }: { report?: DossierSourceFileCaseReportV1 }) {
   if (asRecord(report?.subjectIntelligenceBriefV1)) {
     return <SubjectIntelligenceBriefView report={report as DossierSourceFileCaseReportV1} />;
@@ -448,7 +546,7 @@ function CaseReportView({ report }: { report?: DossierSourceFileCaseReportV1 }) 
   const sections: ReportSection[] = [
     { title: "Case Summary", value: report.caseSummary },
     { title: "Dossier Use", value: report.dossierUse },
-    { title: "Public-Safe Claims", value: report.publicSafeClaims },
+    { title: "Public-ready Claims", value: report.publicSafeClaims },
     { title: "Evidence Summary", value: report.evidenceSummary },
     { title: "Community Context", value: report.communityContext },
     { title: "Creative / Music Context", value: report.creativeMusicContext, optional: true },
@@ -513,7 +611,7 @@ export function DossierSourceFileArchiveRawData({ latestSourceFileArchive }: { l
   const oldReportSections: ReportSection[] = report ? [
     { title: "Case Summary", value: report.caseSummary },
     { title: "Dossier Use", value: report.dossierUse },
-    { title: "Public-Safe Claims", value: report.publicSafeClaims },
+    { title: "Public-ready Claims", value: report.publicSafeClaims },
     { title: "Evidence Summary", value: report.evidenceSummary },
     { title: "Community Context", value: report.communityContext },
     { title: "Creative / Music Context", value: report.creativeMusicContext, optional: true },
@@ -540,7 +638,7 @@ export function DossierSourceFileArchiveRawData({ latestSourceFileArchive }: { l
         <SnapshotItem label="Size" value={`${latestSourceFileArchive.archiveSize} bytes`} />
         <SnapshotItem label="Chunks" value={String(latestSourceFileArchive.chunkCount)} />
         <SnapshotItem label="Updated" value={formatSnapshotDate(latestSourceFileArchive.updatedAt)} />
-        <SnapshotItem label="Review-only" value={latestSourceFileArchive.reviewOnly ? "Yes" : "No"} />
+        <SnapshotItem label="Admin-review" value={latestSourceFileArchive.reviewOnly ? "Yes" : "No"} />
       </dl>
       {oldReportSections.length > 0 && (
         <section className="mt-3 border border-border/50 bg-background/30 p-2">
@@ -607,7 +705,7 @@ function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint 
           <SnapshotItem label="Confidence" value={blueprint.classification.confidence} />
           <SnapshotItem label="Future prefix" value={`${blueprint.classification.recommendedDesignationPrefix}-###`} />
           <SnapshotItem label="Readiness" value={`${blueprint.readiness.label} (${blueprint.readiness.score}/100)`} />
-          <SnapshotItem label="Evidence counts" value={`${blueprint.evidenceCounts.publicSafeFacts} public-safe / ${blueprint.evidenceCounts.reviewOnlyItems} review-only`} />
+          <SnapshotItem label="Evidence counts" value={`${blueprint.evidenceCounts.publicSafeFacts} Public-ready / ${blueprint.evidenceCounts.reviewOnlyItems} Admin-review`} />
         </dl>
         <section className="border border-border/50 bg-background/30 p-3">
           <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended next action</h4>
@@ -760,7 +858,7 @@ export function DossierSourceFileSummaryPanel({
           </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest">
-          <StatusBadge>Review-only</StatusBadge>
+          <StatusBadge>Admin-review</StatusBadge>
           <StatusBadge>Display-only</StatusBadge>
           <StatusBadge>
             Source: {entityReadout?.readoutSource === "structured" ? "Structured packet" : "Safe fallback"}
@@ -778,6 +876,8 @@ export function DossierSourceFileSummaryPanel({
           Summary badge: {formatDossierSummaryBadge(summary.summarySource)}.
         </p>
       </Section>
+
+      <BnlAnalystReadPanel analystRead={normalizeSubjectAnalystReadV1(latestSourceFileArchive)} refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt} />
 
       {blueprint && <DossierBlueprintView blueprint={blueprint} />}
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -31,6 +31,7 @@ import {
   type DossierSourceFileArchiveAttachStatus,
   type DossierSourceFileArchiveMetadata,
   type DossierSourceFileCaseReportV1,
+  type DossierSubjectAnalystReadV1,
   type DossierSourceFileEnrichmentArchive,
   type DossierRecommendationSourceLane,
   type DossierRecommendationStatus,
@@ -515,6 +516,47 @@ export function sourceArchivePayloadCandidates(input: unknown): SourceArchivePay
   return candidates;
 }
 
+function isSubjectAnalystReadShape(value: unknown) {
+  const read = sourceArchiveObject(value);
+  if (!read) return false;
+  return [
+    "subjectName",
+    "internalRead",
+    "likelySubjectType",
+    "confidence",
+    "publicDraftPosture",
+    "strongestSignals",
+    "publicReadyClaims",
+    "sourceFileReviewClaims",
+    "reviewNeededClaims",
+    "sourceBlindInsights",
+    "privateOrInternalExclusions",
+    "doNotSayPublicly",
+    "missingInfoQuestions",
+    "recommendedAdminActions",
+    "draftIngredients",
+    "sourceFileIngredients",
+    "provenanceSummary",
+  ].some((key) => read[key] !== undefined);
+}
+
+function findSubjectAnalystReadV1(input: unknown) {
+  for (const candidate of sourceArchivePayloadCandidates(input)) {
+    const brief = sourceArchiveObject(candidate.value.sourceFileBriefV2);
+    const report = sourceArchiveObject(candidate.value.sourceFileCaseReportV1);
+    const nestedReport = sourceArchiveObject(brief?.sourceFileCaseReportV1);
+    const checks: Array<{ value: unknown; path: string }> = [
+      { value: candidate.value.subjectAnalystReadV1, path: `${candidate.path}.subjectAnalystReadV1` },
+      { value: report?.subjectAnalystReadV1, path: `${candidate.path}.sourceFileCaseReportV1.subjectAnalystReadV1` },
+      { value: nestedReport?.subjectAnalystReadV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1.subjectAnalystReadV1` },
+      { value: brief?.subjectAnalystReadV1, path: `${candidate.path}.sourceFileBriefV2.subjectAnalystReadV1` },
+    ];
+    const match = checks.find((check) => isSubjectAnalystReadShape(check.value));
+    if (match) return { read: match.value as DossierSubjectAnalystReadV1, path: match.path };
+  }
+  return { read: undefined, path: undefined };
+}
+
 function isSourceFileCaseReportShape(value: unknown) {
   const report = sourceArchiveObject(value);
   if (!report) return false;
@@ -611,12 +653,14 @@ function normalizeSourceFileArchiveInput(
       subjectMemoryPacketPresent: boolean;
       caseReportExtractedFrom?: string;
       sourceFileBriefExtractedFrom?: string;
+      subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
     })
   | null {
   const subjectName = compactArchiveText(input.subjectName, 200);
   if (!subjectName) return null;
   const caseReport = findSourceFileCaseReportV1(input);
   const sourceFileBrief = findSourceFileBriefV2(input);
+  const analystRead = findSubjectAnalystReadV1(input);
   return {
     ...input,
     candidateId: compactArchiveText(input.candidateId, 200),
@@ -636,6 +680,7 @@ function normalizeSourceFileArchiveInput(
     ),
     sourceFileCaseReportV1: caseReport.report,
     sourceFileBriefV2: sourceFileBrief.brief,
+    subjectAnalystReadV1: analystRead.read,
     caseReportPresent: Boolean(caseReport.report),
     subjectMemoryPacketPresent: sourceArchiveHasSubjectMemoryPacket(input),
     caseReportExtractedFrom: caseReport.path,
@@ -2643,6 +2688,7 @@ export async function ingestDossierSourceFileArchive(
       evidenceReceiptSummary: normalized.evidenceReceiptSummary,
       sourceFileCaseReportV1: normalized.sourceFileCaseReportV1,
       sourceFileBriefV2: normalized.sourceFileBriefV2,
+      subjectAnalystReadV1: normalized.subjectAnalystReadV1,
       caseReportPresent: normalized.caseReportPresent,
       subjectMemoryPacketPresent: normalized.subjectMemoryPacketPresent,
       caseReportExtractedFrom: normalized.caseReportExtractedFrom,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -162,6 +162,26 @@ export type DossierSubjectIntelligenceBriefV1 = {
   doNotSayPubliclyYet?: unknown;
 };
 
+export type DossierSubjectAnalystReadV1 = {
+  subjectName?: string;
+  internalRead?: string;
+  likelySubjectType?: string;
+  confidence?: "high" | "medium" | "low" | string;
+  publicDraftPosture?: string;
+  strongestSignals?: string[];
+  publicReadyClaims?: string[];
+  sourceFileReviewClaims?: string[];
+  reviewNeededClaims?: string[];
+  sourceBlindInsights?: string[];
+  privateOrInternalExclusions?: string[];
+  doNotSayPublicly?: string[];
+  missingInfoQuestions?: string[];
+  recommendedAdminActions?: string[];
+  draftIngredients?: string[];
+  sourceFileIngredients?: string[];
+  provenanceSummary?: string[];
+};
+
 export type DossierSourceFileCaseReportV1 = {
   version?: string;
   generatedAt?: string;
@@ -183,6 +203,7 @@ export type DossierSourceFileCaseReportV1 = {
   confidenceNotes?: string | string[];
   memoryCoverage?: string | string[];
   subjectIntelligenceBriefV1?: DossierSubjectIntelligenceBriefV1;
+  subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
 };
 
 export type DossierSourceFileBriefV2 = {
@@ -190,6 +211,7 @@ export type DossierSourceFileBriefV2 = {
   adminSummary?: string;
   recommendedNextAction?: string;
   sourceFileCaseReportV1?: DossierSourceFileCaseReportV1;
+  subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   caseFileReport?: unknown;
 };
 
@@ -202,6 +224,7 @@ export type DossierSourceFileArchiveCompactReadout = {
   evidenceReceiptSummary?: string[];
   sourceFileCaseReportV1?: DossierSourceFileCaseReportV1;
   sourceFileBriefV2?: DossierSourceFileBriefV2;
+  subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   archivePayload?: unknown;
   archive?: unknown;
   payload?: unknown;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -8548,7 +8548,7 @@ test("Source File page renders Entity Intelligence Review Console sections", () 
   assertIncludesCopy(summaryPanel, "BNL Case File Report");
   assertIncludesCopy(summaryPanel, "Recommended Next Steps");
   assertIncludesCopy(summaryPanel, "Queue / Submission Context");
-  assertIncludesCopy(summaryPanel, "Review-only");
+  assertIncludesCopy(summaryPanel, "Admin-review");
   assertIncludesCopy(summaryPanel, "Structured packet");
   assertIncludesCopy(summaryPanel, "Safe fallback");
   assertIncludesCopy(summaryPanel, "Evidence Summary");
@@ -8626,6 +8626,110 @@ function sourceFileReportTestSummary() {
 }
 
 
+
+
+
+test("Source File page extracts and renders subjectAnalystReadV1 from archive root", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-analyst-root",
+    candidateId: "candidate-analyst-root",
+    subjectName: "Analyst Root",
+    sourceDigest: "abcdef1234567890",
+    createdAt: "2026-06-14T00:00:00.000Z",
+    updatedAt: "2026-06-14T01:00:00.000Z",
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    subjectAnalystReadV1: {
+      internalRead: "BNL internal read says this source file has recurring creative signals.",
+      likelySubjectType: "artist",
+      confidence: "high",
+      publicDraftPosture: "draft ingredients available after review",
+      strongestSignals: ["Repeated public music references."],
+      publicReadyClaims: ["Public-ready claim from root."],
+      reviewNeededClaims: ["Admin-review claim from root."],
+      sourceBlindInsights: ["Pattern exists but needs provenance."],
+      privateOrInternalExclusions: ["Withhold internal relationship context."],
+      missingInfoQuestions: ["Confirm primary public link."],
+      recommendedAdminActions: ["Verify owner-safe wording."],
+      provenanceSummary: ["Generated from Source File archive root."],
+    },
+  };
+  assert.deepEqual(sourceSummaryPanelComponent.normalizeSubjectAnalystReadV1(archive).publicReadyClaims, ["Public-ready claim from root."]);
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /BNL Analyst Read/);
+  assert.match(text, /Internal Source File intelligence\. Not public dossier copy\./);
+  assert.match(text, /artist/);
+  assert.match(text, /high/);
+  assert.match(text, /draft ingredients available after review/);
+  assert.match(text, /BNL internal read says this source file has recurring creative signals/);
+  assert.match(text, /Repeated public music references/);
+  assert.match(text, /Public-ready claim from root/);
+  assert.match(text, /Admin-review claim from root/);
+  assert.match(text, /Confirm primary public link/);
+  assert.match(text, /Verify owner-safe wording/);
+  assert.match(text, /Generated from Source File archive root/);
+  assert.match(text, /Public-ready/);
+  assert.match(text, /Admin-review/);
+  assert.match(text, /Needs confirmation|Missing Confirmations/);
+  assert.match(text, /Source-blind/);
+  assert.match(text, /Private\/internal withheld/);
+});
+
+test("Source File page extracts subjectAnalystReadV1 from sourceFileCaseReportV1 and handles old archives", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-analyst-report",
+    candidateId: "candidate-analyst-report",
+    subjectName: "Analyst Report",
+    sourceDigest: "1234567890abcdef",
+    createdAt: "2026-06-14T00:00:00.000Z",
+    updatedAt: "2026-06-14T02:00:00.000Z",
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileCaseReportV1: {
+      caseSummary: "Case report exists.",
+      subjectAnalystReadV1: {
+        internalRead: "Nested report analyst read.",
+        likelySubjectType: "community node",
+        confidence: "medium",
+        publicDraftPosture: "hold for confirmation",
+        strongestSignals: ["Nested signal."],
+        publicReadyClaims: ["Nested public-ready claim."],
+        sourceFileReviewClaims: ["Nested review-needed claim."],
+        missingInfoQuestions: ["Nested missing confirmation."],
+        recommendedAdminActions: ["Nested admin action."],
+      },
+    },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /Nested report analyst read/);
+  assert.match(text, /community node/);
+  assert.match(text, /medium/);
+  assert.match(text, /hold for confirmation/);
+  assert.match(text, /Nested signal/);
+  assert.match(text, /Nested public-ready claim/);
+  assert.match(text, /Nested review-needed claim/);
+  assert.match(text, /Nested missing confirmation/);
+  assert.match(text, /Nested admin action/);
+
+  const oldText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: { ...archive, sourceFileCaseReportV1: { caseSummary: "Old report only." } } }));
+  assert.match(oldText, /No BNL analyst read stored yet\. Refresh this Source File after bot PR #284 is deployed\./);
+});
+
+
+
+test("public dossier/read-model routes do not expose subjectAnalystReadV1", () => {
+  for (const routePath of [
+    "src/app/api/bnl/read-model/route.ts",
+    "src/components/DossierPageView.tsx",
+    "src/lib/dossier-page-view-model.ts",
+  ]) {
+    assert.doesNotMatch(normalizedSource(routePath), /subjectAnalystReadV1/);
+  }
+});
 
 test("Source File page renders subjectIntelligenceBriefV1 as the primary report with one collapsed debug fallback", () => {
   const summary = sourceFileReportTestSummary();
@@ -8765,7 +8869,7 @@ test("Source File page renders only BNL-authored Case File Reports and keeps raw
   assert.match(visibleText, /BNL Case File Report/);
   assert.match(visibleText, /BNL-authored case summary sentence/);
   assert.match(visibleText, /Dossier Use/);
-  assert.match(visibleText, /Public-Safe Claims/);
+  assert.match(visibleText, /Public-ready Claims/);
   assert.match(visibleText, /Confidence \/ Memory Coverage/);
   assert.doesNotMatch(visibleText, /COMPACT_SUMMARY_SHOULD_STAY_ARCHIVED|RAW_MISSING_INFO_SHOULD_STAY_ARCHIVED|RAW_EVIDENCE_CATEGORY_FRAGMENT_SHOULD_STAY_ARCHIVED/);
   assert.doesNotMatch(visibleText, /Missing Info|What BNL Knows|Evidence by Category|Latest BNL Source Archive Readout/);
@@ -8892,7 +8996,7 @@ test("Entity Intelligence Review Console collapses duplicate safe bullets and ke
   assert.match(text, /BNL Source File Display Layer/);
   assert.match(text, /BNL Case File Report/);
   assert.match(text, /has not generated a dossier-ready Case File Report/);
-  assert.match(text, /Review-only/);
+  assert.match(text, /Admin-review/);
   assert.doesNotMatch(text, /BNL found an internal local profile match for Crow/);
   assert.doesNotMatch(text, /BNL found prior relationship\/context notes connected to Crow/);
   assert.doesNotMatch(


### PR DESCRIPTION
### Motivation

- Surface the new `subjectAnalystReadV1` intelligence produced by BNL so admins can see a concise, operational case-file readout instead of a raw archive dump.
- Keep all analyst read material admin-only and tolerant of older archives that lack the new field so the UI does not crash on legacy data.
- Improve display language for evidence lanes to clearer operational labels (`Public-ready`, `Admin-review`, `Needs confirmation`, `Source-blind`, `Private/internal withheld`) without changing underlying workflow or public pages.

### Description

- Add a tolerant `DossierSubjectAnalystReadV1` type and preserve `subjectAnalystReadV1` on archive metadata so the site can store and surface analyst reads from multiple archive shapes; changed `src/lib/dossier-workflow.ts`.
- Extract analyst reads from archive root and wrapped locations (`subjectAnalystReadV1` at archive root, `sourceFileCaseReportV1.subjectAnalystReadV1`, `sourceFileBriefV2.sourceFileCaseReportV1.subjectAnalystReadV1`, and `sourceFileBriefV2.subjectAnalystReadV1`) and persist on ingest; changed `src/lib/dossier-workflow-store.ts`.
- Add an admin-only `BNL Analyst Read` panel to the top of the Source File display with snapshot chips (subject type, confidence, posture, last refreshed) and sections for Internal Read, Strongest Signals, Public-Ready Claims, Review-Needed Claims, Source-Blind/Withheld Context, Missing Confirmations, Recommended Admin Actions, and Provenance Summary; changed `src/components/DossierSourceFileSummaryPanel.tsx` and added `normalizeSubjectAnalystReadV1` + UI components.
- Update labels and small UX items and add tests that exercise extraction, rendering, old-archive empty states, and public boundary protections; changed `tests/admin-dossiers.test.mjs` (added tests and adjusted label expectations).

Files changed and why:
- `src/lib/dossier-workflow.ts` — add `DossierSubjectAnalystReadV1` type and wire into case-report/brief/archive shapes.
- `src/lib/dossier-workflow-store.ts` — detect and extract `subjectAnalystReadV1` from multiple archive payload shapes and persist on archive metadata during ingest.
- `src/components/DossierSourceFileSummaryPanel.tsx` — add `normalizeSubjectAnalystReadV1`, new `BNL Analyst Read` panel, small lane label updates, and placement before raw/archive diagnostics.
- `tests/admin-dossiers.test.mjs` — add tests for extraction from archive root and nested case report, old-archive empty state, and ensure public read-model files do not expose `subjectAnalystReadV1`.

### Testing

- Type-check: ran `npx tsc --noEmit`, which completed successfully.
- Unit suite: ran `node --test tests/admin-dossiers.test.mjs`, which completed and all tests passed after making the label expectation adjustments (final run: 209 tests passing).
- Lint: ran `npm run lint`, which surfaced existing unrelated lint errors in archived/legacy files (these are existing issues and not caused by this change); lint returned errors separate from this PR.
- Latest repository state: commit `c7f7e5d672e3ccba49b4dbafc462142d9aac1352` contains these changes.

If desired next steps: add small visual polish to the `BNL Analyst Read` panel (icons, action placeholders for future promotion controls) and gate any future promotion buttons behind existing owner/admin flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3fa93eec8321b98056ad17286939)