### PR TITLE
Add Source File claim review controls

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -21,6 +21,7 @@ import {
 import {
   DossierSourceFileArchiveRawData,
   DossierSourceFileSummaryPanel,
+  type DossierSourceFileReviewableClaim,
 } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
 import {
@@ -1550,6 +1551,32 @@ export default function CandidateReviewPage() {
     }
   }
 
+  async function reviewSourceFileClaim(
+    claim: DossierSourceFileReviewableClaim,
+    decision: "pending" | "confirmed_public" | "confirmed_internal" | "rejected" | "needs_more_info" | "edited",
+    options: { publicSafe?: boolean; editedText?: string; decisionNote?: string } = {},
+  ) {
+    if (!candidate) return;
+    const publicSafe = options.publicSafe === true || decision === "edited";
+    await postWorkflow({
+      action: decision === "edited" ? "editSourceFileClaim" : "reviewSourceFileClaim",
+      candidateId,
+      input: {
+        claimId: claim.id,
+        claimText: claim.claimText,
+        claimType: claim.claimType,
+        sourceSection: claim.sourceSection,
+        decision: decision === "edited" ? "edited" : decision,
+        editedText: options.editedText,
+        decisionNote: options.decisionNote,
+        publicSafe,
+        sourceArchiveId: candidate.latestSourceFileArchive?.id,
+        sourceProvenance: candidate.latestSourceFileArchive?.subjectAnalystReadV1?.provenanceSummary,
+      },
+    });
+    setNotice("Claim decision saved. Refresh BNL Source File to let BNL update the analyst read.");
+  }
+
   async function createDraft() {
     if (!canCreateDraft) return;
     try {
@@ -2601,6 +2628,9 @@ export default function CandidateReviewPage() {
               currentLane={candidate.status}
               latestRecommendationTimestamp={latestRecommendationTimestamp}
               latestSourceFileArchive={candidate.latestSourceFileArchive}
+              candidateId={candidate.id}
+              claimReviews={candidate.sourceFileClaimReviews ?? []}
+              onReviewClaim={reviewSourceFileClaim}
               sourceFileTargetStatus={
                 isExistingDossierUpdate
                   ? "existing dossier update"

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -18,6 +18,7 @@ import {
   type DossierIdentityLinkVisibility,
   type CreateDossierRecommendationInput,
   type CreateDossierSourceFileNoteInput,
+  type ReviewDossierSourceFileClaimInput,
   type UpdateDossierSourceFileSummaryInput,
   type DossierCandidateStatus,
   type DossierDraft,
@@ -32,6 +33,7 @@ import {
   applyPopulationReviewRecommendationAction,
   reconcilePopulationSignals,
   addDossierSourceFileNote,
+  reviewDossierSourceFileClaim,
   updateDossierSourceFileSummary,
   archiveDossierCandidate,
   archiveDossierRecommendation,
@@ -136,6 +138,9 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "mergeCandidates",
   "updateSourceFileSummary",
   "addSourceFileNote",
+  "reviewSourceFileClaim",
+  "editSourceFileClaim",
+  "resetSourceFileClaimReview",
   "requestSourceFileRefresh",
   "recordSourceFileOpen",
   "addDossierIdentityLink",
@@ -250,6 +255,32 @@ function sourceFileNoteInputFromBody(
     publicSafe: input.publicSafe === true,
     appliesToDraftId: input.appliesToDraftId,
     createdBy: input.createdBy,
+  };
+}
+
+function sourceFileClaimReviewInputFromBody(
+  body: Record<string, unknown>,
+): ReviewDossierSourceFileClaimInput | null {
+  const candidateId = candidateIdFromBody(body);
+  const input = body.input;
+  if (!candidateId || !input || typeof input !== "object") return null;
+  const value = input as Partial<ReviewDossierSourceFileClaimInput>;
+  if (typeof value.claimText !== "string" || !value.claimText.trim()) return null;
+  if (typeof value.claimType !== "string" || typeof value.sourceSection !== "string") return null;
+  return {
+    candidateId,
+    claimId: value.claimId,
+    claimText: value.claimText,
+    claimType: value.claimType as ReviewDossierSourceFileClaimInput["claimType"],
+    sourceSection: value.sourceSection,
+    decision: value.decision ?? "pending",
+    editedText: value.editedText,
+    decisionNote: value.decisionNote,
+    publicSafe: value.publicSafe === true,
+    sourceArchiveId: value.sourceArchiveId,
+    sourceRefreshId: value.sourceRefreshId,
+    sourceProvenance: value.sourceProvenance,
+    decidedBy: value.decidedBy ?? "admin",
   };
 }
 
@@ -504,6 +535,29 @@ export async function POST(req: Request) {
       const note = await addDossierSourceFileNote(input);
       const payload = await workflowPayload();
       return NextResponse.json({ ok: true, action, note, ...payload });
+    }
+
+    if (action === "reviewSourceFileClaim" || action === "editSourceFileClaim" || action === "resetSourceFileClaimReview") {
+      const input = sourceFileClaimReviewInputFromBody(body);
+      if (!input) {
+        return NextResponse.json(
+          { error: "Valid candidateId and Source File claim review input are required" },
+          { status: 400 },
+        );
+      }
+      const review = await reviewDossierSourceFileClaim({
+        ...input,
+        decision: action === "resetSourceFileClaimReview" ? "pending" : input.decision,
+        decisionNote: action === "resetSourceFileClaimReview" ? undefined : input.decisionNote,
+      });
+      const payload = await workflowPayload();
+      return NextResponse.json({
+        ok: true,
+        action,
+        review,
+        message: "Claim decision saved. Refresh BNL Source File to let BNL update the analyst read.",
+        ...payload,
+      });
     }
 
     if (action === "recordSourceFileOpen") {

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -4,6 +4,9 @@ import type React from "react";
 import type { DossierEntityActivityReadout } from "@/lib/dossier-entity-activity-readout";
 import type {
   DossierRecommendation,
+  DossierSourceFileClaimReview,
+  DossierSourceFileClaimReviewDecision,
+  DossierSourceFileClaimType,
   DossierSourceFileArchiveMetadata,
   DossierSourceFileCaseReportV1,
   DossierSourceFileNote,
@@ -477,12 +480,105 @@ function AnalystList({ value, empty }: { value: unknown; empty: string }) {
   );
 }
 
+export type DossierSourceFileReviewableClaim = {
+  id: string;
+  claimText: string;
+  claimType: DossierSourceFileClaimType;
+  sourceSection: string;
+  review?: DossierSourceFileClaimReview;
+};
+
+function stableClaimId(input: { candidateId?: string; sourceSection: string; claimText: string; sourceArchiveId?: string }) {
+  const normalized = `${input.candidateId ?? "candidate"}|${input.sourceSection}|${input.claimText.trim().toLowerCase().replace(/\s+/g, " ")}|${input.sourceArchiveId ?? ""}`;
+  let hash = 0;
+  for (let index = 0; index < normalized.length; index += 1) hash = (hash * 31 + normalized.charCodeAt(index)) >>> 0;
+  return `source_file_claim_${hash.toString(36)}`;
+}
+
+export function deriveDossierSourceFileReviewableClaims(input: {
+  analystRead?: DossierSubjectAnalystReadV1;
+  candidateId?: string;
+  sourceArchiveId?: string;
+  reviews?: DossierSourceFileClaimReview[];
+}): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[] } {
+  const sections: Array<{ sourceSection: string; claimType: DossierSourceFileClaimType; values: unknown }> = [
+    { sourceSection: "publicReadyClaims", claimType: "public_ready", values: input.analystRead?.publicReadyClaims },
+    { sourceSection: stringItems(input.analystRead?.sourceFileReviewClaims).length ? "sourceFileReviewClaims" : "reviewNeededClaims", claimType: "review_needed", values: stringItems(input.analystRead?.sourceFileReviewClaims).length ? input.analystRead?.sourceFileReviewClaims : input.analystRead?.reviewNeededClaims },
+    { sourceSection: "sourceBlindInsights", claimType: "source_blind", values: input.analystRead?.sourceBlindInsights },
+    { sourceSection: "missingInfoQuestions", claimType: "missing_info", values: input.analystRead?.missingInfoQuestions },
+    { sourceSection: "recommendedAdminActions", claimType: "recommended_action", values: input.analystRead?.recommendedAdminActions },
+    { sourceSection: "doNotSayPublicly", claimType: "do_not_say", values: input.analystRead?.doNotSayPublicly },
+  ];
+  const reviewById = new Map((input.reviews ?? []).map((review) => [review.id, review]));
+  const current = sections.flatMap((section) => stringItems(section.values).map((claimText) => {
+    const id = stableClaimId({ candidateId: input.candidateId, sourceSection: section.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
+    return { id, claimText, claimType: section.claimType, sourceSection: section.sourceSection, review: reviewById.get(id) };
+  }));
+  const currentIds = new Set(current.map((claim) => claim.id));
+  return {
+    current,
+    previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
+      id: review.id,
+      claimText: review.claimText,
+      claimType: review.claimType,
+      sourceSection: review.sourceSection,
+      review,
+    })),
+  };
+}
+
+function ClaimReviewControls({ claim, onReview }: {
+  claim: DossierSourceFileReviewableClaim;
+  onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
+}) {
+  const decision = claim.review?.decision ?? "pending";
+  const buttons: Array<[string, DossierSourceFileClaimReviewDecision, boolean?]> =
+    claim.claimType === "public_ready" ? [["Confirm public-ready", "confirmed_public", true], ["Keep internal", "confirmed_internal"], ["Reject", "rejected"]]
+    : claim.claimType === "review_needed" ? [["Confirm public-ready", "confirmed_public", true], ["Confirm internal", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
+    : claim.claimType === "source_blind" ? [["Keep source-blind/internal", "confirmed_internal"], ["Needs provenance", "needs_more_info"], ["Reject", "rejected"]]
+    : claim.claimType === "missing_info" ? [["Mark answered", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
+    : claim.claimType === "recommended_action" ? [["Mark done", "confirmed_internal"], ["Keep open", "needs_more_info"], ["Reject", "rejected"]]
+    : [["Keep boundary", "confirmed_internal"], ["Reject boundary", "rejected"]];
+  return (
+    <div className="mt-2 space-y-2">
+      <span className={`inline-block border px-2 py-1 text-[0.65rem] uppercase tracking-widest ${decision === "confirmed_public" ? "border-accent text-accent" : "border-border text-muted"}`}>
+        {decision.replace(/_/g, " ")}
+      </span>
+      <div className="flex flex-wrap gap-2">
+        {buttons.map(([label, nextDecision, publicSafe]) => (
+          <button key={label} type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, nextDecision, { publicSafe: publicSafe === true })}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <form className="flex flex-col gap-2 sm:flex-row" onSubmit={(event) => {
+        event.preventDefault();
+        const form = new FormData(event.currentTarget);
+        const editedText = String(form.get("editedText") ?? "").trim();
+        if (editedText) onReview?.(claim, "edited", { editedText, publicSafe: true });
+        event.currentTarget.reset();
+      }}>
+        <input name="editedText" className="flex-1 border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder="Edit + confirm public-safe text" />
+        <button type="submit" className="border border-accent px-2 py-1 text-xs text-accent">Edit + confirm</button>
+      </form>
+    </div>
+  );
+}
+
 function BnlAnalystReadPanel({
   analystRead,
   refreshedAt,
+  candidateId,
+  sourceArchiveId,
+  claimReviews,
+  onReviewClaim,
 }: {
   analystRead?: DossierSubjectAnalystReadV1;
   refreshedAt?: string;
+  candidateId?: string;
+  sourceArchiveId?: string;
+  claimReviews?: DossierSourceFileClaimReview[];
+  onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
 }) {
   if (!analystRead) {
     return (
@@ -491,14 +587,15 @@ function BnlAnalystReadPanel({
       </Section>
     );
   }
-  const reviewClaims = stringItems(analystRead.reviewNeededClaims).length
-    ? analystRead.reviewNeededClaims
-    : analystRead.sourceFileReviewClaims;
-  const withheldContext = [
-    ...stringItems(analystRead.sourceBlindInsights).map((item) => `Source-blind: ${item}`),
-    ...stringItems(analystRead.privateOrInternalExclusions).map((item) => `Private/internal withheld: ${item}`),
-    ...stringItems(analystRead.doNotSayPublicly).map((item) => `Do not say publicly: ${item}`),
-  ];
+  const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, reviews: claimReviews });
+  const sectionEntries = [
+    ["publicReadyClaims", "Public-Ready Claims"],
+    [stringItems(analystRead.sourceFileReviewClaims).length ? "sourceFileReviewClaims" : "reviewNeededClaims", "Review-Needed Claims"],
+    ["sourceBlindInsights", "Source-blind / Withheld Context"],
+    ["missingInfoQuestions", "Missing Confirmations"],
+    ["recommendedAdminActions", "Recommended Admin Actions"],
+    ["doNotSayPublicly", "Do Not Say Publicly"],
+  ] as const;
   return (
     <Section title="BNL Analyst Read" tone="review" helper="Internal Source File intelligence. Not public dossier copy.">
       <div className="space-y-4">
@@ -510,11 +607,12 @@ function BnlAnalystReadPanel({
         </dl>
         <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Internal Read</h4><BriefParagraphs value={analystRead.internalRead} /></section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Public-Ready Claims</h4><AnalystList value={analystRead.publicReadyClaims} empty="No public-ready claims yet." /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Review-Needed Claims</h4><AnalystList value={reviewClaims} empty="No review-needed claims reported." /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Source-Blind / Withheld Context</h4><AnalystList value={withheldContext} empty="No source-blind insights reported." /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Missing Confirmations</h4><AnalystList value={analystRead.missingInfoQuestions} empty="No missing confirmations reported." /></section>
-        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended Admin Actions</h4><AnalystList value={analystRead.recommendedAdminActions} empty="No recommended admin actions reported." /></section>
+        {sectionEntries.map(([section, label]) => {
+          const claims = reviewable.current.filter((claim) => claim.sourceSection === section);
+          const privateExclusions = section === "sourceBlindInsights" ? stringItems(analystRead.privateOrInternalExclusions) : [];
+          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => <li key={claim.id} className="border border-border/40 p-2"><p>{claim.claimText}</p><ClaimReviewControls claim={claim} onReview={onReviewClaim} /></li>)}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
+        })}
+        {reviewable.previous.length > 0 && <details className="border border-border/50 bg-background/20 p-3"><summary className="cursor-pointer text-xs font-bold uppercase tracking-widest text-foreground">Previously reviewed claims</summary><ul className="mt-3 space-y-3 text-foreground">{reviewable.previous.map((claim) => <li key={claim.id} className="border border-border/40 p-2"><p>{claim.claimText}</p><ClaimReviewControls claim={claim} onReview={onReviewClaim} /></li>)}</ul></details>}
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Provenance Summary</h4><AnalystList value={analystRead.provenanceSummary} empty="No provenance summary reported." /></section>
       </div>
     </Section>
@@ -812,6 +910,9 @@ export function DossierSourceFileSummaryPanel({
   sourceFileTargetStatus,
   latestSourceFileArchive,
   blueprint,
+  candidateId,
+  claimReviews = [],
+  onReviewClaim,
 }: {
   summary: DossierSourceFileSummary;
   entityReadout?: DossierEntityActivityReadout | null;
@@ -824,6 +925,9 @@ export function DossierSourceFileSummaryPanel({
   sourceFileTargetStatus?: string;
   latestSourceFileArchive?: DossierSourceFileArchiveMetadata;
   blueprint?: DossierDraftBlueprint;
+  candidateId?: string;
+  claimReviews?: DossierSourceFileClaimReview[];
+  onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
@@ -877,7 +981,14 @@ export function DossierSourceFileSummaryPanel({
         </p>
       </Section>
 
-      <BnlAnalystReadPanel analystRead={normalizeSubjectAnalystReadV1(latestSourceFileArchive)} refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt} />
+      <BnlAnalystReadPanel
+        analystRead={normalizeSubjectAnalystReadV1(latestSourceFileArchive)}
+        refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
+        candidateId={candidateId}
+        sourceArchiveId={latestSourceFileArchive?.id}
+        claimReviews={claimReviews}
+        onReviewClaim={onReviewClaim}
+      />
 
       {blueprint && <DossierBlueprintView blueprint={blueprint} />}
 

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -43,6 +43,8 @@ import {
   type DossierSourceFileNote,
   type DossierSourceFileNoteSource,
   type DossierSourceFileNoteType,
+  type DossierSourceFileClaimReview,
+  type ReviewDossierSourceFileClaimInput,
   type DossierDuplicateRisk,
   type DossierPopulationRecommendedAction,
   type DossierPopulationRecommendedLane,
@@ -349,6 +351,9 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
           ...candidate,
           sourceFileNotes: Array.isArray(candidate.sourceFileNotes)
             ? candidate.sourceFileNotes
+            : [],
+          sourceFileClaimReviews: Array.isArray(candidate.sourceFileClaimReviews)
+            ? candidate.sourceFileClaimReviews
             : [],
           sourceFileSummary:
             candidate.sourceFileSummary &&
@@ -773,6 +778,20 @@ async function readSourceFileArchiveRecord(
 
 function createSourceFileNoteId(): string {
   return `source_file_note_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createSourceFileClaimReviewId(input: {
+  candidateId: string;
+  sourceSection: string;
+  claimText: string;
+  sourceArchiveId?: string;
+}): string {
+  return `source_file_claim_${createHash("sha1").update([
+    input.candidateId,
+    input.sourceSection,
+    input.claimText.trim().toLowerCase().replace(/\s+/g, " "),
+    input.sourceArchiveId ?? "",
+  ].join("|")).digest("hex").slice(0, 24)}`;
 }
 
 function createSourceFileRefreshRequestId(): string {
@@ -4287,6 +4306,89 @@ export async function addDossierSourceFileNote(
   return saved ?? note;
 }
 
+export async function reviewDossierSourceFileClaim(
+  input: ReviewDossierSourceFileClaimInput,
+): Promise<DossierSourceFileClaimReview> {
+  const candidateId = boundedText(input.candidateId, 200);
+  const claimText = boundedText(input.claimText);
+  const sourceSection = boundedText(input.sourceSection, 120);
+  const editedText = boundedText(input.editedText);
+  const allowedDecisions = new Set(["pending", "confirmed_public", "confirmed_internal", "rejected", "needs_more_info", "edited"]);
+  if (!candidateId || !claimText || !sourceSection || !allowedDecisions.has(input.decision)) {
+    throw new DossierWorkflowInputError("Valid candidate, claim text, source section, and decision are required", 400, "invalid_claim_review");
+  }
+  if (input.decision === "confirmed_public" && input.publicSafe !== true) {
+    throw new DossierWorkflowInputError("Public-ready confirmation requires explicit publicSafe true", 400, "public_safe_required");
+  }
+  if (input.claimType === "do_not_say" && input.decision === "confirmed_public") {
+    throw new DossierWorkflowInputError("Do-not-say boundaries cannot become public-ready claims", 400, "do_not_say_public_blocked");
+  }
+  if ((input.claimType === "source_blind" || input.claimType === "review_needed") && input.decision === "confirmed_public" && !editedText) {
+    throw new DossierWorkflowInputError("Source-blind/internal claims require edited public-safe text before public confirmation", 400, "edited_public_text_required");
+  }
+  const now = new Date().toISOString();
+  const sourceArchiveId = boundedText(input.sourceArchiveId, 200) || undefined;
+  const id = boundedText(input.claimId, 200) || createSourceFileClaimReviewId({ candidateId, sourceSection, claimText, sourceArchiveId });
+  let saved: DossierSourceFileClaimReview | null = null;
+
+  await updateDossierWorkflowState((currentState) => {
+    let found = false;
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== candidateId) return candidate;
+      found = true;
+      const existing = (candidate.sourceFileClaimReviews ?? []).find((item) => item.id === id);
+      const review: DossierSourceFileClaimReview = {
+        id,
+        candidateId,
+        claimText,
+        claimType: input.claimType,
+        sourceSection,
+        decision: input.decision,
+        publicSafe: input.publicSafe === true,
+        editedText: editedText || undefined,
+        decisionNote: boundedText(input.decisionNote, 1000) || undefined,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+        decidedAt: input.decision === "pending" ? undefined : now,
+        decidedBy: boundedText(input.decidedBy, 200) || "admin",
+        sourceArchiveId,
+        sourceRefreshId: boundedText(input.sourceRefreshId, 200) || undefined,
+        sourceProvenance: normalizeStringArray(input.sourceProvenance).slice(0, 10),
+      };
+      const notes = [...(candidate.sourceFileNotes ?? [])];
+      if (["confirmed_public", "confirmed_internal", "needs_more_info", "edited"].includes(review.decision)) {
+        const noteId = `source_file_note_${review.id}`;
+        const oldNote = notes.find((note) => note.id === noteId);
+        const note: DossierSourceFileNote = {
+          id: noteId,
+          candidateId,
+          type: review.decision === "needs_more_info" ? "missing_info" : review.decision === "confirmed_public" || review.decision === "edited" ? "fact" : "general_note",
+          text: review.editedText || review.claimText,
+          source: "admin_manual",
+          status: "active",
+          publicSafe: review.decision === "confirmed_public" || review.decision === "edited",
+          createdAt: oldNote?.createdAt ?? now,
+          updatedAt: now,
+          createdBy: review.decidedBy,
+        };
+        const noteIndex = notes.findIndex((item) => item.id === noteId);
+        if (noteIndex >= 0) notes[noteIndex] = note;
+        else notes.unshift(note);
+      }
+      saved = review;
+      return {
+        ...candidate,
+        sourceFileClaimReviews: [review, ...(candidate.sourceFileClaimReviews ?? []).filter((item) => item.id !== id)],
+        sourceFileNotes: notes,
+        updatedAt: now,
+      };
+    });
+    if (!found) throw new DossierWorkflowInputError("Candidate not found", 404, "candidate_not_found");
+    return { ...currentState, candidates, updatedAt: now };
+  });
+  return saved!;
+}
+
 export async function createDossierRecommendation(
   input: CreateDossierRecommendationInput,
 ): Promise<DossierRecommendation> {
@@ -7616,11 +7718,13 @@ export async function runSubjectConsolidation(input: { groupId?: string } = {}):
           continue;
         }
         const sourceNotes = sources.flatMap((source) => source.sourceFileNotes ?? []);
+        const sourceClaimReviews = sources.flatMap((source) => source.sourceFileClaimReviews ?? []);
         const aliases = sources.flatMap((source) => source.identityLinks ?? []);
         const recommendationIds = sources.flatMap((source) => source.connectedRecommendationIds ?? []);
         const updatedTarget: DossierCandidate = {
           ...target,
           sourceFileNotes: [...(target.sourceFileNotes ?? []), ...sourceNotes.map((note) => ({ ...note, candidateId: target.id, updatedAt: now }))],
+          sourceFileClaimReviews: [...(target.sourceFileClaimReviews ?? []), ...sourceClaimReviews.map((review) => ({ ...review, candidateId: target.id, updatedAt: now }))],
           identityLinks: [...(target.identityLinks ?? []), ...aliases.map((link) => ({ ...link, candidateId: target.id, visibility: "internal_only" as const, useInPublicDossier: false, updatedAt: now }))],
           connectedRecommendationIds: uniqueStrings(target.connectedRecommendationIds, recommendationIds),
           mergeSourceCandidateIds: uniqueStrings(target.mergeSourceCandidateIds, sources.map((source) => source.id)),

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -276,6 +276,41 @@ export type DossierSourceFileNote = {
   ingestSource?: DossierRecommendationIngestSource;
 };
 
+export type DossierSourceFileClaimType =
+  | "public_ready"
+  | "review_needed"
+  | "source_blind"
+  | "missing_info"
+  | "recommended_action"
+  | "do_not_say";
+
+export type DossierSourceFileClaimReviewDecision =
+  | "pending"
+  | "confirmed_public"
+  | "confirmed_internal"
+  | "rejected"
+  | "needs_more_info"
+  | "edited";
+
+export type DossierSourceFileClaimReview = {
+  id: string;
+  candidateId: string;
+  claimText: string;
+  claimType: DossierSourceFileClaimType;
+  sourceSection: string;
+  decision: DossierSourceFileClaimReviewDecision;
+  publicSafe: boolean;
+  editedText?: string;
+  decisionNote?: string;
+  createdAt: string;
+  updatedAt: string;
+  decidedAt?: string;
+  decidedBy?: string;
+  sourceArchiveId?: string;
+  sourceRefreshId?: string;
+  sourceProvenance?: string[];
+};
+
 export type DossierIdentityLinkType =
   | "alias"
   | "artist_name"
@@ -370,6 +405,7 @@ export type DossierCandidate = {
   latestSourceFileArchive?: DossierSourceFileArchiveMetadata;
   sourceFileSummary?: DossierSourceFileOperatorSummary;
   sourceFileNotes?: DossierSourceFileNote[];
+  sourceFileClaimReviews?: DossierSourceFileClaimReview[];
   identityLinks?: DossierIdentityLink[];
   sourceLanes?: DossierRecommendationSourceLane[];
   ingestKey?: string;
@@ -2887,6 +2923,22 @@ export type CreateDossierSourceFileNoteInput = {
   createdBy?: string;
 };
 
+export type ReviewDossierSourceFileClaimInput = {
+  candidateId: string;
+  claimId?: string;
+  claimText: string;
+  claimType: DossierSourceFileClaimType;
+  sourceSection: string;
+  decision: DossierSourceFileClaimReviewDecision;
+  editedText?: string;
+  decisionNote?: string;
+  publicSafe?: boolean;
+  sourceArchiveId?: string;
+  sourceRefreshId?: string;
+  sourceProvenance?: string[];
+  decidedBy?: string;
+};
+
 export type CreateDossierSourceFileArchiveInput =
   DossierSourceFileArchiveCompactReadout & {
     candidateId?: string;
@@ -3003,6 +3055,9 @@ export type DossierWorkflowAction =
   | "markNeedsMoreEvidence"
   | "updateSourceFileSummary"
   | "addSourceFileNote"
+  | "reviewSourceFileClaim"
+  | "editSourceFileClaim"
+  | "resetSourceFileClaimReview"
   | "requestSourceFileRefresh"
   | "recordSourceFileOpen"
   | "addDossierIdentityLink"
@@ -3066,6 +3121,9 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "markNeedsMoreEvidence",
   "updateSourceFileSummary",
   "addSourceFileNote",
+  "reviewSourceFileClaim",
+  "editSourceFileClaim",
+  "resetSourceFileClaimReview",
   "requestSourceFileRefresh",
   "recordSourceFileOpen",
   "addDossierIdentityLink",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -841,9 +841,171 @@ async function resetWorkflowStore() {
     candidates: [],
     drafts: [],
     recommendations: [],
+    sourceFileRefreshRequests: [],
     updatedAt: new Date(0).toISOString(),
   });
 }
+
+function claimReviewCandidate() {
+  const now = "2026-06-15T00:00:00.000Z";
+  return {
+    id: "claim-review-candidate",
+    name: "Claim Review Subject",
+    candidateType: "artist",
+    source: "bnl_source_file_enrichment",
+    tier: "draft_ready",
+    score: 75,
+    whyNow: "BNL analyst read needs admin claim decisions.",
+    reason: "Source File review fixture.",
+    evidenceSummary: "Review-only fixture.",
+    sourceFileNotes: [],
+    sourceFileClaimReviews: [],
+    latestSourceFileArchive: {
+      id: "archive-claim-review",
+      candidateId: "claim-review-candidate",
+      subjectName: "Claim Review Subject",
+      sourceDigest: "digest",
+      createdAt: now,
+      updatedAt: now,
+      archiveSize: 1,
+      chunkCount: 1,
+      reviewOnly: true,
+      subjectAnalystReadV1: {
+        publicReadyClaims: ["Public ready fixture claim."],
+        reviewNeededClaims: ["Review needed fixture claim."],
+        sourceBlindInsights: ["Source blind fixture claim."],
+        doNotSayPublicly: ["Boundary fixture claim."],
+      },
+    },
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+test("Source File claim review decisions persist and update safe Source File notes", async () => {
+  await resetWorkflowStore();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [claimReviewCandidate()],
+    drafts: [],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+
+  const publicResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_public_fixture",
+      claimText: "Public ready fixture claim.",
+      claimType: "public_ready",
+      sourceSection: "publicReadyClaims",
+      decision: "confirmed_public",
+      publicSafe: true,
+      sourceArchiveId: "archive-claim-review",
+    },
+  });
+  assert.equal(publicResponse.status, 200);
+  let state = await store.getDossierWorkflowState();
+  let candidate = state.candidates[0];
+  assert.equal(candidate.sourceFileClaimReviews[0].decision, "confirmed_public");
+  assert.equal(candidate.sourceFileNotes[0].type, "fact");
+  assert.equal(candidate.sourceFileNotes[0].publicSafe, true);
+
+  const internalResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_internal_fixture",
+      claimText: "Review needed fixture claim.",
+      claimType: "review_needed",
+      sourceSection: "reviewNeededClaims",
+      decision: "confirmed_internal",
+      publicSafe: false,
+    },
+  });
+  assert.equal(internalResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  candidate = state.candidates[0];
+  assert.equal(candidate.sourceFileNotes[0].publicSafe, false);
+  assert.equal(candidate.sourceFileNotes[0].type, "general_note");
+
+  const rejectResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_reject_fixture",
+      claimText: "Rejected fixture claim.",
+      claimType: "public_ready",
+      sourceSection: "publicReadyClaims",
+      decision: "rejected",
+      publicSafe: false,
+    },
+  });
+  assert.equal(rejectResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates[0].sourceFileClaimReviews.some((review) => review.decision === "rejected"), true);
+});
+
+test("Source File claim review validation protects public boundaries", async () => {
+  await resetWorkflowStore();
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [claimReviewCandidate()],
+    drafts: [],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: new Date(0).toISOString(),
+  });
+
+  const editedResponse = await authedPost({
+    action: "editSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_edited_fixture",
+      claimText: "Original internal-ish claim.",
+      claimType: "public_ready",
+      sourceSection: "publicReadyClaims",
+      decision: "edited",
+      editedText: "Edited public-safe claim.",
+      publicSafe: true,
+    },
+  });
+  assert.equal(editedResponse.status, 200);
+  let state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates[0].sourceFileNotes[0].text, "Edited public-safe claim.");
+
+  const sourceBlindResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimText: "Source blind fixture claim.",
+      claimType: "source_blind",
+      sourceSection: "sourceBlindInsights",
+      decision: "confirmed_public",
+      publicSafe: true,
+    },
+  });
+  assert.equal(sourceBlindResponse.status, 400);
+
+  const doNotSayResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimText: "Boundary fixture claim.",
+      claimType: "do_not_say",
+      sourceSection: "doNotSayPublicly",
+      decision: "confirmed_public",
+      publicSafe: true,
+      editedText: "Boundary fixture claim.",
+    },
+  });
+  assert.equal(doNotSayResponse.status, 400);
+});
 
 async function authedGet() {
   return route.GET(


### PR DESCRIPTION
### Motivation
- Provide admin-level claim review controls for BNL Analyst Read output so admins can confirm, edit, reject, or hold analyst claims and persist those decisions as structured Source File truth. 
- Ensure confirmed public-safe facts flow into Source File notes for future refreshes and proposed-dossier generation while preserving public/private boundaries and not publishing anything automatically.

### Description
- Add a lightweight claim-review model and attach it to candidates by adding `DossierSourceFileClaimReview` and `sourceFileClaimReviews?: DossierSourceFileClaimReview[]` to the workflow types, plus `ReviewDossierSourceFileClaimInput` and action enums. (core: `src/lib/dossier-workflow.ts`)
- Implement review persistence, validation rules, and Source File note upserts so `confirmed_public`/`edited` produce `fact` notes, `confirmed_internal` produces `general_note`, and `needs_more_info` produces `missing_info`; also protect do-not-say and source-blind boundaries. (store logic: `src/lib/dossier-workflow-store.ts`)
- Expose admin actions `reviewSourceFileClaim`, `editSourceFileClaim`, and `resetSourceFileClaimReview` through the existing admin workflow API and return the requested refresh guidance message. (API changes: `src/app/api/admin/dossiers/route.ts`)
- Add UI wiring to derive reviewable claim rows from `subjectAnalystReadV1`, show per-claim status badges, action buttons, and an edit+confirm form in the BNL Analyst Read panel, and submit decisions to the admin API from the Source File page. (components/pages: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`)
- Tests added to assert creation/persistence of claim reviews, Source File note promotion for public/internal/edited decisions, rejection persistence, edited-text promotion, and public-boundary validation. (tests: `tests/admin-dossiers.test.mjs`)
- Files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/app/api/admin/dossiers/route.ts`, `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, and `tests/admin-dossiers.test.mjs`.

### Testing
- Ran `npx tsc --noEmit` — success.
- Ran `node --test tests/admin-dossiers.test.mjs` — all tests passed (211 tests, 0 failures after changes).
- Ran `npm run lint` — lint run surfaced pre-existing unrelated errors in archived and other files; no new lint errors were introduced by these changes.

Commit SHA: `90919fb0ad23d9155d90a5728551b2a5b43eebde`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f6dc40c70832192be8976024dab5f)