### PR TITLE
Improve Source File claim review cards

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -1559,7 +1559,7 @@ export default function CandidateReviewPage() {
     if (!candidate) return;
     const publicSafe = options.publicSafe === true || decision === "edited";
     await postWorkflow({
-      action: decision === "edited" ? "editSourceFileClaim" : "reviewSourceFileClaim",
+      action: decision === "pending" ? "resetSourceFileClaimReview" : decision === "edited" ? "editSourceFileClaim" : "reviewSourceFileClaim",
       candidateId,
       input: {
         claimId: claim.id,

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -508,6 +508,8 @@ export type DossierSourceFileReviewableClaim = {
   canReject?: boolean;
   canNeedMoreInfo?: boolean;
   requiresEditedTextForPublic?: boolean;
+  whatAmIDeciding?: string;
+  isWeakEvidenceLabel?: boolean;
   review?: DossierSourceFileClaimReview;
 };
 
@@ -545,6 +547,15 @@ function isSignalSummaryText(text: string, record?: UnknownRecord) {
   return /music discussion only|song\/track\/demo\/wip|feedback requests|generic links|moderation\/community support|source files\/dossiers|pattern summary|signal summary|signal_count|evidence_signal/.test(joined);
 }
 
+function isWeakEvidenceLabelText(text: string, record?: UnknownRecord) {
+  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision"]) ?? ""}`.toLowerCase();
+  return /^(possible review claim:\s*)?(contest organizer|rules\/instructions poster|lore-heavy|theory\/anomaly-heavy|antagonistic\/challenging)$/i.test(text.trim()) || /weak evidence label|weak_label|evidence label/.test(joined);
+}
+
+function subjectLabel(value?: string) {
+  return value?.trim() || "this subject";
+}
+
 function splitSignal(text: string) {
   const match = text.match(/^(.+?):\s*(\d+)$/);
   return { label: (match?.[1] ?? text).trim(), count: match?.[2] };
@@ -559,34 +570,34 @@ function signalSuggestion(label: string) {
   return "Context signal. BNL used this pattern during analysis, but it is not a public-ready fact by itself.";
 }
 
-function buildCardGuidance(claimText: string, claimType: DossierSourceFileClaimType, record?: UnknownRecord) {
+function buildCardGuidance(claimText: string, claimType: DossierSourceFileClaimType, record: UnknownRecord | undefined, subjectName: string) {
   const lower = `${claimText} ${analystString(record, ["claimType", "title"]) ?? ""}`.toLowerCase();
   if (lower.includes("display name") || lower.includes("preferred name")) return {
     decisionQuestion: "What exact display name may BNL use publicly?",
-    placeholderText: "Crow",
-    exampleApprovedTexts: ["Crow", "Use Crow publicly; keep other aliases internal."],
+    placeholderText: subjectName,
+    exampleApprovedTexts: [subjectName, `Use ${subjectName} publicly; keep other aliases internal.`],
   };
   if (lower.includes("role") || lower.includes("title")) return {
     title: "Confirm public role/title",
-    decisionQuestion: "Which public label, if any, may BNL use for Crow?",
+    decisionQuestion: `Which public label, if any, may BNL use for ${subjectName}?`,
     whyItExists: "BNL found role/community/music/context signals, but not enough confirmed public-safe evidence to state a formal role.",
-    placeholderText: "Crow is a BARCODE Network community member.",
-    exampleApprovedTexts: ["Crow is a BARCODE Network community member.", "Crow is a BARCODE Radio viewer/community participant.", "Do not state a public role for Crow yet."],
+    placeholderText: `${subjectName} is a BARCODE Network community member.`,
+    exampleApprovedTexts: [`${subjectName} is a BARCODE Network community member.`, `${subjectName} is a BARCODE Radio viewer/community participant.`, `Do not state a public role for ${subjectName} yet.`],
   };
   if (lower.includes("link")) return {
     decisionQuestion: "Which links are owned/approved for public reference?",
     placeholderText: "No public links approved yet.",
-    exampleApprovedTexts: ["No public links approved yet.", "Approved public link: https://...", "Do not mention Crow music links until owner confirms them."],
+    exampleApprovedTexts: ["No public links approved yet.", "Approved public link: https://...", `Do not mention ${subjectName} music links until owner confirms them.`],
   };
   if (lower.includes("orion")) return {
-    decisionQuestion: "Can BNL mention Orion in public Crow context, or keep it internal?",
+    decisionQuestion: `Can BNL mention Orion in public ${subjectName} context, or keep it internal?`,
     placeholderText: "Keep Orion context internal for now.",
-    exampleApprovedTexts: ["Keep Orion context internal for now.", "BNL may reference Orion only as internal BARCODE context, not public dossier copy.", "BNL may mention Crow has recurring Orion-related BARCODE lore/context."],
+    exampleApprovedTexts: ["Keep Orion context internal for now.", "BNL may reference Orion only as internal BARCODE context, not public dossier copy.", `BNL may mention ${subjectName} has recurring Orion-related BARCODE context.`],
   };
   if (lower.includes("queue") || lower.includes("submission")) return {
-    decisionQuestion: "Can BNL mention Crow’s queue/submission history publicly?",
+    decisionQuestion: `Can BNL mention ${subjectName}’s queue/submission history publicly?`,
     placeholderText: "Do not reference queue/submission history publicly.",
-    exampleApprovedTexts: ["Do not reference queue/submission history publicly.", "Crow has submitted music to BARCODE Radio.", "Keep queue/submission history internal."],
+    exampleApprovedTexts: ["Do not reference queue/submission history publicly.", `${subjectName} has submitted music to BARCODE Radio.`, "Keep queue/submission history internal."],
   };
   return {
     decisionQuestion: claimType === "source_blind" ? "Should this source-blind context stay internal, need provenance, or be rejected?" : "What decision should admins make for this Source File item?",
@@ -595,14 +606,18 @@ function buildCardGuidance(claimText: string, claimType: DossierSourceFileClaimT
   };
 }
 
-function buildClaimCard(input: { value: unknown; sourceSection: string; claimType: DossierSourceFileClaimType; candidateId?: string; sourceArchiveId?: string; reviews?: Map<string, DossierSourceFileClaimReview> }): DossierSourceFileReviewableClaim | undefined {
+function buildClaimCard(input: { value: unknown; sourceSection: string; claimType: DossierSourceFileClaimType; candidateId?: string; sourceArchiveId?: string; subjectName?: string; reviews?: Map<string, DossierSourceFileClaimReview> }): DossierSourceFileReviewableClaim | undefined {
   const record = asRecord(input.value);
   const claimText = displayValue(input.value) ?? analystString(record, ["claimText", "text", "claim", "question", "action", "boundary"]);
   if (!claimText) return undefined;
   const claimType = classifyClaimType(input.sourceSection, record) || input.claimType;
-  const guidance = claimType === "recommended_action" || claimType === "do_not_say"
-    ? { decisionQuestion: claimType === "recommended_action" ? "What admin follow-up should happen for this task?" : "Should this public boundary stay in force?", placeholderText: "", exampleApprovedTexts: [] }
-    : buildCardGuidance(claimText, claimType, record);
+  const displaySubject = subjectLabel(input.subjectName ?? analystString(record, ["subjectName"]));
+  const weakLabel = isWeakEvidenceLabelText(claimText, record);
+  const guidance = weakLabel
+    ? { title: "Weak evidence label / pattern", decisionQuestion: "Is this label accurate and useful, or should it be rejected?", placeholderText: "Only enter wording here if this label is true and public-safe. Otherwise reject this claim.", exampleApprovedTexts: [`Keep ${displaySubject} label internal until confirmed.`, "Reject this label as inaccurate or not useful."] }
+    : claimType === "recommended_action" || claimType === "do_not_say"
+      ? { decisionQuestion: claimType === "recommended_action" ? "What admin follow-up should happen for this task?" : "Should this public boundary stay in force?", placeholderText: "", exampleApprovedTexts: [] }
+      : buildCardGuidance(claimText, claimType, record, displaySubject);
   const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
   const blockedBy = stringItems(record?.blockedBy);
   return {
@@ -610,24 +625,40 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     claimText,
     claimType,
     sourceSection: input.sourceSection,
+    isWeakEvidenceLabel: weakLabel,
+    whatAmIDeciding: weakLabel
+      ? "This appears to be an evidence label or pattern, not a confirmed fact. Do not approve it as public unless you know the exact public-safe wording is true."
+      : claimType === "source_blind"
+        ? "You are deciding whether this source-blind context should stay internal, needs a public source, or should be rejected as irrelevant/incorrect."
+        : /contest organizer/i.test(claimText)
+          ? `You are deciding whether ${displaySubject} is actually a contest organizer. If not, reject this claim.`
+          : /role|title/i.test(claimText)
+            ? "You are deciding whether this role/title is true for this subject, and whether BNL may use it publicly."
+            : /link/i.test(claimText)
+              ? "You are deciding whether these links are owned/approved for public reference."
+              : /orion/i.test(claimText)
+                ? "You are deciding whether Orion may be mentioned publicly, kept internal, or rejected as irrelevant/incorrect."
+                : /queue|submission/i.test(claimText)
+                  ? "You are deciding whether queue/submission history can be referenced publicly, kept internal, or rejected."
+                  : "You are deciding whether this claim is true, whether it is useful internally, and whether exact public wording is approved.",
     title: analystString(record, ["title", "label"]) ?? guidance.title ?? (claimType === "do_not_say" ? "Public boundary" : claimType === "recommended_action" ? "Admin task" : claimType === "missing_info" ? "Missing confirmation" : "Review Source File claim"),
     decisionQuestion: analystString(record, ["decisionQuestion", "question"]) ?? guidance.decisionQuestion,
-    whyItExists: analystString(record, ["why", "whyItExists", "reason"]) ?? guidance.whyItExists ?? "BNL flagged this because it needs an explicit admin decision before use.",
+    whyItExists: analystString(record, ["why", "whyItExists", "reason"]) ?? (("whyItExists" in guidance ? guidance.whyItExists : undefined) ?? "BNL flagged this because it needs an explicit admin decision before use."),
     safeEvidenceSummary: analystString(record, ["safeEvidenceSummary", "evidenceSummary", "summary"]),
     reviewLane: analystString(record, ["reviewLane", "lane", "safetyLane"]),
     confidence: analystString(record, ["confidence"]),
     suggestedDecision: analystString(record, ["suggestedDecision", "recommendation"]),
-    safestDefault: analystString(record, ["safestDefault"]) ?? (claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or needs more info until owner/admin confirms the wording."),
+    safestDefault: analystString(record, ["safestDefault"]) ?? (weakLabel ? "Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording." : claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or needs more info until owner/admin confirms the wording."),
     blockedBy,
     whatYouAreApproving: claimType === "recommended_action" ? "An admin task state, not a public claim approval." : claimType === "do_not_say" ? "A public-copy boundary that protects against unsupported claims." : claimType === "source_blind" ? "Only a separately confirmed public-safe replacement, not the source-blind text itself." : "A Source File review decision. Confirming public-ready does not publish a dossier.",
     whatToEnter: claimType === "recommended_action" ? "No public-safe text is required unless this task explicitly creates a Source File note." : claimType === "do_not_say" ? "No public-ready wording should be entered for boundaries." : claimType === "source_blind" ? "Add public-safe replacement text, if owner/admin confirms it elsewhere." : "Enter the exact sentence BNL may use as a Source File fact.",
     placeholderText: guidance.placeholderText,
     exampleApprovedTexts: guidance.exampleApprovedTexts,
     actionConsequences: {
-      confirmed_public: "Creates a public-safe Source File fact. It does not publish a dossier.",
-      confirmed_internal: "Stores this as internal Source File context only.",
-      needs_more_info: "Keeps this open as a missing confirmation.",
-      rejected: "Marks this claim as rejected so it does not keep appearing as pending.",
+      confirmed_public: "Use this only if the claim is true and the exact public wording is approved. This creates a public-safe Source File fact. It does not publish a dossier.",
+      confirmed_internal: claimType === "recommended_action" ? "Marks this admin task done." : claimType === "do_not_say" ? "Keeps this public-copy boundary in force." : "Use this if the claim may be useful to BNL internally but should not be public copy.",
+      needs_more_info: "Use this if BNL should keep asking for confirmation before using this claim.",
+      rejected: claimType === "do_not_say" ? "Removes this boundary from the active review queue." : "Use this if the claim is wrong, misleading, irrelevant, or not worth keeping.",
       edited: claimType === "source_blind" ? "Adds only the edited public-safe replacement wording after separate confirmation." : "Saves edited public-safe Source File wording.",
     },
     canConfirmPublic: claimType === "public_ready" || claimType === "review_needed",
@@ -644,6 +675,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   candidateId?: string;
   sourceArchiveId?: string;
   reviews?: DossierSourceFileClaimReview[];
+  subjectName?: string;
 }): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[]; signals: SourceFileSignalSummary[] } {
   const reviewById = new Map((input.reviews ?? []).map((review) => [review.id, review]));
   const structured = listValues(input.analystRead?.reviewableClaims);
@@ -660,7 +692,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     { sourceSection: "doNotSayPublicly", claimType: "do_not_say", values: input.analystRead?.doNotSayPublicly },
   );
   const allCards = sections.flatMap((section) => listValues(section.values).flatMap((value) => {
-    const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, reviews: reviewById });
+    const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, subjectName: input.subjectName ?? input.analystRead?.subjectName, reviews: reviewById });
     return card ? [card] : [];
   }));
   const signals = allCards.filter((card) => isSignalSummaryText(card.claimText, asRecord(card))).map((card) => {
@@ -682,29 +714,46 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   };
 }
 
+function claimDecisionLabel(claim: DossierSourceFileReviewableClaim) {
+  const decision = claim.review?.decision ?? "pending";
+  if (decision === "confirmed_public" || decision === "edited") return "Approved as public fact";
+  if (decision === "confirmed_internal") return claim.claimType === "do_not_say" ? "Boundary kept" : "Kept internal";
+  if (decision === "needs_more_info") return "Needs more info";
+  if (decision === "rejected") return claim.claimType === "do_not_say" ? "Boundary removed" : "Rejected as false / not useful";
+  return "Pending";
+}
+
 function ClaimReviewControls({ claim, onReview }: {
   claim: DossierSourceFileReviewableClaim;
   onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
 }) {
   const decision = claim.review?.decision ?? "pending";
   const buttons: Array<[string, DossierSourceFileClaimReviewDecision, boolean?]> =
-    claim.claimType === "do_not_say" ? [["Keep boundary", "confirmed_internal"], ["Reject boundary", "rejected"]]
+    claim.claimType === "do_not_say" ? [["Keep boundary", "confirmed_internal"], ["Remove boundary", "rejected"]]
     : claim.claimType === "recommended_action" ? [["Mark done", "confirmed_internal"], ["Keep open", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "source_blind" ? [["Keep internal", "confirmed_internal"], ["Needs provenance", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "missing_info" ? [["Mark answered", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "public_ready" ? [["Confirm public-ready", "confirmed_public", true], ["Keep internal", "confirmed_internal"], ["Reject", "rejected"]]
-    : [["Confirm public-ready", "confirmed_public", true], ["Confirm internal", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]];
+    : claim.claimType === "source_blind" ? [["Keep internal", "confirmed_internal"], ["Needs public source", "needs_more_info"], ["Reject as false / not useful", "rejected"]]
+    : claim.claimType === "missing_info" ? [["Save answer", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject / not needed", "rejected"]]
+    : claim.claimType === "public_ready" ? [["Approve as public fact", "confirmed_public", true], ["Keep as internal context", "confirmed_internal"], ["Reject as false / not useful", "rejected"]]
+    : [["Approve as public fact", "confirmed_public", true], ["Keep as internal context", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject as false / not useful", "rejected"]];
   return (
     <div className="mt-3 space-y-3">
       <span className={`inline-block border px-2 py-1 text-[0.65rem] uppercase tracking-widest ${decision === "confirmed_public" ? "border-accent text-accent" : "border-border text-muted"}`}>
-        {decision.replace(/_/g, " ")}
+        {claimDecisionLabel(claim)}
       </span>
       <div className="grid gap-2 sm:grid-cols-2">
         {buttons.map(([label, nextDecision, publicSafe]) => (
           <div key={label} className="border border-border/40 p-2">
-            <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => {
-              if (claim.claimType === "missing_info" && nextDecision === "confirmed_internal") return;
-              onReview?.(claim, nextDecision, { publicSafe: publicSafe === true });
+            <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={(event) => {
+              const container = event.currentTarget.closest("[data-claim-card]");
+              const input = container?.querySelector<HTMLInputElement>("[data-claim-answer]");
+              const validation = container?.querySelector<HTMLElement>("[data-claim-validation]");
+              const editedText = input?.value.trim() ?? "";
+              if ((nextDecision === "confirmed_public" && (claim.claimType === "review_needed" || claim.claimType === "source_blind") && !editedText) || (claim.claimType === "missing_info" && nextDecision === "confirmed_internal" && !editedText)) {
+                if (validation) validation.textContent = nextDecision === "confirmed_public" ? "Enter the exact public-safe sentence first, or choose Keep internal / Needs more info / Reject." : "Enter the exact answer BNL should use, or choose Needs more info / Reject.";
+                return;
+              }
+              if (validation) validation.textContent = "";
+              onReview?.(claim, nextDecision, { publicSafe: publicSafe === true, editedText: editedText || undefined });
             }}>
               {label}
             </button>
@@ -712,7 +761,7 @@ function ClaimReviewControls({ claim, onReview }: {
           </div>
         ))}
       </div>
-      {claim.claimType === "missing_info" && <p className="text-xs text-accent">Enter the exact answer BNL should use, or choose Needs more info / Reject.</p>}
+      <p data-claim-validation="true" className="text-xs text-accent">{claim.claimType === "missing_info" ? "Enter the exact answer BNL should use, or choose Needs more info / Reject." : ""}</p>
       {claim.claimType !== "recommended_action" && claim.claimType !== "do_not_say" && <form className="flex flex-col gap-2" onSubmit={(event) => {
         event.preventDefault();
         const form = new FormData(event.currentTarget);
@@ -722,8 +771,8 @@ function ClaimReviewControls({ claim, onReview }: {
         event.currentTarget.reset();
       }}>
         {claim.claimType === "source_blind" && <p className="border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
-        <label className="text-xs font-bold text-foreground" htmlFor={`${claim.id}-edited`}>{claim.whatToEnter}</label>
-        <input id={`${claim.id}-edited`} name="editedText" className="border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder={claim.placeholderText ?? "Enter exact public-safe wording"} />
+        <label className="text-xs font-bold text-foreground" htmlFor={`${claim.id}-edited`}>{claim.claimType === "missing_info" ? "Answer to save" : claim.whatToEnter}</label>
+        <input data-claim-answer="true" id={`${claim.id}-edited`} name="editedText" className="border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder={claim.placeholderText ?? "Enter exact public-safe wording"} />
         <button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">{claim.claimType === "source_blind" ? "Add public-safe replacement" : "Save exact answer / edited text"}</button>
       </form>}
     </div>
@@ -732,14 +781,15 @@ function ClaimReviewControls({ claim, onReview }: {
 
 function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
   return (
-    <li className="border border-border/40 bg-background/30 p-3">
+    <li data-claim-card="true" className="border border-border/40 bg-background/30 p-3">
       <h5 className="text-sm font-bold text-foreground">{claim.title}</h5>
       <p className="mt-1 text-foreground">{claim.claimText}</p>
+      {claim.whatAmIDeciding && <p className="mt-2 border border-border/50 bg-background/40 p-2 text-xs text-foreground"><strong>What am I deciding?</strong> {claim.whatAmIDeciding}</p>}
       {claim.claimType === "source_blind" && <p className="mt-2 border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
       <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
-        <div><dt className="font-bold text-accent">Decision needed</dt><dd className="text-foreground">{claim.decisionQuestion}</dd></div>
+        <div><dt className="font-bold text-accent">{claim.claimType === "missing_info" ? "Question" : "Decision needed"}</dt><dd className="text-foreground">{claim.decisionQuestion}</dd></div>
         <div><dt className="font-bold text-accent">What BNL thinks</dt><dd className="text-foreground">{claim.suggestedDecision ?? "Admin review is needed before use."}</dd></div>
-        <div><dt className="font-bold text-accent">Why BNL flagged this</dt><dd className="text-foreground">{claim.whyItExists}</dd></div>
+        <div><dt className="font-bold text-accent">{claim.claimType === "missing_info" ? "Why BNL needs it" : "Why BNL flagged this"}</dt><dd className="text-foreground">{claim.whyItExists}</dd></div>
         <div><dt className="font-bold text-accent">Evidence summary</dt><dd className="text-foreground">{claim.safeEvidenceSummary ?? "No public-safe evidence summary provided."}</dd></div>
         <div><dt className="font-bold text-accent">Safety lane</dt><dd className="text-foreground">{claim.reviewLane ?? claim.claimType.replace(/_/g, " ")}{claim.confidence ? ` · ${claim.confidence} confidence` : ""}</dd></div>
         <div><dt className="font-bold text-accent">Safest default</dt><dd className="text-foreground">{claim.safestDefault}</dd></div>
@@ -766,6 +816,7 @@ function BnlAnalystReadPanel({
   refreshedAt,
   candidateId,
   sourceArchiveId,
+  subjectName,
   claimReviews,
   onReviewClaim,
 }: {
@@ -773,6 +824,7 @@ function BnlAnalystReadPanel({
   refreshedAt?: string;
   candidateId?: string;
   sourceArchiveId?: string;
+  subjectName?: string;
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
 }) {
@@ -783,7 +835,7 @@ function BnlAnalystReadPanel({
       </Section>
     );
   }
-  const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, reviews: claimReviews });
+  const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, subjectName: subjectName ?? analystRead.subjectName, reviews: claimReviews });
   const sectionEntries = [
     ["reviewableClaims", "Source File Claim Decisions"],
     ["publicReadyClaims", "Public-Ready Claims"],
@@ -1186,6 +1238,7 @@ export function DossierSourceFileSummaryPanel({
         refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
         candidateId={candidateId}
         sourceArchiveId={latestSourceFileArchive?.id}
+        subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
         claimReviews={claimReviews}
         onReviewClaim={onReviewClaim}
       />

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -162,6 +162,9 @@ function hasAnalystReadShape(value: unknown): value is DossierSubjectAnalystRead
     "publicReadyClaims",
     "sourceFileReviewClaims",
     "reviewNeededClaims",
+    "reviewableClaims",
+    "missingConfirmations",
+    "withheldEvidenceAudit",
     "sourceBlindInsights",
     "privateOrInternalExclusions",
     "doNotSayPublicly",
@@ -485,7 +488,35 @@ export type DossierSourceFileReviewableClaim = {
   claimText: string;
   claimType: DossierSourceFileClaimType;
   sourceSection: string;
+  title?: string;
+  decisionQuestion?: string;
+  whyItExists?: string;
+  safeEvidenceSummary?: string;
+  reviewLane?: string;
+  confidence?: string;
+  suggestedDecision?: string;
+  safestDefault?: string;
+  blockedBy?: string[];
+  whatYouAreApproving?: string;
+  whatToEnter?: string;
+  placeholderText?: string;
+  exampleApprovedTexts?: string[];
+  actionConsequences?: Record<string, string>;
+  isSignalSummary?: boolean;
+  canConfirmPublic?: boolean;
+  canConfirmInternal?: boolean;
+  canReject?: boolean;
+  canNeedMoreInfo?: boolean;
+  requiresEditedTextForPublic?: boolean;
   review?: DossierSourceFileClaimReview;
+};
+
+type SourceFileSignalSummary = {
+  id: string;
+  label: string;
+  count?: string;
+  suggestion: string;
+  actionable: string;
 };
 
 function stableClaimId(input: { candidateId?: string; sourceSection: string; claimText: string; sourceArchiveId?: string }) {
@@ -495,28 +526,152 @@ function stableClaimId(input: { candidateId?: string; sourceSection: string; cla
   return `source_file_claim_${hash.toString(36)}`;
 }
 
+function analystString(record: UnknownRecord | undefined, keys: string[]) {
+  return displayValue(valueByKeys(record, keys));
+}
+
+function classifyClaimType(sourceSection: string, record?: UnknownRecord): DossierSourceFileClaimType {
+  const lane = `${analystString(record, ["reviewLane", "lane", "safetyLane"]) ?? ""} ${analystString(record, ["claimType", "type"]) ?? ""}`.toLowerCase();
+  if (sourceSection === "sourceBlindInsights" || /source[-_ ]?blind|withheld|private|internal/.test(lane)) return "source_blind";
+  if (sourceSection === "missingInfoQuestions" || sourceSection === "missingConfirmations") return "missing_info";
+  if (sourceSection === "recommendedAdminActions") return "recommended_action";
+  if (sourceSection === "doNotSayPublicly") return "do_not_say";
+  if (/public[-_ ]?ready/.test(lane) || record?.publicSafe === true) return "public_ready";
+  return "review_needed";
+}
+
+function isSignalSummaryText(text: string, record?: UnknownRecord) {
+  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision"]) ?? ""}`.toLowerCase();
+  return /music discussion only|song\/track\/demo\/wip|feedback requests|generic links|moderation\/community support|source files\/dossiers|pattern summary|signal summary|signal_count|evidence_signal/.test(joined);
+}
+
+function splitSignal(text: string) {
+  const match = text.match(/^(.+?):\s*(\d+)$/);
+  return { label: (match?.[1] ?? text).trim(), count: match?.[2] };
+}
+
+function signalSuggestion(label: string) {
+  const lower = label.toLowerCase();
+  if (lower.includes("music discussion")) return "Music discussion signal. BNL found repeated music discussion, but this does not prove a public music identity or owned link.";
+  if (lower.includes("feedback")) return "Feedback request signal. BNL found review/feedback patterns, but this is context rather than a public-ready fact.";
+  if (lower.includes("song") || lower.includes("track")) return "Music mention signal. BNL found song/track/demo/WIP language without enough public-safe link ownership evidence.";
+  if (lower.includes("generic links")) return "Generic link signal. BNL found links, but they still need ownership and public-use confirmation.";
+  return "Context signal. BNL used this pattern during analysis, but it is not a public-ready fact by itself.";
+}
+
+function buildCardGuidance(claimText: string, claimType: DossierSourceFileClaimType, record?: UnknownRecord) {
+  const lower = `${claimText} ${analystString(record, ["claimType", "title"]) ?? ""}`.toLowerCase();
+  if (lower.includes("display name") || lower.includes("preferred name")) return {
+    decisionQuestion: "What exact display name may BNL use publicly?",
+    placeholderText: "Crow",
+    exampleApprovedTexts: ["Crow", "Use Crow publicly; keep other aliases internal."],
+  };
+  if (lower.includes("role") || lower.includes("title")) return {
+    title: "Confirm public role/title",
+    decisionQuestion: "Which public label, if any, may BNL use for Crow?",
+    whyItExists: "BNL found role/community/music/context signals, but not enough confirmed public-safe evidence to state a formal role.",
+    placeholderText: "Crow is a BARCODE Network community member.",
+    exampleApprovedTexts: ["Crow is a BARCODE Network community member.", "Crow is a BARCODE Radio viewer/community participant.", "Do not state a public role for Crow yet."],
+  };
+  if (lower.includes("link")) return {
+    decisionQuestion: "Which links are owned/approved for public reference?",
+    placeholderText: "No public links approved yet.",
+    exampleApprovedTexts: ["No public links approved yet.", "Approved public link: https://...", "Do not mention Crow music links until owner confirms them."],
+  };
+  if (lower.includes("orion")) return {
+    decisionQuestion: "Can BNL mention Orion in public Crow context, or keep it internal?",
+    placeholderText: "Keep Orion context internal for now.",
+    exampleApprovedTexts: ["Keep Orion context internal for now.", "BNL may reference Orion only as internal BARCODE context, not public dossier copy.", "BNL may mention Crow has recurring Orion-related BARCODE lore/context."],
+  };
+  if (lower.includes("queue") || lower.includes("submission")) return {
+    decisionQuestion: "Can BNL mention Crow’s queue/submission history publicly?",
+    placeholderText: "Do not reference queue/submission history publicly.",
+    exampleApprovedTexts: ["Do not reference queue/submission history publicly.", "Crow has submitted music to BARCODE Radio.", "Keep queue/submission history internal."],
+  };
+  return {
+    decisionQuestion: claimType === "source_blind" ? "Should this source-blind context stay internal, need provenance, or be rejected?" : "What decision should admins make for this Source File item?",
+    placeholderText: claimType === "source_blind" ? "Add separate public-safe replacement wording only if confirmed elsewhere." : "Enter the exact sentence BNL may use as a Source File fact.",
+    exampleApprovedTexts: claimType === "source_blind" ? ["Keep this context internal until provenance is confirmed."] : ["Enter the exact public-safe wording admins have confirmed."],
+  };
+}
+
+function buildClaimCard(input: { value: unknown; sourceSection: string; claimType: DossierSourceFileClaimType; candidateId?: string; sourceArchiveId?: string; reviews?: Map<string, DossierSourceFileClaimReview> }): DossierSourceFileReviewableClaim | undefined {
+  const record = asRecord(input.value);
+  const claimText = displayValue(input.value) ?? analystString(record, ["claimText", "text", "claim", "question", "action", "boundary"]);
+  if (!claimText) return undefined;
+  const claimType = classifyClaimType(input.sourceSection, record) || input.claimType;
+  const guidance = claimType === "recommended_action" || claimType === "do_not_say"
+    ? { decisionQuestion: claimType === "recommended_action" ? "What admin follow-up should happen for this task?" : "Should this public boundary stay in force?", placeholderText: "", exampleApprovedTexts: [] }
+    : buildCardGuidance(claimText, claimType, record);
+  const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
+  const blockedBy = stringItems(record?.blockedBy);
+  return {
+    id,
+    claimText,
+    claimType,
+    sourceSection: input.sourceSection,
+    title: analystString(record, ["title", "label"]) ?? guidance.title ?? (claimType === "do_not_say" ? "Public boundary" : claimType === "recommended_action" ? "Admin task" : claimType === "missing_info" ? "Missing confirmation" : "Review Source File claim"),
+    decisionQuestion: analystString(record, ["decisionQuestion", "question"]) ?? guidance.decisionQuestion,
+    whyItExists: analystString(record, ["why", "whyItExists", "reason"]) ?? guidance.whyItExists ?? "BNL flagged this because it needs an explicit admin decision before use.",
+    safeEvidenceSummary: analystString(record, ["safeEvidenceSummary", "evidenceSummary", "summary"]),
+    reviewLane: analystString(record, ["reviewLane", "lane", "safetyLane"]),
+    confidence: analystString(record, ["confidence"]),
+    suggestedDecision: analystString(record, ["suggestedDecision", "recommendation"]),
+    safestDefault: analystString(record, ["safestDefault"]) ?? (claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or needs more info until owner/admin confirms the wording."),
+    blockedBy,
+    whatYouAreApproving: claimType === "recommended_action" ? "An admin task state, not a public claim approval." : claimType === "do_not_say" ? "A public-copy boundary that protects against unsupported claims." : claimType === "source_blind" ? "Only a separately confirmed public-safe replacement, not the source-blind text itself." : "A Source File review decision. Confirming public-ready does not publish a dossier.",
+    whatToEnter: claimType === "recommended_action" ? "No public-safe text is required unless this task explicitly creates a Source File note." : claimType === "do_not_say" ? "No public-ready wording should be entered for boundaries." : claimType === "source_blind" ? "Add public-safe replacement text, if owner/admin confirms it elsewhere." : "Enter the exact sentence BNL may use as a Source File fact.",
+    placeholderText: guidance.placeholderText,
+    exampleApprovedTexts: guidance.exampleApprovedTexts,
+    actionConsequences: {
+      confirmed_public: "Creates a public-safe Source File fact. It does not publish a dossier.",
+      confirmed_internal: "Stores this as internal Source File context only.",
+      needs_more_info: "Keeps this open as a missing confirmation.",
+      rejected: "Marks this claim as rejected so it does not keep appearing as pending.",
+      edited: claimType === "source_blind" ? "Adds only the edited public-safe replacement wording after separate confirmation." : "Saves edited public-safe Source File wording.",
+    },
+    canConfirmPublic: claimType === "public_ready" || claimType === "review_needed",
+    canConfirmInternal: claimType !== "do_not_say",
+    canReject: true,
+    canNeedMoreInfo: claimType !== "do_not_say",
+    requiresEditedTextForPublic: claimType === "source_blind",
+    review: input.reviews?.get(id),
+  };
+}
+
 export function deriveDossierSourceFileReviewableClaims(input: {
   analystRead?: DossierSubjectAnalystReadV1;
   candidateId?: string;
   sourceArchiveId?: string;
   reviews?: DossierSourceFileClaimReview[];
-}): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[] } {
-  const sections: Array<{ sourceSection: string; claimType: DossierSourceFileClaimType; values: unknown }> = [
-    { sourceSection: "publicReadyClaims", claimType: "public_ready", values: input.analystRead?.publicReadyClaims },
-    { sourceSection: stringItems(input.analystRead?.sourceFileReviewClaims).length ? "sourceFileReviewClaims" : "reviewNeededClaims", claimType: "review_needed", values: stringItems(input.analystRead?.sourceFileReviewClaims).length ? input.analystRead?.sourceFileReviewClaims : input.analystRead?.reviewNeededClaims },
-    { sourceSection: "sourceBlindInsights", claimType: "source_blind", values: input.analystRead?.sourceBlindInsights },
-    { sourceSection: "missingInfoQuestions", claimType: "missing_info", values: input.analystRead?.missingInfoQuestions },
+}): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[]; signals: SourceFileSignalSummary[] } {
+  const reviewById = new Map((input.reviews ?? []).map((review) => [review.id, review]));
+  const structured = listValues(input.analystRead?.reviewableClaims);
+  const sections: Array<{ sourceSection: string; claimType: DossierSourceFileClaimType; values: unknown }> = structured.length
+    ? [{ sourceSection: "reviewableClaims", claimType: "review_needed", values: structured }]
+    : [
+      { sourceSection: "publicReadyClaims", claimType: "public_ready", values: input.analystRead?.publicReadyClaims },
+      { sourceSection: stringItems(input.analystRead?.sourceFileReviewClaims).length ? "sourceFileReviewClaims" : "reviewNeededClaims", claimType: "review_needed", values: stringItems(input.analystRead?.sourceFileReviewClaims).length ? input.analystRead?.sourceFileReviewClaims : input.analystRead?.reviewNeededClaims },
+      { sourceSection: "sourceBlindInsights", claimType: "source_blind", values: input.analystRead?.sourceBlindInsights },
+    ];
+  sections.push(
+    { sourceSection: "missingConfirmations", claimType: "missing_info", values: input.analystRead?.missingConfirmations ?? input.analystRead?.missingInfoQuestions },
     { sourceSection: "recommendedAdminActions", claimType: "recommended_action", values: input.analystRead?.recommendedAdminActions },
     { sourceSection: "doNotSayPublicly", claimType: "do_not_say", values: input.analystRead?.doNotSayPublicly },
-  ];
-  const reviewById = new Map((input.reviews ?? []).map((review) => [review.id, review]));
-  const current = sections.flatMap((section) => stringItems(section.values).map((claimText) => {
-    const id = stableClaimId({ candidateId: input.candidateId, sourceSection: section.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
-    return { id, claimText, claimType: section.claimType, sourceSection: section.sourceSection, review: reviewById.get(id) };
+  );
+  const allCards = sections.flatMap((section) => listValues(section.values).flatMap((value) => {
+    const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, reviews: reviewById });
+    return card ? [card] : [];
   }));
+  const signals = allCards.filter((card) => isSignalSummaryText(card.claimText, asRecord(card))).map((card) => {
+    const split = splitSignal(card.claimText);
+    return { id: card.id, label: split.label, count: split.count, suggestion: signalSuggestion(split.label), actionable: "Not directly actionable as a public fact." };
+  });
+  const current = allCards.filter((card) => !signals.some((signal) => signal.id === card.id));
   const currentIds = new Set(current.map((claim) => claim.id));
   return {
     current,
+    signals,
     previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
       id: review.id,
       claimText: review.claimText,
@@ -533,36 +688,77 @@ function ClaimReviewControls({ claim, onReview }: {
 }) {
   const decision = claim.review?.decision ?? "pending";
   const buttons: Array<[string, DossierSourceFileClaimReviewDecision, boolean?]> =
-    claim.claimType === "public_ready" ? [["Confirm public-ready", "confirmed_public", true], ["Keep internal", "confirmed_internal"], ["Reject", "rejected"]]
-    : claim.claimType === "review_needed" ? [["Confirm public-ready", "confirmed_public", true], ["Confirm internal", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "source_blind" ? [["Keep source-blind/internal", "confirmed_internal"], ["Needs provenance", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "missing_info" ? [["Mark answered", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
+    claim.claimType === "do_not_say" ? [["Keep boundary", "confirmed_internal"], ["Reject boundary", "rejected"]]
     : claim.claimType === "recommended_action" ? [["Mark done", "confirmed_internal"], ["Keep open", "needs_more_info"], ["Reject", "rejected"]]
-    : [["Keep boundary", "confirmed_internal"], ["Reject boundary", "rejected"]];
+    : claim.claimType === "source_blind" ? [["Keep internal", "confirmed_internal"], ["Needs provenance", "needs_more_info"], ["Reject", "rejected"]]
+    : claim.claimType === "missing_info" ? [["Mark answered", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]]
+    : claim.claimType === "public_ready" ? [["Confirm public-ready", "confirmed_public", true], ["Keep internal", "confirmed_internal"], ["Reject", "rejected"]]
+    : [["Confirm public-ready", "confirmed_public", true], ["Confirm internal", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject", "rejected"]];
   return (
-    <div className="mt-2 space-y-2">
+    <div className="mt-3 space-y-3">
       <span className={`inline-block border px-2 py-1 text-[0.65rem] uppercase tracking-widest ${decision === "confirmed_public" ? "border-accent text-accent" : "border-border text-muted"}`}>
         {decision.replace(/_/g, " ")}
       </span>
-      <div className="flex flex-wrap gap-2">
+      <div className="grid gap-2 sm:grid-cols-2">
         {buttons.map(([label, nextDecision, publicSafe]) => (
-          <button key={label} type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, nextDecision, { publicSafe: publicSafe === true })}>
-            {label}
-          </button>
+          <div key={label} className="border border-border/40 p-2">
+            <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => {
+              if (claim.claimType === "missing_info" && nextDecision === "confirmed_internal") return;
+              onReview?.(claim, nextDecision, { publicSafe: publicSafe === true });
+            }}>
+              {label}
+            </button>
+            <p className="mt-1 text-[0.7rem] text-muted/80">{claim.actionConsequences?.[nextDecision] ?? "Stores this admin decision."}</p>
+          </div>
         ))}
       </div>
-      <form className="flex flex-col gap-2 sm:flex-row" onSubmit={(event) => {
+      {claim.claimType === "missing_info" && <p className="text-xs text-accent">Enter the exact answer BNL should use, or choose Needs more info / Reject.</p>}
+      {claim.claimType !== "recommended_action" && claim.claimType !== "do_not_say" && <form className="flex flex-col gap-2" onSubmit={(event) => {
         event.preventDefault();
         const form = new FormData(event.currentTarget);
         const editedText = String(form.get("editedText") ?? "").trim();
-        if (editedText) onReview?.(claim, "edited", { editedText, publicSafe: true });
+        if (!editedText) return;
+        onReview?.(claim, "edited", { editedText, publicSafe: claim.claimType !== "source_blind" || Boolean(editedText) });
         event.currentTarget.reset();
       }}>
-        <input name="editedText" className="flex-1 border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder="Edit + confirm public-safe text" />
-        <button type="submit" className="border border-accent px-2 py-1 text-xs text-accent">Edit + confirm</button>
-      </form>
+        {claim.claimType === "source_blind" && <p className="border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
+        <label className="text-xs font-bold text-foreground" htmlFor={`${claim.id}-edited`}>{claim.whatToEnter}</label>
+        <input id={`${claim.id}-edited`} name="editedText" className="border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder={claim.placeholderText ?? "Enter exact public-safe wording"} />
+        <button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">{claim.claimType === "source_blind" ? "Add public-safe replacement" : "Save exact answer / edited text"}</button>
+      </form>}
     </div>
   );
+}
+
+function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
+  return (
+    <li className="border border-border/40 bg-background/30 p-3">
+      <h5 className="text-sm font-bold text-foreground">{claim.title}</h5>
+      <p className="mt-1 text-foreground">{claim.claimText}</p>
+      {claim.claimType === "source_blind" && <p className="mt-2 border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
+      <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+        <div><dt className="font-bold text-accent">Decision needed</dt><dd className="text-foreground">{claim.decisionQuestion}</dd></div>
+        <div><dt className="font-bold text-accent">What BNL thinks</dt><dd className="text-foreground">{claim.suggestedDecision ?? "Admin review is needed before use."}</dd></div>
+        <div><dt className="font-bold text-accent">Why BNL flagged this</dt><dd className="text-foreground">{claim.whyItExists}</dd></div>
+        <div><dt className="font-bold text-accent">Evidence summary</dt><dd className="text-foreground">{claim.safeEvidenceSummary ?? "No public-safe evidence summary provided."}</dd></div>
+        <div><dt className="font-bold text-accent">Safety lane</dt><dd className="text-foreground">{claim.reviewLane ?? claim.claimType.replace(/_/g, " ")}{claim.confidence ? ` · ${claim.confidence} confidence` : ""}</dd></div>
+        <div><dt className="font-bold text-accent">Safest default</dt><dd className="text-foreground">{claim.safestDefault}</dd></div>
+        <div><dt className="font-bold text-accent">What to enter if approving</dt><dd className="text-foreground">{claim.whatToEnter}</dd></div>
+        <div><dt className="font-bold text-accent">What you are approving</dt><dd className="text-foreground">{claim.whatYouAreApproving}</dd></div>
+      </dl>
+      {claim.blockedBy && claim.blockedBy.length > 0 && <p className="mt-2 text-xs text-muted">Blocked by: {claim.blockedBy.join(", ")}</p>}
+      {claim.exampleApprovedTexts && claim.exampleApprovedTexts.length > 0 && <div className="mt-2 text-xs"><p className="font-bold text-foreground">Example approved text</p><ul className="list-disc pl-5 text-muted">{claim.exampleApprovedTexts.map((example) => <li key={example}>{example}</li>)}</ul></div>}
+      <ClaimReviewControls claim={claim} onReview={onReview} />
+    </li>
+  );
+}
+
+function WithheldEvidenceAudit({ audit }: { audit: unknown }) {
+  const record = asRecord(audit);
+  if (!record) return null;
+  const categories = listRecords(record.categories ?? record.categoryCounts ?? record.counts);
+  const examples = stringItems(record.safeExamples ?? record.redactedExamples ?? record.examples).filter((example) => !/@|stripe|payment|customer|priority|token|raw id|database row/i.test(example));
+  return <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Withheld Evidence Audit</h4><p className="mb-2 text-xs text-muted/80">This explains what BNL excluded. These are not items you need to review one by one.</p><p className="text-foreground">Total withheld: {scalarLabel(record.totalWithheld ?? record.total ?? record.count)}</p>{categories.length > 0 && <ul className="mt-2 space-y-2 text-foreground">{categories.map((category, index) => <li key={index} className="border border-border/40 p-2">{scalarLabel(category.category ?? category.label ?? category.type)}: {scalarLabel(category.count)}{displayValue(category.reason) ? ` — ${displayValue(category.reason)}` : ""}</li>)}</ul>}{examples.length > 0 && <div className="mt-2"><p className="text-xs font-bold text-foreground">Safe redacted examples</p><ul className="list-disc pl-5 text-foreground">{examples.map((example) => <li key={example}>{example}</li>)}</ul></div>}</section>;
 }
 
 function BnlAnalystReadPanel({
@@ -589,10 +785,11 @@ function BnlAnalystReadPanel({
   }
   const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, reviews: claimReviews });
   const sectionEntries = [
+    ["reviewableClaims", "Source File Claim Decisions"],
     ["publicReadyClaims", "Public-Ready Claims"],
     [stringItems(analystRead.sourceFileReviewClaims).length ? "sourceFileReviewClaims" : "reviewNeededClaims", "Review-Needed Claims"],
     ["sourceBlindInsights", "Source-blind / Withheld Context"],
-    ["missingInfoQuestions", "Missing Confirmations"],
+    ["missingConfirmations", "Missing Confirmations"],
     ["recommendedAdminActions", "Recommended Admin Actions"],
     ["doNotSayPublicly", "Do Not Say Publicly"],
   ] as const;
@@ -607,11 +804,14 @@ function BnlAnalystReadPanel({
         </dl>
         <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Internal Read</h4><BriefParagraphs value={analystRead.internalRead} /></section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
+        {reviewable.signals.length > 0 && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Evidence Signals / Pattern Summary</h4><p className="mb-2 text-xs text-muted/80">These are pattern counts and context signals BNL used for analysis. They are not public-ready facts by themselves.</p><ul className="space-y-2 text-foreground">{reviewable.signals.map((signal) => <li key={signal.id} className="border border-border/40 p-2"><p className="font-bold">{signal.label}{signal.count ? `: ${signal.count}` : ""}</p><p className="text-xs text-muted">{signal.suggestion}</p><p className="text-xs text-muted">Action: {signal.actionable}</p></li>)}</ul></section>}
         {sectionEntries.map(([section, label]) => {
           const claims = reviewable.current.filter((claim) => claim.sourceSection === section);
+          if (!claims.length && section === "reviewableClaims") return null;
           const privateExclusions = section === "sourceBlindInsights" ? stringItems(analystRead.privateOrInternalExclusions) : [];
-          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => <li key={claim.id} className="border border-border/40 p-2"><p>{claim.claimText}</p><ClaimReviewControls claim={claim} onReview={onReviewClaim} /></li>)}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
+          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => <ClaimDecisionCard key={claim.id} claim={claim} onReview={onReviewClaim} />)}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
         })}
+        <WithheldEvidenceAudit audit={analystRead.withheldEvidenceAudit} />
         {reviewable.previous.length > 0 && <details className="border border-border/50 bg-background/20 p-3"><summary className="cursor-pointer text-xs font-bold uppercase tracking-widest text-foreground">Previously reviewed claims</summary><ul className="mt-3 space-y-3 text-foreground">{reviewable.previous.map((claim) => <li key={claim.id} className="border border-border/40 p-2"><p>{claim.claimText}</p><ClaimReviewControls claim={claim} onReview={onReviewClaim} /></li>)}</ul></details>}
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Provenance Summary</h4><AnalystList value={analystRead.provenanceSummary} empty="No provenance summary reported." /></section>
       </div>

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -513,8 +513,17 @@ export type DossierSourceFileReviewableClaim = {
   suggestedApprovedText?: string;
   suggestedInternalText?: string;
   suggestedAnswerText?: string;
+  suggestedRejectionReason?: string;
+  suggestedTextSource?: "bnl" | "site_fallback" | "none";
+  suggestedInternalTextSource?: "bnl" | "site_fallback" | "none";
+  suggestedAnswerTextSource?: "bnl" | "site_fallback" | "none";
   bnlRecommendationText?: string;
+  recommendedAction?: string;
+  recommendedActionReason?: string;
+  cannotSuggestPublicReason?: string;
+  actionability?: string;
   hasSafePublicSuggestion?: boolean;
+  isVagueArtifact?: boolean;
   review?: DossierSourceFileClaimReview;
 };
 
@@ -538,23 +547,28 @@ function analystString(record: UnknownRecord | undefined, keys: string[]) {
 }
 
 function classifyClaimType(sourceSection: string, record?: UnknownRecord): DossierSourceFileClaimType {
-  const lane = `${analystString(record, ["reviewLane", "lane", "safetyLane"]) ?? ""} ${analystString(record, ["claimType", "type"]) ?? ""}`.toLowerCase();
-  if (sourceSection === "sourceBlindInsights" || /source[-_ ]?blind|withheld|private|internal/.test(lane)) return "source_blind";
-  if (sourceSection === "missingInfoQuestions" || sourceSection === "missingConfirmations") return "missing_info";
-  if (sourceSection === "recommendedAdminActions") return "recommended_action";
-  if (sourceSection === "doNotSayPublicly") return "do_not_say";
+  const lane = `${analystString(record, ["reviewLane", "lane", "safetyLane"]) ?? ""} ${analystString(record, ["claimType", "type", "actionability"]) ?? ""}`.toLowerCase();
+  if (sourceSection === "sourceBlindInsights" || /source[-_ ]?blind|source_blind_warning|withheld|private|internal/.test(lane)) return "source_blind";
+  if (sourceSection === "missingInfoQuestions" || sourceSection === "missingConfirmations" || /missing_confirmation/.test(lane)) return "missing_info";
+  if (sourceSection === "recommendedAdminActions" || /admin_task/.test(lane)) return "recommended_action";
+  if (sourceSection === "doNotSayPublicly" || /boundary/.test(lane)) return "do_not_say";
   if (/public[-_ ]?ready/.test(lane) || record?.publicSafe === true) return "public_ready";
   return "review_needed";
 }
 
 function isSignalSummaryText(text: string, record?: UnknownRecord) {
-  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision"]) ?? ""}`.toLowerCase();
+  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision", "actionability"]) ?? ""}`.toLowerCase();
   return /music discussion only|song\/track\/demo\/wip|feedback requests|generic links|moderation\/community support|source files\/dossiers|pattern summary|signal summary|signal_count|evidence_signal/.test(joined);
 }
 
 function isWeakEvidenceLabelText(text: string, record?: UnknownRecord) {
-  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision"]) ?? ""}`.toLowerCase();
+  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "suggestedDecision", "actionability"]) ?? ""}`.toLowerCase();
   return /^(possible review claim:\s*)?(contest organizer|rules\/instructions poster|lore-heavy|theory\/anomaly-heavy|antagonistic\/challenging)$/i.test(text.trim()) || /weak evidence label|weak_label|evidence label/.test(joined);
+}
+
+function isVagueArtifactText(text: string, record?: UnknownRecord) {
+  const joined = `${text} ${analystString(record, ["claimType", "type", "reviewLane", "actionability"]) ?? ""}`.toLowerCase();
+  return /subject-owned\/keyed local evidence exists|some subject memory lacked public-safe provenance|local evidence exists|raw source evidence exists|source-blind\/internal context|non_actionable_artifact/.test(joined);
 }
 
 function subjectLabel(value?: string) {
@@ -571,25 +585,29 @@ function humanBnlRecommendation(claimType: DossierSourceFileClaimType, suggested
   return "BNL recommends admin review before use.";
 }
 
-function suggestedTextsForClaim(input: { claimText: string; claimType: DossierSourceFileClaimType; record?: UnknownRecord; subjectName: string; weakLabel: boolean }) {
-  const explicit = analystString(input.record, ["suggestedApprovedText", "suggestedPublicText", "publicSafeText", "approvedText", "suggestedText"]);
-  const internal = analystString(input.record, ["suggestedInternalText", "suggestedInternalNote", "internalNote"]);
-  const answer = analystString(input.record, ["suggestedAnswer", "suggestedAnswerText", "answer"]);
+function suggestedTextsForClaim(input: { claimText: string; claimType: DossierSourceFileClaimType; record?: UnknownRecord; subjectName: string; weakLabel: boolean; vagueArtifact: boolean }) {
+  const explicitPublic = analystString(input.record, ["suggestedPublicWording"]);
+  const legacyExplicitPublic = analystString(input.record, ["suggestedApprovedText", "suggestedPublicText", "publicSafeText", "approvedText"]);
+  const explicitInternal = analystString(input.record, ["suggestedInternalNote"]);
+  const legacyInternal = analystString(input.record, ["suggestedInternalText", "internalNote"]);
+  const explicitQuestion = analystString(input.record, ["suggestedMissingInfoQuestion"]);
+  const legacyAnswer = analystString(input.record, ["suggestedAnswer", "suggestedAnswerText", "answer"]);
+  const rejection = analystString(input.record, ["suggestedRejectionReason"]);
   const lower = `${input.claimText} ${analystString(input.record, ["claimType", "title"]) ?? ""}`.toLowerCase();
-  if (input.weakLabel || lower.trim() === "contest organizer") {
-    return {
-      approved: undefined,
-      internal: internal ?? "Keep this as internal pattern context only.",
-      answer,
-      fallback: `Reject this claim if ${input.subjectName} is not actually a contest organizer.`,
-    };
-  }
-  if (lower.includes("display name") || lower.includes("preferred name")) return { approved: explicit ?? input.subjectName, internal: internal ?? `Use ${input.subjectName} publicly; keep other aliases internal.`, answer: answer ?? input.subjectName };
-  if (lower.includes("role") || lower.includes("title")) return { approved: explicit ?? `${input.subjectName} is a BARCODE Network community member.`, internal: internal ?? `Keep role/title internal until owner confirms ${input.subjectName}.`, answer: answer ?? `Do not state a public role for ${input.subjectName} yet.` };
-  if (lower.includes("link")) return { approved: explicit, internal: internal ?? `No public links are approved for ${input.subjectName} yet.`, answer: answer ?? `No public links are approved for ${input.subjectName} yet.` };
-  if (lower.includes("orion")) return { approved: explicit, internal: internal ?? "Keep Orion context internal for now.", answer: answer ?? "Keep Orion context internal for now." };
-  if (lower.includes("queue") || lower.includes("submission")) return { approved: explicit, internal: internal ?? `Do not reference ${input.subjectName}'s queue/submission history publicly.`, answer: answer ?? "Do not reference queue/submission history publicly." };
-  return { approved: explicit ?? (input.record?.publicSafe === true ? input.claimText : undefined), internal: internal ?? input.claimText, answer };
+  const publicText = explicitPublic ?? legacyExplicitPublic;
+  const publicSource = explicitPublic ? "bnl" : legacyExplicitPublic ? "site_fallback" : "none";
+  const internal = explicitInternal ?? legacyInternal;
+  const internalSource = explicitInternal ? "bnl" : legacyInternal ? "site_fallback" : "none";
+  const question = explicitQuestion ?? legacyAnswer;
+  const questionSource = explicitQuestion ? "bnl" : legacyAnswer ? "site_fallback" : "none";
+  if (input.vagueArtifact) return { approved: publicText, publicSource, internal: internal ?? "Keep as internal audit context only.", internalSource: internal ? internalSource : "site_fallback", answer: question, answerSource: questionSource, rejection };
+  if (input.weakLabel || lower.trim() === "contest organizer") return { approved: publicText, publicSource, internal: internal ?? "Keep this as internal pattern context only.", internalSource: internal ? internalSource : "site_fallback", answer: question ?? `Reject this claim if ${input.subjectName} is not actually a contest organizer.`, answerSource: question ? questionSource : "site_fallback", rejection };
+  if (lower.includes("display name") || lower.includes("preferred name")) return { approved: publicText, publicSource, internal: internal ?? `Use ${input.subjectName} publicly; keep other aliases internal.`, internalSource: internal ? internalSource : "site_fallback", answer: question ?? input.subjectName, answerSource: question ? questionSource : "site_fallback", rejection };
+  if (lower.includes("role") || lower.includes("title")) return { approved: publicText, publicSource, internal: internal ?? `Keep role/title internal until owner confirms ${input.subjectName}.`, internalSource: internal ? internalSource : "site_fallback", answer: question ?? `Do not state a public role for ${input.subjectName} yet.`, answerSource: question ? questionSource : "site_fallback", rejection };
+  if (lower.includes("link")) return { approved: publicText, publicSource, internal: internal ?? `No public links are approved for ${input.subjectName} yet.`, internalSource: internal ? internalSource : "site_fallback", answer: question ?? `No public links are approved for ${input.subjectName} yet.`, answerSource: question ? questionSource : "site_fallback", rejection };
+  if (lower.includes("orion")) return { approved: publicText, publicSource, internal: internal ?? "Keep Orion context internal for now.", internalSource: internal ? internalSource : "site_fallback", answer: question ?? "Keep Orion context internal for now.", answerSource: question ? questionSource : "site_fallback", rejection };
+  if (lower.includes("queue") || lower.includes("submission")) return { approved: publicText, publicSource, internal: internal ?? `Do not reference ${input.subjectName}'s queue/submission history publicly.`, internalSource: internal ? internalSource : "site_fallback", answer: question ?? "Do not reference queue/submission history publicly.", answerSource: question ? questionSource : "site_fallback", rejection };
+  return { approved: publicText, publicSource, internal: internal ?? input.claimText, internalSource: internal ? internalSource : "site_fallback", answer: question, answerSource: questionSource, rejection };
 }
 
 function splitSignal(text: string) {
@@ -649,13 +667,14 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
   const claimType = classifyClaimType(input.sourceSection, record) || input.claimType;
   const displaySubject = subjectLabel(input.subjectName ?? analystString(record, ["subjectName"]));
   const weakLabel = isWeakEvidenceLabelText(claimText, record);
+  const vagueArtifact = isVagueArtifactText(claimText, record);
   const guidance = weakLabel
     ? { title: "Weak evidence label / pattern", decisionQuestion: "Is this label accurate and useful, or should it be rejected?", placeholderText: "Only enter wording here if this label is true and public-safe. Otherwise reject this claim.", exampleApprovedTexts: [`Keep ${displaySubject} label internal until confirmed.`, "Reject this label as inaccurate or not useful."] }
     : claimType === "recommended_action" || claimType === "do_not_say"
       ? { decisionQuestion: claimType === "recommended_action" ? "What admin follow-up should happen for this task?" : "Should this public boundary stay in force?", placeholderText: "", exampleApprovedTexts: [] }
       : buildCardGuidance(claimText, claimType, record, displaySubject);
-  const suggested = suggestedTextsForClaim({ claimText, claimType, record, subjectName: displaySubject, weakLabel });
-  const rawSuggestedDecision = analystString(record, ["suggestedDecision", "recommendation"]);
+  const suggested = suggestedTextsForClaim({ claimText, claimType, record, subjectName: displaySubject, weakLabel, vagueArtifact });
+  const rawSuggestedDecision = analystString(record, ["recommendedAction", "suggestedDecision", "recommendation"]);
   const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
   const blockedBy = stringItems(record?.blockedBy);
   return {
@@ -664,9 +683,11 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     claimType,
     sourceSection: input.sourceSection,
     isWeakEvidenceLabel: weakLabel,
-    whatAmIDeciding: weakLabel
-      ? "This appears to be an evidence label or pattern, not a confirmed fact. Do not approve it as public unless you know the exact public-safe wording is true."
-      : claimType === "source_blind"
+    whatAmIDeciding: vagueArtifact
+      ? "This is not a public-ready claim. BNL has not provided a concrete fact to approve."
+      : weakLabel
+        ? "This appears to be an evidence label or pattern, not a confirmed fact. Do not approve it as public unless BNL or an admin provides exact public-safe wording that is true."
+        : claimType === "source_blind"
         ? "You are deciding whether this source-blind context should stay internal, needs a public source, or should be rejected as irrelevant/incorrect."
         : /contest organizer/i.test(claimText)
           ? `You are deciding whether ${displaySubject} is actually a contest organizer. If not, reject this claim.`
@@ -689,9 +710,18 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     bnlRecommendationText: humanBnlRecommendation(claimType, rawSuggestedDecision, weakLabel),
     suggestedApprovedText: suggested.approved,
     suggestedInternalText: suggested.internal,
-    suggestedAnswerText: suggested.answer ?? suggested.fallback,
-    hasSafePublicSuggestion: Boolean(suggested.approved && (record?.publicSafe === true || claimType === "public_ready" || /public/.test((rawSuggestedDecision ?? "").toLowerCase())) && !weakLabel && claimType !== "source_blind"),
-    safestDefault: analystString(record, ["safestDefault"]) ?? (weakLabel ? "Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording." : claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or needs more info until owner/admin confirms the wording."),
+    suggestedAnswerText: suggested.answer,
+    suggestedRejectionReason: suggested.rejection,
+    suggestedTextSource: suggested.publicSource as "bnl" | "site_fallback" | "none",
+    suggestedInternalTextSource: suggested.internalSource as "bnl" | "site_fallback" | "none",
+    suggestedAnswerTextSource: suggested.answerSource as "bnl" | "site_fallback" | "none",
+    recommendedAction: analystString(record, ["recommendedAction"]),
+    recommendedActionReason: analystString(record, ["recommendedActionReason"]),
+    cannotSuggestPublicReason: analystString(record, ["cannotSuggestPublicReason"]),
+    actionability: analystString(record, ["actionability"]),
+    isVagueArtifact: vagueArtifact,
+    hasSafePublicSuggestion: Boolean(suggested.approved && suggested.publicSource === "bnl" && (record?.publicSafe === true || claimType === "public_ready" || /approve_public|public/.test((rawSuggestedDecision ?? "").toLowerCase())) && !weakLabel && !vagueArtifact && claimType !== "source_blind"),
+    safestDefault: analystString(record, ["safestDefault"]) ?? (vagueArtifact ? "Keep as internal audit context, ask for a public source, or dismiss the artifact." : weakLabel ? "Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording." : claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or ask for confirmation until owner/admin confirms the wording."),
     blockedBy,
     whatYouAreApproving: claimType === "recommended_action" ? "An admin task state, not a public claim approval." : claimType === "do_not_say" ? "A public-copy boundary that protects against unsupported claims." : claimType === "source_blind" ? "Only a separately confirmed public-safe replacement, not the source-blind text itself." : "A Source File review decision. Confirming public-ready does not publish a dossier.",
     whatToEnter: claimType === "recommended_action" ? "No public-safe text is required unless this task explicitly creates a Source File note." : claimType === "do_not_say" ? "No public-ready wording should be entered for boundaries." : claimType === "source_blind" ? "Add public-safe replacement text, if owner/admin confirms it elsewhere." : "Enter the exact sentence BNL may use as a Source File fact.",
@@ -794,51 +824,59 @@ function ClaimReviewControls({ claim, onReview }: {
   const publicSuggestion = claim.suggestedApprovedText?.trim();
   const internalSuggestion = claim.suggestedInternalText?.trim() || claim.claimText;
   const answerSuggestion = claim.suggestedAnswerText?.trim();
-  const canApproveSuggestion = Boolean(claim.hasSafePublicSuggestion && publicSuggestion && (claim.claimType === "public_ready" || claim.claimType === "review_needed"));
+  const rejectionSuggestion = claim.suggestedRejectionReason?.trim();
+  const canApproveSuggestion = Boolean(claim.hasSafePublicSuggestion && claim.suggestedTextSource === "bnl" && publicSuggestion && (claim.claimType === "public_ready" || claim.claimType === "review_needed"));
+  const rejectLabel = claim.isVagueArtifact ? "Dismiss artifact" : claim.isWeakEvidenceLabel ? "Reject label" : "Reject claim";
+  const internalLabel = claim.suggestedInternalTextSource === "bnl" ? "BNL suggested internal note" : "Fallback guidance";
+
   if (claim.claimType === "do_not_say") {
     return <div className="mt-3 grid gap-2 sm:grid-cols-2"><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false })}>Keep boundary</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Remove boundary</button></div>;
   }
   if (claim.claimType === "recommended_action") {
-    return <div className="mt-3 grid gap-2 sm:grid-cols-3"><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false })}>Mark done</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Keep open</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button></div>;
+    return <div className="mt-3 grid gap-2 sm:grid-cols-3"><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false })}>Mark done</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Keep open</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject claim</button></div>;
   }
-  if (claim.claimType === "source_blind") {
+  if (claim.claimType === "missing_info") {
+    const answerLabel = claim.suggestedAnswerTextSource === "bnl" ? "BNL suggested confirmation question" : "Suggested fallback question";
     return (
       <div className="mt-3 space-y-3">
-        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested internal note</p><p className="text-foreground">{internalSuggestion}</p></div>
+        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">{answerLabel}</p><p className="text-foreground">{answerSuggestion ?? "No BNL confirmation question yet."}</p></div>
         <div className="grid gap-2 sm:grid-cols-2">
-          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>Keep internal</button>
-          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit internal note</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={internalSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save internal note</button></form></details>
-          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs public source</button>
-          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button>
+          {answerSuggestion && <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: answerSuggestion })}>{claim.suggestedAnswerTextSource === "bnl" ? "Save suggested question" : "Save fallback question"}</button><p className="mt-1 text-[11px] text-muted">Creates or keeps a missing confirmation question for owner/admin review.</p></div>}
+          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit question</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={answerSuggestion ?? ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save edited question</button></form></details>
+          <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Ask for confirmation</button><p className="mt-1 text-[11px] text-muted">Creates or keeps a missing confirmation question for owner/admin review.</p></div>
+          <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false, decisionNote: rejectionSuggestion })}>Reject / not needed</button><p className="mt-1 text-[11px] text-muted">Rejects this question without requiring public wording.</p></div>
         </div>
       </div>
     );
   }
-  if (claim.claimType === "missing_info") {
+  if (claim.claimType === "source_blind" || claim.isVagueArtifact) {
     return (
       <div className="mt-3 space-y-3">
-        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">Suggested answer</p><p className="text-foreground">{answerSuggestion ?? "BNL does not have a suggested answer yet."}</p></div>
+        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">{internalLabel}</p><p className="text-foreground">{internalSuggestion}</p></div>
+        <p className="text-xs text-muted">This is not a public-ready claim. BNL has not provided a concrete fact to approve.</p>
         <div className="grid gap-2 sm:grid-cols-2">
-          {answerSuggestion && <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: answerSuggestion })}>Save suggested answer</button>}
-          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit answer</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={answerSuggestion ?? ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save edited answer</button></form></details>
-          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs more info</button>
-          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject / not needed</button>
+          <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>{claim.suggestedInternalTextSource === "bnl" ? "Save suggested internal note" : "Keep as internal audit context"}</button><p className="mt-1 text-[11px] text-muted">Stores this for Source File memory only. It will not become public dossier copy.</p></div>
+          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit internal note</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={internalSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save internal note</button></form></details>
+          <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Ask for public source</button><p className="mt-1 text-[11px] text-muted">Keeps this blocked until a public-safe source or owner-approved wording exists.</p></div>
+          <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false, decisionNote: rejectionSuggestion })}>{rejectLabel}</button><p className="mt-1 text-[11px] text-muted">Marks this technical/vague evidence artifact as not useful for Source File review.</p></div>
         </div>
       </div>
     );
   }
   return (
     <div className="mt-3 space-y-3">
-      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested wording</p>{publicSuggestion ? <p className="text-foreground">{publicSuggestion}</p> : <p className="text-muted">BNL does not have safe public wording for this yet. Choose Keep internal, Needs more info, Reject, or write approved wording manually.</p>}</div>
-      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested internal note</p><p className="text-foreground">{internalSuggestion}</p></div>
+      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">{claim.suggestedTextSource === "bnl" ? "BNL suggested public wording" : publicSuggestion ? "Example wording" : "No BNL suggested wording yet"}</p>{publicSuggestion ? <p className="text-foreground">{publicSuggestion}</p> : <p className="text-muted">BNL has not provided safe public wording for this yet. Choose Keep as internal audit context, Ask for confirmation, Reject claim, or write public wording manually.</p>}</div>
+      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">{internalLabel}</p><p className="text-foreground">{internalSuggestion}</p></div>
+      {rejectionSuggestion && <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested rejection reason</p><p className="text-foreground">{rejectionSuggestion}</p></div>}
       <div className="grid gap-2 sm:grid-cols-2">
-        {canApproveSuggestion && <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_public", { publicSafe: true, editedText: publicSuggestion })}>Approve suggested wording</button>}
-        {!canApproveSuggestion && <p className="border border-border/40 p-2 text-xs text-muted">BNL does not have safe public wording for this yet.</p>}
-        <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">{publicSuggestion ? "Edit wording" : "Write approved wording manually"}</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "edited", { publicSafe: true, editedText }); }}><textarea name="editedText" defaultValue={publicSuggestion ?? ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save edited wording</button></form></details>
-        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>Keep suggested internal context</button>
+        {canApproveSuggestion && <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_public", { publicSafe: true, editedText: publicSuggestion })}>Approve suggested wording</button><p className="mt-1 text-[11px] text-muted">Saves BNL’s suggested sentence as a public-safe Source File fact. This does not publish a dossier.</p></div>}
+        {!canApproveSuggestion && <p className="border border-border/40 p-2 text-xs text-muted">BNL has not provided safe public wording for this yet.</p>}
+        <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">{claim.suggestedTextSource === "bnl" ? "Edit wording" : "Write public wording manually"}</summary><p className="mt-1 text-[11px] text-muted">{claim.suggestedTextSource === "bnl" ? "Edit the suggested sentence before saving it as a public-safe Source File fact." : "Creates an admin-written public-safe Source File fact; this is not BNL’s recommendation."}</p><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "edited", { publicSafe: true, editedText }); }}><textarea name="editedText" defaultValue={claim.suggestedTextSource === "bnl" ? publicSuggestion : ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save public wording</button></form></details>
+        <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>{claim.suggestedInternalTextSource === "bnl" ? "Save suggested internal note" : "Keep as internal audit context"}</button><p className="mt-1 text-[11px] text-muted">Stores this for Source File memory only. It will not become public dossier copy.</p></div>
         <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit internal note</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={internalSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save internal note</button></form></details>
-        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs more info</button>
-        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button>
+        <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Ask for confirmation</button><p className="mt-1 text-[11px] text-muted">Creates or keeps a missing confirmation question for owner/admin review.</p></div>
+        {rejectionSuggestion ? <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit rejection reason</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const decisionNote = String(new FormData(event.currentTarget).get("decisionNote") ?? "").trim(); onReview?.(claim, "rejected", { publicSafe: false, decisionNote }); }}><textarea name="decisionNote" defaultValue={rejectionSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Reject with edited reason</button></form></details> : <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>{rejectLabel}</button><p className="mt-1 text-[11px] text-muted">Rejects this without requiring public wording.</p></div>}
+        {rejectionSuggestion && <div><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false, decisionNote: rejectionSuggestion })}>Reject with suggested reason</button><p className="mt-1 text-[11px] text-muted">Rejects this without requiring public wording.</p></div>}
       </div>
     </div>
   );

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -510,6 +510,11 @@ export type DossierSourceFileReviewableClaim = {
   requiresEditedTextForPublic?: boolean;
   whatAmIDeciding?: string;
   isWeakEvidenceLabel?: boolean;
+  suggestedApprovedText?: string;
+  suggestedInternalText?: string;
+  suggestedAnswerText?: string;
+  bnlRecommendationText?: string;
+  hasSafePublicSuggestion?: boolean;
   review?: DossierSourceFileClaimReview;
 };
 
@@ -554,6 +559,37 @@ function isWeakEvidenceLabelText(text: string, record?: UnknownRecord) {
 
 function subjectLabel(value?: string) {
   return value?.trim() || "this subject";
+}
+
+function humanBnlRecommendation(claimType: DossierSourceFileClaimType, suggestedDecision: string | undefined, weakLabel: boolean) {
+  const decision = (suggestedDecision ?? "").toLowerCase();
+  if (weakLabel || /reject/.test(decision)) return "BNL recommends rejecting this if the label is inaccurate.";
+  if (claimType === "source_blind") return "BNL thinks this is source-blind and needs public provenance before use.";
+  if (/internal|keep/.test(decision)) return "BNL recommends keeping this internal unless owner/admin confirms it.";
+  if (/public/.test(decision)) return "BNL thinks this can be public only if the suggested wording is approved.";
+  if (/more|confirm|needs/.test(decision)) return "BNL recommends more confirmation before public use.";
+  return "BNL recommends admin review before use.";
+}
+
+function suggestedTextsForClaim(input: { claimText: string; claimType: DossierSourceFileClaimType; record?: UnknownRecord; subjectName: string; weakLabel: boolean }) {
+  const explicit = analystString(input.record, ["suggestedApprovedText", "suggestedPublicText", "publicSafeText", "approvedText", "suggestedText"]);
+  const internal = analystString(input.record, ["suggestedInternalText", "suggestedInternalNote", "internalNote"]);
+  const answer = analystString(input.record, ["suggestedAnswer", "suggestedAnswerText", "answer"]);
+  const lower = `${input.claimText} ${analystString(input.record, ["claimType", "title"]) ?? ""}`.toLowerCase();
+  if (input.weakLabel || lower.trim() === "contest organizer") {
+    return {
+      approved: undefined,
+      internal: internal ?? "Keep this as internal pattern context only.",
+      answer,
+      fallback: `Reject this claim if ${input.subjectName} is not actually a contest organizer.`,
+    };
+  }
+  if (lower.includes("display name") || lower.includes("preferred name")) return { approved: explicit ?? input.subjectName, internal: internal ?? `Use ${input.subjectName} publicly; keep other aliases internal.`, answer: answer ?? input.subjectName };
+  if (lower.includes("role") || lower.includes("title")) return { approved: explicit ?? `${input.subjectName} is a BARCODE Network community member.`, internal: internal ?? `Keep role/title internal until owner confirms ${input.subjectName}.`, answer: answer ?? `Do not state a public role for ${input.subjectName} yet.` };
+  if (lower.includes("link")) return { approved: explicit, internal: internal ?? `No public links are approved for ${input.subjectName} yet.`, answer: answer ?? `No public links are approved for ${input.subjectName} yet.` };
+  if (lower.includes("orion")) return { approved: explicit, internal: internal ?? "Keep Orion context internal for now.", answer: answer ?? "Keep Orion context internal for now." };
+  if (lower.includes("queue") || lower.includes("submission")) return { approved: explicit, internal: internal ?? `Do not reference ${input.subjectName}'s queue/submission history publicly.`, answer: answer ?? "Do not reference queue/submission history publicly." };
+  return { approved: explicit ?? (input.record?.publicSafe === true ? input.claimText : undefined), internal: internal ?? input.claimText, answer };
 }
 
 function splitSignal(text: string) {
@@ -618,6 +654,8 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     : claimType === "recommended_action" || claimType === "do_not_say"
       ? { decisionQuestion: claimType === "recommended_action" ? "What admin follow-up should happen for this task?" : "Should this public boundary stay in force?", placeholderText: "", exampleApprovedTexts: [] }
       : buildCardGuidance(claimText, claimType, record, displaySubject);
+  const suggested = suggestedTextsForClaim({ claimText, claimType, record, subjectName: displaySubject, weakLabel });
+  const rawSuggestedDecision = analystString(record, ["suggestedDecision", "recommendation"]);
   const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
   const blockedBy = stringItems(record?.blockedBy);
   return {
@@ -647,7 +685,12 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     safeEvidenceSummary: analystString(record, ["safeEvidenceSummary", "evidenceSummary", "summary"]),
     reviewLane: analystString(record, ["reviewLane", "lane", "safetyLane"]),
     confidence: analystString(record, ["confidence"]),
-    suggestedDecision: analystString(record, ["suggestedDecision", "recommendation"]),
+    suggestedDecision: rawSuggestedDecision,
+    bnlRecommendationText: humanBnlRecommendation(claimType, rawSuggestedDecision, weakLabel),
+    suggestedApprovedText: suggested.approved,
+    suggestedInternalText: suggested.internal,
+    suggestedAnswerText: suggested.answer ?? suggested.fallback,
+    hasSafePublicSuggestion: Boolean(suggested.approved && (record?.publicSafe === true || claimType === "public_ready" || /public/.test((rawSuggestedDecision ?? "").toLowerCase())) && !weakLabel && claimType !== "source_blind"),
     safestDefault: analystString(record, ["safestDefault"]) ?? (weakLabel ? "Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording." : claimType === "public_ready" ? "Confirm only if the wording is public-safe and sourced." : "Keep internal or needs more info until owner/admin confirms the wording."),
     blockedBy,
     whatYouAreApproving: claimType === "recommended_action" ? "An admin task state, not a public claim approval." : claimType === "do_not_say" ? "A public-copy boundary that protects against unsupported claims." : claimType === "source_blind" ? "Only a separately confirmed public-safe replacement, not the source-blind text itself." : "A Source File review decision. Confirming public-ready does not publish a dossier.",
@@ -723,63 +766,86 @@ function claimDecisionLabel(claim: DossierSourceFileReviewableClaim) {
   return "Pending";
 }
 
+function savedReviewText(claim: DossierSourceFileReviewableClaim) {
+  return claim.review?.editedText || claim.review?.claimText || claim.claimText;
+}
+
+function CompletedClaimCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
+  const decision = claim.review?.decision ?? "pending";
+  const text = savedReviewText(claim);
+  return (
+    <li data-claim-card="true" className="border border-border/40 bg-background/30 p-3">
+      <h5 className="text-sm font-bold text-foreground">{claim.title}</h5>
+      <p className="mt-1 text-xs uppercase tracking-widest text-accent">{claimDecisionLabel(claim)}</p>
+      {(decision === "confirmed_public" || decision === "edited") && <p className="mt-2 text-sm text-foreground">Saved wording: &quot;{text}&quot;</p>}
+      {decision === "confirmed_internal" && <p className="mt-2 text-sm text-foreground">Saved note: &quot;{text}&quot;</p>}
+      {decision === "needs_more_info" && <p className="mt-2 text-sm text-foreground">Open question: &quot;{text}&quot;</p>}
+      {decision === "rejected" && <p className="mt-2 text-sm text-foreground">No Source File fact was created.</p>}
+      {(decision === "confirmed_public" || decision === "edited") && <p className="mt-1 text-xs text-muted">No dossier was published.</p>}
+      <button type="button" className="mt-3 border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "pending", { publicSafe: false })}>Undo choice</button>
+    </li>
+  );
+}
+
 function ClaimReviewControls({ claim, onReview }: {
   claim: DossierSourceFileReviewableClaim;
   onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
 }) {
-  const decision = claim.review?.decision ?? "pending";
-  const buttons: Array<[string, DossierSourceFileClaimReviewDecision, boolean?]> =
-    claim.claimType === "do_not_say" ? [["Keep boundary", "confirmed_internal"], ["Remove boundary", "rejected"]]
-    : claim.claimType === "recommended_action" ? [["Mark done", "confirmed_internal"], ["Keep open", "needs_more_info"], ["Reject", "rejected"]]
-    : claim.claimType === "source_blind" ? [["Keep internal", "confirmed_internal"], ["Needs public source", "needs_more_info"], ["Reject as false / not useful", "rejected"]]
-    : claim.claimType === "missing_info" ? [["Save answer", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject / not needed", "rejected"]]
-    : claim.claimType === "public_ready" ? [["Approve as public fact", "confirmed_public", true], ["Keep as internal context", "confirmed_internal"], ["Reject as false / not useful", "rejected"]]
-    : [["Approve as public fact", "confirmed_public", true], ["Keep as internal context", "confirmed_internal"], ["Needs more info", "needs_more_info"], ["Reject as false / not useful", "rejected"]];
+  const publicSuggestion = claim.suggestedApprovedText?.trim();
+  const internalSuggestion = claim.suggestedInternalText?.trim() || claim.claimText;
+  const answerSuggestion = claim.suggestedAnswerText?.trim();
+  const canApproveSuggestion = Boolean(claim.hasSafePublicSuggestion && publicSuggestion && (claim.claimType === "public_ready" || claim.claimType === "review_needed"));
+  if (claim.claimType === "do_not_say") {
+    return <div className="mt-3 grid gap-2 sm:grid-cols-2"><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false })}>Keep boundary</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Remove boundary</button></div>;
+  }
+  if (claim.claimType === "recommended_action") {
+    return <div className="mt-3 grid gap-2 sm:grid-cols-3"><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false })}>Mark done</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Keep open</button><button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button></div>;
+  }
+  if (claim.claimType === "source_blind") {
+    return (
+      <div className="mt-3 space-y-3">
+        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested internal note</p><p className="text-foreground">{internalSuggestion}</p></div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>Keep internal</button>
+          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit internal note</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={internalSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save internal note</button></form></details>
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs public source</button>
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button>
+        </div>
+      </div>
+    );
+  }
+  if (claim.claimType === "missing_info") {
+    return (
+      <div className="mt-3 space-y-3">
+        <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">Suggested answer</p><p className="text-foreground">{answerSuggestion ?? "BNL does not have a suggested answer yet."}</p></div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {answerSuggestion && <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: answerSuggestion })}>Save suggested answer</button>}
+          <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit answer</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={answerSuggestion ?? ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save edited answer</button></form></details>
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs more info</button>
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject / not needed</button>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="mt-3 space-y-3">
-      <span className={`inline-block border px-2 py-1 text-[0.65rem] uppercase tracking-widest ${decision === "confirmed_public" ? "border-accent text-accent" : "border-border text-muted"}`}>
-        {claimDecisionLabel(claim)}
-      </span>
+      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested wording</p>{publicSuggestion ? <p className="text-foreground">{publicSuggestion}</p> : <p className="text-muted">BNL does not have safe public wording for this yet. Choose Keep internal, Needs more info, Reject, or write approved wording manually.</p>}</div>
+      <div className="border border-border/40 bg-background/40 p-2"><p className="text-xs font-bold uppercase tracking-widest text-accent">BNL suggested internal note</p><p className="text-foreground">{internalSuggestion}</p></div>
       <div className="grid gap-2 sm:grid-cols-2">
-        {buttons.map(([label, nextDecision, publicSafe]) => (
-          <div key={label} className="border border-border/40 p-2">
-            <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={(event) => {
-              const container = event.currentTarget.closest("[data-claim-card]");
-              const input = container?.querySelector<HTMLInputElement>("[data-claim-answer]");
-              const validation = container?.querySelector<HTMLElement>("[data-claim-validation]");
-              const editedText = input?.value.trim() ?? "";
-              if ((nextDecision === "confirmed_public" && (claim.claimType === "review_needed" || claim.claimType === "source_blind") && !editedText) || (claim.claimType === "missing_info" && nextDecision === "confirmed_internal" && !editedText)) {
-                if (validation) validation.textContent = nextDecision === "confirmed_public" ? "Enter the exact public-safe sentence first, or choose Keep internal / Needs more info / Reject." : "Enter the exact answer BNL should use, or choose Needs more info / Reject.";
-                return;
-              }
-              if (validation) validation.textContent = "";
-              onReview?.(claim, nextDecision, { publicSafe: publicSafe === true, editedText: editedText || undefined });
-            }}>
-              {label}
-            </button>
-            <p className="mt-1 text-[0.7rem] text-muted/80">{claim.actionConsequences?.[nextDecision] ?? "Stores this admin decision."}</p>
-          </div>
-        ))}
+        {canApproveSuggestion && <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_public", { publicSafe: true, editedText: publicSuggestion })}>Approve suggested wording</button>}
+        {!canApproveSuggestion && <p className="border border-border/40 p-2 text-xs text-muted">BNL does not have safe public wording for this yet.</p>}
+        <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">{publicSuggestion ? "Edit wording" : "Write approved wording manually"}</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "edited", { publicSafe: true, editedText }); }}><textarea name="editedText" defaultValue={publicSuggestion ?? ""} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save edited wording</button></form></details>
+        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText: internalSuggestion })}>Keep suggested internal context</button>
+        <details className="border border-border/40 p-2"><summary className="cursor-pointer text-xs text-foreground">Edit internal note</summary><form className="mt-2 flex flex-col gap-2" onSubmit={(event) => { event.preventDefault(); const editedText = String(new FormData(event.currentTarget).get("editedText") ?? "").trim(); if (editedText) onReview?.(claim, "confirmed_internal", { publicSafe: false, editedText }); }}><textarea name="editedText" defaultValue={internalSuggestion} className="min-h-20 border border-border bg-background p-2 text-xs text-foreground" /><button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">Save internal note</button></form></details>
+        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "needs_more_info", { publicSafe: false })}>Needs more info</button>
+        <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "rejected", { publicSafe: false })}>Reject</button>
       </div>
-      <p data-claim-validation="true" className="text-xs text-accent">{claim.claimType === "missing_info" ? "Enter the exact answer BNL should use, or choose Needs more info / Reject." : ""}</p>
-      {claim.claimType !== "recommended_action" && claim.claimType !== "do_not_say" && <form className="flex flex-col gap-2" onSubmit={(event) => {
-        event.preventDefault();
-        const form = new FormData(event.currentTarget);
-        const editedText = String(form.get("editedText") ?? "").trim();
-        if (!editedText) return;
-        onReview?.(claim, "edited", { editedText, publicSafe: claim.claimType !== "source_blind" || Boolean(editedText) });
-        event.currentTarget.reset();
-      }}>
-        {claim.claimType === "source_blind" && <p className="border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
-        <label className="text-xs font-bold text-foreground" htmlFor={`${claim.id}-edited`}>{claim.claimType === "missing_info" ? "Answer to save" : claim.whatToEnter}</label>
-        <input data-claim-answer="true" id={`${claim.id}-edited`} name="editedText" className="border border-border bg-background px-2 py-1 text-xs text-foreground" placeholder={claim.placeholderText ?? "Enter exact public-safe wording"} />
-        <button type="submit" className="w-fit border border-accent px-2 py-1 text-xs text-accent">{claim.claimType === "source_blind" ? "Add public-safe replacement" : "Save exact answer / edited text"}</button>
-      </form>}
     </div>
   );
 }
 
 function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
+  if (claim.review && claim.review.decision !== "pending") return <CompletedClaimCard claim={claim} onReview={onReview} />;
   return (
     <li data-claim-card="true" className="border border-border/40 bg-background/30 p-3">
       <h5 className="text-sm font-bold text-foreground">{claim.title}</h5>
@@ -788,7 +854,7 @@ function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReview
       {claim.claimType === "source_blind" && <p className="mt-2 border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Source-blind context cannot become public copy by itself. Only enter public-safe replacement wording if you have separate confirmation.</p>}
       <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
         <div><dt className="font-bold text-accent">{claim.claimType === "missing_info" ? "Question" : "Decision needed"}</dt><dd className="text-foreground">{claim.decisionQuestion}</dd></div>
-        <div><dt className="font-bold text-accent">What BNL thinks</dt><dd className="text-foreground">{claim.suggestedDecision ?? "Admin review is needed before use."}</dd></div>
+        <div><dt className="font-bold text-accent">What BNL thinks</dt><dd className="text-foreground">{claim.bnlRecommendationText ?? "BNL recommends admin review before use."}</dd></div>
         <div><dt className="font-bold text-accent">{claim.claimType === "missing_info" ? "Why BNL needs it" : "Why BNL flagged this"}</dt><dd className="text-foreground">{claim.whyItExists}</dd></div>
         <div><dt className="font-bold text-accent">Evidence summary</dt><dd className="text-foreground">{claim.safeEvidenceSummary ?? "No public-safe evidence summary provided."}</dd></div>
         <div><dt className="font-bold text-accent">Safety lane</dt><dd className="text-foreground">{claim.reviewLane ?? claim.claimType.replace(/_/g, " ")}{claim.confidence ? ` · ${claim.confidence} confidence` : ""}</dd></div>

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -172,11 +172,14 @@ export type DossierSubjectAnalystReadV1 = {
   publicReadyClaims?: string[];
   sourceFileReviewClaims?: string[];
   reviewNeededClaims?: string[];
+  reviewableClaims?: unknown;
   sourceBlindInsights?: string[];
   privateOrInternalExclusions?: string[];
   doNotSayPublicly?: string[];
   missingInfoQuestions?: string[];
-  recommendedAdminActions?: string[];
+  missingConfirmations?: unknown;
+  recommendedAdminActions?: unknown;
+  withheldEvidenceAudit?: unknown;
   draftIngredients?: string[];
   sourceFileIngredients?: string[];
   provenanceSummary?: string[];

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -173,6 +173,14 @@ export type DossierSubjectAnalystReadV1 = {
   sourceFileReviewClaims?: string[];
   reviewNeededClaims?: string[];
   reviewableClaims?: unknown;
+  suggestedPublicWording?: string;
+  suggestedInternalNote?: string;
+  suggestedMissingInfoQuestion?: string;
+  suggestedRejectionReason?: string;
+  recommendedAction?: "approve_public" | "keep_internal" | "needs_more_info" | "reject" | "needs_public_source" | "keep_boundary" | string;
+  recommendedActionReason?: string;
+  cannotSuggestPublicReason?: string;
+  actionability?: "actionable_claim" | "missing_confirmation" | "source_blind_warning" | "evidence_signal" | "weak_label" | "non_actionable_artifact" | "admin_task" | "boundary" | string;
   sourceBlindInsights?: string[];
   privateOrInternalExclusions?: string[];
   doNotSayPublicly?: string[];

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -8927,6 +8927,8 @@ test("Source File analyst review cards render structured decisions, signals, bou
           claimType: "public_role_title",
           reviewLane: "needs_public_confirmation",
           suggestedDecision: "needs_more_info",
+          suggestedInternalNote: "Keep Raven role/title internal until owner confirms it.",
+          suggestedRejectionReason: "Reject if Raven is not confirmed to hold this role/title.",
           why: "BNL found role/community/music/context signals, but not enough confirmed public-safe evidence to state a formal role.",
           publicSafe: false,
           confidence: "medium",
@@ -8938,6 +8940,8 @@ test("Source File analyst review cards render structured decisions, signals, bou
           claimType: "public_role_title",
           reviewLane: "public_ready",
           suggestedDecision: "public_ready",
+          suggestedPublicWording: "Raven is a BARCODE Network community member.",
+          recommendedAction: "approve_public",
           publicSafe: true,
           safeEvidenceSummary: "Owner/admin-safe community member wording is available.",
         },
@@ -8958,10 +8962,18 @@ test("Source File analyst review cards render structured decisions, signals, bou
           safeEvidenceSummary: "Possible review claim label, not a confirmed role.",
         },
         {
+          claimText: "subject-owned/keyed local evidence exists",
+          claimType: "non_actionable_artifact",
+          actionability: "non_actionable_artifact",
+          why: "Technical evidence inventory only.",
+          safeEvidenceSummary: "No concrete fact was supplied for approval.",
+        },
+        {
           claimText: "Source-blind Orion context exists.",
           claimType: "source_blind",
           reviewLane: "source_blind",
           suggestedDecision: "keep_internal",
+          suggestedInternalNote: "Keep Orion source-blind context internal until public provenance exists.",
           why: "Useful internally but provenance is withheld.",
           safeEvidenceSummary: "Redacted source-blind context summary.",
         },
@@ -8969,6 +8981,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
       missingConfirmations: [
         {
           claimText: "Preferred display name",
+          suggestedMissingInfoQuestion: "What exact display name may BNL use publicly for Raven?",
           why: "Public name must be exact before use.",
           safeEvidenceSummary: "Candidate is referred to as Raven in public-safe context.",
         },
@@ -9007,17 +9020,20 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.doesNotMatch(text, /needs_more_info/);
   assert.match(text, /Which public label, if any, may BNL use for Raven/);
   assert.match(text, /Enter the exact sentence BNL may use as a Source File fact/);
-  assert.match(text, /BNL suggested wording/);
+  assert.match(text, /No BNL suggested wording yet/);
+  assert.match(text, /BNL has not provided safe public wording for this yet/);
+  assert.match(text, /BNL suggested public wording/);
   assert.match(text, /Raven is a BARCODE Network community member/);
   assert.match(text, /BNL suggested internal note/);
-  assert.match(text, /Keep role\/title internal until owner confirms Raven/);
+  assert.match(text, /Keep Raven role\/title internal until owner confirms it/);
   assert.doesNotMatch(text, /Edit \+ confirm public-safe text/);
   assert.match(text, /What am I deciding/);
   assert.match(text, /You are deciding whether this role\/title is true for this subject/);
   assert.match(text, /Approve suggested wording/);
-  assert.match(text, /BNL suggested wording/);
-  assert.match(text, /Keep suggested internal context/);
-  assert.match(text, /Reject/);
+  assert.match(text, /Saves BNL’s suggested sentence as a public-safe Source File fact/);
+  assert.match(text, /Save suggested internal note/);
+  assert.doesNotMatch(text, /Keep suggested internal context/);
+  assert.match(text, /Reject claim|Reject label/);
   assert.match(text, /Weak evidence label \/ pattern/);
   assert.match(text, /Is this label accurate and useful, or should it be rejected/);
   assert.match(text, /Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording/);
@@ -9027,15 +9043,18 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.doesNotMatch(text, /Music discussion only: 44 Confirm public-ready/);
   assert.match(text, /What exact display name may BNL use publicly/);
   assert.match(text, /Use Raven publicly; keep other aliases internal/);
-  assert.match(text, /Suggested answer/);
-  assert.match(text, /Save suggested answer/);
+  assert.match(text, /BNL suggested confirmation question/);
+  assert.match(text, /What exact display name may BNL use publicly for Raven/);
+  assert.match(text, /Save suggested question/);
   assert.match(text, /Question/);
-  assert.match(text, /Edit answer/);
-  assert.match(text, /Save suggested answer/);
+  assert.match(text, /Edit question/);
   assert.doesNotMatch(text, /Mark answered/);
   assert.match(text, /Source-blind context cannot become public copy by itself/);
   assert.match(text, /Add public-safe replacement text, if owner\/admin confirms it elsewhere/);
-  assert.match(text, /Needs public source/);
+  assert.match(text, /Ask for public source/);
+  assert.match(text, /subject-owned\/keyed local evidence exists/);
+  assert.match(text, /This is not a public-ready claim\. BNL has not provided a concrete fact to approve/);
+  assert.match(text, /Dismiss artifact/);
   assert.doesNotMatch(text, /Source-blind Orion context exists[\s\S]*Approve as public fact/);
   assert.match(text, /Withheld Evidence Audit/);
   assert.match(text, /Total withheld:\s+3/);
@@ -9045,6 +9064,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.doesNotMatch(text, /person@example\.com|Stripe customer token/);
   assert.match(text, /Admin task/);
   assert.match(text, /Mark done/);
+  assert.doesNotMatch(text, />Needs more info</);
   assert.doesNotMatch(text, /Crow is a BARCODE Network community member|Use Crow publicly|Do not state a public role for Crow/);
   assert.doesNotMatch(text, /Ask owner\/admin to confirm public-safe role wording\.[\s\S]*Edit \+ confirm public-safe text/);
   assert.match(text, /Public boundary/);
@@ -9059,6 +9079,15 @@ test("Source File analyst review cards render structured decisions, signals, bou
   });
   const roleClaim = derived.current.find((claim) => /public role\/title/.test(claim.claimText));
   assert.ok(roleClaim);
+  const publicReadyClaim = derived.current.find((claim) => claim.suggestedApprovedText === "Raven is a BARCODE Network community member.");
+  assert.equal(publicReadyClaim?.suggestedTextSource, "bnl");
+  assert.equal(publicReadyClaim?.hasSafePublicSuggestion, true);
+  const weakLabelClaim = derived.current.find((claim) => claim.claimText === "contest organizer");
+  assert.equal(weakLabelClaim?.suggestedTextSource, "none");
+  assert.equal(weakLabelClaim?.hasSafePublicSuggestion, false);
+  const artifactClaim = derived.current.find((claim) => claim.claimText === "subject-owned/keyed local evidence exists");
+  assert.equal(artifactClaim?.isVagueArtifact, true);
+  assert.equal(artifactClaim?.hasSafePublicSuggestion, false);
   const completedText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
     summary,
     latestSourceFileArchive: archive,

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -933,6 +933,48 @@ test("Source File claim review decisions persist and update safe Source File not
   assert.equal(candidate.sourceFileNotes[0].publicSafe, false);
   assert.equal(candidate.sourceFileNotes[0].type, "general_note");
 
+  const suggestedPublicResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_suggested_public_fixture",
+      claimText: "Confirm public role/title",
+      claimType: "review_needed",
+      sourceSection: "reviewableClaims",
+      decision: "confirmed_public",
+      editedText: "Claim Review Subject is a BARCODE Network community member.",
+      publicSafe: true,
+    },
+  });
+  assert.equal(suggestedPublicResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  candidate = state.candidates[0];
+  const suggestedPublicNote = candidate.sourceFileNotes.find((note) => note.id === "source_file_note_claim_suggested_public_fixture");
+  assert.equal(suggestedPublicNote?.text, "Claim Review Subject is a BARCODE Network community member.");
+  assert.equal(suggestedPublicNote?.type, "fact");
+  assert.equal(suggestedPublicNote?.publicSafe, true);
+
+  const editedPublicResponse = await authedPost({
+    action: "editSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_edited_public_fixture",
+      claimText: "Confirm public role/title",
+      claimType: "review_needed",
+      sourceSection: "reviewableClaims",
+      decision: "edited",
+      editedText: "Claim Review Subject is a BARCODE Radio viewer/community participant.",
+      publicSafe: true,
+    },
+  });
+  assert.equal(editedPublicResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  candidate = state.candidates[0];
+  const editedPublicNote = candidate.sourceFileNotes.find((note) => note.id === "source_file_note_claim_edited_public_fixture");
+  assert.equal(editedPublicNote?.text, "Claim Review Subject is a BARCODE Radio viewer/community participant.");
+  assert.equal(editedPublicNote?.type, "fact");
+  assert.equal(editedPublicNote?.publicSafe, true);
+
   const missingAnswerResponse = await authedPost({
     action: "reviewSourceFileClaim",
     candidateId: "claim-review-candidate",
@@ -8892,6 +8934,14 @@ test("Source File analyst review cards render structured decisions, signals, bou
           blockedBy: ["owner wording"],
         },
         {
+          claimText: "Raven is a BARCODE Network community member.",
+          claimType: "public_role_title",
+          reviewLane: "public_ready",
+          suggestedDecision: "public_ready",
+          publicSafe: true,
+          safeEvidenceSummary: "Owner/admin-safe community member wording is available.",
+        },
+        {
           claimText: "Music discussion only: 44",
           claimType: "evidence_signal",
           reviewLane: "signal_summary",
@@ -8953,16 +9003,21 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.match(text, /What BNL thinks/);
   assert.match(text, /Why BNL flagged this/);
   assert.match(text, /Public-safe community participation signals only/);
-  assert.match(text, /needs_more_info/);
+  assert.match(text, /BNL recommends more confirmation before public use/);
+  assert.doesNotMatch(text, /needs_more_info/);
   assert.match(text, /Which public label, if any, may BNL use for Raven/);
   assert.match(text, /Enter the exact sentence BNL may use as a Source File fact/);
+  assert.match(text, /BNL suggested wording/);
   assert.match(text, /Raven is a BARCODE Network community member/);
+  assert.match(text, /BNL suggested internal note/);
+  assert.match(text, /Keep role\/title internal until owner confirms Raven/);
+  assert.doesNotMatch(text, /Edit \+ confirm public-safe text/);
   assert.match(text, /What am I deciding/);
   assert.match(text, /You are deciding whether this role\/title is true for this subject/);
-  assert.match(text, /Approve as public fact/);
-  assert.match(text, /Use this only if the claim is true and the exact public wording is approved/);
-  assert.match(text, /Keep as internal context/);
-  assert.match(text, /Reject as false \/ not useful/);
+  assert.match(text, /Approve suggested wording/);
+  assert.match(text, /BNL suggested wording/);
+  assert.match(text, /Keep suggested internal context/);
+  assert.match(text, /Reject/);
   assert.match(text, /Weak evidence label \/ pattern/);
   assert.match(text, /Is this label accurate and useful, or should it be rejected/);
   assert.match(text, /Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording/);
@@ -8972,11 +9027,12 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.doesNotMatch(text, /Music discussion only: 44 Confirm public-ready/);
   assert.match(text, /What exact display name may BNL use publicly/);
   assert.match(text, /Use Raven publicly; keep other aliases internal/);
+  assert.match(text, /Suggested answer/);
+  assert.match(text, /Save suggested answer/);
   assert.match(text, /Question/);
-  assert.match(text, /Answer to save/);
-  assert.match(text, /Save answer/);
+  assert.match(text, /Edit answer/);
+  assert.match(text, /Save suggested answer/);
   assert.doesNotMatch(text, /Mark answered/);
-  assert.match(text, /Enter the exact answer BNL should use, or choose Needs more info \/ Reject/);
   assert.match(text, /Source-blind context cannot become public copy by itself/);
   assert.match(text, /Add public-safe replacement text, if owner\/admin confirms it elsewhere/);
   assert.match(text, /Needs public source/);
@@ -8994,6 +9050,36 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.match(text, /Public boundary/);
   assert.match(text, /Keep boundary/);
   assert.doesNotMatch(text, /Do not say Raven is an official collaborator\.[\s\S]*Approve as public fact/);
+
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({
+    analystRead: archive.subjectAnalystReadV1,
+    candidateId: archive.candidateId,
+    sourceArchiveId: archive.id,
+    subjectName: archive.subjectName,
+  });
+  const roleClaim = derived.current.find((claim) => /public role\/title/.test(claim.claimText));
+  assert.ok(roleClaim);
+  const completedText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: archive,
+    candidateId: archive.candidateId,
+    claimReviews: [{
+      id: roleClaim.id,
+      candidateId: archive.candidateId,
+      claimText: roleClaim.claimText,
+      claimType: roleClaim.claimType,
+      sourceSection: roleClaim.sourceSection,
+      decision: "confirmed_public",
+      publicSafe: true,
+      editedText: "Raven is a BARCODE Network community member.",
+      createdAt: "2026-06-15T00:00:00.000Z",
+      updatedAt: "2026-06-15T00:00:00.000Z",
+    }],
+  }));
+  assert.match(completedText, /Approved as public fact/);
+  assert.match(completedText, /Saved wording:\s+"\s*Raven is a BARCODE Network community member\.\s*"/);
+  assert.match(completedText, /No dossier was published/);
+  assert.match(completedText, /Undo choice/);
 });
 
 test("Source File page extracts subjectAnalystReadV1 from sourceFileCaseReportV1 and handles old archives", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -933,6 +933,27 @@ test("Source File claim review decisions persist and update safe Source File not
   assert.equal(candidate.sourceFileNotes[0].publicSafe, false);
   assert.equal(candidate.sourceFileNotes[0].type, "general_note");
 
+  const missingAnswerResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: "claim-review-candidate",
+    input: {
+      claimId: "claim_missing_answer_fixture",
+      claimText: "Confirm public role/title",
+      claimType: "missing_info",
+      sourceSection: "missingConfirmations",
+      decision: "confirmed_internal",
+      editedText: "Claim Review Subject is a BARCODE Network community member.",
+      publicSafe: false,
+    },
+  });
+  assert.equal(missingAnswerResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  candidate = state.candidates[0];
+  const missingAnswerNote = candidate.sourceFileNotes.find((note) => note.id === "source_file_note_claim_missing_answer_fixture");
+  assert.equal(missingAnswerNote?.text, "Claim Review Subject is a BARCODE Network community member.");
+  assert.equal(missingAnswerNote?.type, "general_note");
+  assert.equal(missingAnswerNote?.publicSafe, false);
+
   const rejectResponse = await authedPost({
     action: "reviewSourceFileClaim",
     candidateId: "claim-review-candidate",
@@ -8845,7 +8866,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
   const archive = {
     id: "archive-structured-review-cards",
     candidateId: "candidate-structured-review-cards",
-    subjectName: "Crow",
+    subjectName: "Raven",
     sourceDigest: "abcdef1234567890",
     createdAt: "2026-06-15T00:00:00.000Z",
     updatedAt: "2026-06-15T01:00:00.000Z",
@@ -8860,7 +8881,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
       strongestSignals: ["Community and music discussion signals."],
       reviewableClaims: [
         {
-          claimText: "Confirm public role/title: Is Crow a community participant, artist, collaborator, or something else?",
+          claimText: "Confirm public role/title: Is Raven a community participant, artist, collaborator, or something else?",
           claimType: "public_role_title",
           reviewLane: "needs_public_confirmation",
           suggestedDecision: "needs_more_info",
@@ -8879,6 +8900,14 @@ test("Source File analyst review cards render structured decisions, signals, bou
           safeEvidenceSummary: "Repeated music discussion without owned-link proof.",
         },
         {
+          claimText: "contest organizer",
+          claimType: "weak_label",
+          reviewLane: "weak_label",
+          suggestedDecision: "reject_if_inaccurate",
+          why: "Weak analyst label only.",
+          safeEvidenceSummary: "Possible review claim label, not a confirmed role.",
+        },
+        {
           claimText: "Source-blind Orion context exists.",
           claimType: "source_blind",
           reviewLane: "source_blind",
@@ -8891,7 +8920,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
         {
           claimText: "Preferred display name",
           why: "Public name must be exact before use.",
-          safeEvidenceSummary: "Candidate is referred to as Crow in public-safe context.",
+          safeEvidenceSummary: "Candidate is referred to as Raven in public-safe context.",
         },
       ],
       recommendedAdminActions: [
@@ -8903,7 +8932,7 @@ test("Source File analyst review cards render structured decisions, signals, bou
       ],
       doNotSayPublicly: [
         {
-          boundary: "Do not say Crow is an official collaborator.",
+          boundary: "Do not say Raven is an official collaborator.",
           why: "No confirmed public-safe collaborator evidence.",
           protects: "Avoids overstating relationship context.",
         },
@@ -8925,20 +8954,33 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.match(text, /Why BNL flagged this/);
   assert.match(text, /Public-safe community participation signals only/);
   assert.match(text, /needs_more_info/);
-  assert.match(text, /Which public label, if any, may BNL use for Crow/);
+  assert.match(text, /Which public label, if any, may BNL use for Raven/);
   assert.match(text, /Enter the exact sentence BNL may use as a Source File fact/);
-  assert.match(text, /Crow is a BARCODE Network community member/);
+  assert.match(text, /Raven is a BARCODE Network community member/);
+  assert.match(text, /What am I deciding/);
+  assert.match(text, /You are deciding whether this role\/title is true for this subject/);
+  assert.match(text, /Approve as public fact/);
+  assert.match(text, /Use this only if the claim is true and the exact public wording is approved/);
+  assert.match(text, /Keep as internal context/);
+  assert.match(text, /Reject as false \/ not useful/);
+  assert.match(text, /Weak evidence label \/ pattern/);
+  assert.match(text, /Is this label accurate and useful, or should it be rejected/);
+  assert.match(text, /Reject if inaccurate; keep internal if useful; do not approve public without exact confirmed wording/);
   assert.match(text, /Evidence Signals \/ Pattern Summary/);
   assert.match(text, /These are pattern counts and context signals BNL used for analysis/);
   assert.match(text, /Music discussion signal/);
   assert.doesNotMatch(text, /Music discussion only: 44 Confirm public-ready/);
   assert.match(text, /What exact display name may BNL use publicly/);
-  assert.match(text, /Use Crow publicly; keep other aliases internal/);
+  assert.match(text, /Use Raven publicly; keep other aliases internal/);
+  assert.match(text, /Question/);
+  assert.match(text, /Answer to save/);
+  assert.match(text, /Save answer/);
+  assert.doesNotMatch(text, /Mark answered/);
   assert.match(text, /Enter the exact answer BNL should use, or choose Needs more info \/ Reject/);
   assert.match(text, /Source-blind context cannot become public copy by itself/);
   assert.match(text, /Add public-safe replacement text, if owner\/admin confirms it elsewhere/);
-  assert.match(text, /Needs provenance/);
-  assert.doesNotMatch(text, /Source-blind Orion context exists[\s\S]*Confirm public-ready/);
+  assert.match(text, /Needs public source/);
+  assert.doesNotMatch(text, /Source-blind Orion context exists[\s\S]*Approve as public fact/);
   assert.match(text, /Withheld Evidence Audit/);
   assert.match(text, /Total withheld:\s+3/);
   assert.match(text, /private messages\s+:\s+2/);
@@ -8947,10 +8989,11 @@ test("Source File analyst review cards render structured decisions, signals, bou
   assert.doesNotMatch(text, /person@example\.com|Stripe customer token/);
   assert.match(text, /Admin task/);
   assert.match(text, /Mark done/);
+  assert.doesNotMatch(text, /Crow is a BARCODE Network community member|Use Crow publicly|Do not state a public role for Crow/);
   assert.doesNotMatch(text, /Ask owner\/admin to confirm public-safe role wording\.[\s\S]*Edit \+ confirm public-safe text/);
   assert.match(text, /Public boundary/);
   assert.match(text, /Keep boundary/);
-  assert.doesNotMatch(text, /Do not say Crow is an official collaborator\.[\s\S]*Confirm public-ready/);
+  assert.doesNotMatch(text, /Do not say Raven is an official collaborator\.[\s\S]*Approve as public fact/);
 });
 
 test("Source File page extracts subjectAnalystReadV1 from sourceFileCaseReportV1 and handles old archives", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -8839,6 +8839,120 @@ test("Source File page extracts and renders subjectAnalystReadV1 from archive ro
   assert.match(text, /Private\/internal withheld/);
 });
 
+
+test("Source File analyst review cards render structured decisions, signals, boundaries, tasks, and withheld audit safely", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-structured-review-cards",
+    candidateId: "candidate-structured-review-cards",
+    subjectName: "Crow",
+    sourceDigest: "abcdef1234567890",
+    createdAt: "2026-06-15T00:00:00.000Z",
+    updatedAt: "2026-06-15T01:00:00.000Z",
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    subjectAnalystReadV1: {
+      internalRead: "Structured read fixture.",
+      likelySubjectType: "community participant",
+      confidence: "medium",
+      publicDraftPosture: "hold for admin review",
+      strongestSignals: ["Community and music discussion signals."],
+      reviewableClaims: [
+        {
+          claimText: "Confirm public role/title: Is Crow a community participant, artist, collaborator, or something else?",
+          claimType: "public_role_title",
+          reviewLane: "needs_public_confirmation",
+          suggestedDecision: "needs_more_info",
+          why: "BNL found role/community/music/context signals, but not enough confirmed public-safe evidence to state a formal role.",
+          publicSafe: false,
+          confidence: "medium",
+          safeEvidenceSummary: "Public-safe community participation signals only.",
+          blockedBy: ["owner wording"],
+        },
+        {
+          claimText: "Music discussion only: 44",
+          claimType: "evidence_signal",
+          reviewLane: "signal_summary",
+          suggestedDecision: "internal_context_only",
+          why: "Pattern count only.",
+          safeEvidenceSummary: "Repeated music discussion without owned-link proof.",
+        },
+        {
+          claimText: "Source-blind Orion context exists.",
+          claimType: "source_blind",
+          reviewLane: "source_blind",
+          suggestedDecision: "keep_internal",
+          why: "Useful internally but provenance is withheld.",
+          safeEvidenceSummary: "Redacted source-blind context summary.",
+        },
+      ],
+      missingConfirmations: [
+        {
+          claimText: "Preferred display name",
+          why: "Public name must be exact before use.",
+          safeEvidenceSummary: "Candidate is referred to as Crow in public-safe context.",
+        },
+      ],
+      recommendedAdminActions: [
+        {
+          action: "Ask owner/admin to confirm public-safe role wording.",
+          why: "This prevents unsupported role claims.",
+          suggestedNextStep: "Collect exact sentence before public use.",
+        },
+      ],
+      doNotSayPublicly: [
+        {
+          boundary: "Do not say Crow is an official collaborator.",
+          why: "No confirmed public-safe collaborator evidence.",
+          protects: "Avoids overstating relationship context.",
+        },
+      ],
+      withheldEvidenceAudit: {
+        totalWithheld: 3,
+        categories: [
+          { category: "private messages", count: 2, reason: "private/source-blind" },
+          { category: "payment metadata", count: 1, reason: "payment details excluded" },
+        ],
+        safeExamples: ["[redacted private message pattern]", "raw email person@example.com should not render", "Stripe customer token should not render"],
+      },
+      provenanceSummary: ["Structured Bot #285 output."],
+    },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /Decision needed/);
+  assert.match(text, /What BNL thinks/);
+  assert.match(text, /Why BNL flagged this/);
+  assert.match(text, /Public-safe community participation signals only/);
+  assert.match(text, /needs_more_info/);
+  assert.match(text, /Which public label, if any, may BNL use for Crow/);
+  assert.match(text, /Enter the exact sentence BNL may use as a Source File fact/);
+  assert.match(text, /Crow is a BARCODE Network community member/);
+  assert.match(text, /Evidence Signals \/ Pattern Summary/);
+  assert.match(text, /These are pattern counts and context signals BNL used for analysis/);
+  assert.match(text, /Music discussion signal/);
+  assert.doesNotMatch(text, /Music discussion only: 44 Confirm public-ready/);
+  assert.match(text, /What exact display name may BNL use publicly/);
+  assert.match(text, /Use Crow publicly; keep other aliases internal/);
+  assert.match(text, /Enter the exact answer BNL should use, or choose Needs more info \/ Reject/);
+  assert.match(text, /Source-blind context cannot become public copy by itself/);
+  assert.match(text, /Add public-safe replacement text, if owner\/admin confirms it elsewhere/);
+  assert.match(text, /Needs provenance/);
+  assert.doesNotMatch(text, /Source-blind Orion context exists[\s\S]*Confirm public-ready/);
+  assert.match(text, /Withheld Evidence Audit/);
+  assert.match(text, /Total withheld:\s+3/);
+  assert.match(text, /private messages\s+:\s+2/);
+  assert.match(text, /Safe redacted examples/);
+  assert.match(text, /\[redacted private message pattern\]/);
+  assert.doesNotMatch(text, /person@example\.com|Stripe customer token/);
+  assert.match(text, /Admin task/);
+  assert.match(text, /Mark done/);
+  assert.doesNotMatch(text, /Ask owner\/admin to confirm public-safe role wording\.[\s\S]*Edit \+ confirm public-safe text/);
+  assert.match(text, /Public boundary/);
+  assert.match(text, /Keep boundary/);
+  assert.doesNotMatch(text, /Do not say Crow is an official collaborator\.[\s\S]*Confirm public-ready/);
+});
+
 test("Source File page extracts subjectAnalystReadV1 from sourceFileCaseReportV1 and handles old archives", () => {
   const summary = sourceFileReportTestSummary();
   const archive = {


### PR DESCRIPTION
### Motivation
- The Source File review UI showed vague string rows and generic controls that did not explain what decision was needed, what BNL (the bot) recommended, or what exact text admins should enter.
- Bot PR #285 provides structured `reviewableClaims`, `missingConfirmations`, and `withheldEvidenceAudit` fields that the site should prefer to produce actionable admin decision cards.
- This change aims to render structured decision cards, separate pattern/signal summaries from public-ready claims, and make source-blind and withheld evidence safer to view and act on.

### Description
- Prefer structured analyst fields by recognizing `subjectAnalystReadV1.reviewableClaims`, `missingConfirmations`, and `withheldEvidenceAudit` and fall back to legacy arrays when absent, so Bot #285 output is the primary source for review cards. (files changed: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/lib/dossier-workflow.ts`).
- Introduced a claim-card view model and helpers that convert analyst claim objects into rich `DossierSourceFileReviewableClaim` cards with fields like `decisionQuestion`, `whyItExists`, `safeEvidenceSummary`, `exampleApprovedTexts`, `actionConsequences`, `requiresEditedTextForPublic`, and action booleans, and added signal-summary extraction. (file changed: `src/components/DossierSourceFileSummaryPanel.tsx`).
- Rendered new decision-oriented card UI: explicit sections for Decision needed, What BNL thinks, Why flagged, Evidence summary, Safety lane, Safest default, What to enter if approving, Example approved texts, and inline button consequence help; separated Evidence Signals / Pattern Summary (no public-ready approval) and an admin-only Withheld Evidence Audit that redacts sensitive raw examples. (file changed: `src/components/DossierSourceFileSummaryPanel.tsx`).
- Treated recommended admin actions as tasks and do-not-say items as boundaries rather than public claim approvals, and preserved existing review API paths and persistence (`reviewSourceFileClaim`, `editSourceFileClaim`, `resetSourceFileClaimReview`) so workflow behavior is unchanged. (files changed: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/lib/dossier-workflow.ts`).
- Added/updated unit tests that cover structured `reviewableClaims`, missing confirmations guidance, signal separation, source-blind protections, withheld evidence audit redaction, admin-task rendering, and ensured existing claim-review actions still map to the same API calls. (file changed: `tests/admin-dossiers.test.mjs`).

### Testing
- Type-check: ran `npx tsc --noEmit` and it succeeded.
- Unit tests: ran `node --test tests/admin-dossiers.test.mjs` and the test suite covering Source File analyst read and the new structured claim card scenarios passed.
- Lint: ran `npm run lint`; it reported pre-existing unrelated lint errors in archived/other components, and no new lint failures were introduced by the changed files.

Files changed
- `src/components/DossierSourceFileSummaryPanel.tsx` — prefer structured analyst fields, add claim-card view model, render decision cards, evidence signal section, source-blind protections, and withheld evidence audit.
- `src/lib/dossier-workflow.ts` — extend `DossierSubjectAnalystReadV1` types to include `reviewableClaims`, `missingConfirmations`, and `withheldEvidenceAudit` while preserving legacy fields.
- `tests/admin-dossiers.test.mjs` — added tests asserting structured claim rendering, signal separation, missing-confirmation guidance, source-blind protections, withheld audit redaction, task/boundary rendering, and preserved review action behavior.

Notes/constraints
- No public pages or publishing behavior were changed and no new workflow systems were introduced; the change only improves how existing analyst data is rendered and how admin decisions are presented.
- Local checkout had no `origin` remote/main branch available, so the audit and changes were applied against the current local work branch.

Commit SHA: `2a66ae0818534a59b4d6ab9e76ce4fb8ddfbd2a8`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f93ad58048321ac964ee65287c17e)