### PR TITLE
Site PR #226 — Persist Source File completion requests

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -17,6 +17,8 @@ import {
   type DossierRecommendation,
   type DossierSourceFileRefreshRequest,
   type DossierSourceFileNoteType,
+  type DossierSourceFileCompletionRequest,
+  type DossierSourceFileCompletionRequestStatus,
 } from "@/lib/dossier-workflow";
 import {
   DossierSourceFileArchiveRawData,
@@ -1577,6 +1579,21 @@ export default function CandidateReviewPage() {
     setNotice("Claim decision saved. Refresh BNL Source File to let BNL update the analyst read.");
   }
 
+  async function updateCompletionRequestStatus(
+    request: DossierSourceFileCompletionRequest,
+    status: DossierSourceFileCompletionRequestStatus,
+  ) {
+    await postWorkflow({
+      action: "updateSourceFileCompletionRequestStatus",
+      candidateId,
+      input: {
+        requestId: request.id,
+        status,
+      },
+    });
+    setNotice("Completion request status saved.");
+  }
+
   async function createDraft() {
     if (!canCreateDraft) return;
     try {
@@ -2631,6 +2648,8 @@ export default function CandidateReviewPage() {
               candidateId={candidate.id}
               claimReviews={candidate.sourceFileClaimReviews ?? []}
               onReviewClaim={reviewSourceFileClaim}
+              completionRequests={candidate.sourceFileCompletionRequests ?? []}
+              onUpdateCompletionRequestStatus={updateCompletionRequestStatus}
               sourceFileTargetStatus={
                 isExistingDossierUpdate
                   ? "existing dossier update"

--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -26,6 +26,7 @@ import {
   type DossierRecommendation,
   type DossierSourceFileRefreshRequest,
   type DossierWorkflowAction,
+  type DossierSourceFileCompletionRequestStatus,
   type MergeDossierCandidatesInput,
 } from "@/lib/dossier-workflow";
 import {
@@ -70,6 +71,7 @@ import {
   updateDossierCandidateStatus,
   updateDossierIdentityLink,
   updateDossierSourceFileRefreshRequestStatus,
+  updateSourceFileCompletionRequestStatus,
   validateDossierDraftFieldsForOwnerReview,
   type DossierWorkflowState,
   type PopulationReconcileSummary,
@@ -141,6 +143,7 @@ const IMPLEMENTED_ACTIONS = new Set<DossierWorkflowAction>([
   "reviewSourceFileClaim",
   "editSourceFileClaim",
   "resetSourceFileClaimReview",
+  "updateSourceFileCompletionRequestStatus",
   "requestSourceFileRefresh",
   "recordSourceFileOpen",
   "addDossierIdentityLink",
@@ -281,6 +284,23 @@ function sourceFileClaimReviewInputFromBody(
     sourceRefreshId: value.sourceRefreshId,
     sourceProvenance: value.sourceProvenance,
     decidedBy: value.decidedBy ?? "admin",
+  };
+}
+
+function sourceFileCompletionRequestStatusInputFromBody(
+  body: Record<string, unknown>,
+): { candidateId: string; requestId: string; status: DossierSourceFileCompletionRequestStatus; statusReason?: string } | null {
+  const candidateId = candidateIdFromBody(body);
+  const value = body.input;
+  if (!candidateId || !value || typeof value !== "object") return null;
+  const input = value as { requestId?: unknown; status?: unknown; statusReason?: unknown };
+  const allowed = new Set(["open", "ready_to_ask", "asked", "not_applicable", "declined"]);
+  if (typeof input.requestId !== "string" || !input.requestId.trim() || typeof input.status !== "string" || !allowed.has(input.status)) return null;
+  return {
+    candidateId,
+    requestId: input.requestId.trim(),
+    status: input.status as DossierSourceFileCompletionRequestStatus,
+    statusReason: typeof input.statusReason === "string" ? input.statusReason : undefined,
   };
 }
 
@@ -558,6 +578,19 @@ export async function POST(req: Request) {
         message: "Claim decision saved. Refresh BNL Source File to let BNL update the analyst read.",
         ...payload,
       });
+    }
+
+    if (action === "updateSourceFileCompletionRequestStatus") {
+      const input = sourceFileCompletionRequestStatusInputFromBody(body);
+      if (!input) {
+        return NextResponse.json(
+          { error: "Valid candidateId, completion request id, and status are required" },
+          { status: 400 },
+        );
+      }
+      const completionRequest = await updateSourceFileCompletionRequestStatus(input);
+      const payload = await workflowPayload();
+      return NextResponse.json({ ok: true, action, completionRequest, ...payload });
     }
 
     if (action === "recordSourceFileOpen") {

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1388,11 +1388,17 @@ function BnlAnalystReadPanel({
         {reviewable.signals.length > 0 && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Evidence Signals / Pattern Summary</h4><p className="mb-2 text-xs text-muted/80">These are pattern counts and context signals BNL used for analysis. They are not public-ready facts by themselves.</p><ul className="space-y-2 text-foreground">{reviewable.signals.map((signal) => <li key={signal.id} className="border border-border/40 p-2"><p className="font-bold">{signal.label}{signal.count ? `: ${signal.count}` : ""}</p><p className="text-xs text-muted">{signal.suggestion}</p><p className="text-xs text-muted">Action: {signal.actionable}</p></li>)}</ul></section>}
         {sectionEntries.map(([section, label]) => {
           const claims = reviewable.current.filter((claim) => claim.sourceSection === section);
-          if (!claims.length && (section === "reviewableClaims" || section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds")) return null;
+          const hidesInactiveCompletionRequests = section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds";
+          const visibleClaims = hidesInactiveCompletionRequests
+            ? claims.filter((claim) => {
+                const request = completionRequestForClaim(claim, completionRequests);
+                return !request || !["superseded", "declined", "not_applicable"].includes(request.status);
+              })
+            : claims;
+          if (!visibleClaims.length && (section === "reviewableClaims" || hidesInactiveCompletionRequests)) return null;
           const privateExclusions = section === "sourceBlindInsights" ? stringItems(analystRead.privateOrInternalExclusions) : [];
-          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => {
-            const request = section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds" ? completionRequestForClaim(claim, completionRequests) : undefined;
-            if (request && ["superseded", "declined", "not_applicable"].includes(request.status)) return null;
+          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{visibleClaims.length ? <ul className="space-y-3 text-foreground">{visibleClaims.map((claim) => {
+            const request = hidesInactiveCompletionRequests ? completionRequestForClaim(claim, completionRequests) : undefined;
             return <ClaimDecisionCard key={claim.id} claim={claim} onReview={onReviewClaim} completionBadge={request ? <CompletionRequestBadge request={request} onUpdateStatus={onUpdateCompletionRequestStatus} /> : undefined} />;
           })}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
         })}

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -9,6 +9,8 @@ import type {
   DossierSourceFileClaimType,
   DossierSourceFileArchiveMetadata,
   DossierSourceFileCaseReportV1,
+  DossierSourceFileCompletionRequest,
+  DossierSourceFileCompletionRequestStatus,
   DossierSourceFileNote,
   DossierSubjectAnalystReadV1,
   DossierSourceFileConfirmationTarget,
@@ -1054,7 +1056,18 @@ function dedupeVerificationQuestions(questions: Array<{ text: string; audience: 
   return sections;
 }
 
-function verificationPacketSections(claims: DossierSourceFileReviewableClaim[]) {
+function activeCompletionRequests(requests: DossierSourceFileCompletionRequest[] = []) {
+  return requests.filter((request) => request.status === "open" || request.status === "ready_to_ask");
+}
+
+function verificationPacketSections(claims: DossierSourceFileReviewableClaim[], completionRequests: DossierSourceFileCompletionRequest[] = []) {
+  const persisted = activeCompletionRequests(completionRequests).filter((request) => safeCopyQuestions([request.question]).length > 0);
+  if (persisted.length) {
+    return dedupeVerificationQuestions(persisted.map((request) => ({
+      text: request.question,
+      audience: verificationAudienceKey(request.audience ?? request.recipientClass),
+    })));
+  }
   return dedupeVerificationQuestions(claims.flatMap((claim) => savedFollowUpQuestionsForClaim(claim).map((text) => ({
     text,
     audience: verificationAudienceKey(claim.relatedReadinessQuestions?.find((question) => question.question === text)?.audience ?? claim.verificationPacketAudience ?? claim.confirmationTarget),
@@ -1074,10 +1087,10 @@ function copyTextToClipboard(text: string) {
   void navigator.clipboard?.writeText(text);
 }
 
-function VerificationPacket({ claims }: { claims: DossierSourceFileReviewableClaim[]; subjectName?: string }) {
+function VerificationPacket({ claims, completionRequests }: { claims: DossierSourceFileReviewableClaim[]; subjectName?: string; completionRequests?: DossierSourceFileCompletionRequest[] }) {
   const unresolved = unresolvedReviewItems(claims);
   const locked = unresolved.length > 0;
-  const sections = verificationPacketSections(claims);
+  const sections = verificationPacketSections(claims, completionRequests);
   const hasQuestions = Object.values(sections).some((questions) => questions.length > 0);
   const copyText = verificationPacketCopyText(sections);
   return (
@@ -1115,6 +1128,39 @@ function VerificationPacket({ claims }: { claims: DossierSourceFileReviewableCla
   );
 }
 
+function completionRequestForClaim(claim: DossierSourceFileReviewableClaim, requests: DossierSourceFileCompletionRequest[] = []) {
+  return requests.find((request) => request.relatedReviewClaimIds?.includes(claim.id)) ??
+    requests.find((request) => normalizeVerificationQuestion(request.question) === normalizeVerificationQuestion(claim.claimText));
+}
+
+function CompletionRequestBadge({
+  request,
+  onUpdateStatus,
+}: {
+  request?: DossierSourceFileCompletionRequest;
+  onUpdateStatus?: (request: DossierSourceFileCompletionRequest, status: DossierSourceFileCompletionRequestStatus) => void;
+}) {
+  if (!request) return null;
+  const actions: DossierSourceFileCompletionRequestStatus[] = request.status === "open"
+    ? ["ready_to_ask", "asked", "not_applicable", "declined"]
+    : request.status === "ready_to_ask"
+      ? ["asked", "open", "not_applicable", "declined"]
+      : request.status === "asked"
+        ? ["open", "not_applicable", "declined"]
+        : ["open"];
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-muted">
+      <span className="border border-border/60 bg-background/40 px-2 py-1">Completion request: {request.status.replace(/_/g, " ")}</span>
+      <span>Seen {formatSnapshotDate(request.firstSeenAt)} → {formatSnapshotDate(request.lastSeenAt)}</span>
+      {onUpdateStatus && actions.map((status) => (
+        <button key={status} type="button" className="border border-border px-2 py-1 text-foreground hover:border-accent" onClick={() => onUpdateStatus(request, status)}>
+          {status === "open" ? "Reopen" : `Mark ${status.replace(/_/g, " ")}`}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function claimDecisionLabel(claim: DossierSourceFileReviewableClaim) {
   const decision = claim.review?.decision ?? "pending";
   if (decision === "confirmed_public" || decision === "edited") return "Approved as public fact";
@@ -1140,7 +1186,7 @@ function followUpActionLabel(claim: DossierSourceFileReviewableClaim) {
   return "Add question to follow-up";
 }
 
-function CompletedClaimCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
+function CompletedClaimCard({ claim, onReview, completionBadge }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void; completionBadge?: React.ReactNode }) {
   const decision = claim.review?.decision ?? "pending";
   const text = savedReviewText(claim);
   return (
@@ -1154,6 +1200,7 @@ function CompletedClaimCard({ claim, onReview }: { claim: DossierSourceFileRevie
       {decision === "needs_more_info" && <p className="mt-2 text-sm text-foreground">Open question: &quot;{text}&quot;</p>}
       {decision === "rejected" && <p className="mt-2 text-sm text-foreground">No Source File fact was created.</p>}
       {(decision === "confirmed_public" || decision === "edited") && <p className="mt-1 text-xs text-muted">No dossier was published.</p>}
+      {completionBadge}
       <button type="button" className="mt-3 border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => onReview?.(claim, "pending", { publicSafe: false })}>Undo choice</button>
     </li>
   );
@@ -1232,8 +1279,8 @@ function ClaimReviewControls({ claim, onReview }: {
   );
 }
 
-function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void }) {
-  if (claim.review && claim.review.decision !== "pending") return <CompletedClaimCard claim={claim} onReview={onReview} />;
+function ClaimDecisionCard({ claim, onReview, completionBadge }: { claim: DossierSourceFileReviewableClaim; onReview?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void; completionBadge?: React.ReactNode }) {
+  if (claim.review && claim.review.decision !== "pending") return <CompletedClaimCard claim={claim} onReview={onReview} completionBadge={completionBadge} />;
   return (
     <li data-claim-card="true" className="border border-border bg-background/30 p-3 shadow-[inset_0_3px_0_rgba(255,255,255,0.08)]">
       <div className="-mx-3 -mt-3 mb-2 border-b border-border/60 bg-background/40 px-3 py-2">
@@ -1272,6 +1319,7 @@ function ClaimDecisionCard({ claim, onReview }: { claim: DossierSourceFileReview
       {!claim.isInternalAuditArtifact && claim.recommendedAdminActionCards && claim.recommendedAdminActionCards.length > 0 && <div className="mt-2 border border-border/40 p-2 text-xs"><p className="font-bold text-foreground">Recommended action cards</p>{claim.recommendedAdminActionCards.map((card, index) => <p key={index} className="text-muted">{displayValue(card.title ?? card.label ?? card.action) ?? "Recommended admin action"}{displayValue(card.body ?? card.reason) ? ` — ${displayValue(card.body ?? card.reason)}` : ""}</p>)}</div>}
       {claim.blockedBy && claim.blockedBy.length > 0 && <p className="mt-2 text-xs text-muted">Blocked by: {claim.blockedBy.join(", ")}</p>}
       {!claim.isInternalAuditArtifact && claim.exampleApprovedTexts && claim.exampleApprovedTexts.length > 0 && <div className="mt-2 text-xs"><p className="font-bold text-foreground">Example approved text</p><ul className="list-disc pl-5 text-muted">{claim.exampleApprovedTexts.map((example) => <li key={example}>{example}</li>)}</ul></div>}
+      {completionBadge}
       <ClaimReviewControls claim={claim} onReview={onReview} />
     </li>
   );
@@ -1293,6 +1341,8 @@ function BnlAnalystReadPanel({
   subjectName,
   claimReviews,
   onReviewClaim,
+  completionRequests,
+  onUpdateCompletionRequestStatus,
 }: {
   analystRead?: DossierSubjectAnalystReadV1;
   refreshedAt?: string;
@@ -1301,6 +1351,8 @@ function BnlAnalystReadPanel({
   subjectName?: string;
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
+  completionRequests?: DossierSourceFileCompletionRequest[];
+  onUpdateCompletionRequestStatus?: (request: DossierSourceFileCompletionRequest, status: DossierSourceFileCompletionRequestStatus) => void;
 }) {
   if (!analystRead) {
     return (
@@ -1338,9 +1390,14 @@ function BnlAnalystReadPanel({
           const claims = reviewable.current.filter((claim) => claim.sourceSection === section);
           if (!claims.length && (section === "reviewableClaims" || section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds")) return null;
           const privateExclusions = section === "sourceBlindInsights" ? stringItems(analystRead.privateOrInternalExclusions) : [];
-          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => <ClaimDecisionCard key={claim.id} claim={claim} onReview={onReviewClaim} />)}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
+          return <section key={section} className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">{label}</h4>{claims.length ? <ul className="space-y-3 text-foreground">{claims.map((claim) => {
+            const request = section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds" ? completionRequestForClaim(claim, completionRequests) : undefined;
+            if (request && ["superseded", "declined", "not_applicable"].includes(request.status)) return null;
+            return <ClaimDecisionCard key={claim.id} claim={claim} onReview={onReviewClaim} completionBadge={request ? <CompletionRequestBadge request={request} onUpdateStatus={onUpdateCompletionRequestStatus} /> : undefined} />;
+          })}</ul> : <p className="text-muted">No reviewable claims in this section.</p>}{privateExclusions.length > 0 && <ul className="mt-3 list-disc space-y-2 pl-5 text-foreground">{privateExclusions.map((item, index) => <li key={`private-exclusion-${index}`}>Private/internal withheld: {item}</li>)}</ul>}</section>;
         })}
-        <VerificationPacket claims={reviewable.current} subjectName={analystRead?.subjectName} />
+        <VerificationPacket claims={reviewable.current} subjectName={analystRead?.subjectName} completionRequests={completionRequests} />
+        {(completionRequests ?? []).some((request) => ["superseded", "declined", "not_applicable"].includes(request.status)) && <details className="border border-border/50 bg-background/20 p-3"><summary className="cursor-pointer text-xs font-bold uppercase tracking-widest text-foreground">Inactive completion requests</summary><ul className="mt-2 space-y-2 text-xs text-muted">{(completionRequests ?? []).filter((request) => ["superseded", "declined", "not_applicable"].includes(request.status)).map((request) => <li key={request.id} className="border border-border/40 p-2"><span className="font-bold text-foreground">{request.status.replace(/_/g, " ")}</span>: {request.question}</li>)}</ul></details>}
         <WithheldEvidenceAudit audit={analystRead.withheldEvidenceAudit} />
         {reviewable.previous.length > 0 && <details className="border border-border/50 bg-background/20 p-3"><summary className="cursor-pointer text-xs font-bold uppercase tracking-widest text-foreground">Previously reviewed claims</summary><ul className="mt-3 space-y-3 text-foreground">{reviewable.previous.map((claim) => <li key={claim.id} className="border border-border/40 p-2"><p>{claim.claimText}</p><ClaimReviewControls claim={claim} onReview={onReviewClaim} /></li>)}</ul></details>}
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Provenance Summary</h4><AnalystList value={analystRead.provenanceSummary} empty="No provenance summary reported." /></section>
@@ -1643,6 +1700,8 @@ export function DossierSourceFileSummaryPanel({
   candidateId,
   claimReviews = [],
   onReviewClaim,
+  completionRequests = [],
+  onUpdateCompletionRequestStatus,
 }: {
   summary: DossierSourceFileSummary;
   entityReadout?: DossierEntityActivityReadout | null;
@@ -1658,6 +1717,8 @@ export function DossierSourceFileSummaryPanel({
   candidateId?: string;
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
+  completionRequests?: DossierSourceFileCompletionRequest[];
+  onUpdateCompletionRequestStatus?: (request: DossierSourceFileCompletionRequest, status: DossierSourceFileCompletionRequestStatus) => void;
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
@@ -1719,6 +1780,8 @@ export function DossierSourceFileSummaryPanel({
         subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
         claimReviews={claimReviews}
         onReviewClaim={onReviewClaim}
+        completionRequests={completionRequests}
+        onUpdateCompletionRequestStatus={onUpdateCompletionRequestStatus}
       />
 
       {blueprint && <DossierBlueprintView blueprint={blueprint} />}

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -44,6 +44,9 @@ import {
   type DossierSourceFileNoteSource,
   type DossierSourceFileNoteType,
   type DossierSourceFileClaimReview,
+  type DossierSourceFileCompletionRequest,
+  type DossierSourceFileCompletionRequestStatus,
+  type DossierReadinessQuestionV1,
   type ReviewDossierSourceFileClaimInput,
   type DossierDuplicateRisk,
   type DossierPopulationRecommendedAction,
@@ -107,6 +110,7 @@ function emptyWorkflowState(): DossierWorkflowState {
 }
 
 function normalizeStringArray(value: unknown): string[] {
+  if (typeof value === "string") return value.split(",").map((item) => item.trim()).filter(Boolean);
   if (!Array.isArray(value)) return [];
   return value
     .filter((item): item is string => typeof item === "string")
@@ -354,6 +358,9 @@ function sanitizeWorkflowState(value: unknown): DossierWorkflowState {
             : [],
           sourceFileClaimReviews: Array.isArray(candidate.sourceFileClaimReviews)
             ? candidate.sourceFileClaimReviews
+            : [],
+          sourceFileCompletionRequests: Array.isArray(candidate.sourceFileCompletionRequests)
+            ? candidate.sourceFileCompletionRequests
             : [],
           sourceFileSummary:
             candidate.sourceFileSummary &&
@@ -792,6 +799,201 @@ function createSourceFileClaimReviewId(input: {
     input.claimText.trim().toLowerCase().replace(/\s+/g, " "),
     input.sourceArchiveId ?? "",
   ].join("|")).digest("hex").slice(0, 24)}`;
+}
+
+const COMPLETION_REQUEST_SAFE_BOUNDARY =
+  "BNL can see protected context here, but it needs approved wording or a public source before anything can be used publicly.";
+const COMPLETION_REQUEST_TERMINAL_STATUSES = new Set<DossierSourceFileCompletionRequestStatus>(["answered", "declined", "not_applicable", "superseded"]);
+const COMPLETION_REQUEST_ACTIVE_STATUSES = new Set<DossierSourceFileCompletionRequestStatus>(["open", "ready_to_ask"]);
+
+function normalizeCompletionRequestText(value: unknown) {
+  const text = boundedText(value, 1000).replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  if (/@|stripe|payment|customer|token|env|config|raw evidence|database|table|source[- ]blind|private|mod-only|internal alias|alias:/i.test(text)) {
+    return COMPLETION_REQUEST_SAFE_BOUNDARY;
+  }
+  return text;
+}
+
+function completionAudience(value: DossierReadinessQuestionV1) {
+  const raw = boundedText(value.verificationPacketAudience ?? value.recipientClass ?? value.audience ?? value.confirmationTarget, 80)
+    .toLowerCase()
+    .replace(/[ -]+/g, "_");
+  return raw || "unknown";
+}
+
+export function createSourceFileCompletionRequestKey(input: {
+  candidateId: string;
+  sourceType: DossierSourceFileCompletionRequest["sourceType"];
+  question: DossierReadinessQuestionV1;
+  safeQuestion: string;
+}) {
+  const explicitId = boundedText(input.question.id, 200);
+  if (explicitId) return `source_file_completion:${input.candidateId}:${input.sourceType}:id:${explicitId}`;
+  const related = normalizeStringArray(input.question.relatedReviewClaimIds).sort().join(",");
+  const fingerprint = [
+    input.candidateId,
+    input.sourceType,
+    input.safeQuestion.toLowerCase().replace(/\s+/g, " "),
+    completionAudience(input.question),
+    boundedText(input.question.dossierSection, 120).toLowerCase(),
+    boundedText(input.question.answerType, 120).toLowerCase(),
+    related,
+  ].join("|");
+  return `source_file_completion:${createHash("sha1").update(fingerprint).digest("hex").slice(0, 32)}`;
+}
+
+function completionRequestFromQuestion(input: {
+  candidateId: string;
+  question: DossierReadinessQuestionV1;
+  sourceType: DossierSourceFileCompletionRequest["sourceType"];
+  sourceArchiveId?: string;
+  sourceArchiveDigest?: string;
+  sourceRefreshId?: string;
+  now: string;
+}): DossierSourceFileCompletionRequest | null {
+  const safeQuestion = normalizeCompletionRequestText(input.question.question ?? input.question.text);
+  if (!safeQuestion) return null;
+  const requestKey = createSourceFileCompletionRequestKey({ candidateId: input.candidateId, sourceType: input.sourceType, question: input.question, safeQuestion });
+  const audience = completionAudience(input.question);
+  const sourceCountRaw = Number(input.question.sourceCount);
+  return {
+    id: `source_file_completion_${createHash("sha1").update(requestKey).digest("hex").slice(0, 24)}`,
+    candidateId: input.candidateId,
+    requestKey,
+    question: safeQuestion,
+    audience,
+    recipientClass: audience,
+    audienceLabel: audience.replace(/_/g, " "),
+    dossierSection: boundedText(input.question.dossierSection, 120) || undefined,
+    priority: boundedText(input.question.priority, 80) || undefined,
+    answerType: boundedText(input.question.answerType, 120) || undefined,
+    sourceSafety: normalizeCompletionRequestText(input.question.sourceSafety) || undefined,
+    sourceCount: Number.isFinite(sourceCountRaw) ? Math.max(0, Math.floor(sourceCountRaw)) : undefined,
+    relatedReviewClaimIds: normalizeStringArray(input.question.relatedReviewClaimIds),
+    sourceArchiveId: input.sourceArchiveId,
+    sourceArchiveDigest: input.sourceArchiveDigest,
+    sourceRefreshId: input.sourceRefreshId,
+    sourceType: input.sourceType,
+    status: "open",
+    firstSeenAt: input.now,
+    lastSeenAt: input.now,
+    createdAt: input.now,
+    updatedAt: input.now,
+    statusUpdatedAt: input.now,
+  };
+}
+
+function readinessQuestionsFromAnalystRead(analystRead?: DossierSubjectAnalystReadV1) {
+  const readiness = Array.isArray(analystRead?.dossierReadinessQuestions) ? analystRead.dossierReadinessQuestions : [];
+  const clarification = Array.isArray(analystRead?.dossierClarificationNeeds) ? analystRead.dossierClarificationNeeds : [];
+  return [
+    ...readiness.map((question) => ({ question: question as DossierReadinessQuestionV1, sourceType: "dossier_readiness_question" as const })),
+    ...clarification.map((question) => ({ question: question as DossierReadinessQuestionV1, sourceType: "dossier_clarification_need" as const })),
+  ];
+}
+
+export function syncSourceFileCompletionRequestsFromAnalystRead(
+  candidate: DossierCandidate,
+  archive: DossierSourceFileArchiveMetadata | undefined = candidate.latestSourceFileArchive,
+  options: { now?: string; sourceRefreshId?: string } = {},
+): DossierCandidate {
+  const analystRead = archive?.subjectAnalystReadV1;
+  const incoming = readinessQuestionsFromAnalystRead(analystRead);
+  if (!archive || !incoming.length) return candidate;
+  const now = options.now ?? new Date().toISOString();
+  const existing = candidate.sourceFileCompletionRequests ?? [];
+  const byKey = new Map(existing.map((request) => [request.requestKey, request]));
+  const seenKeys = new Set<string>();
+  const upserts: DossierSourceFileCompletionRequest[] = [];
+  for (const item of incoming) {
+    const next = completionRequestFromQuestion({
+      candidateId: candidate.id,
+      question: item.question,
+      sourceType: item.sourceType,
+      sourceArchiveId: archive.id,
+      sourceArchiveDigest: archive.sourceDigest,
+      sourceRefreshId: options.sourceRefreshId,
+      now,
+    });
+    if (!next) continue;
+    seenKeys.add(next.requestKey);
+    const old = byKey.get(next.requestKey);
+    upserts.push(old ? {
+      ...old,
+      question: next.question,
+      audience: next.audience,
+      recipientClass: next.recipientClass,
+      audienceLabel: next.audienceLabel,
+      dossierSection: next.dossierSection,
+      priority: next.priority,
+      answerType: next.answerType,
+      sourceSafety: next.sourceSafety,
+      sourceCount: next.sourceCount,
+      relatedReviewClaimIds: next.relatedReviewClaimIds,
+      sourceArchiveId: next.sourceArchiveId,
+      sourceArchiveDigest: next.sourceArchiveDigest,
+      sourceRefreshId: next.sourceRefreshId,
+      sourceType: next.sourceType,
+      lastSeenAt: now,
+      updatedAt: now,
+    } : next);
+  }
+  const preserved = existing.filter((request) => !seenKeys.has(request.requestKey)).map((request) => (
+    COMPLETION_REQUEST_ACTIVE_STATUSES.has(request.status) && request.sourceArchiveId && request.sourceArchiveId !== archive.id
+      ? { ...request, status: "superseded" as const, statusReason: "No longer present in latest BNL analyst read.", updatedAt: now, statusUpdatedAt: now }
+      : request
+  ));
+  return { ...candidate, sourceFileCompletionRequests: [...upserts, ...preserved] };
+}
+
+function updateCompletionRequestsForClaimReview(candidate: DossierCandidate, review: DossierSourceFileClaimReview, now: string): DossierCandidate {
+  const requests = candidate.sourceFileCompletionRequests ?? [];
+  if (!requests.length) return candidate;
+  let changed = false;
+  const next = requests.map((request) => {
+    const related = request.relatedReviewClaimIds ?? [];
+    if (!related.includes(review.id) || !COMPLETION_REQUEST_ACTIVE_STATUSES.has(request.status)) return request;
+    if (review.decision === "rejected") {
+      changed = true;
+      return { ...request, status: "not_applicable" as const, statusReason: "Related Source File claim was rejected.", updatedAt: now, statusUpdatedAt: now };
+    }
+    return request;
+  });
+  return changed ? { ...candidate, sourceFileCompletionRequests: next } : candidate;
+}
+
+export async function updateSourceFileCompletionRequestStatus(input: {
+  candidateId: string;
+  requestId: string;
+  status: DossierSourceFileCompletionRequestStatus;
+  statusReason?: string;
+}): Promise<DossierSourceFileCompletionRequest> {
+  const candidateId = boundedText(input.candidateId, 200);
+  const requestId = boundedText(input.requestId, 200);
+  const allowed = new Set<DossierSourceFileCompletionRequestStatus>(["open", "ready_to_ask", "asked", "not_applicable", "declined"]);
+  if (!candidateId || !requestId || !allowed.has(input.status)) {
+    throw new DossierWorkflowInputError("Valid completion request status input is required", 400, "invalid_completion_request_status");
+  }
+  const now = new Date().toISOString();
+  let saved: DossierSourceFileCompletionRequest | null = null;
+  await updateDossierWorkflowState((currentState) => {
+    let found = false;
+    const candidates = currentState.candidates.map((candidate) => {
+      if (candidate.id !== candidateId) return candidate;
+      const requests = candidate.sourceFileCompletionRequests ?? [];
+      const next = requests.map((request) => {
+        if (request.id !== requestId) return request;
+        found = true;
+        saved = { ...request, status: input.status, statusReason: boundedText(input.statusReason, 500) || undefined, updatedAt: now, statusUpdatedAt: now };
+        return saved;
+      });
+      return found ? { ...candidate, sourceFileCompletionRequests: next, updatedAt: now } : candidate;
+    });
+    if (!found) throw new DossierWorkflowInputError("Completion request not found", 404, "completion_request_not_found");
+    return { ...currentState, candidates, updatedAt: now };
+  });
+  return saved!;
 }
 
 function createSourceFileRefreshRequestId(): string {
@@ -2722,7 +2924,7 @@ export async function ingestDossierSourceFileArchive(
       [archiveId],
       candidate.sourceFileArchiveIds,
     );
-    const nextCandidate: DossierCandidate = {
+    const nextCandidate: DossierCandidate = syncSourceFileCompletionRequestsFromAnalystRead({
       ...candidate,
       sourceFileArchiveIds: archiveIds,
       latestSourceFileArchiveId: archiveId,
@@ -2730,7 +2932,7 @@ export async function ingestDossierSourceFileArchive(
       latestSourceFileArchiveUpdatedAt: now,
       latestSourceFileArchive: metadata,
       updatedAt: now,
-    };
+    }, metadata, { now });
     attachStatus = archiveAttachStatusForCandidate(candidate);
     savedCandidate = nextCandidate;
     savedCandidateLatestArchiveId = nextCandidate.latestSourceFileArchiveId;
@@ -4376,12 +4578,12 @@ export async function reviewDossierSourceFileClaim(
         else notes.unshift(note);
       }
       saved = review;
-      return {
+      return updateCompletionRequestsForClaimReview({
         ...candidate,
         sourceFileClaimReviews: [review, ...(candidate.sourceFileClaimReviews ?? []).filter((item) => item.id !== id)],
         sourceFileNotes: notes,
         updatedAt: now,
-      };
+      }, review, now);
     });
     if (!found) throw new DossierWorkflowInputError("Candidate not found", 404, "candidate_not_found");
     return { ...currentState, candidates, updatedAt: now };

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -893,16 +893,48 @@ function readinessQuestionsFromAnalystRead(analystRead?: DossierSubjectAnalystRe
   ];
 }
 
+function analystReadHasCompletionRequestShape(analystRead?: DossierSubjectAnalystReadV1) {
+  if (!analystRead) return false;
+  return (
+    "dossierReadinessQuestions" in analystRead ||
+    "dossierClarificationNeeds" in analystRead ||
+    "readyForDraft" in analystRead ||
+    "draftReadinessReason" in analystRead ||
+    "dossierBlockedBy" in analystRead ||
+    "dossierReadinessSummary" in analystRead
+  );
+}
+
+function supersedeStaleActiveCompletionRequest(
+  request: DossierSourceFileCompletionRequest,
+  now: string,
+): DossierSourceFileCompletionRequest {
+  if (!COMPLETION_REQUEST_ACTIVE_STATUSES.has(request.status)) return request;
+  return {
+    ...request,
+    status: "superseded",
+    statusReason: "No longer present in latest BNL analyst read.",
+    updatedAt: now,
+    statusUpdatedAt: now,
+  };
+}
+
 export function syncSourceFileCompletionRequestsFromAnalystRead(
   candidate: DossierCandidate,
   archive: DossierSourceFileArchiveMetadata | undefined = candidate.latestSourceFileArchive,
   options: { now?: string; sourceRefreshId?: string } = {},
 ): DossierCandidate {
   const analystRead = archive?.subjectAnalystReadV1;
+  if (!archive || !analystRead || !analystReadHasCompletionRequestShape(analystRead)) return candidate;
   const incoming = readinessQuestionsFromAnalystRead(analystRead);
-  if (!archive || !incoming.length) return candidate;
   const now = options.now ?? new Date().toISOString();
   const existing = candidate.sourceFileCompletionRequests ?? [];
+  if (!incoming.length) {
+    return {
+      ...candidate,
+      sourceFileCompletionRequests: existing.map((request) => supersedeStaleActiveCompletionRequest(request, now)),
+    };
+  }
   const byKey = new Map(existing.map((request) => [request.requestKey, request]));
   const seenKeys = new Set<string>();
   const upserts: DossierSourceFileCompletionRequest[] = [];
@@ -940,9 +972,7 @@ export function syncSourceFileCompletionRequestsFromAnalystRead(
     } : next);
   }
   const preserved = existing.filter((request) => !seenKeys.has(request.requestKey)).map((request) => (
-    COMPLETION_REQUEST_ACTIVE_STATUSES.has(request.status) && request.sourceArchiveId && request.sourceArchiveId !== archive.id
-      ? { ...request, status: "superseded" as const, statusReason: "No longer present in latest BNL analyst read.", updatedAt: now, statusUpdatedAt: now }
-      : request
+    supersedeStaleActiveCompletionRequest(request, now)
   ));
   return { ...candidate, sourceFileCompletionRequests: [...upserts, ...preserved] };
 }

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -391,6 +391,48 @@ export type DossierSourceFileClaimReview = DossierSourceFileHumanDisplayFields &
   sourceProvenance?: string[];
 };
 
+export type DossierSourceFileCompletionRequestStatus =
+  | "open"
+  | "ready_to_ask"
+  | "asked"
+  | "answered"
+  | "declined"
+  | "not_applicable"
+  | "superseded";
+
+export type DossierSourceFileCompletionRequestSourceType =
+  | "dossier_readiness_question"
+  | "dossier_clarification_need"
+  | "verification_fallback";
+
+export type DossierSourceFileCompletionRequest = {
+  id: string;
+  candidateId: string;
+  requestKey: string;
+  question: string;
+  audience?: DossierSourceFileVerificationPacketAudience | string;
+  recipientClass?: DossierSourceFileVerificationPacketAudience | string;
+  audienceLabel?: string;
+  dossierSection?: string;
+  priority?: string;
+  answerType?: string;
+  sourceSafety?: string;
+  sourceCount?: number;
+  relatedReviewClaimIds?: string[];
+  sourceArchiveId?: string;
+  sourceArchiveDigest?: string;
+  sourceRefreshId?: string;
+  sourceType: DossierSourceFileCompletionRequestSourceType;
+  status: DossierSourceFileCompletionRequestStatus;
+  statusReason?: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  createdAt: string;
+  updatedAt: string;
+  statusUpdatedAt?: string;
+  supersededByRequestId?: string;
+};
+
 export type DossierIdentityLinkType =
   | "alias"
   | "artist_name"
@@ -486,6 +528,7 @@ export type DossierCandidate = {
   sourceFileSummary?: DossierSourceFileOperatorSummary;
   sourceFileNotes?: DossierSourceFileNote[];
   sourceFileClaimReviews?: DossierSourceFileClaimReview[];
+  sourceFileCompletionRequests?: DossierSourceFileCompletionRequest[];
   identityLinks?: DossierIdentityLink[];
   sourceLanes?: DossierRecommendationSourceLane[];
   ingestKey?: string;
@@ -3138,6 +3181,7 @@ export type DossierWorkflowAction =
   | "reviewSourceFileClaim"
   | "editSourceFileClaim"
   | "resetSourceFileClaimReview"
+  | "updateSourceFileCompletionRequestStatus"
   | "requestSourceFileRefresh"
   | "recordSourceFileOpen"
   | "addDossierIdentityLink"
@@ -3204,6 +3248,7 @@ export const DOSSIER_WORKFLOW_ACTIONS: DossierWorkflowAction[] = [
   "reviewSourceFileClaim",
   "editSourceFileClaim",
   "resetSourceFileClaimReview",
+  "updateSourceFileCompletionRequestStatus",
   "requestSourceFileRefresh",
   "recordSourceFileOpen",
   "addDossierIdentityLink",

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1070,6 +1070,130 @@ test("Source File claim review validation protects public boundaries", async () 
   assert.equal(doNotSayResponse.status, 400);
 });
 
+test("Source File completion requests persist BNL readiness questions with stable status handling", async () => {
+  await resetWorkflowStore();
+  const now = "2026-06-18T00:00:00.000Z";
+  const base = {
+    ...claimReviewCandidate(),
+    id: "completion-request-candidate",
+    name: "Completion Request Subject",
+    latestSourceFileArchive: {
+      ...claimReviewCandidate().latestSourceFileArchive,
+      id: "archive-completion-1",
+      candidateId: "completion-request-candidate",
+      sourceDigest: "digest-completion-1",
+      updatedAt: now,
+      subjectAnalystReadV1: {
+        subjectName: "Completion Request Subject",
+        reviewableClaims: [{ id: "claim-role", claim: "Confirm public role/title", type: "review_needed" }],
+        dossierReadinessQuestions: [
+          { id: "readiness-role", question: "Which public source confirms the public role?", audience: "public_source", dossierSection: "identity", answerType: "url", sourceSafety: "public source", relatedReviewClaimIds: ["claim-role"] },
+          { question: "What owner-approved wording should be used?", audience: "owner_approved_wording", dossierSection: "summary", answerType: "wording" },
+          { question: "private source-blind raw evidence id db_123", audience: "admin", dossierSection: "safety", answerType: "boundary" },
+        ],
+        dossierClarificationNeeds: [
+          { question: "Which mod can clarify timing without approving public copy?", audience: "mod", dossierSection: "context", answerType: "person" },
+        ],
+      },
+    },
+    latestSourceFileArchiveId: "archive-completion-1",
+    latestSourceFileArchiveDigest: "digest-completion-1",
+    latestSourceFileArchiveUpdatedAt: now,
+    sourceFileCompletionRequests: undefined,
+  };
+
+  const synced = store.syncSourceFileCompletionRequestsFromAnalystRead(base, base.latestSourceFileArchive, { now });
+  assert.equal(synced.sourceFileCompletionRequests.length, 4);
+  assert.ok(synced.sourceFileCompletionRequests.every((request) => request.requestKey.includes("2026-06-18") === false));
+  assert.ok(synced.sourceFileCompletionRequests.some((request) => request.requestKey === "source_file_completion:completion-request-candidate:dossier_readiness_question:id:readiness-role"));
+  assert.ok(synced.sourceFileCompletionRequests.some((request) => request.question === "BNL can see protected context here, but it needs approved wording or a public source before anything can be used publicly."));
+  const duplicateSync = store.syncSourceFileCompletionRequestsFromAnalystRead(synced, { ...base.latestSourceFileArchive, id: "archive-completion-2", sourceDigest: "digest-completion-2" }, { now: "2026-06-18T01:00:00.000Z" });
+  assert.equal(duplicateSync.sourceFileCompletionRequests.length, 4);
+  assert.equal(duplicateSync.sourceFileCompletionRequests.find((request) => request.requestKey.includes("readiness-role"))?.lastSeenAt, "2026-06-18T01:00:00.000Z");
+
+  await store.saveDossierWorkflowState({
+    version: 1,
+    revision: 0,
+    candidates: [duplicateSync],
+    drafts: [],
+    recommendations: [],
+    sourceFileRefreshRequests: [],
+    updatedAt: now,
+  });
+  const targetRequest = duplicateSync.sourceFileCompletionRequests.find((request) => request.requestKey.includes("readiness-role"));
+  for (const status of ["ready_to_ask", "asked", "not_applicable", "declined", "open"]) {
+    const response = await authedPost({
+      action: "updateSourceFileCompletionRequestStatus",
+      candidateId: duplicateSync.id,
+      input: { requestId: targetRequest.id, status },
+    });
+    assert.equal(response.status, 200);
+    const state = await store.getDossierWorkflowState();
+    assert.equal(state.candidates[0].sourceFileCompletionRequests.find((request) => request.id === targetRequest.id).status, status);
+  }
+
+  const rejectResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: duplicateSync.id,
+    input: {
+      claimId: "claim-role",
+      claimText: "Confirm public role/title",
+      claimType: "review_needed",
+      sourceSection: "reviewableClaims",
+      decision: "rejected",
+      publicSafe: false,
+    },
+  });
+  assert.equal(rejectResponse.status, 200);
+  let state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates[0].sourceFileCompletionRequests.find((request) => request.id === targetRequest.id).status, "not_applicable");
+
+  state.candidates[0].sourceFileCompletionRequests[0].status = "open";
+  await store.saveDossierWorkflowState(state);
+  const internalResponse = await authedPost({
+    action: "reviewSourceFileClaim",
+    candidateId: duplicateSync.id,
+    input: {
+      claimId: "claim-role",
+      claimText: "Confirm public role/title",
+      claimType: "review_needed",
+      sourceSection: "reviewableClaims",
+      decision: "confirmed_internal",
+      publicSafe: false,
+    },
+  });
+  assert.equal(internalResponse.status, 200);
+  state = await store.getDossierWorkflowState();
+  assert.equal(state.candidates[0].sourceFileCompletionRequests[0].status, "open");
+});
+
+test("Verification Packet prefers active persisted completion requests and falls back for old Source Files", () => {
+  const packetArchive = {
+    ...claimReviewCandidate().latestSourceFileArchive,
+    subjectAnalystReadV1: { subjectName: "Claim Review Subject" },
+  };
+  const summary = sourceFileSummary.createDossierSourceFileSummary({ candidate: { ...claimReviewCandidate(), latestSourceFileArchive: packetArchive }, recommendations: [] });
+  const activeText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: packetArchive,
+    claimReviews: [],
+    completionRequests: [
+      { id: "cr-open", candidateId: "claim-review-candidate", requestKey: "k-open", question: "Ask the subject for public link ownership.", audience: "link_ownership", sourceType: "dossier_readiness_question", status: "open", firstSeenAt: "2026-06-18T00:00:00.000Z", lastSeenAt: "2026-06-18T00:00:00.000Z", createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" },
+      { id: "cr-asked", candidateId: "claim-review-candidate", requestKey: "k-asked", question: "Do not ask this already asked question.", audience: "subject", sourceType: "dossier_readiness_question", status: "asked", firstSeenAt: "2026-06-18T00:00:00.000Z", lastSeenAt: "2026-06-18T00:00:00.000Z", createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" },
+      { id: "cr-declined", candidateId: "claim-review-candidate", requestKey: "k-declined", question: "Do not ask declined.", audience: "subject", sourceType: "dossier_readiness_question", status: "declined", firstSeenAt: "2026-06-18T00:00:00.000Z", lastSeenAt: "2026-06-18T00:00:00.000Z", createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" },
+    ],
+  }));
+  assert.match(activeText, /Ask the subject for public link ownership/);
+  assert.doesNotMatch(activeText, /Do not ask this already asked question/);
+
+  const fallbackText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: packetArchive,
+    claimReviews: [{ id: "followup", candidateId: "claim-review-candidate", claimText: "Fallback follow-up question?", claimType: "missing_info", sourceSection: "missingConfirmations", decision: "needs_more_info", publicSafe: false, createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" }],
+  }));
+  assert.match(fallbackText, /Fallback follow-up question/);
+});
+
 async function authedGet() {
   return route.GET(
     new Request("https://example.test/api/admin/dossiers", {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -1110,6 +1110,49 @@ test("Source File completion requests persist BNL readiness questions with stabl
   const duplicateSync = store.syncSourceFileCompletionRequestsFromAnalystRead(synced, { ...base.latestSourceFileArchive, id: "archive-completion-2", sourceDigest: "digest-completion-2" }, { now: "2026-06-18T01:00:00.000Z" });
   assert.equal(duplicateSync.sourceFileCompletionRequests.length, 4);
   assert.equal(duplicateSync.sourceFileCompletionRequests.find((request) => request.requestKey.includes("readiness-role"))?.lastSeenAt, "2026-06-18T01:00:00.000Z");
+  const olderShape = store.syncSourceFileCompletionRequestsFromAnalystRead(duplicateSync, {
+    ...base.latestSourceFileArchive,
+    id: "archive-older-no-readiness",
+    sourceDigest: "digest-older-no-readiness",
+    subjectAnalystReadV1: { subjectName: "Completion Request Subject" },
+  }, { now: "2026-06-18T02:00:00.000Z" });
+  assert.deepEqual(
+    olderShape.sourceFileCompletionRequests.map((request) => request.status),
+    duplicateSync.sourceFileCompletionRequests.map((request) => request.status),
+  );
+  const terminalFixture = {
+    ...duplicateSync,
+    sourceFileCompletionRequests: duplicateSync.sourceFileCompletionRequests.map((request, index) => ({
+      ...request,
+      status: ["open", "ready_to_ask", "answered", "declined"][index] ?? request.status,
+    })),
+  };
+  const emptyReadiness = store.syncSourceFileCompletionRequestsFromAnalystRead(terminalFixture, {
+    ...base.latestSourceFileArchive,
+    id: "archive-empty-readiness",
+    sourceDigest: "digest-empty-readiness",
+    subjectAnalystReadV1: {
+      subjectName: "Completion Request Subject",
+      dossierReadinessQuestions: [],
+      dossierClarificationNeeds: [],
+      draftReadinessReason: "No remaining completion requests.",
+    },
+  }, { now: "2026-06-18T03:00:00.000Z" });
+  assert.deepEqual(emptyReadiness.sourceFileCompletionRequests.map((request) => request.status), ["superseded", "superseded", "answered", "declined"]);
+  assert.equal(emptyReadiness.sourceFileCompletionRequests[0].statusReason, "No longer present in latest BNL analyst read.");
+  const readyForDraftEmpty = store.syncSourceFileCompletionRequestsFromAnalystRead({
+    ...duplicateSync,
+    sourceFileCompletionRequests: duplicateSync.sourceFileCompletionRequests.map((request) => ({ ...request, status: "open" })),
+  }, {
+    ...base.latestSourceFileArchive,
+    id: "archive-ready-for-draft",
+    sourceDigest: "digest-ready-for-draft",
+    subjectAnalystReadV1: {
+      subjectName: "Completion Request Subject",
+      readyForDraft: true,
+    },
+  }, { now: "2026-06-18T04:00:00.000Z" });
+  assert.ok(readyForDraftEmpty.sourceFileCompletionRequests.every((request) => request.status === "superseded"));
 
   await store.saveDossierWorkflowState({
     version: 1,
@@ -1185,6 +1228,29 @@ test("Verification Packet prefers active persisted completion requests and falls
   }));
   assert.match(activeText, /Ask the subject for public link ownership/);
   assert.doesNotMatch(activeText, /Do not ask this already asked question/);
+
+  const inactiveArchive = {
+    ...packetArchive,
+    subjectAnalystReadV1: {
+      subjectName: "Claim Review Subject",
+      dossierReadinessQuestions: [{ id: "inactive-readiness", question: "Inactive readiness question?", audience: "subject" }],
+      dossierClarificationNeeds: [{ id: "inactive-clarification", question: "Inactive clarification question?", audience: "mod" }],
+    },
+  };
+  const inactiveText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: inactiveArchive,
+    claimReviews: [],
+    completionRequests: [
+      { id: "cr-inactive-readiness", candidateId: "claim-review-candidate", requestKey: "inactive-readiness", question: "Inactive readiness question?", audience: "subject", sourceType: "dossier_readiness_question", status: "superseded", firstSeenAt: "2026-06-18T00:00:00.000Z", lastSeenAt: "2026-06-18T00:00:00.000Z", createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" },
+      { id: "cr-inactive-clarification", candidateId: "claim-review-candidate", requestKey: "inactive-clarification", question: "Inactive clarification question?", audience: "mod", sourceType: "dossier_clarification_need", status: "not_applicable", firstSeenAt: "2026-06-18T00:00:00.000Z", lastSeenAt: "2026-06-18T00:00:00.000Z", createdAt: "2026-06-18T00:00:00.000Z", updatedAt: "2026-06-18T00:00:00.000Z" },
+    ],
+  }));
+  assert.doesNotMatch(inactiveText, /Dossier Readiness Questions/);
+  assert.doesNotMatch(inactiveText, /Dossier Clarification Needs/);
+  assert.match(inactiveText, /Inactive completion requests/);
+  assert.match(inactiveText, /Inactive readiness question/);
+  assert.match(inactiveText, /Inactive clarification question/);
 
   const fallbackText = collectReactText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
     summary,


### PR DESCRIPTION
### Motivation
- PR #225 surfaced BNL readiness/clarification fields at render time but did not persist completion requests on Source File candidates, causing duplicate or stale follow-ups across refreshes and archive updates.
- The change should persist BNL completion requests into the existing dossier workflow state so requests survive refreshes and are deduped and status-managed conservatively.

### Description
- Added a new optional field `sourceFileCompletionRequests?: DossierSourceFileCompletionRequest[]` to `DossierCandidate` and defined `DossierSourceFileCompletionRequest` and related enums/types. (types in `src/lib/dossier-workflow.ts`).
- Implemented deterministic `requestKey` generation, safety filtering (safe boundary wording for protected/raw text), and helpers to derive/normalize audience and stable keys. (helpers in `src/lib/dossier-workflow-store.ts`).
- Added `syncSourceFileCompletionRequestsFromAnalystRead(candidate, archive)` that upserts completion requests from `dossierReadinessQuestions` and `dossierClarificationNeeds`, updates first/last-seen timestamps, preserves request status, and supersedes stale active requests. This runs when attaching a Source File archive. (store changes in `src/lib/dossier-workflow-store.ts`).
- Made completion requests respond conservatively to claim-review decisions (rejected -> mark related requests `not_applicable`). (store changes in `src/lib/dossier-workflow-store.ts`).
- Added minimal admin action `updateSourceFileCompletionRequestStatus` and wired it into the existing admin dossiers POST action set (`src/app/api/admin/dossiers/route.ts`) to allow status changes (ready_to_ask, asked, not_applicable, declined, reopen).
- Integrated persisted requests into the admin UI: pass requests + status action handler into `DossierSourceFileSummaryPanel`, show compact completion-request badges on readiness/clarification cards, hide inactive requests from the main active flow (collapsed under diagnostics), and prefer active persisted requests in the Verification Packet while preserving fallback behavior. (UI changes in `src/components/DossierSourceFileSummaryPanel.tsx` and `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`).
- Safety: no raw evidence IDs, database names, internal aliases, or protected evidence text are exposed — unsafe strings are replaced with a safe boundary sentence before storage/display.

### Testing
- Type-check: ran `npx tsc --noEmit` (successful).
- Unit/integration tests: ran `node --test tests/admin-dossiers.test.mjs`; all tests passed locally including new tests that verify:
  - completion requests are created from analyst reads and accepted on candidates without breaking fixtures,
  - deterministic request keys (no volatile timestamps),
  - duplicate readiness questions update existing requests rather than duplicate,
  - unsafe/private/raw readiness text is converted to safe boundary wording,
  - related review claim rejection marks related open requests `not_applicable`,
  - related review claim `confirmed_internal` does not incorrectly mark public/source requests answered,
  - admin status action `updateSourceFileCompletionRequestStatus` can mark requests `ready_to_ask`, `asked`, `not_applicable`, `declined`, and `open`,
  - Verification Packet prefers active persisted requests and falls back to legacy follow-ups for older Source Files.

Files changed
- src/lib/dossier-workflow.ts — types: new completion request types and field on `DossierCandidate`.
- src/lib/dossier-workflow-store.ts — sync/upsert, key gen, safety filtering, claim-review interaction, persistence hookup when attaching archives, status update helper.
- src/components/DossierSourceFileSummaryPanel.tsx — UI: compact badges, Verification Packet preference for persisted requests, collapsed diagnostics for inactive requests.
- src/app/admin/dossiers/candidates/[candidateId]/page.tsx — pass completion requests and admin status action handler into the summary panel.
- src/app/api/admin/dossiers/route.ts — new admin action `updateSourceFileCompletionRequestStatus` input parsing and handler wiring.
- tests/admin-dossiers.test.mjs — added tests for completion request persistence, dedupe, safety filtering, admin status updates, claim-review interactions, and Verification Packet behavior.

What was intentionally not changed
- No new public pages, queues, dashboards, bot contracts, answer intake, or publishing behavior were added or changed.
- Existing BNL Source File, claim-review cards, Verification Packet flow, Proposed Dossier, Owner Review, source refresh behavior, and public/private safety behavior were preserved.

Notes
- This PR persists completion requests into the existing dossier workflow store and exposes minimal admin status actions via the existing admin route; further features (answer intake, sending, or public exposure) will be implemented in follow-up PRs.
- No VPS deploy required; a Vercel deploy is recommended after merge to validate behavior in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337dd4b08c8321a7de0e41b2b14b2e)