### PR TITLE
Resolve BNL dossier questions from Source File truth

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -2631,6 +2631,7 @@ export default function CandidateReviewPage() {
               candidateId={candidate.id}
               claimReviews={candidate.sourceFileClaimReviews ?? []}
               onReviewClaim={reviewSourceFileClaim}
+              candidate={candidate}
               sourceFileTargetStatus={
                 isExistingDossierUpdate
                   ? "existing dossier update"

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -13,9 +13,11 @@ import type {
   DossierSubjectAnalystReadV1,
   DossierSourceFileConfirmationTarget,
   DossierSourceFileVerificationPacketAudience,
+  DossierCandidate,
 } from "@/lib/dossier-workflow";
 import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
 import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
+import { resolveBnlDossierQuestionFromExistingTruth, type DossierResolvedQuestionReadModel } from "@/lib/dossier-workflow-store";
 import {
   formatDossierSummaryBadge,
   type DossierSourceFileSummary,
@@ -542,6 +544,7 @@ export type DossierSourceFileReviewableClaim = {
   verificationPacketAudience?: string;
   recommendedAdminActionCards?: UnknownRecord[];
   review?: DossierSourceFileClaimReview;
+  resolvedQuestion?: DossierResolvedQuestionReadModel;
 };
 
 type SourceFileSignalSummary = {
@@ -590,6 +593,7 @@ type ReadinessQuestion = {
   sourceCount?: string;
   relatedReviewClaimIds: string[];
   clarificationOnly?: boolean;
+  resolution?: DossierResolvedQuestionReadModel;
 };
 
 function readinessAudienceKey(value: unknown): DossierSourceFileVerificationPacketAudience {
@@ -796,7 +800,7 @@ function buildCardGuidance(claimText: string, claimType: DossierSourceFileClaimT
   };
 }
 
-function buildClaimCard(input: { value: unknown; sourceSection: string; claimType: DossierSourceFileClaimType; candidateId?: string; sourceArchiveId?: string; subjectName?: string; reviews?: Map<string, DossierSourceFileClaimReview> }): DossierSourceFileReviewableClaim | undefined {
+function buildClaimCard(input: { value: unknown; sourceSection: string; claimType: DossierSourceFileClaimType; candidateId?: string; sourceArchiveId?: string; subjectName?: string; reviews?: Map<string, DossierSourceFileClaimReview>; candidate?: Partial<DossierCandidate> }): DossierSourceFileReviewableClaim | undefined {
   const record = asRecord(input.value);
   const claimText = displayValue(input.value) ?? analystString(record, ["claimText", "text", "claim", "question", "action", "boundary"]);
   if (!claimText) return undefined;
@@ -805,6 +809,8 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
   const weakLabel = isWeakEvidenceLabelText(claimText, record);
   const vagueArtifact = isVagueArtifactText(claimText, record);
   const displayTitle = displayField(record, "displayTitle");
+  const resolutionQuestion = { ...(record ?? {}), question: analystString(record, ["verificationPacketQuestion", "question", "text", "claimText"]) ?? claimText, dossierSection: analystString(record, ["dossierSection"]) ?? input.sourceSection };
+  const resolvedQuestion = input.candidate ? resolveBnlDossierQuestionFromExistingTruth({ question: resolutionQuestion, candidate: input.candidate }) : undefined;
   const internalArtifact = vagueArtifact || /^internal evidence artifact$/i.test(displayTitle ?? "") || /^vague internal evidence marker$/i.test(claimText.trim());
   const guidance = weakLabel
     ? { title: "Weak evidence label / pattern", decisionQuestion: "Is this label accurate and useful, or should it be rejected?", placeholderText: "Only enter wording here if this label is true and public-safe. Otherwise reject this claim.", exampleApprovedTexts: [`Keep ${displaySubject} label internal until confirmed.`, "Reject this label as inaccurate or not useful."] }
@@ -886,6 +892,7 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     canNeedMoreInfo: claimType !== "do_not_say",
     requiresEditedTextForPublic: claimType === "source_blind",
     review: input.reviews?.get(id),
+    resolvedQuestion: resolvedQuestion?.safeToSuppressFromActivePacket ? resolvedQuestion : undefined,
   };
 }
 
@@ -895,7 +902,8 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   sourceArchiveId?: string;
   reviews?: DossierSourceFileClaimReview[];
   subjectName?: string;
-}): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[]; signals: SourceFileSignalSummary[] } {
+  candidate?: Partial<DossierCandidate>;
+}): { current: DossierSourceFileReviewableClaim[]; previous: DossierSourceFileReviewableClaim[]; signals: SourceFileSignalSummary[]; resolvedQuestions: DossierResolvedQuestionReadModel[] } {
   const reviewById = new Map((input.reviews ?? []).map((review) => [review.id, review]));
   const structured = listValues(input.analystRead?.reviewableClaims);
   const sections: Array<{ sourceSection: string; claimType: DossierSourceFileClaimType; values: unknown }> = structured.length
@@ -910,9 +918,14 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     { sourceSection: "recommendedAdminActions", claimType: "recommended_action", values: input.analystRead?.recommendedAdminActions },
     { sourceSection: "doNotSayPublicly", claimType: "do_not_say", values: input.analystRead?.doNotSayPublicly },
   );
-  const readinessQuestions = analystReadinessQuestions(input.analystRead);
+  const readinessQuestions = analystReadinessQuestions(input.analystRead).map((question) => ({
+    ...question,
+    resolution: resolveBnlDossierQuestionFromExistingTruth({ question: { ...question, question: question.question }, candidate: input.candidate }),
+  }));
+  const resolvedReadinessQuestions = readinessQuestions.filter((question) => question.resolution.safeToSuppressFromActivePacket);
+  const activeReadinessQuestions = readinessQuestions.filter((question) => !question.resolution.safeToSuppressFromActivePacket);
   const allCards = sections.flatMap((section) => listValues(section.values).flatMap((value) => {
-    const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, subjectName: input.subjectName ?? input.analystRead?.subjectName, reviews: reviewById });
+    const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, subjectName: input.subjectName ?? input.analystRead?.subjectName, reviews: reviewById, candidate: input.candidate });
     return card ? [card] : [];
   }));
   const signals = allCards.filter((card) => isSignalSummaryText(card.claimText, asRecord(card))).map((card) => {
@@ -921,11 +934,11 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   });
   const attachedQuestionIds = new Set<string>();
   const cardsWithReadiness = allCards.map((card) => {
-    const relatedReadinessQuestions = readinessQuestions.filter((question) => question.relatedReviewClaimIds.includes(card.id));
+    const relatedReadinessQuestions = activeReadinessQuestions.filter((question) => question.relatedReviewClaimIds.includes(card.id));
     relatedReadinessQuestions.forEach((question) => attachedQuestionIds.add(question.id));
     return relatedReadinessQuestions.length ? { ...card, relatedReadinessQuestions } : card;
   });
-  const readinessCards: DossierSourceFileReviewableClaim[] = readinessQuestions.filter((question) => !attachedQuestionIds.has(question.id)).flatMap((question) => {
+  const readinessCards: DossierSourceFileReviewableClaim[] = activeReadinessQuestions.filter((question) => !attachedQuestionIds.has(question.id)).flatMap((question) => {
     const card = buildClaimCard({
     value: {
       claimText: question.question,
@@ -947,14 +960,16 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     sourceArchiveId: input.sourceArchiveId,
     subjectName: input.subjectName ?? input.analystRead?.subjectName,
     reviews: reviewById,
+    candidate: input.candidate,
     });
-    return card ? [{ ...card, readinessMetadata: readinessMetadataItems(question) }] : [];
+    return card ? [{ ...card, readinessMetadata: readinessMetadataItems(question), resolvedQuestion: question.resolution }] : [];
   });
   const current = [...cardsWithReadiness, ...readinessCards].filter((card) => !signals.some((signal) => signal.id === card.id));
   const currentIds = new Set(current.map((claim) => claim.id));
   return {
     current,
     signals,
+    resolvedQuestions: resolvedReadinessQuestions.map((question) => question.resolution),
     previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
       id: review.id,
       claimText: review.claimText,
@@ -1011,6 +1026,7 @@ function isSavedFollowUpQuestion(claim: DossierSourceFileReviewableClaim) {
 }
 
 function savedFollowUpQuestionsForClaim(claim: DossierSourceFileReviewableClaim) {
+  if (claim.resolvedQuestion?.safeToSuppressFromActivePacket) return [];
   if (!isSavedFollowUpQuestion(claim)) return [];
   const editedText = claim.review?.editedText?.trim();
   if (editedText) return safeCopyQuestions([editedText]);
@@ -1293,6 +1309,7 @@ function BnlAnalystReadPanel({
   subjectName,
   claimReviews,
   onReviewClaim,
+  candidate,
 }: {
   analystRead?: DossierSubjectAnalystReadV1;
   refreshedAt?: string;
@@ -1301,6 +1318,7 @@ function BnlAnalystReadPanel({
   subjectName?: string;
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
+  candidate?: Partial<DossierCandidate>;
 }) {
   if (!analystRead) {
     return (
@@ -1309,7 +1327,7 @@ function BnlAnalystReadPanel({
       </Section>
     );
   }
-  const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, subjectName: subjectName ?? analystRead.subjectName, reviews: claimReviews });
+  const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, subjectName: subjectName ?? analystRead.subjectName, reviews: claimReviews, candidate });
   const sectionEntries = [
     ["reviewableClaims", "Source File Claim Decisions"],
     ["publicReadyClaims", "Public-Ready Claims"],
@@ -1334,6 +1352,7 @@ function BnlAnalystReadPanel({
         {(readinessStatusLine(analystRead) || stringItems(analystRead.dossierBlockedBy).length > 0 || stringItems(analystRead.dossierReadinessSummary).length > 0) && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Dossier readiness</h4>{readinessStatusLine(analystRead) && <p className="text-foreground">{readinessStatusLine(analystRead)}</p>}{stringItems(analystRead.dossierReadinessSummary).length > 0 && <ul className="mt-2 list-disc pl-5 text-foreground">{stringItems(analystRead.dossierReadinessSummary).map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul>}{stringItems(analystRead.dossierBlockedBy).length > 0 && <div className="mt-2"><p className="text-xs font-bold text-accent">Compact blockers</p><ul className="list-disc pl-5 text-foreground">{stringItems(analystRead.dossierBlockedBy).map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul></div>}</section>}
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
         {reviewable.signals.length > 0 && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Evidence Signals / Pattern Summary</h4><p className="mb-2 text-xs text-muted/80">These are pattern counts and context signals BNL used for analysis. They are not public-ready facts by themselves.</p><ul className="space-y-2 text-foreground">{reviewable.signals.map((signal) => <li key={signal.id} className="border border-border/40 p-2"><p className="font-bold">{signal.label}{signal.count ? `: ${signal.count}` : ""}</p><p className="text-xs text-muted">{signal.suggestion}</p><p className="text-xs text-muted">Action: {signal.actionable}</p></li>)}</ul></section>}
+        {reviewable.resolvedQuestions.length > 0 && <details className="border border-border/50 bg-background/20 p-3 text-xs text-muted"><summary className="cursor-pointer font-semibold text-foreground">Automatically resolved BNL questions ({reviewable.resolvedQuestions.length})</summary><ul className="mt-2 space-y-1">{reviewable.resolvedQuestions.map((question) => <li key={question.questionKey}><span className="font-semibold text-foreground">{question.resolutionState}</span>: {question.resolutionSummary}</li>)}</ul></details>}
         {sectionEntries.map(([section, label]) => {
           const claims = reviewable.current.filter((claim) => claim.sourceSection === section);
           if (!claims.length && (section === "reviewableClaims" || section === "dossierReadinessQuestions" || section === "dossierClarificationNeeds")) return null;
@@ -1643,6 +1662,7 @@ export function DossierSourceFileSummaryPanel({
   candidateId,
   claimReviews = [],
   onReviewClaim,
+  candidate,
 }: {
   summary: DossierSourceFileSummary;
   entityReadout?: DossierEntityActivityReadout | null;
@@ -1658,6 +1678,7 @@ export function DossierSourceFileSummaryPanel({
   candidateId?: string;
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
+  candidate?: Partial<DossierCandidate>;
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
@@ -1719,6 +1740,7 @@ export function DossierSourceFileSummaryPanel({
         subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
         claimReviews={claimReviews}
         onReviewClaim={onReviewClaim}
+        candidate={candidate}
       />
 
       {blueprint && <DossierBlueprintView blueprint={blueprint} />}

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -969,7 +969,10 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   return {
     current,
     signals,
-    resolvedQuestions: resolvedReadinessQuestions.map((question) => question.resolution),
+    resolvedQuestions: [
+      ...resolvedReadinessQuestions.map((question) => question.resolution),
+      ...current.flatMap(suppressedSavedPacketResolutionsForClaim),
+    ],
     previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
       id: review.id,
       claimText: review.claimText,
@@ -1025,22 +1028,79 @@ function isSavedFollowUpQuestion(claim: DossierSourceFileReviewableClaim) {
   return claim.claimType === "missing_info" && decision === "confirmed_internal";
 }
 
-function savedFollowUpQuestionsForClaim(claim: DossierSourceFileReviewableClaim) {
+
+type SavedPacketTextClassification =
+  | "active_question"
+  | "resolved_answer"
+  | "boundary_instruction"
+  | "internal_only_resolution"
+  | "unsafe_or_not_public";
+
+export function classifySavedPacketTextForVerificationPacket(text: string): SavedPacketTextClassification {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  const lower = normalized.toLowerCase();
+  if (!normalized) return "unsafe_or_not_public";
+  if (/@|stripe|payment|customer|token|raw evidence|source-blind|private|database row/i.test(normalized)) return "unsafe_or_not_public";
+  if (/^(do not|don’t|dont)\b/.test(lower) || /\bdo not use this publicly\b/.test(lower) || /\bdo not reference\b/.test(lower) || /\bdo not state\b/.test(lower)) return "boundary_instruction";
+  if (/^(keep|keeps)\b.*\binternal\b/.test(lower) || /\binternal (only|context)\b/.test(lower)) return "internal_only_resolution";
+  if (/^(no|none)\b.*\b(approved|public|source|links?|role|title)\b.*\b(yet|approved|available)?[.!]?$/.test(lower) || /\bno approved public source yet\b/.test(lower)) return "resolved_answer";
+  if (/\b(not approved|not public-ready|not public ready)\b/.test(lower)) return "resolved_answer";
+  if (/[?]\s*$/.test(normalized) || /^(what|which|who|when|where|why|how|should|was|were|did|do|does|is|are|can|could)\b/i.test(normalized)) return "active_question";
+  return "resolved_answer";
+}
+
+function isActiveVerificationPacketQuestion(text: string) {
+  return classifySavedPacketTextForVerificationPacket(text) === "active_question";
+}
+
+function safeActivePacketQuestions(questions: string[]) {
+  return safeCopyQuestions(questions).filter(isActiveVerificationPacketQuestion);
+}
+
+function suppressedPacketResolutionForClaim(claim: DossierSourceFileReviewableClaim, text: string, classification = classifySavedPacketTextForVerificationPacket(text)): DossierResolvedQuestionReadModel | undefined {
+  if (classification === "active_question") return undefined;
+  const resolutionState = classification === "boundary_instruction" || classification === "unsafe_or_not_public"
+    ? "resolved_by_rejection_or_boundary"
+    : classification === "internal_only_resolution"
+      ? "resolved_by_claim_review"
+      : "resolved_by_existing_public_fact";
+  return {
+    questionKey: `${claim.id}:suppressed:${normalizeVerificationQuestion(text).slice(0, 80)}`,
+    resolved: true,
+    resolutionState,
+    resolutionSummary: `Suppressed saved ${classification.replace(/_/g, " ")} from the active Verification Packet: ${text.trim().replace(/\s+/g, " ")}`,
+    sourceIds: claim.review?.id ? [claim.review.id] : [claim.id],
+    stillNeedsHuman: false,
+    safeToSuppressFromActivePacket: true,
+  };
+}
+
+function savedPacketTextCandidatesForClaim(claim: DossierSourceFileReviewableClaim) {
   if (claim.resolvedQuestion?.safeToSuppressFromActivePacket) return [];
   if (!isSavedFollowUpQuestion(claim)) return [];
   const editedText = claim.review?.editedText?.trim();
-  if (editedText) return safeCopyQuestions([editedText]);
+  if (editedText) return [editedText];
   const relatedReadinessQuestions = claim.review?.decision === "needs_more_info" ? (claim.relatedReadinessQuestions?.map((question) => question.question) ?? []) : [];
-  if (relatedReadinessQuestions.length) return safeCopyQuestions(relatedReadinessQuestions);
+  if (relatedReadinessQuestions.length) return relatedReadinessQuestions;
   const reviewClaimText = claim.review?.claimText?.trim();
   const shouldSkipClaimTextFallback = claim.isVagueArtifact || claim.isInternalAuditArtifact;
-  if (claim.review?.decision === "needs_more_info" && reviewClaimText && !shouldSkipClaimTextFallback) return safeCopyQuestions([reviewClaimText]);
-  const verificationQuestions = safeCopyQuestions(claim.verificationPacketQuestions ?? []);
-  if (verificationQuestions.length) return verificationQuestions;
+  if (claim.verificationPacketQuestions?.length) return claim.verificationPacketQuestions;
+  if (claim.review?.decision === "needs_more_info" && reviewClaimText && !shouldSkipClaimTextFallback) return [reviewClaimText];
   const suggestedAnswerText = claim.suggestedAnswerText?.trim();
-  if (suggestedAnswerText) return safeCopyQuestions([suggestedAnswerText]);
-  if (claim.claimType === "missing_info" && claim.claimText && !shouldSkipClaimTextFallback) return safeCopyQuestions([claim.claimText]);
+  if (suggestedAnswerText) return [suggestedAnswerText];
+  if (claim.claimType === "missing_info" && claim.claimText && !shouldSkipClaimTextFallback) return [claim.claimText];
   return [];
+}
+
+function savedFollowUpQuestionsForClaim(claim: DossierSourceFileReviewableClaim) {
+  return safeActivePacketQuestions(savedPacketTextCandidatesForClaim(claim));
+}
+
+function suppressedSavedPacketResolutionsForClaim(claim: DossierSourceFileReviewableClaim) {
+  return safeCopyQuestions(savedPacketTextCandidatesForClaim(claim)).flatMap((text) => {
+    const resolution = suppressedPacketResolutionForClaim(claim, text);
+    return resolution ? [resolution] : [];
+  });
 }
 
 function dedupeVerificationQuestions(questions: Array<{ text: string; audience: VerificationPacketAudience }>): VerificationPacketSections {

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -586,6 +586,15 @@ type ReadinessQuestion = {
   audience: DossierSourceFileVerificationPacketAudience;
   audienceLabel: string;
   whyItMatters?: string;
+  questionKey?: string;
+  questionFamily?: string;
+  questionCategory?: string;
+  questionVersion?: string;
+  scopeKey?: string;
+  subjectKey?: string;
+  supersedesQuestionKeys?: string[];
+  narrowsQuestionKeys?: string[];
+  replacedByQuestionKey?: string;
   dossierSection?: string;
   priority?: string;
   answerType?: string;
@@ -627,6 +636,15 @@ function readinessQuestionsFrom(value: unknown, clarificationOnly = false): Read
       audience,
       audienceLabel: readinessAudienceLabel(audience),
       whyItMatters: safeHumanText(valueByKeys(record, ["whyItMatters", "reason", "why"])),
+      questionKey: textValue(record?.questionKey),
+      questionFamily: textValue(record?.questionFamily),
+      questionCategory: textValue(record?.questionCategory),
+      questionVersion: textValue(record?.questionVersion),
+      scopeKey: textValue(record?.scopeKey),
+      subjectKey: textValue(record?.subjectKey),
+      supersedesQuestionKeys: stringItems(record?.supersedesQuestionKeys),
+      narrowsQuestionKeys: stringItems(record?.narrowsQuestionKeys),
+      replacedByQuestionKey: textValue(record?.replacedByQuestionKey),
       dossierSection: safeHumanText(record?.dossierSection),
       priority: safeHumanText(record?.priority),
       answerType: safeHumanText(record?.answerType),
@@ -951,6 +969,15 @@ export function deriveDossierSourceFileReviewableClaims(input: {
       confirmationTarget: question.audience,
       verificationPacketAudience: question.audience,
       verificationPacketQuestion: question.question,
+      questionKey: question.questionKey,
+      questionFamily: question.questionFamily,
+      questionCategory: question.questionCategory,
+      questionVersion: question.questionVersion,
+      scopeKey: question.scopeKey,
+      subjectKey: question.subjectKey,
+      supersedesQuestionKeys: question.supersedesQuestionKeys,
+      narrowsQuestionKeys: question.narrowsQuestionKeys,
+      replacedByQuestionKey: question.replacedByQuestionKey,
       actionability: "missing_confirmation",
       reviewLane: question.clarificationOnly ? "clarification_need" : "dossier_readiness",
     },

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -806,6 +806,151 @@ function createDraftId(): string {
   return `dossier_draft_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+
+export type DossierQuestionResolutionState =
+  | "resolved_by_claim_review"
+  | "resolved_by_source_file_note"
+  | "resolved_by_identity_link"
+  | "resolved_by_existing_public_fact"
+  | "resolved_by_rejection_or_boundary"
+  | "unresolved"
+  | "ambiguous";
+
+export type DossierResolvedQuestionReadModel = {
+  questionKey: string;
+  resolved: boolean;
+  resolutionState: DossierQuestionResolutionState;
+  resolutionSummary: string;
+  sourceIds: string[];
+  stillNeedsHuman: boolean;
+  safeToSuppressFromActivePacket: boolean;
+};
+
+type DossierQuestionLike = Record<string, unknown> | string;
+
+function normalizeQuestionKeyText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function questionRecord(value: DossierQuestionLike): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? value : undefined;
+}
+
+function questionText(value: DossierQuestionLike): string {
+  const record = questionRecord(value);
+  const raw = record ? (record.question ?? record.text ?? record.prompt ?? record.need ?? record.claimText ?? record.verificationPacketQuestion) : value;
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function questionField(value: DossierQuestionLike, key: string): string {
+  const raw = questionRecord(value)?.[key];
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+export function dossierQuestionResolutionKey(value: DossierQuestionLike): string {
+  const explicit = questionField(value, "questionKey");
+  if (explicit) return explicit.trim();
+  return [
+    questionText(value),
+    questionField(value, "dossierSection"),
+    questionField(value, "audience") || questionField(value, "recipientClass") || questionField(value, "confirmationTarget") || questionField(value, "verificationPacketAudience"),
+    questionField(value, "answerType"),
+  ].map(normalizeQuestionKeyText).filter(Boolean).join("|") || "unknown_question";
+}
+
+function hasQuestionKeyMatch(question: DossierQuestionLike, source: Record<string, unknown>): boolean {
+  const key = questionField(question, "questionKey");
+  return Boolean(key && source.questionKey === key);
+}
+
+function textMatchesQuestion(question: DossierQuestionLike, text: unknown): boolean {
+  const q = normalizeQuestionKeyText(questionText(question));
+  const t = normalizeQuestionKeyText(text);
+  if (!q || !t) return false;
+  return q === t || t.includes(q) || q.includes(t);
+}
+
+function questionAudience(question: DossierQuestionLike): string {
+  return normalizeQuestionKeyText(questionField(question, "audience") || questionField(question, "recipientClass") || questionField(question, "confirmationTarget") || questionField(question, "verificationPacketAudience"));
+}
+
+function isPublicQuestion(question: DossierQuestionLike): boolean {
+  const joined = normalizeQuestionKeyText(`${questionText(question)} ${questionField(question, "dossierSection")} ${questionField(question, "answerType")} ${questionAudience(question)}`);
+  return /public|wording|source|link/.test(joined);
+}
+
+function isBoundaryQuestion(question: DossierQuestionLike): boolean {
+  const joined = normalizeQuestionKeyText(`${questionText(question)} ${questionField(question, "dossierSection")} ${questionField(question, "answerType")}`);
+  return /boundary|reject|rejected|do not say|do_not_say|public safety|safety|withheld/.test(joined);
+}
+
+function isIdentityQuestion(question: DossierQuestionLike): boolean {
+  const joined = normalizeQuestionKeyText(`${questionText(question)} ${questionField(question, "dossierSection")} ${questionField(question, "answerType")}`);
+  return /identity|name|alias|handle|persona|display/.test(joined);
+}
+
+function resolved(state: DossierQuestionResolutionState, summary: string, sourceIds: string[], suppress = true): DossierResolvedQuestionReadModel {
+  return { questionKey: "", resolved: true, resolutionState: state, resolutionSummary: summary, sourceIds, stillNeedsHuman: false, safeToSuppressFromActivePacket: suppress };
+}
+
+export function resolveBnlDossierQuestionFromExistingTruth(input: {
+  question: DossierQuestionLike;
+  candidate?: Partial<DossierCandidate>;
+  draft?: Partial<DossierDraft>;
+}): DossierResolvedQuestionReadModel {
+  const { question, candidate } = input;
+  const key = dossierQuestionResolutionKey(question);
+  const reviews = candidate?.sourceFileClaimReviews ?? [];
+  const publicQuestion = isPublicQuestion(question);
+  const boundaryQuestion = isBoundaryQuestion(question);
+  const identityQuestion = isIdentityQuestion(question);
+  for (const review of reviews) {
+    const record = review as unknown as Record<string, unknown>;
+    const text = review.editedText || review.claimText;
+    const matches = hasQuestionKeyMatch(question, record) || textMatchesQuestion(question, text) || (Array.isArray(record.relatedQuestionKeys) && record.relatedQuestionKeys.includes(key));
+    if (!matches) continue;
+    if (review.decision === "needs_more_info" || review.decision === "pending") return { questionKey: key, resolved: false, resolutionState: "ambiguous", resolutionSummary: "Matching claim review still needs more information.", sourceIds: [review.id], stillNeedsHuman: true, safeToSuppressFromActivePacket: false };
+    if (review.decision === "rejected") return { ...resolved("resolved_by_rejection_or_boundary", "Question matched a rejected Source File claim boundary, not public proof.", [review.id], boundaryQuestion), questionKey: key };
+    if (review.decision === "confirmed_internal" && !publicQuestion) return { ...resolved("resolved_by_claim_review", "Question matched an internal-only confirmed Source File claim.", [review.id]), questionKey: key };
+    if ((review.decision === "confirmed_public" || review.decision === "edited") && (review.publicSafe || publicQuestion)) return { ...resolved("resolved_by_claim_review", "Question matched existing public-safe reviewed Source File wording.", [review.id]), questionKey: key };
+  }
+  if (identityQuestion) {
+    const link = (candidate?.identityLinks ?? []).find((item) => item.status === "confirmed" && (hasQuestionKeyMatch(question, item as unknown as Record<string, unknown>) || textMatchesQuestion(question, item.label) || textMatchesQuestion(question, item.normalizedLabel)) && (!publicQuestion || (item.visibility === "public_safe" && item.useInPublicDossier)));
+    if (link) return { ...resolved("resolved_by_identity_link", "Question matched a compatible confirmed identity link.", [link.id]), questionKey: key };
+  }
+  const notes = candidate?.sourceFileNotes ?? [];
+  for (const note of notes) {
+    const matches = textMatchesQuestion(question, note.text) || hasQuestionKeyMatch(question, note as unknown as Record<string, unknown>);
+    if (!matches) continue;
+    if ((note.type === "do_not_say" || note.type === "public_safety") && boundaryQuestion) return { ...resolved("resolved_by_rejection_or_boundary", "Question matched an existing public-safety/do-not-say boundary.", [note.id]), questionKey: key };
+    if (["fact", "link_note", "correction"].includes(note.type) && note.publicSafe !== false) return { ...resolved("resolved_by_source_file_note", "Question matched an existing public-safe Source File note.", [note.id]), questionKey: key };
+  }
+  const facts = [...(candidate?.knownFacts ?? []), ...(candidate?.missingInfo ?? []), ...(candidate?.doNotSay ?? []), ...(candidate?.publicSafetyNotes ?? [])];
+  const factIndex = facts.findIndex((fact) => textMatchesQuestion(question, fact));
+  if (factIndex >= 0) {
+    const boundary = boundaryQuestion || factIndex >= (candidate?.knownFacts?.length ?? 0) + (candidate?.missingInfo?.length ?? 0);
+    return { ...resolved(boundary ? "resolved_by_rejection_or_boundary" : "resolved_by_existing_public_fact", boundary ? "Question matched an existing candidate boundary/safety note." : "Question matched an existing candidate public-safe fact.", [`candidate:${factIndex}`], !((candidate?.missingInfo ?? []).includes(facts[factIndex]))), questionKey: key };
+  }
+  return { questionKey: key, resolved: false, resolutionState: "unresolved", resolutionSummary: "No matching existing Source File truth was found.", sourceIds: [], stillNeedsHuman: true, safeToSuppressFromActivePacket: false };
+}
+
+export function resolveBnlDossierQuestionsFromExistingTruth(input: {
+  questions: DossierQuestionLike[];
+  candidate?: Partial<DossierCandidate>;
+  draft?: Partial<DossierDraft>;
+}): DossierResolvedQuestionReadModel[] {
+  return input.questions.map((question) => resolveBnlDossierQuestionFromExistingTruth({ question, candidate: input.candidate, draft: input.draft }));
+}
+
 export async function getDossierWorkflowState(): Promise<DossierWorkflowState> {
   const redis = getRedis();
   if (!redis) return memoryState;

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -164,6 +164,7 @@ export type DossierSubjectIntelligenceBriefV1 = {
 
 export type DossierReadinessQuestionV1 = {
   id?: string;
+  questionKey?: string;
   audience?: DossierSourceFileVerificationPacketAudience | DossierSourceFileConfirmationTarget | string;
   recipientClass?: DossierSourceFileVerificationPacketAudience | DossierSourceFileConfirmationTarget | string;
   confirmationTarget?: DossierSourceFileConfirmationTarget;

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -165,6 +165,14 @@ export type DossierSubjectIntelligenceBriefV1 = {
 export type DossierReadinessQuestionV1 = {
   id?: string;
   questionKey?: string;
+  questionFamily?: string;
+  questionCategory?: string;
+  questionVersion?: string;
+  scopeKey?: string;
+  subjectKey?: string;
+  supersedesQuestionKeys?: string[] | string;
+  narrowsQuestionKeys?: string[] | string;
+  replacedByQuestionKey?: string;
   audience?: DossierSourceFileVerificationPacketAudience | DossierSourceFileConfirmationTarget | string;
   recipientClass?: DossierSourceFileVerificationPacketAudience | DossierSourceFileConfirmationTarget | string;
   confirmationTarget?: DossierSourceFileConfirmationTarget;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12156,3 +12156,65 @@ test("BNL resolved dossier questions suppress active Verification Packet output 
   assert.match(panelText.slice(panelText.lastIndexOf("Verification Packet")), /Which admin still needs to confirm Packet Subject/);
   assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /DossierResolvedQuestionReadModel|resolutionState|safeToSuppressFromActivePacket|sourceFileClaimReviews/);
 });
+
+test("Verification Packet suppresses saved answer and boundary text while keeping real questions", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const suppressedTexts = [
+    "No public links are approved for Crow yet.",
+    "Do not state a public role for Crow yet.",
+    "Keep Orion context internal for now.",
+    "Do not reference queue/submission history publicly.",
+    "Do not use this publicly.",
+    "Keep this internal.",
+    "No approved public source yet.",
+  ];
+  const activeQuestion = "What exact public name may BNL use for Crow?";
+  const unresolvedQuestion = "Which public links, if any, may BNL associate with Crow?";
+  const analystRead = {
+    subjectName: "Crow",
+    reviewableClaims: [
+      ...suppressedTexts.map((text, index) => ({
+        claimText: `Saved answer fixture ${index}`,
+        displayTitle: `Saved answer fixture ${index}`,
+        verificationPacketQuestion: `Original packet question ${index}?`,
+        verificationPacketAudience: "subject",
+        suggestedMissingInfoQuestion: text,
+      })),
+      { claimText: "Name question fixture", verificationPacketQuestion: activeQuestion, verificationPacketAudience: "subject" },
+      { claimText: unresolvedQuestion, verificationPacketQuestion: unresolvedQuestion, verificationPacketAudience: "public_source" },
+    ],
+  };
+  const first = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: "crow_packet", sourceArchiveId: "archive_crow", subjectName: "Crow" });
+  const reviews = first.current.map((claim) => {
+    const suppressedIndex = suppressedTexts.findIndex((_, index) => claim.claimText === `Saved answer fixture ${index}`);
+    return {
+      id: claim.id,
+      candidateId: "crow_packet",
+      claimText: claim.claimText,
+      claimType: claim.claimType,
+      sourceSection: claim.sourceSection,
+      decision: "needs_more_info",
+      publicSafe: false,
+      editedText: suppressedIndex >= 0 ? suppressedTexts[suppressedIndex] : undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+  });
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: "crow_packet", sourceArchiveId: "archive_crow", subjectName: "Crow", reviews });
+  assert.ok(derived.resolvedQuestions.length >= suppressedTexts.length);
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "manual", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "needs_review", nextAction: "review", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_crow", candidateId: "crow_packet", subjectName: "Crow", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: "crow_packet",
+    claimReviews: reviews,
+  }));
+  const packetText = text.slice(text.lastIndexOf("Verification Packet"));
+  for (const suppressed of suppressedTexts) {
+    assert.doesNotMatch(packetText, new RegExp(suppressed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(packetText, /What exact public name may BNL use for Crow\?/);
+  assert.match(packetText, /Which public links, if any, may BNL associate with Crow\?/);
+  assert.match(text, /Automatically resolved BNL questions/);
+  assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /Suppressed saved/);
+  assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /classifySavedPacketTextForVerificationPacket|safeToSuppressFromActivePacket|resolutionState/);
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12136,7 +12136,21 @@ test("BNL resolved dossier questions suppress active Verification Packet output 
     subjectName: "Packet Subject",
     dossierReadinessQuestions: [
       { questionKey: "q:packet_done", question: "Which public source confirms Packet Subject's role?", audience: "public_source", dossierSection: "role", answerType: "public_fact" },
-      { question: "Which admin still needs to confirm Packet Subject?", audience: "admin", dossierSection: "role", answerType: "confirmation" },
+      {
+        questionKey: "q:packet_unresolved",
+        questionFamily: "identity_readiness",
+        questionCategory: "admin_confirmation",
+        questionVersion: "v1",
+        scopeKey: "crow:role",
+        subjectKey: "packet_subject",
+        supersedesQuestionKeys: ["q:old_packet"],
+        narrowsQuestionKeys: ["q:broad_packet"],
+        replacedByQuestionKey: "q:packet_future",
+        question: "Which admin still needs to confirm Packet Subject?",
+        audience: "admin",
+        dossierSection: "role",
+        answerType: "confirmation",
+      },
     ],
   };
   const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: candidate.id, sourceArchiveId: "archive_packet", subjectName: "Packet Subject", reviews: [], candidate });
@@ -12144,6 +12158,8 @@ test("BNL resolved dossier questions suppress active Verification Packet output 
   assert.equal(derived.current.some((claim) => /Which public source confirms Packet Subject/.test(claim.claimText)), false);
   assert.equal(derived.current.some((claim) => /Which admin still needs/.test(claim.claimText)), true);
   const unresolvedClaim = derived.current.find((claim) => /Which admin still needs/.test(claim.claimText));
+  assert.equal(unresolvedClaim?.resolvedQuestion?.questionKey, "q:packet_unresolved");
+  assert.equal(unresolvedClaim?.resolvedQuestion?.safeToSuppressFromActivePacket, false);
   const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
     summary: { summarySource: "manual", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "needs_review", nextAction: "review", existingPublicDossier: "no" },
     latestSourceFileArchive: { id: "archive_packet", candidateId: candidate.id, subjectName: "Packet Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
@@ -12167,8 +12183,12 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
     "Do not use this publicly.",
     "Keep this internal.",
     "No approved public source yet.",
+    "No public links are approved yet.",
+    "Do not state this publicly.",
+    "Do not mention this publicly.",
   ];
   const activeQuestion = "What exact public name may BNL use for Crow?";
+  const aiQuestion = "What AI/persona/project connection is this referring to?";
   const unresolvedQuestion = "Which public links, if any, may BNL associate with Crow?";
   const analystRead = {
     subjectName: "Crow",
@@ -12181,6 +12201,7 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
         suggestedMissingInfoQuestion: text,
       })),
       { claimText: "Name question fixture", verificationPacketQuestion: activeQuestion, verificationPacketAudience: "subject" },
+      { claimText: "AI question fixture", verificationPacketQuestion: aiQuestion, verificationPacketAudience: "admin" },
       { claimText: unresolvedQuestion, verificationPacketQuestion: unresolvedQuestion, verificationPacketAudience: "public_source" },
     ],
   };
@@ -12213,6 +12234,7 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
     assert.doesNotMatch(packetText, new RegExp(suppressed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
   assert.match(packetText, /What exact public name may BNL use for Crow\?/);
+  assert.match(packetText, /What AI\/persona\/project connection is this referring to\?/);
   assert.match(packetText, /Which public links, if any, may BNL associate with Crow\?/);
   assert.match(text, /Automatically resolved BNL questions/);
   assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /Suppressed saved/);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12077,3 +12077,82 @@ test("Source File intelligence and dynamic main actions are readiness-driven", (
   assert.doesNotMatch(pageCopy, /Review source context and decide whether to attach or convert into a BNL Source File/);
   assert.doesNotMatch(pageCopy, /RELATIONSHIP_JOURNAL[\s\S]{0,200}BNL Dossier Intelligence/);
 });
+
+test("BNL canonical dossier questions resolve from existing Source File truth", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const baseCandidate = {
+    id: "candidate_question_resolution",
+    name: "Question Subject",
+    candidateType: "artist",
+    source: "manual",
+    tier: "draft_ready",
+    score: 80,
+    whyNow: "Fixture.",
+    reason: "Fixture.",
+    evidenceSummary: "Fixture.",
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+    knownFacts: ["Question Subject has a public-safe BARCODE role."],
+    missingInfo: ["Which public source confirms the unresolved role?"],
+    doNotSay: ["Do not say Question Subject runs payments."],
+    publicSafetyNotes: ["Keep private member activity out of public copy."],
+    identityLinks: [{ id: "identity_public_name", candidateId: "candidate_question_resolution", label: "Question Alias", normalizedLabel: "question alias", type: "public_persona", visibility: "public_safe", status: "confirmed", source: "owner_confirmed", useForMatching: true, useInPublicDossier: true, createdAt: now, updatedAt: now }],
+    sourceFileNotes: [
+      { id: "note_public_fact", candidateId: "candidate_question_resolution", type: "fact", text: "Question Subject has a public-safe link.", source: "admin_manual", status: "active", publicSafe: true, createdAt: now, updatedAt: now },
+      { id: "note_boundary", candidateId: "candidate_question_resolution", type: "do_not_say", text: "Do not say Question Subject runs payments.", source: "admin_manual", status: "active", publicSafe: false, createdAt: now, updatedAt: now },
+      { id: "note_safety", candidateId: "candidate_question_resolution", type: "public_safety", text: "Keep private member activity out of public copy.", source: "admin_manual", status: "active", publicSafe: false, createdAt: now, updatedAt: now },
+    ],
+    sourceFileClaimReviews: [
+      { id: "review_public", candidateId: "candidate_question_resolution", questionKey: "q:public_role", claimText: "What public role may BNL use for Question Subject?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "confirmed_public", publicSafe: true, createdAt: now, updatedAt: now },
+      { id: "review_edited", candidateId: "candidate_question_resolution", claimText: "Original public wording question", editedText: "Question Subject has edited public wording.", claimType: "review_needed", sourceSection: "reviewableClaims", decision: "edited", publicSafe: true, createdAt: now, updatedAt: now },
+      { id: "review_internal", candidateId: "candidate_question_resolution", claimText: "Which public source confirms internal role?", claimType: "review_needed", sourceSection: "reviewableClaims", decision: "confirmed_internal", publicSafe: false, createdAt: now, updatedAt: now },
+      { id: "review_rejected", candidateId: "candidate_question_resolution", claimText: "Should BNL reject the unsupported sponsor claim?", claimType: "review_needed", sourceSection: "reviewableClaims", decision: "rejected", publicSafe: false, createdAt: now, updatedAt: now },
+      { id: "review_more", candidateId: "candidate_question_resolution", claimText: "Which public source confirms the unresolved role?", claimType: "missing_info", sourceSection: "reviewableClaims", decision: "needs_more_info", publicSafe: false, createdAt: now, updatedAt: now },
+    ],
+  };
+  const resolve = (question) => store.resolveBnlDossierQuestionFromExistingTruth({ question, candidate: baseCandidate });
+  assert.equal(resolve({ questionKey: "q:public_role", question: "Different text", audience: "public_source" }).resolutionState, "resolved_by_claim_review");
+  assert.equal(resolve({ question: "Question Subject has edited public wording.", audience: "public_source" }).resolutionState, "resolved_by_claim_review");
+  assert.equal(resolve({ question: "Which public source confirms internal role?", audience: "public_source" }).resolved, false);
+  assert.equal(resolve({ question: "Should BNL reject the unsupported sponsor claim?", answerType: "boundary" }).resolutionState, "resolved_by_rejection_or_boundary");
+  assert.equal(resolve({ question: "Which public source confirms the unresolved role?", audience: "subject" }).stillNeedsHuman, true);
+  assert.equal(resolve({ question: "Question Alias", dossierSection: "identity" }).resolutionState, "resolved_by_identity_link");
+  assert.equal(resolve({ question: "Question Subject has a public-safe link.", answerType: "link" }).resolutionState, "resolved_by_source_file_note");
+  assert.equal(resolve({ question: "Do not say Question Subject runs payments.", answerType: "boundary" }).resolutionState, "resolved_by_rejection_or_boundary");
+  assert.equal(resolve({ question: "Keep private member activity out of public copy.", answerType: "public_safety" }).resolutionState, "resolved_by_rejection_or_boundary");
+  assert.equal(resolve({ question: "Question Subject has a public-safe BARCODE role.", dossierSection: "role", audience: "public_source", answerType: "public_fact" }).resolutionState, "resolved_by_existing_public_fact");
+  assert.equal(resolve({ question: "Completely unknown public fact?", audience: "subject" }).resolutionState, "unresolved");
+});
+
+test("BNL resolved dossier questions suppress active Verification Packet output without public read-model metadata", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const candidate = {
+    id: "candidate_packet_resolution",
+    name: "Packet Subject",
+    sourceFileClaimReviews: [{ id: "review_packet", candidateId: "candidate_packet_resolution", questionKey: "q:packet_done", claimText: "Which public source confirms Packet Subject's role?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "confirmed_public", publicSafe: true, createdAt: now, updatedAt: now }],
+  };
+  const analystRead = {
+    subjectName: "Packet Subject",
+    dossierReadinessQuestions: [
+      { questionKey: "q:packet_done", question: "Which public source confirms Packet Subject's role?", audience: "public_source", dossierSection: "role", answerType: "public_fact" },
+      { question: "Which admin still needs to confirm Packet Subject?", audience: "admin", dossierSection: "role", answerType: "confirmation" },
+    ],
+  };
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: candidate.id, sourceArchiveId: "archive_packet", subjectName: "Packet Subject", reviews: [], candidate });
+  assert.equal(derived.resolvedQuestions.length, 1);
+  assert.equal(derived.current.some((claim) => /Which public source confirms Packet Subject/.test(claim.claimText)), false);
+  assert.equal(derived.current.some((claim) => /Which admin still needs/.test(claim.claimText)), true);
+  const unresolvedClaim = derived.current.find((claim) => /Which admin still needs/.test(claim.claimText));
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "manual", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "needs_review", nextAction: "review", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_packet", candidateId: candidate.id, subjectName: "Packet Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: candidate.id,
+    candidate,
+    claimReviews: unresolvedClaim ? [{ id: unresolvedClaim.id, candidateId: candidate.id, claimText: unresolvedClaim.claimText, claimType: unresolvedClaim.claimType, sourceSection: unresolvedClaim.sourceSection, decision: "needs_more_info", publicSafe: false, createdAt: now, updatedAt: now }] : [],
+  }));
+  assert.match(panelText, /Automatically resolved BNL questions/);
+  assert.doesNotMatch(panelText.slice(panelText.lastIndexOf("Verification Packet")), /Which public source confirms Packet Subject's role/);
+  assert.match(panelText.slice(panelText.lastIndexOf("Verification Packet")), /Which admin still needs to confirm Packet Subject/);
+  assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /DossierResolvedQuestionReadModel|resolutionState|safeToSuppressFromActivePacket|sourceFileClaimReviews/);
+});


### PR DESCRIPTION
### Motivation
- Make BNL canonical dossier questions (Bot PR #304) respect existing Site Source File truth so already-answered questions are not re-asked in active follow-up packets.
- Prefer explicit `questionKey` but support legacy Source Files without it by normalizing question text + section + audience + answerType.
- Avoid adding any new public behavior, status lifecycle, queues, identity merges, or publishing side-effects while reducing admin workload.

### Description
- Add a resolver and read-model types in `src/lib/dossier-workflow-store.ts` that compute `DossierResolvedQuestionReadModel` with states: `resolved_by_claim_review`, `resolved_by_source_file_note`, `resolved_by_identity_link`, `resolved_by_existing_public_fact`, `resolved_by_rejection_or_boundary`, `unresolved`, and `ambiguous`, and that prefer `questionKey` then a normalized fallback. (F: `src/lib/dossier-workflow-store.ts`)
- Integrate resolution logic into the Source File review derivation so readiness questions that are safely resolved are omitted from active follow-up cards and the Verification Packet, while unresolved/ambiguous questions remain visible. (F: `src/components/DossierSourceFileSummaryPanel.tsx`)
- Wire the candidate’s existing Source File truth into the panel and derivation pipeline so claim reviews, sourceFileNotes, identityLinks, knownFacts/missingInfo/doNotSay/publicSafetyNotes, and edited claim text are used as resolution sources without exposing internal metadata publicly. (F: `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/components/DossierSourceFileSummaryPanel.tsx`, `src/lib/dossier-workflow-store.ts`)
- Add `questionKey` to the readiness question type for backward/forward compatibility while tolerating missing fields. (F: `src/lib/dossier-workflow.ts`)
- Display a compact, collapsed admin-only diagnostics block inside the existing Source File panel that lists automatically resolved BNL questions; no new dashboard panels or public read-model fields were introduced. (F: `src/components/DossierSourceFileSummaryPanel.tsx`)
- Small test additions to validate resolution mapping, canonical `questionKey` and legacy fallback behavior, and suppression from the active Verification Packet. (F: `tests/admin-dossiers.test.mjs`)

### Testing
- Type-checked the project with `npx tsc --noEmit` and it succeeded. 
- Ran the full admin dossier tests with `node --test tests/admin-dossiers.test.mjs` and all tests passed (218 tests, 0 failures).
- Test coverage includes claim-review resolution, edited-claim resolution, internal vs public decision boundaries, needs-more-info ambiguity, identity-link resolution, source-file note resolution, candidate fact/boundary matching, `questionKey` and legacy fallback paths, and verification-packet suppression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33974d78088321893419bd86f3d4be)