### PR TITLE
Pass Source File workflow context into BNL refresh

### DIFF
--- a/src/app/api/admin/dossiers/route.ts
+++ b/src/app/api/admin/dossiers/route.ts
@@ -31,6 +31,7 @@ import {
 import {
   addDossierIdentityLink,
   applyPopulationReviewRecommendationAction,
+  buildDossierSourceFileWorkflowContext,
   reconcilePopulationSignals,
   addDossierSourceFileNote,
   reviewDossierSourceFileClaim,
@@ -391,6 +392,17 @@ async function verifySourceFileCaseReportAfterImmediateRefresh(input: {
   };
 }
 
+async function sourceFileWorkflowContextForRefresh(candidateId?: string) {
+  if (!candidateId) return undefined;
+  try {
+    const state = await getDossierWorkflowState();
+    const candidate = state.candidates.find((item) => item.id === candidateId);
+    return buildDossierSourceFileWorkflowContext({ candidate });
+  } catch {
+    return undefined;
+  }
+}
+
 async function workflowPayload(
   state?: DossierWorkflowState,
   populationReconcile?: PopulationReconcileSummary,
@@ -579,6 +591,7 @@ export async function POST(req: Request) {
             request: refresh.request,
             source: "admin_open_source_file",
             requestingSiteOrigin,
+            sourceFileWorkflowContext: await sourceFileWorkflowContextForRefresh(refresh.request.candidateId),
           })
         : {
             ok: false,
@@ -636,6 +649,7 @@ export async function POST(req: Request) {
         request: refresh.request,
         source: "admin_manual",
         requestingSiteOrigin,
+        sourceFileWorkflowContext: await sourceFileWorkflowContextForRefresh(refresh.request.candidateId),
       });
       const immediateRefresh = await verifySourceFileCaseReportAfterImmediateRefresh({
         request: refresh.request,

--- a/src/lib/bnl-source-file-refresh-now.ts
+++ b/src/lib/bnl-source-file-refresh-now.ts
@@ -1,4 +1,5 @@
 import type { DossierSourceFileRefreshRequest } from "@/lib/dossier-workflow";
+import type { DossierSourceFileWorkflowContextReadModel } from "@/lib/dossier-workflow-store";
 import { safeOriginHost } from "@/lib/trusted-requesting-site-origin";
 
 export type BnlSourceFileImmediateRefreshStatus =
@@ -15,6 +16,8 @@ export type BnlSourceFileImmediateRefreshResult = {
   failureReason?: string;
   callbackBaseSent?: boolean;
   callbackBaseHost?: string;
+  sourceFileWorkflowContextSent?: boolean;
+  sourceFileWorkflowContextCounts?: Record<string, number>;
 };
 
 export type BnlSourceFileImmediateRefreshInput = {
@@ -22,6 +25,7 @@ export type BnlSourceFileImmediateRefreshInput = {
   source?: string;
   timeoutMs?: number;
   requestingSiteOrigin?: string;
+  sourceFileWorkflowContext?: DossierSourceFileWorkflowContextReadModel;
 };
 
 const DEFAULT_REFRESH_NOW_TIMEOUT_MS = 25_000;
@@ -61,6 +65,16 @@ function failureReasonFromPayload(payload: unknown): string | undefined {
   );
 }
 
+function contextCounts(context: DossierSourceFileWorkflowContextReadModel | undefined): Record<string, number> | undefined {
+  if (!context) return undefined;
+  return Object.fromEntries(
+    Object.entries(context).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.length : 0,
+    ]),
+  );
+}
+
 export async function refreshBnlSourceFileNow(
   input: BnlSourceFileImmediateRefreshInput,
 ): Promise<BnlSourceFileImmediateRefreshResult> {
@@ -80,6 +94,13 @@ export async function refreshBnlSourceFileNow(
     callbackBaseSent: Boolean(callbackBaseUrl),
     ...(callbackBaseUrl
       ? { callbackBaseHost: safeOriginHost(callbackBaseUrl) }
+      : {}),
+  };
+  const sourceFileWorkflowContext = input.sourceFileWorkflowContext;
+  const workflowContextDiagnostics = {
+    sourceFileWorkflowContextSent: Boolean(sourceFileWorkflowContext),
+    ...(sourceFileWorkflowContext
+      ? { sourceFileWorkflowContextCounts: contextCounts(sourceFileWorkflowContext) }
       : {}),
   };
 
@@ -113,6 +134,9 @@ export async function refreshBnlSourceFileNow(
               sourceFileArchiveCallbackBaseUrl: callbackBaseUrl,
             }
           : {}),
+        ...(sourceFileWorkflowContext
+          ? { sourceFileWorkflowContext }
+          : {}),
       }),
       cache: "no-store",
       signal: controller.signal,
@@ -130,6 +154,7 @@ export async function refreshBnlSourceFileNow(
         failureReason:
           failureReason ?? `BNL immediate refresh returned HTTP ${response.status}.`,
         ...callbackDiagnostics,
+        ...workflowContextDiagnostics,
       };
     }
 
@@ -144,6 +169,7 @@ export async function refreshBnlSourceFileNow(
         recommendationId,
         failureReason,
         ...callbackDiagnostics,
+        ...workflowContextDiagnostics,
       };
     }
     if (payloadStatus === "failed") {
@@ -153,6 +179,7 @@ export async function refreshBnlSourceFileNow(
         recommendationId,
         failureReason,
         ...callbackDiagnostics,
+        ...workflowContextDiagnostics,
       };
     }
 
@@ -162,6 +189,7 @@ export async function refreshBnlSourceFileNow(
       recommendationId,
       failureReason,
       ...callbackDiagnostics,
+      ...workflowContextDiagnostics,
     };
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
@@ -170,6 +198,7 @@ export async function refreshBnlSourceFileNow(
         status: "timeout",
         failureReason: "BNL immediate refresh timed out.",
         ...callbackDiagnostics,
+        ...workflowContextDiagnostics,
       };
     }
     return {
@@ -180,6 +209,7 @@ export async function refreshBnlSourceFileNow(
           ? error.message
           : "BNL immediate refresh could not be reached.",
       ...callbackDiagnostics,
+      ...workflowContextDiagnostics,
     };
   } finally {
     clearTimeout(timeout);

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -818,12 +818,30 @@ export type DossierQuestionResolutionState =
 
 export type DossierResolvedQuestionReadModel = {
   questionKey: string;
+  questionFamily?: string;
+  questionCategory?: string;
+  dossierSection?: string;
+  audience?: string;
+  answerType?: string;
   resolved: boolean;
   resolutionState: DossierQuestionResolutionState;
   resolutionSummary: string;
   sourceIds: string[];
   stillNeedsHuman: boolean;
   safeToSuppressFromActivePacket: boolean;
+  relatedQuestionKeys?: string[];
+};
+
+export type DossierSourceFileWorkflowContextReadModel = {
+  resolvedQuestions: DossierResolvedQuestionReadModel[];
+  claimReviews: Array<Record<string, unknown>>;
+  sourceFileNotes: Array<Record<string, unknown>>;
+  identityLinks: Array<Record<string, unknown>>;
+  suppressedPacketItems: DossierResolvedQuestionReadModel[];
+  knownFacts: string[];
+  missingInfo: string[];
+  doNotSay: string[];
+  publicSafetyNotes: string[];
 };
 
 type DossierQuestionLike = Record<string, unknown> | string;
@@ -854,6 +872,24 @@ function questionText(value: DossierQuestionLike): string {
 function questionField(value: DossierQuestionLike, key: string): string {
   const raw = questionRecord(value)?.[key];
   return typeof raw === "string" ? raw.trim() : "";
+}
+
+function questionStringArrayField(value: DossierQuestionLike, key: string): string[] {
+  const raw = questionRecord(value)?.[key];
+  if (Array.isArray(raw)) return raw.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+  return typeof raw === "string" && raw.trim() ? [raw.trim()] : [];
+}
+
+function enrichResolvedQuestionWithQuestionFields(question: DossierQuestionLike, resolution: DossierResolvedQuestionReadModel): DossierResolvedQuestionReadModel {
+  return {
+    ...resolution,
+    questionFamily: questionField(question, "questionFamily") || undefined,
+    questionCategory: questionField(question, "questionCategory") || undefined,
+    dossierSection: questionField(question, "dossierSection") || questionField(question, "sourceSection") || undefined,
+    audience: questionField(question, "audience") || questionField(question, "recipientClass") || questionField(question, "confirmationTarget") || questionField(question, "verificationPacketAudience") || undefined,
+    answerType: questionField(question, "answerType") || undefined,
+    relatedQuestionKeys: questionStringArrayField(question, "relatedQuestionKeys"),
+  };
 }
 
 export function dossierQuestionResolutionKey(value: DossierQuestionLike): string {
@@ -940,7 +976,7 @@ export function resolveBnlDossierQuestionFromExistingTruth(input: {
     const boundary = boundaryQuestion || factIndex >= (candidate?.knownFacts?.length ?? 0) + (candidate?.missingInfo?.length ?? 0);
     return { ...resolved(boundary ? "resolved_by_rejection_or_boundary" : "resolved_by_existing_public_fact", boundary ? "Question matched an existing candidate boundary/safety note." : "Question matched an existing candidate public-safe fact.", [`candidate:${factIndex}`], !((candidate?.missingInfo ?? []).includes(facts[factIndex]))), questionKey: key };
   }
-  return { questionKey: key, resolved: false, resolutionState: "unresolved", resolutionSummary: "No matching existing Source File truth was found.", sourceIds: [], stillNeedsHuman: true, safeToSuppressFromActivePacket: false };
+  return enrichResolvedQuestionWithQuestionFields(question, { questionKey: key, resolved: false, resolutionState: "unresolved", resolutionSummary: "No matching existing Source File truth was found.", sourceIds: [], stillNeedsHuman: true, safeToSuppressFromActivePacket: false });
 }
 
 export function resolveBnlDossierQuestionsFromExistingTruth(input: {
@@ -949,6 +985,166 @@ export function resolveBnlDossierQuestionsFromExistingTruth(input: {
   draft?: Partial<DossierDraft>;
 }): DossierResolvedQuestionReadModel[] {
   return input.questions.map((question) => resolveBnlDossierQuestionFromExistingTruth({ question, candidate: input.candidate, draft: input.draft }));
+}
+
+const SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT = 25;
+const SOURCE_FILE_REFRESH_CONTEXT_TEXT_LIMIT = 300;
+const PRIVATE_CONTEXT_PATTERN = /@|stripe|payment|customer|token|secret|password|raw evidence|source-blind|private|member-only|database row|account/i;
+
+function compactWorkflowText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const compacted = value.trim().replace(/\s+/g, " ");
+  if (!compacted || PRIVATE_CONTEXT_PATTERN.test(compacted)) return undefined;
+  return compacted.length > SOURCE_FILE_REFRESH_CONTEXT_TEXT_LIMIT
+    ? `${compacted.slice(0, SOURCE_FILE_REFRESH_CONTEXT_TEXT_LIMIT - 1).trimEnd()}…`
+    : compacted;
+}
+
+function compactWorkflowTexts(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values.flatMap((value) => {
+    const text = compactWorkflowText(value);
+    return text ? [text] : [];
+  }).slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT);
+}
+
+function optionalCompactField(target: Record<string, unknown>, key: string, value: unknown) {
+  const text = compactWorkflowText(value);
+  if (text) target[key] = text;
+}
+
+function optionalStringField(target: Record<string, unknown>, key: string, value: unknown) {
+  if (typeof value === "string" && value.trim()) target[key] = value.trim();
+}
+
+function optionalStringArrayField(target: Record<string, unknown>, key: string, value: unknown) {
+  const values = Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim())
+    : typeof value === "string" && value.trim()
+      ? [value.trim()]
+      : [];
+  if (values.length) target[key] = values.slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT);
+}
+
+function compactQuestionResolutionFromSource(input: {
+  source: Record<string, unknown>;
+  state: DossierQuestionResolutionState;
+  summary: string;
+  sourceIds: string[];
+  suppress?: boolean;
+}): DossierResolvedQuestionReadModel | undefined {
+  const questionKey = typeof input.source.questionKey === "string" && input.source.questionKey.trim()
+    ? input.source.questionKey.trim()
+    : undefined;
+  if (!questionKey) return undefined;
+  const resolutionSummary = compactWorkflowText(input.summary);
+  return {
+    questionKey,
+    questionFamily: compactWorkflowText(input.source.questionFamily),
+    questionCategory: compactWorkflowText(input.source.questionCategory),
+    dossierSection: compactWorkflowText(input.source.dossierSection ?? input.source.sourceSection),
+    audience: compactWorkflowText(input.source.audience ?? input.source.recipientClass ?? input.source.confirmationTarget ?? input.source.verificationPacketAudience),
+    answerType: compactWorkflowText(input.source.answerType),
+    resolved: input.state !== "unresolved" && input.state !== "ambiguous",
+    resolutionState: input.state,
+    resolutionSummary: resolutionSummary ?? "Existing Source File workflow item resolved this BNL question.",
+    sourceIds: input.sourceIds.slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT),
+    stillNeedsHuman: input.state === "unresolved" || input.state === "ambiguous",
+    safeToSuppressFromActivePacket: input.suppress !== false && input.state !== "unresolved" && input.state !== "ambiguous",
+    relatedQuestionKeys: Array.isArray(input.source.relatedQuestionKeys)
+      ? input.source.relatedQuestionKeys.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT)
+      : undefined,
+  };
+}
+
+export function buildDossierSourceFileWorkflowContext(input: {
+  candidate?: Partial<DossierCandidate> | null;
+}): DossierSourceFileWorkflowContextReadModel | undefined {
+  const candidate = input.candidate;
+  if (!candidate) return undefined;
+  const claimReviews = (candidate.sourceFileClaimReviews ?? []).slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT).map((review) => {
+    const record = review as unknown as Record<string, unknown>;
+    const item: Record<string, unknown> = {
+      id: review.id,
+      decision: review.decision,
+      publicSafe: review.publicSafe === true,
+      sourceSection: review.sourceSection,
+    };
+    optionalCompactField(item, "claimText", review.claimText);
+    optionalCompactField(item, "editedText", review.editedText);
+    optionalStringField(item, "questionKey", record.questionKey);
+    optionalStringArrayField(item, "relatedQuestionKeys", record.relatedQuestionKeys);
+    optionalStringField(item, "confirmationTarget", review.confirmationTarget);
+    optionalStringField(item, "verificationPacketAudience", review.verificationPacketAudience);
+    return item;
+  });
+  const sourceFileNotes = (candidate.sourceFileNotes ?? []).filter((note) => note.status !== "ignored" && note.status !== "superseded").slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT).flatMap((note) => {
+    const text = compactWorkflowText(note.text);
+    if (!text) return [];
+    const record = note as unknown as Record<string, unknown>;
+    const item: Record<string, unknown> = { id: note.id, type: note.type, text, publicSafe: note.publicSafe === true };
+    optionalStringField(item, "questionKey", record.questionKey);
+    optionalStringArrayField(item, "relatedQuestionKeys", record.relatedQuestionKeys);
+    return [item];
+  });
+  const identityLinks = (candidate.identityLinks ?? []).filter((link) => link.visibility === "public_safe" || link.useInPublicDossier || link.status !== "confirmed").slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT).map((link) => {
+    const record = link as unknown as Record<string, unknown>;
+    const item: Record<string, unknown> = {
+      id: link.id,
+      label: compactWorkflowText(link.label),
+      normalizedLabel: compactWorkflowText(link.normalizedLabel),
+      status: link.status,
+      visibility: link.visibility,
+      useInPublicDossier: link.useInPublicDossier === true,
+    };
+    optionalStringField(item, "questionKey", record.questionKey);
+    optionalStringArrayField(item, "relatedQuestionKeys", record.relatedQuestionKeys);
+    return item;
+  });
+  const resolvedQuestions = [
+    ...(candidate.sourceFileClaimReviews ?? []).flatMap((review) => {
+      const state: DossierQuestionResolutionState = review.decision === "rejected"
+        ? "resolved_by_rejection_or_boundary"
+        : review.decision === "needs_more_info" || review.decision === "pending"
+          ? "ambiguous"
+          : "resolved_by_claim_review";
+      return compactQuestionResolutionFromSource({
+        source: review as unknown as Record<string, unknown>,
+        state,
+        summary: review.decision === "rejected" ? "Existing Source File review rejected or bounded this claim." : "Existing Source File claim review answered this question.",
+        sourceIds: [review.id],
+        suppress: review.decision !== "needs_more_info" && review.decision !== "pending",
+      }) ?? [];
+    }),
+    ...(candidate.sourceFileNotes ?? []).flatMap((note) => compactQuestionResolutionFromSource({
+      source: note as unknown as Record<string, unknown>,
+      state: note.type === "do_not_say" || note.type === "public_safety" ? "resolved_by_rejection_or_boundary" : "resolved_by_source_file_note",
+      summary: "Existing Source File note answered or bounded this question.",
+      sourceIds: [note.id],
+    }) ?? []),
+    ...(candidate.identityLinks ?? []).flatMap((link) => compactQuestionResolutionFromSource({
+      source: link as unknown as Record<string, unknown>,
+      state: "resolved_by_identity_link",
+      summary: "Existing identity link answered this question.",
+      sourceIds: [link.id],
+      suppress: link.status === "confirmed",
+    }) ?? []),
+  ].slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT);
+  const suppressedPacketItems = resolvedQuestions
+    .filter((item) => item.safeToSuppressFromActivePacket)
+    .slice(0, SOURCE_FILE_REFRESH_CONTEXT_ITEM_LIMIT);
+  const context = {
+    resolvedQuestions,
+    claimReviews,
+    sourceFileNotes,
+    identityLinks,
+    suppressedPacketItems,
+    knownFacts: compactWorkflowTexts(candidate.knownFacts),
+    missingInfo: compactWorkflowTexts(candidate.missingInfo),
+    doNotSay: compactWorkflowTexts(candidate.doNotSay),
+    publicSafetyNotes: compactWorkflowTexts(candidate.publicSafetyNotes),
+  };
+  return Object.values(context).some((value) => Array.isArray(value) && value.length > 0) ? context : undefined;
 }
 
 export async function getDossierWorkflowState(): Promise<DossierWorkflowState> {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -67,6 +67,7 @@ const dossierTaxonomy = require("../src/lib/dossier-taxonomy.ts");
 const dossierClassification = require("../src/lib/dossier-classification.ts");
 const dossierStylePacket = require("../src/lib/dossier-style-packet.ts");
 const bnlDossierDraft = require("../src/lib/bnl-dossier-draft.ts");
+const bnlSourceFileRefreshNow = require("../src/lib/bnl-source-file-refresh-now.ts");
 
 
 test("BNL dossier draft packet keeps internal aliases out and declares site/BNL ownership boundaries", () => {
@@ -1447,6 +1448,194 @@ test("Source File refresh does not forward untrusted callback origins", async ()
     delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
     delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
   }
+});
+
+test("Source File immediate refresh sends compact bounded workflow context without raw private evidence", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Workflow Context Fixture",
+      candidateType: "artist",
+      reason: "Operator wants workflow context refresh coverage.",
+      whyNow: "Source File has prior decisions.",
+      evidenceSummary: "Admin fixture evidence.",
+    },
+  })).json();
+  const candidateId = created.candidate.id;
+  await authedPost({ action: "promoteCandidateToSourceFile", candidateId });
+
+  const state = await store.getDossierWorkflowState();
+  const now = "2026-06-18T00:00:00.000Z";
+  await store.saveDossierWorkflowState({
+    ...state,
+    candidates: state.candidates.map((candidate) =>
+      candidate.id === candidateId
+        ? {
+            ...candidate,
+            knownFacts: Array.from({ length: 30 }, (_, index) => `Public-safe known fact ${index}`),
+            missingInfo: ["Confirm public link", "private member-only account note"],
+            doNotSay: ["Do not publish unapproved sponsor claim", "token secret should vanish"],
+            publicSafetyNotes: ["Use reviewed public facts only", "customer payment row should vanish"],
+            sourceFileClaimReviews: [
+              {
+                id: "review-public",
+                candidateId,
+                claimText: "Approved public-safe role line.",
+                editedText: "Approved edited public-safe role line.",
+                claimType: "public_ready",
+                sourceSection: "publicReadyClaims",
+                decision: "edited",
+                publicSafe: true,
+                questionKey: "role.public_line",
+                questionFamily: "role",
+                questionCategory: "public_identity",
+                dossierSection: "role",
+                audience: "subject",
+                answerType: "short_text",
+                relatedQuestionKeys: ["role.confirmation"],
+                confirmationTarget: "subject",
+                verificationPacketAudience: "subject",
+                createdAt: now,
+                updatedAt: now,
+                sourceProvenance: ["RAW_EVIDENCE_SHOULD_NOT_SEND"],
+              },
+              {
+                id: "review-raw",
+                candidateId,
+                claimText: "raw evidence private@example.test token stripe customer payment account",
+                claimType: "review_needed",
+                sourceSection: "reviewNeededClaims",
+                decision: "rejected",
+                publicSafe: false,
+                questionKey: "boundary.raw_private",
+                createdAt: now,
+                updatedAt: now,
+              },
+              ...Array.from({ length: 30 }, (_, index) => ({
+                id: `review-cap-${index}`,
+                candidateId,
+                claimText: `Cap safe claim ${index}`,
+                claimType: "review_needed",
+                sourceSection: "reviewNeededClaims",
+                decision: "confirmed_internal",
+                publicSafe: false,
+                questionKey: `cap.question.${index}`,
+                createdAt: now,
+                updatedAt: now,
+              })),
+            ],
+            sourceFileNotes: [
+              { id: "note-public", candidateId, type: "fact", text: "Public-safe note that should be compact.", source: "admin_manual", status: "active", publicSafe: true, questionKey: "note.public_fact", relatedQuestionKeys: ["note.related"], createdAt: now, updatedAt: now },
+              { id: "note-private", candidateId, type: "general_note", text: "private@example.test token raw evidence payment customer account", source: "admin_manual", status: "active", publicSafe: false, createdAt: now, updatedAt: now },
+              { id: "note-long", candidateId, type: "fact", text: `Long ${"safe ".repeat(100)}`, source: "admin_manual", status: "active", publicSafe: true, createdAt: now, updatedAt: now },
+            ],
+            identityLinks: [
+              { id: "identity-public", candidateId, label: "Public Persona", normalizedLabel: "public persona", type: "public_persona", visibility: "public_safe", status: "confirmed", source: "admin_manual", useForMatching: true, useInPublicDossier: true, questionKey: "identity.public", relatedQuestionKeys: ["identity.related"], createdAt: now, updatedAt: now },
+              { id: "identity-internal", candidateId, label: "PrivateAlias", normalizedLabel: "privatealias", type: "alias", visibility: "internal_only", status: "confirmed", source: "admin_manual", useForMatching: true, useInPublicDossier: false, createdAt: now, updatedAt: now },
+            ],
+          }
+        : candidate,
+    ),
+    updatedAt: now,
+  });
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (_url, options = {}) => {
+    calls.push(JSON.parse(options.body));
+    return Response.json({ ok: true, status: "success", recommendationId: "context-refresh" });
+  };
+
+  try {
+    const response = await (await authedPost({
+      action: "requestSourceFileRefresh",
+      candidateId,
+      reason: "Send compact workflow context.",
+    })).json();
+    assert.equal(response.immediateRefresh.ok, true);
+    assert.equal(response.immediateRefresh.sourceFileWorkflowContextSent, true);
+    assert.equal(response.immediateRefresh.sourceFileWorkflowContextCounts.resolvedQuestions, 25);
+    const context = calls[0].sourceFileWorkflowContext;
+    assert.ok(context);
+    assert.equal(context.resolvedQuestions.length, 25);
+    assert.equal(context.claimReviews.length, 25);
+    assert.equal(context.knownFacts.length, 25);
+    assert.equal(context.resolvedQuestions[0].questionKey, "role.public_line");
+    assert.equal(context.resolvedQuestions[0].resolutionState, "resolved_by_claim_review");
+    assert.equal(context.resolvedQuestions[0].questionFamily, "role");
+    assert.equal(context.claimReviews[0].decision, "edited");
+    assert.equal(context.claimReviews[0].editedText, "Approved edited public-safe role line.");
+    assert.equal(context.claimReviews[0].publicSafe, true);
+    assert.equal(context.claimReviews[0].sourceProvenance, undefined);
+    assert.equal(context.sourceFileNotes.some((note) => note.id === "note-public"), true);
+    assert.equal(context.sourceFileNotes.some((note) => note.id === "note-private"), false);
+    assert.ok(context.sourceFileNotes.find((note) => note.id === "note-long").text.length <= 300);
+    assert.deepEqual(context.identityLinks.map((link) => link.id), ["identity-public"]);
+    assert.equal(context.identityLinks[0].questionKey, "identity.public");
+    assert.ok(context.suppressedPacketItems.some((item) => item.questionKey === "role.public_line"));
+    const serialized = JSON.stringify(context);
+    assert.doesNotMatch(serialized, /RAW_EVIDENCE_SHOULD_NOT_SEND|private@example|stripe|payment|customer|token|account|sourceProvenance|sourceFileWorkflowContext":/);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  }
+});
+
+test("Source File immediate refresh remains compatible without workflow context", async () => {
+  await resetWorkflowStore();
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL = "https://bnl.example.test/internal/source-files/refresh-now";
+  process.env.BNL_SOURCE_FILE_REFRESH_TOKEN = "test-refresh-token";
+  process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS = "1000";
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (_url, options = {}) => {
+    calls.push(JSON.parse(options.body));
+    return Response.json({ ok: true, status: "success", recommendationId: "no-context-refresh" });
+  };
+
+  try {
+    const response = await bnlSourceFileRefreshNow.refreshBnlSourceFileNow({
+      request: {
+        id: "refresh-no-context",
+        candidateId: "candidate-no-context",
+        subjectName: "No Context Fixture",
+        normalizedSubjectKey: "no-context-fixture",
+        status: "pending",
+        reason: "No context fixture.",
+        requestedAt: "2026-06-18T00:00:00.000Z",
+        updatedAt: "2026-06-18T00:00:00.000Z",
+        requestSource: "manual_admin",
+        priority: 1,
+      },
+      source: "admin_manual",
+    });
+    assert.equal(response.ok, true);
+    assert.equal(response.sourceFileWorkflowContextSent, false);
+    assert.equal(calls[0].sourceFileWorkflowContext, undefined);
+  } finally {
+    global.fetch = originalFetch;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_URL;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_TOKEN;
+    delete process.env.BNL_SOURCE_FILE_REFRESH_NOW_TIMEOUT_MS;
+  }
+});
+
+test("Source File workflow context stays out of public and BNL read-model routes", () => {
+  const publicAndReadModelSources = [
+    "src/app/api/bnl/read-model/route.ts",
+    "src/app/api/bnl/source-files/route.ts",
+    "src/app/api/bnl/population-context/route.ts",
+    "src/lib/dossier-page-view-model.ts",
+  ].map((filePath) => fs.readFileSync(path.join(projectRoot, filePath), "utf8")).join("\n");
+  assert.doesNotMatch(publicAndReadModelSources, /sourceFileWorkflowContext/);
 });
 
 


### PR DESCRIPTION
### Motivation
- Ensure immediate BNL Source File refreshes receive a compact, safe snapshot of resolved Source File workflow truth so BNL can avoid re-asking already-resolved questions, avoid resurrecting rejected/internal facts, and preserve unresolved questions. 
- Preserve backward compatibility and avoid sending raw/private evidence while surfacing only admin diagnostics about whether context was included.

### Description
- Added a bounded, redacted read model `DossierSourceFileWorkflowContextReadModel` and enriched `DossierResolvedQuestionReadModel` with canonical question fields and related keys, and implemented `buildDossierSourceFileWorkflowContext` to produce compact context (file: `src/lib/dossier-workflow-store.ts`).
- Context construction compacts text (300 char cap), omits private/raw/payment/token/email-like patterns, and caps arrays at 25 items per category; the payload shape is `sourceFileWorkflowContext: { resolvedQuestions, claimReviews, sourceFileNotes, identityLinks, suppressedPacketItems, knownFacts, missingInfo, doNotSay, publicSafetyNotes }` (file: `src/lib/dossier-workflow-store.ts`).
- Extended the BNL refresh helper `refreshBnlSourceFileNow` to accept `sourceFileWorkflowContext` and include it in the POST body only when present, and return admin-only diagnostics `sourceFileWorkflowContextSent` and `sourceFileWorkflowContextCounts` (file: `src/lib/bnl-source-file-refresh-now.ts`).
- Wired admin Source File open and manual refresh endpoints to build and pass the optional context (safely catching errors and falling back to refresh without context), and added tests asserting non-exposure of the context in public/read-model code (file: `src/app/api/admin/dossiers/route.ts`).

### Testing
- Type-check: ran `npx tsc --noEmit` successfully with no type errors.
- Unit tests: ran `node --test tests/admin-dossiers.test.mjs` and all tests passed (222 tests, 0 failures); new coverage includes compact/context tests: immediate refresh sends context when available, fields are compacted/capped/redacted, claim reviews/notes/identityLinks are compact, suppressed packet items included, and refresh remains compatible when no context exists (file: `tests/admin-dossiers.test.mjs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b5cf2ba8832199077b8a2417dd15)