### PR TITLE
Make BNL Source File readiness authoritative

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
+  createDossierSourceFileDraftReadinessReadModel,
   getDossierSourceFileMetrics,
   normalizeDossierSubjectName,
   type DossierCandidate,
@@ -21,6 +22,7 @@ import {
 import {
   DossierSourceFileArchiveRawData,
   DossierSourceFileSummaryPanel,
+  normalizeSubjectAnalystReadV1,
   type DossierSourceFileReviewableClaim,
 } from "@/components/DossierSourceFileSummaryPanel";
 import { createHumanReadableSourceFileNoteView } from "@/lib/dossier-note-display";
@@ -568,13 +570,13 @@ function primaryActionForSourceFile(input: {
   return "add_missing_evidence";
 }
 
-function actionExplanation(action: MainSourceFileAction, readinessLabel: DossierReadinessLabel) {
+function actionExplanation(action: MainSourceFileAction, readiness: { primaryReason: string; recommendedNextAction: string }) {
   if (action === "add_to_source_file") return "This record needs to become a BNL Source File before drafting is available.";
   if (action === "create_draft") return "The Source File has enough public-safe dossier intelligence to create a reviewable Proposed Dossier draft.";
   if (action === "open_draft") return "The Proposed Dossier draft is current with the Source File.";
   if (action === "update_draft") return "The Source File has changed since the current draft was created or updated.";
   if (action === "open_update_workspace") return "A public dossier is already linked, so this should move through the Dossier Update workspace instead of a new Proposed Dossier.";
-  return `Draft blocked: missing public-safe identity / role / activity evidence. Current readiness: ${readinessLabel}.`;
+  return readiness.recommendedNextAction || `Draft blocked: ${readiness.primaryReason}`;
 }
 
 function sourceWarningLabels(input: {
@@ -1930,7 +1932,7 @@ export default function CandidateReviewPage() {
   const sourceFileExists = !isCandidateIntake && !isArchivedCandidate && !isCandidateClosed(candidate);
   const identityNeedsReview =
     proposedIdentityLinks.length > 0 || candidate.identityReviewStatus === "needs_confirmation";
-  const readiness = readinessForSourceFile({
+  const fallbackReadiness = readinessForSourceFile({
     sourceFileExists,
     identityNeedsReview,
     publicSafeFactCount: rawPublicSafeFacts.length,
@@ -1939,7 +1941,18 @@ export default function CandidateReviewPage() {
     missingInfoCount: (candidate.missingInfo ?? []).length + (sourceFileSummary?.missingInfo ?? []).length,
     reviewOnlyEvidenceCount: reviewOnlyNotes[0] === "No review-only evidence notes recorded." ? 0 : reviewOnlyNotes.length,
   });
-  const readyForDraft = readiness.label === "Ready for Proposed Dossier";
+  const readiness = createDossierSourceFileDraftReadinessReadModel({
+    candidate,
+    sourceFileExists,
+    analystRead: normalizeSubjectAnalystReadV1(candidate.latestSourceFileArchive),
+    fallback: {
+      readyForDraft: fallbackReadiness.label === "Ready for Proposed Dossier",
+      primaryReason: fallbackReadiness.reasons[0] ?? "BNL readiness is not available yet; using the conservative site fallback heuristic.",
+      blockers: fallbackReadiness.blockers,
+      recommendedNextAction: fallbackReadiness.label === "Ready for Proposed Dossier" ? "Request BNL draft generation from this Source File." : "Refresh the Source File so BNL can provide draft readiness.",
+    },
+  });
+  const readyForDraft = readiness.readyForDraft;
   const mainAction = primaryActionForSourceFile({
     sourceFileExists,
     hasPublicDossier: Boolean(candidate.existingDossierMatch),
@@ -1966,7 +1979,7 @@ export default function CandidateReviewPage() {
   const dossierIntelligenceSummary = firstMeaningful([
     sourceFileSummary?.currentRead,
     entityActivityReadout?.currentRead,
-    `${candidate.name} is classified as ${entityType}. Dossier readiness is ${readiness.label.toLowerCase()} based on ${rawPublicSafeFacts.length} public-safe fact${rawPublicSafeFacts.length === 1 ? "" : "s"} and ${activitySignals.length} activity signal${activitySignals.length === 1 ? "" : "s"}.`,
+    `${candidate.name} is classified as ${entityType}. Dossier readiness is ${readiness.readinessState.replace(/_/g, " ")} based on ${rawPublicSafeFacts.length} public-safe fact${rawPublicSafeFacts.length === 1 ? "" : "s"} and ${activitySignals.length} activity signal${activitySignals.length === 1 ? "" : "s"}.`,
   ], `${candidate.name} needs more BNL dossier intelligence before public drafting.`);
   const whatToAddGroups = [
     {
@@ -1999,7 +2012,7 @@ export default function CandidateReviewPage() {
     },
     {
       title: "Dossier decision",
-      items: [actionExplanation(mainAction, readiness.label)],
+      items: [actionExplanation(mainAction, readiness)],
     },
   ].map((group) => ({ ...group, items: group.items.filter(Boolean) as string[] }));
 
@@ -2127,7 +2140,7 @@ export default function CandidateReviewPage() {
             <div className="border border-border bg-background/20 p-3 lg:col-span-2">
               <p className="mb-3 text-accent">Main actions</p>
               <p className="mb-3 text-sm normal-case tracking-normal text-muted">
-                {actionExplanation(mainAction, readiness.label)}
+                {actionExplanation(mainAction, readiness)}
               </p>
               <div className="flex flex-wrap gap-3">
                 <Link
@@ -2211,7 +2224,7 @@ export default function CandidateReviewPage() {
                     type="button"
                     disabled
                     className="border border-border px-4 py-2 text-muted opacity-60"
-                    title={actionExplanation(mainAction, readiness.label)}
+                    title={actionExplanation(mainAction, readiness)}
                   >
                     Draft blocked: missing public-safe identity / role / activity evidence
                   </button>
@@ -2367,7 +2380,7 @@ export default function CandidateReviewPage() {
               </div>
               <div className="border border-border/60 bg-background/30 p-3">
                 <dt className="text-xs uppercase tracking-widest text-accent">Dossier decision</dt>
-                <dd className="mt-1">{readiness.label}</dd>
+                <dd className="mt-1">{readiness.readinessState.replace(/_/g, " ")}</dd>
               </div>
             </dl>
             <div>
@@ -2452,16 +2465,16 @@ export default function CandidateReviewPage() {
 
         <Section title="Dossier Readiness">
           <div className="space-y-3">
-            <p className="text-xl font-bold text-foreground">{readiness.label}</p>
+            <p className="text-xl font-bold text-foreground">{readiness.readinessState.replace(/_/g, " ")}</p>
             <div>
               <h3 className="font-semibold text-foreground">Readiness reasons</h3>
-              {meaningFirstList(readiness.reasons, "No positive readiness reasons recorded yet.", candidate.name)}
+              {meaningFirstList([readiness.primaryReason], "No positive readiness reasons recorded yet.", candidate.name)}
             </div>
             <div>
               <h3 className="font-semibold text-foreground">Blockers</h3>
               {meaningFirstList(readiness.blockers, "No blockers recorded beyond Owner Review.", candidate.name)}
             </div>
-            <p>Recommended next action: {actionExplanation(mainAction, readiness.label)}</p>
+            <p>Recommended next action: {actionExplanation(mainAction, readiness)}</p>
           </div>
         </Section>
 

--- a/src/app/admin/dossiers/page.tsx
+++ b/src/app/admin/dossiers/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
+  createDossierSourceFileDraftReadinessReadModel,
   createDossierPopulationAudit,
   createDossierPopulationMethodAudit,
   getDossierSourceFileMetrics,
@@ -2118,6 +2119,17 @@ export default function DossierControlCenterPage() {
                       candidate,
                       draft,
                     );
+                    const readiness = createDossierSourceFileDraftReadinessReadModel({
+                      candidate,
+                      sourceFileExists: true,
+                      analystRead: candidate.latestSourceFileArchive?.subjectAnalystReadV1,
+                      fallback: {
+                        readyForDraft: false,
+                        primaryReason: "BNL readiness is not available yet; using the conservative site fallback heuristic.",
+                        blockers: candidate.missingInfo ?? [],
+                        recommendedNextAction: "Refresh the Source File so BNL can provide draft readiness.",
+                      },
+                    });
                     const actionLabel = sourceFileActionLabel();
                     const actionHref = `/admin/dossiers/candidates/${candidate.id}`;
                     return (
@@ -2137,9 +2149,10 @@ export default function DossierControlCenterPage() {
                             "Low"}
                         </td>
                         <td className="py-3 pr-3">
-                          {(candidate.missingInfo ?? []).length > 0
-                            ? candidate.missingInfo?.join("; ")
-                            : "—"}
+                          {readiness.blockers.length > 0
+                            ? readiness.blockers.slice(0, 2).join("; ")
+                            : readiness.primaryReason}
+                          <p className="mt-1 text-xs text-muted">{readiness.recommendedNextAction}</p>
                         </td>
                         <td className="py-3 pr-3">{dossierStatus}</td>
                         <td className="py-3 pr-3">

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react";
 import type { DossierEntityActivityReadout } from "@/lib/dossier-entity-activity-readout";
+import { createDossierSourceFileDraftReadinessReadModel } from "@/lib/dossier-workflow";
 import type {
   DossierRecommendation,
   DossierSourceFileClaimReview,
@@ -1415,6 +1416,11 @@ function BnlAnalystReadPanel({
     );
   }
   const reviewable = deriveDossierSourceFileReviewableClaims({ analystRead, candidateId, sourceArchiveId, subjectName: subjectName ?? analystRead.subjectName, reviews: claimReviews, candidate });
+  const draftReadiness = createDossierSourceFileDraftReadinessReadModel({
+    sourceFileExists: true,
+    candidate: { ...(candidate ?? {}), sourceFileClaimReviews: claimReviews ?? candidate?.sourceFileClaimReviews },
+    analystRead,
+  });
   const sectionEntries = [
     ["reviewableClaims", "Source File Claim Decisions"],
     ["publicReadyClaims", "Public-Ready Claims"],
@@ -1436,7 +1442,7 @@ function BnlAnalystReadPanel({
           <SnapshotItem label="Last refreshed" value={formatSnapshotDate(refreshedAt)} />
         </dl>
         <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Internal Read</h4><BriefParagraphs value={analystRead.internalRead} /></section>
-        {(readinessStatusLine(analystRead) || stringItems(analystRead.dossierBlockedBy).length > 0 || stringItems(analystRead.dossierReadinessSummary).length > 0) && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Dossier readiness</h4>{readinessStatusLine(analystRead) && <p className="text-foreground">{readinessStatusLine(analystRead)}</p>}{stringItems(analystRead.dossierReadinessSummary).length > 0 && <ul className="mt-2 list-disc pl-5 text-foreground">{stringItems(analystRead.dossierReadinessSummary).map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul>}{stringItems(analystRead.dossierBlockedBy).length > 0 && <div className="mt-2"><p className="text-xs font-bold text-accent">Compact blockers</p><ul className="list-disc pl-5 text-foreground">{stringItems(analystRead.dossierBlockedBy).map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul></div>}</section>}
+        <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Dossier readiness</h4><p className="text-foreground">{draftReadiness.readinessState.replace(/_/g, " ")} — {safeHumanText(draftReadiness.primaryReason)}</p><p className="mt-1 text-xs text-muted">Authority: {draftReadiness.authority.replace(/_/g, " ")} · resolved {draftReadiness.resolvedQuestionCount} · unresolved {draftReadiness.unresolvedQuestionCount}</p>{draftReadiness.blockers.length > 0 && <div className="mt-2"><p className="text-xs font-bold text-accent">Current BNL blockers</p><ul className="list-disc pl-5 text-foreground">{draftReadiness.blockers.map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul></div>}</section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
         {reviewable.signals.length > 0 && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Evidence Signals / Pattern Summary</h4><p className="mb-2 text-xs text-muted/80">These are pattern counts and context signals BNL used for analysis. They are not public-ready facts by themselves.</p><ul className="space-y-2 text-foreground">{reviewable.signals.map((signal) => <li key={signal.id} className="border border-border/40 p-2"><p className="font-bold">{signal.label}{signal.count ? `: ${signal.count}` : ""}</p><p className="text-xs text-muted">{signal.suggestion}</p><p className="text-xs text-muted">Action: {signal.actionable}</p></li>)}</ul></section>}
         {reviewable.resolvedQuestions.length > 0 && <details className="border border-border/50 bg-background/20 p-3 text-xs text-muted"><summary className="cursor-pointer font-semibold text-foreground">Automatically resolved BNL questions ({reviewable.resolvedQuestions.length})</summary><ul className="mt-2 space-y-1">{reviewable.resolvedQuestions.map((question) => <li key={question.questionKey}><span className="font-semibold text-foreground">{question.resolutionState}</span>: {question.resolutionSummary}</li>)}</ul></details>}

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -218,12 +218,38 @@ export type DossierSubjectAnalystReadV1 = DossierSourceFileHumanDisplayFields & 
   draftIngredients?: string[];
   sourceFileIngredients?: string[];
   provenanceSummary?: string[];
+  sourceFileResolutionAudit?: unknown;
+  resolvedQuestionAudit?: unknown;
   dossierReadinessQuestions?: DossierReadinessQuestionV1[] | unknown;
   dossierReadinessSummary?: string | string[] | unknown;
   dossierBlockedBy?: string[] | string | unknown;
   readyForDraft?: boolean | string | unknown;
   draftReadinessReason?: string | unknown;
   dossierClarificationNeeds?: DossierReadinessQuestionV1[] | unknown;
+};
+
+export type DossierSourceFileDraftReadinessState =
+  | "ready_for_bnl_draft"
+  | "blocked_by_bnl_questions"
+  | "blocked_by_unresolved_review"
+  | "needs_public_evidence"
+  | "fallback_heuristic"
+  | "no_source_file";
+
+export type DossierSourceFileDraftReadinessAuthority =
+  | "bnl_analyst_read"
+  | "bnl_question_resolution"
+  | "site_fallback_heuristic";
+
+export type DossierSourceFileDraftReadinessReadModel = {
+  readinessState: DossierSourceFileDraftReadinessState;
+  readyForDraft: boolean;
+  primaryReason: string;
+  blockers: string[];
+  unresolvedQuestionCount: number;
+  resolvedQuestionCount: number;
+  authority: DossierSourceFileDraftReadinessAuthority;
+  recommendedNextAction: string;
 };
 
 export type DossierSourceFileCaseReportV1 = {
@@ -3469,3 +3495,117 @@ export const DOSSIER_WORKFLOW_RULES = [
   "Sheila/Cliff-style Network characters are BARCODE-controlled records, while mods are community-owned identities.",
   "Loose intake, strict drafting/publishing: BNL discoveries enter Candidate Intake first, active Source Files require admin promotion, and drafting/publishing require evidence, duplicate checks, public-safety review, and owner approval.",
 ] as const;
+
+function draftReadinessStringItems(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string" && Boolean(item.trim())).map((item) => item.trim());
+  return typeof value === "string" && value.trim() ? [value.trim()] : [];
+}
+
+function draftReadinessBool(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "yes", "ready", "ready_for_draft"].includes(normalized)) return true;
+    if (["false", "no", "blocked", "not_ready"].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
+function draftReadinessQuestionText(question: DossierReadinessQuestionV1): string {
+  return (question.question ?? question.text ?? question.reason ?? "BNL readiness question").trim();
+}
+
+function draftReadinessQuestionKey(question: DossierReadinessQuestionV1): string {
+  return (question.questionKey ?? question.id ?? draftReadinessQuestionText(question)).trim().toLowerCase();
+}
+
+function draftReadinessQuestionIsHighPriority(question: DossierReadinessQuestionV1): boolean {
+  const priority = String(question.priority ?? "").toLowerCase();
+  if (["low", "nice_to_have", "optional"].includes(priority)) return false;
+  const joined = `${draftReadinessQuestionText(question)} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.dossierSection ?? ""} ${question.answerType ?? ""} ${question.audience ?? ""} ${question.recipientClass ?? ""} ${question.confirmationTarget ?? ""}`.toLowerCase();
+  return !priority || /high|critical|required|readiness|clarification|public|wording|source|link|identity|role|title|fact|safety|boundary/.test(joined);
+}
+
+function draftReadinessQuestionNeedsPublicProof(question: DossierReadinessQuestionV1): boolean {
+  const joined = `${draftReadinessQuestionText(question)} ${question.dossierSection ?? ""} ${question.answerType ?? ""} ${question.audience ?? ""} ${question.recipientClass ?? ""} ${question.confirmationTarget ?? ""}`.toLowerCase();
+  return /public|wording|source|link|evidence|proof|fact/.test(joined);
+}
+
+function draftReadinessQuestionIsBoundary(question: DossierReadinessQuestionV1): boolean {
+  const joined = `${draftReadinessQuestionText(question)} ${question.dossierSection ?? ""} ${question.answerType ?? ""}`.toLowerCase();
+  return /boundary|reject|rejected|do not say|do_not_say|public safety|safety|withheld/.test(joined);
+}
+
+function draftReadinessReviewMatchesQuestion(review: DossierSourceFileClaimReview, question: DossierReadinessQuestionV1): boolean {
+  const record = review as unknown as Record<string, unknown>;
+  const key = draftReadinessQuestionKey(question);
+  const related = Array.isArray(record.relatedQuestionKeys) ? record.relatedQuestionKeys : [];
+  const questionText = draftReadinessQuestionText(question).toLowerCase();
+  const reviewText = `${review.claimText ?? ""} ${review.editedText ?? ""}`.toLowerCase();
+  return record.questionKey === question.questionKey || related.includes(key) || Boolean(questionText && reviewText && (questionText.includes(reviewText.trim()) || reviewText.includes(questionText)));
+}
+
+function draftReadinessQuestionResolvedByReview(candidate: Partial<DossierCandidate>, question: DossierReadinessQuestionV1): boolean {
+  const publicQuestion = draftReadinessQuestionNeedsPublicProof(question);
+  const boundaryQuestion = draftReadinessQuestionIsBoundary(question);
+  return (candidate.sourceFileClaimReviews ?? []).some((review) => {
+    if (!draftReadinessReviewMatchesQuestion(review, question)) return false;
+    if (review.decision === "rejected") return boundaryQuestion;
+    if (review.decision === "confirmed_internal") return !publicQuestion;
+    return (review.decision === "confirmed_public" || review.decision === "edited") && review.publicSafe !== false;
+  });
+}
+
+function draftReadinessPendingPublicReviews(candidate: Partial<DossierCandidate>): string[] {
+  return (candidate.sourceFileClaimReviews ?? [])
+    .filter((review) => review.decision === "pending" || review.decision === "needs_more_info")
+    .filter((review) => /public|wording|identity|role|title|link|fact|safety|boundary/i.test(`${review.claimText} ${review.sourceSection} ${review.claimType}`))
+    .map((review) => review.claimText.trim())
+    .filter(Boolean);
+}
+
+function draftReadinessHasBnlReadiness(analystRead: DossierSubjectAnalystReadV1 | undefined): analystRead is DossierSubjectAnalystReadV1 {
+  return Boolean(analystRead && (analystRead.readyForDraft !== undefined || analystRead.draftReadinessReason !== undefined || analystRead.dossierBlockedBy !== undefined || analystRead.dossierReadinessQuestions !== undefined || analystRead.dossierClarificationNeeds !== undefined));
+}
+
+export function createDossierSourceFileDraftReadinessReadModel(input: {
+  candidate?: Partial<DossierCandidate>;
+  sourceFileExists: boolean;
+  analystRead?: DossierSubjectAnalystReadV1;
+  fallback?: { readyForDraft: boolean; primaryReason: string; blockers: string[]; recommendedNextAction: string };
+}): DossierSourceFileDraftReadinessReadModel {
+  if (!input.sourceFileExists) {
+    return { readinessState: "no_source_file", readyForDraft: false, primaryReason: "This record has not been added to a BNL Source File yet.", blockers: ["Add it to a Source File before drafting."], unresolvedQuestionCount: 0, resolvedQuestionCount: 0, authority: "site_fallback_heuristic", recommendedNextAction: "Add this record to a BNL Source File before requesting a draft." };
+  }
+  const candidate = input.candidate ?? {};
+  const analystRead = input.analystRead;
+  if (draftReadinessHasBnlReadiness(analystRead)) {
+    const questions = [
+      ...(Array.isArray(analystRead.dossierReadinessQuestions) ? analystRead.dossierReadinessQuestions : []),
+      ...(Array.isArray(analystRead.dossierClarificationNeeds) ? analystRead.dossierClarificationNeeds : []),
+    ] as DossierReadinessQuestionV1[];
+    const highPriority = questions.filter(draftReadinessQuestionIsHighPriority);
+    const unresolvedQuestions = highPriority.filter((question) => !draftReadinessQuestionResolvedByReview(candidate, question));
+    const pendingReviews = draftReadinessPendingPublicReviews(candidate);
+    const bnlReady = draftReadinessBool(analystRead.readyForDraft) === true;
+    const explicitBlockers = draftReadinessStringItems(analystRead.dossierBlockedBy);
+    const blockers = [...unresolvedQuestions.map(draftReadinessQuestionText), ...pendingReviews, ...(bnlReady ? [] : explicitBlockers)].filter(Boolean);
+    const primaryReason = typeof analystRead.draftReadinessReason === "string" && analystRead.draftReadinessReason.trim()
+      ? analystRead.draftReadinessReason.trim()
+      : bnlReady
+        ? "BNL marked this Source File ready for Proposed Dossier draft generation."
+        : "BNL marked this Source File blocked for Proposed Dossier draft generation.";
+    if (unresolvedQuestions.length > 0) {
+      return { readinessState: "blocked_by_bnl_questions", readyForDraft: false, primaryReason, blockers, unresolvedQuestionCount: unresolvedQuestions.length, resolvedQuestionCount: highPriority.length - unresolvedQuestions.length, authority: "bnl_question_resolution", recommendedNextAction: "Answer or resolve the listed BNL readiness questions, then refresh the Source File." };
+    }
+    if (pendingReviews.length > 0) {
+      return { readinessState: "blocked_by_unresolved_review", readyForDraft: false, primaryReason, blockers, unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Resolve pending public wording, identity, role, link, fact, or boundary reviews before drafting." };
+    }
+    if (bnlReady) {
+      return { readinessState: "ready_for_bnl_draft", readyForDraft: true, primaryReason, blockers: [], unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Request BNL draft generation from this Source File." };
+    }
+    return { readinessState: "needs_public_evidence", readyForDraft: false, primaryReason, blockers: blockers.length ? blockers : ["BNL has not marked this Source File ready for draft generation."], unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Add the public-safe evidence or boundary decisions BNL requested, then refresh the Source File." };
+  }
+  const fallback = input.fallback;
+  return { readinessState: "fallback_heuristic", readyForDraft: Boolean(fallback?.readyForDraft), primaryReason: fallback?.primaryReason ?? "BNL readiness is not available yet; using the conservative site fallback heuristic.", blockers: fallback?.blockers ?? [], unresolvedQuestionCount: 0, resolvedQuestionCount: 0, authority: "site_fallback_heuristic", recommendedNextAction: fallback?.recommendedNextAction ?? "Refresh the Source File so BNL can provide draft readiness." };
+}

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -9595,8 +9595,8 @@ test("Source File analyst readiness fields wire into existing review and Verific
 
   const lockedText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive, candidateId: archive.candidateId }));
   assert.match(lockedText, /Dossier readiness/);
-  assert.match(lockedText, /Not ready for draft\s+—\s+BNL still needs owner-approved wording and a public source before drafting/);
-  assert.match(lockedText, /Compact blockers/);
+  assert.match(lockedText, /blocked by bnl questions\s+—\s+BNL still needs owner-approved wording and a public source before drafting/);
+  assert.match(lockedText, /Current BNL blockers/);
   assert.match(lockedText, /Owner-approved wording missing/);
   assert.match(lockedText, /BNL can see protected context here, but it needs approved wording or a public source before anything can be used publicly/);
   assert.match(lockedText, /Related BNL readiness questions/);
@@ -12256,7 +12256,7 @@ test("Source File intelligence and dynamic main actions are readiness-driven", (
 
   const mainActions = page.slice(page.indexOf("<p className=\"mb-3 text-accent\">Main actions</p>"), page.indexOf("<p className=\"mb-3 text-accent\">Review state</p>"));
   assert.doesNotMatch(mainActions, /Create Proposed Dossier Draft[\s\S]*Open Proposed Dossier Draft[\s\S]*Update Draft From Source File[\s\S]*Add to Source File/);
-  assert.match(mainActions, /actionExplanation\(mainAction, readiness\.label\)/);
+  assert.match(mainActions, /actionExplanation\(mainAction, readiness\)/);
 
   const technicalCoverageIndex = page.indexOf("Technical Source Coverage");
   const dossierIntelligenceIndex = page.indexOf("BNL Dossier Intelligence");
@@ -12428,4 +12428,61 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
   assert.match(text, /Automatically resolved BNL questions/);
   assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /Suppressed saved/);
   assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /classifySavedPacketTextForVerificationPacket|safeToSuppressFromActivePacket|resolutionState/);
+});
+
+test("BNL Source File draft readiness read model uses BNL authority before site fallback", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const baseCandidate = {
+    id: "candidate_draft_readiness",
+    name: "Draft Readiness Subject",
+    sourceFileClaimReviews: [
+      { id: "review_role", candidateId: "candidate_draft_readiness", questionKey: "q:role", claimText: "Which public wording confirms the role?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "confirmed_public", publicSafe: true, createdAt: now, updatedAt: now },
+      { id: "review_boundary", candidateId: "candidate_draft_readiness", questionKey: "q:boundary", claimText: "Should BNL use the unsafe boundary?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "rejected", publicSafe: false, createdAt: now, updatedAt: now },
+      { id: "review_internal", candidateId: "candidate_draft_readiness", questionKey: "q:internal", claimText: "Which admin confirms internal context?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "confirmed_internal", publicSafe: false, createdAt: now, updatedAt: now },
+    ],
+  };
+  const readyRead = {
+    readyForDraft: true,
+    draftReadinessReason: "BNL says ready after resolved questions.",
+    dossierReadinessQuestions: [
+      { questionKey: "q:role", question: "Which public wording confirms the role?", priority: "high", audience: "public_source", answerType: "public_fact" },
+      { questionKey: "q:boundary", question: "Should BNL use the unsafe boundary?", priority: "high", answerType: "boundary" },
+    ],
+  };
+  const ready = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: readyRead, fallback: { readyForDraft: false, primaryReason: "Fallback says blocked", blockers: ["Fallback blocker"], recommendedNextAction: "Fallback action" } });
+  assert.equal(ready.readinessState, "ready_for_bnl_draft");
+  assert.equal(ready.readyForDraft, true);
+  assert.equal(ready.authority, "bnl_analyst_read");
+  assert.equal(ready.unresolvedQuestionCount, 0);
+  assert.equal(ready.resolvedQuestionCount, 2);
+
+  const blocked = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: { readyForDraft: false, draftReadinessReason: "BNL needs one more answer.", dossierReadinessQuestions: [{ questionKey: "q:missing", question: "Which public source confirms the title?", priority: "high", audience: "public_source", answerType: "public_fact" }] } });
+  assert.equal(blocked.readinessState, "blocked_by_bnl_questions");
+  assert.equal(blocked.authority, "bnl_question_resolution");
+  assert.match(blocked.blockers.join("\n"), /Which public source confirms the title/);
+
+  const internalDoesNotSatisfyPublic = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: { readyForDraft: true, dossierReadinessQuestions: [{ questionKey: "q:internal", question: "Which public source confirms internal context?", priority: "high", audience: "public_source", answerType: "public_fact" }] } });
+  assert.equal(internalDoesNotSatisfyPublic.readinessState, "blocked_by_bnl_questions");
+
+  const pendingPublicReview = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { ...baseCandidate, sourceFileClaimReviews: [{ id: "review_pending", candidateId: "candidate_draft_readiness", claimText: "Pending public role wording", claimType: "review_needed", sourceSection: "reviewableClaims", decision: "pending", publicSafe: false, createdAt: now, updatedAt: now }] }, analystRead: { readyForDraft: true, draftReadinessReason: "BNL ready if reviews clear." } });
+  assert.equal(pendingPublicReview.readinessState, "blocked_by_unresolved_review");
+
+  const pendingInternalOnly = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { ...baseCandidate, sourceFileClaimReviews: [{ id: "review_pending_internal", candidateId: "candidate_draft_readiness", claimText: "Pending internal-only operator note", claimType: "review_needed", sourceSection: "sourceBlindInsights", decision: "pending", publicSafe: false, createdAt: now, updatedAt: now }] }, analystRead: { readyForDraft: true, draftReadinessReason: "BNL ready." } });
+  assert.equal(pendingInternalOnly.readinessState, "ready_for_bnl_draft");
+
+  const fallback = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, fallback: { readyForDraft: false, primaryReason: "Local heuristic only.", blockers: ["Needs public evidence."], recommendedNextAction: "Refresh BNL." } });
+  assert.equal(fallback.readinessState, "fallback_heuristic");
+  assert.equal(fallback.authority, "site_fallback_heuristic");
+});
+
+test("admin Source File and Control Center render BNL draft readiness read model without public leakage", () => {
+  const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
+  const controlCenter = normalizedSource("src/app/admin/dossiers/page.tsx");
+  const publicReadModel = normalizedSource("src/app/api/bnl/read-model/route.ts");
+  assert.match(sourceFilePage, /createDossierSourceFileDraftReadinessReadModel/);
+  assert.match(sourceFilePage, /normalizeSubjectAnalystReadV1/);
+  assert.doesNotMatch(sourceFilePage, /readyForDraft = readiness\.label === "Ready for Proposed Dossier"/);
+  assert.match(controlCenter, /readiness\.recommendedNextAction/);
+  assert.match(controlCenter, /createDossierSourceFileDraftReadinessReadModel/);
+  assert.doesNotMatch(publicReadModel, /sourceFileResolutionAudit|resolvedQuestionAudit|DossierSourceFileDraftReadinessReadModel|sourceFileClaimReviews/);
 });


### PR DESCRIPTION
### Motivation
- Prevent local site heuristics from diverging with BNL analyst decisions by making BNL readiness the primary authority for Source File → Proposed Dossier readiness while retaining conservative site heuristics as a labeled fallback.

### Description
- Added a compact Source File draft-readiness read model and types (`DossierSourceFileDraftReadinessReadModel`, states, and authority enum) along with helper logic to evaluate authority order, high-priority questions, review resolution, pending public reviews, and fallback behavior in `src/lib/dossier-workflow.ts`.
- Implemented `createDossierSourceFileDraftReadinessReadModel` to apply authority rules: prefer BNL `subjectAnalystReadV1` values, treat unresolved high-priority BNL questions as blockers, treat pending public-facing claim reviews as blockers, treat `confirmed_internal` as internal-only, and use the site heuristic only when no BNL readiness exists.
- Wired the new read model into the admin UI so the Source File page and BNL Analyst Read panel display one concise readiness line (state, primary reason, blockers, authority, resolved/unresolved counts) and use `readyForDraft` from the read model to gate draft actions; updated the Dossier Control Center to prefer the read model for blockers and recommended next action. Files changed: `src/lib/dossier-workflow.ts`, `src/components/DossierSourceFileSummaryPanel.tsx`, `src/app/admin/dossiers/candidates/[candidateId]/page.tsx`, `src/app/admin/dossiers/page.tsx`.
- Added/updated tests in `tests/admin-dossiers.test.mjs` to cover BNL-ready, BNL-blocked, resolved-question suppression, rejected/boundary resolution, `confirmed_internal` limits, pending public review blocking, fallback heuristic authority, admin rendering, and ensuring no private/internal readiness diagnostics are exposed in public read-model output.

### Testing
- Ran typecheck: `npx tsc --noEmit` and it succeeded without errors.
- Ran unit suite: `node --test tests/admin-dossiers.test.mjs` and all tests passed (previous and added tests succeeded).
- Verified admin Source File page and Control Center now render the single BNL-readiness line and that draft action gating uses the read model `readyForDraft` flag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b9fe18288321832df45a6436a818)