### PR TITLE
Consume BNL sourceFileClassificationV1 into existing classification helpers

### DIFF
--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1648,6 +1648,21 @@ function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint 
           <SnapshotItem label="Evidence counts" value={`${blueprint.evidenceCounts.publicSafeFacts} Public-ready / ${blueprint.evidenceCounts.reviewOnlyItems} Admin-review`} />
         </dl>
         <section className="border border-border/50 bg-background/30 p-3">
+          <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Source File Classification</h4>
+          <p className="text-xs uppercase tracking-widest text-muted">Authority: {blueprint.classificationProfile.authority === "bnl_source_file_classification" ? "BNL sourceFileClassificationV1" : "Site fallback classification"}</p>
+          <dl className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <SnapshotItem label="Subject type" value={blueprint.classificationProfile.subjectType ?? "—"} />
+            <SnapshotItem label="Public dossier type" value={blueprint.classificationProfile.publicDossierType ?? "—"} />
+            <SnapshotItem label="Source safety" value={blueprint.classificationProfile.sourceSafety ?? "—"} />
+          </dl>
+          <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <div><p className="text-xs font-bold uppercase tracking-widest text-foreground">Public-safe tags</p><BlueprintList items={blueprint.classificationProfile.publicSafeTags} empty="No BNL public-safe tags." /></div>
+            <div><p className="text-xs font-bold uppercase tracking-widest text-foreground">Needs review tags</p><BlueprintList items={blueprint.classificationProfile.needsReviewTags} empty="No needs-review tags." /></div>
+            <div><p className="text-xs font-bold uppercase tracking-widest text-foreground">Internal-only tags</p><BlueprintList items={blueprint.classificationProfile.internalOnlyTags} empty="No internal-only tags." /></div>
+            <div><p className="text-xs font-bold uppercase tracking-widest text-foreground">Rejected / blocked tags</p><BlueprintList items={[...blueprint.classificationProfile.rejectedTags, ...blueprint.classificationProfile.blockedPublicTags]} empty="No rejected or blocked tags." /></div>
+          </div>
+        </section>
+        <section className="border border-border/50 bg-background/30 p-3">
           <h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Recommended next action</h4>
           <p className="text-foreground">{blueprint.readiness.recommendedNextAction}</p>
         </section>

--- a/src/lib/dossier-classification.ts
+++ b/src/lib/dossier-classification.ts
@@ -10,6 +10,7 @@ import {
   type DossierCandidate,
   type DossierCandidateType,
   type DossierRecommendation,
+  type DossierSourceFileClassificationV1,
   type DossierSourceFileNote,
   type DossierWorkflowLink,
 } from "@/lib/dossier-workflow";
@@ -20,6 +21,25 @@ import type {
 } from "@/content";
 
 export type DossierClassificationConfidence = "low" | "medium" | "high";
+
+
+export type DossierClassificationAuthority = "bnl_source_file_classification" | "site_fallback_classification";
+
+export type DossierSourceFileClassificationReadModel = {
+  subjectType?: string;
+  publicDossierType?: string;
+  confidence?: DossierClassificationConfidence | string;
+  publicSafeTags: string[];
+  needsReviewTags: string[];
+  internalOnlyTags: string[];
+  rejectedTags: string[];
+  routingTags: string[];
+  blockedPublicTags: string[];
+  sourceSafety?: string;
+  reasons: string[];
+  blockers: string[];
+  authority: DossierClassificationAuthority;
+};
 
 export type DossierClassificationAlternate = {
   category: DossierCategory;
@@ -99,6 +119,7 @@ export type DossierDraftBlueprint = {
   version: "1.0";
   subjectName: string;
   classification: DossierClassificationResult;
+  classificationProfile: DossierSourceFileClassificationReadModel;
   suggestedTags: DossierTagSuggestionResult;
   publicSafeFacts: DossierEvidenceDistillation["publicSafe"];
   safeRoleDirection: string;
@@ -418,6 +439,95 @@ export function classifyDossierSourceFileSubject(input: ClassificationInput): Do
   };
 }
 
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringArray(value: unknown, limit = 20): string[] {
+  if (typeof value === "string") return uniqueStrings(value.split(/[,\n]/), limit);
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(value.map((item) => typeof item === "string" ? item : undefined), limit);
+}
+
+function sourceFileClassificationFromCandidate(candidate: DossierCandidate): DossierSourceFileClassificationV1 | undefined {
+  const direct = asRecord(candidate.sourceFileClassificationV1);
+  if (direct) return direct as DossierSourceFileClassificationV1;
+  const archive = asRecord(candidate.latestSourceFileArchive);
+  if (!archive) return undefined;
+  const candidates = [archive, asRecord(archive.sourceFileBriefV2), asRecord(archive.sourceFileCaseReportV1), asRecord(archive.archivePayload), asRecord(archive.archive), asRecord(archive.payload), asRecord(archive.sourceFileArchive)].filter(Boolean) as Record<string, unknown>[];
+  for (const item of candidates) {
+    const found = asRecord(item.sourceFileClassificationV1) ?? asRecord(asRecord(item.sourceFileCaseReportV1)?.sourceFileClassificationV1) ?? asRecord(asRecord(item.sourceFileBriefV2)?.sourceFileClassificationV1);
+    if (found) return found as DossierSourceFileClassificationV1;
+  }
+  return undefined;
+}
+
+const PUBLIC_BLOCKED_TAG_PATTERNS = [
+  /@/, /token|password|secret|payment|customer|account|email|private|member.only|source.blind|internal.alias/i,
+];
+const INTERNAL_BY_DEFAULT_TAG_PATTERNS = [/\b(queue|submission|submitter|moderator|mod|admin|staff|team|role|operator)\b/i];
+
+function normalizeTagForPublic(tag: string): string | undefined {
+  const clean = cleanText(tag)?.toLowerCase().replace(/\s+/g, "-");
+  if (!clean || PUBLIC_BLOCKED_TAG_PATTERNS.some((pattern) => pattern.test(clean))) return undefined;
+  return clean;
+}
+
+export function normalizeBnlSourceFileClassification(input: ClassificationInput): DossierSourceFileClassificationReadModel {
+  const bnl = sourceFileClassificationFromCandidate(input.candidate);
+  if (bnl) {
+    const blocked = uniqueStrings([
+      ...stringArray(bnl.doNotPubliclyTagAs),
+      ...stringArray(bnl.blockedPublicTags),
+      ...stringArray(bnl.rejectedTagCandidates),
+    ], 40).map((tag) => tag.toLowerCase());
+    const blockedSet = new Set(blocked);
+    const sourceSafety = cleanText(bnl.sourceSafety);
+    const sourceBlind = /source[_ -]?blind|internal[_ -]?only/i.test(sourceSafety ?? "");
+    const publicSafeTags = sourceBlind ? [] : uniqueStrings(stringArray(bnl.publicSafeTagCandidates)
+      .map(normalizeTagForPublic)
+      .filter((tag): tag is string => Boolean(tag && !blockedSet.has(tag))), 12);
+    const primarySecondary = uniqueStrings([...stringArray(bnl.primaryTags), ...stringArray(bnl.secondaryTags)], 20);
+    const internalOnlyTags = uniqueStrings([
+      ...stringArray(bnl.internalTags),
+      ...primarySecondary.filter((tag) => !publicSafeTags.includes(tag.toLowerCase().replace(/\s+/g, "-")) || INTERNAL_BY_DEFAULT_TAG_PATTERNS.some((pattern) => pattern.test(tag))),
+      ...stringArray(bnl.routingTags),
+    ], 20);
+    return {
+      subjectType: cleanText(bnl.subjectType),
+      publicDossierType: cleanText(bnl.publicDossierType),
+      confidence: cleanText(bnl.confidence),
+      publicSafeTags,
+      needsReviewTags: stringArray(bnl.needsReviewTagCandidates, 12),
+      internalOnlyTags,
+      rejectedTags: stringArray(bnl.rejectedTagCandidates, 12),
+      routingTags: stringArray(bnl.routingTags, 12),
+      blockedPublicTags: uniqueStrings([...stringArray(bnl.blockedPublicTags), ...stringArray(bnl.doNotPubliclyTagAs)], 20),
+      sourceSafety,
+      reasons: stringArray(bnl.classificationReasons, 8),
+      blockers: stringArray(bnl.classificationBlockedBy, 8),
+      authority: "bnl_source_file_classification",
+    };
+  }
+  const fallback = classifyDossierSourceFileSubject(input);
+  return {
+    subjectType: fallback.category,
+    publicDossierType: fallback.kind,
+    confidence: fallback.confidence,
+    publicSafeTags: [],
+    needsReviewTags: [],
+    internalOnlyTags: [],
+    rejectedTags: [],
+    routingTags: [],
+    blockedPublicTags: [],
+    sourceSafety: undefined,
+    reasons: fallback.reasons,
+    blockers: fallback.blockers,
+    authority: "site_fallback_classification",
+  };
+}
+
 function registryItemFor(tag: string, registryItems: DossierTagRegistryItem[]) {
   const canonical = resolveDossierTagCanonical(tag) ?? tag.toLowerCase();
   return registryItems.find((item) => item.tag.toLowerCase() === canonical || item.canonical.toLowerCase() === canonical);
@@ -444,22 +554,38 @@ export function suggestDossierTags(input: ClassificationInput & { classification
     confirmed.set(item.tag, { tag: item.tag, confidence, reason, registrySource: item.source });
   };
 
-  addTag(classification.kind === "community_member" ? "member" : classification.kind, "Suggested from dossier kind.");
-  if (classification.category === "Artist") addTag("artist", "Artist category maps to the existing artist tag.", "high");
-  if (classification.category === "Collaborator") addTag("collaborator", "Collaborator category maps to the existing collaborator tag.", "high");
-  if (classification.category === "Community") addTag("community", "Community category maps to existing community tag.", "high");
-  if (classification.kind === "radio_regular") addTag("radio", "Radio regular kind maps to the existing radio tag.");
-  if (classification.kind === "moderator") addTag("mod", "Moderator kind maps to the existing mod tag.", "high");
-  if (classification.category === "Production") addTag("producer", "Production records use existing production-oriented tag when applicable.");
-  if (classification.category === "Interface") addTag("systems", "Interface records use existing systems tag when applicable.");
-  if (classification.category === "Sponsor") addTag("sponsor", "Sponsor category maps to existing sponsor tag.", "high");
-  if (classification.category === "Entity") addTag("core", "Entity records can reuse core/entity-oriented registry tags when applicable.");
+  const normalizedClassification = normalizeBnlSourceFileClassification(input);
+  if (normalizedClassification.authority !== "bnl_source_file_classification") {
+    addTag(classification.kind === "community_member" ? "member" : classification.kind, "Suggested from dossier kind.");
+    if (classification.category === "Artist") addTag("artist", "Artist category maps to the existing artist tag.", "high");
+    if (classification.category === "Collaborator") addTag("collaborator", "Collaborator category maps to the existing collaborator tag.", "high");
+    if (classification.category === "Community") addTag("community", "Community category maps to existing community tag.", "high");
+    if (classification.kind === "radio_regular") addTag("radio", "Radio regular kind maps to the existing radio tag.");
+    if (classification.kind === "moderator") addTag("mod", "Moderator kind maps to the existing mod tag.", "high");
+    if (classification.category === "Production") addTag("producer", "Production records use existing production-oriented tag when applicable.");
+    if (classification.category === "Interface") addTag("systems", "Interface records use existing systems tag when applicable.");
+    if (classification.category === "Sponsor") addTag("sponsor", "Sponsor category maps to existing sponsor tag.", "high");
+    if (classification.category === "Entity") addTag("core", "Entity records can reuse core/entity-oriented registry tags when applicable.");
+  }
 
-  for (const tag of input.candidate.recommendedTags ?? []) addTag(tag, "Existing candidate recommendation reused when present in registry.");
-  for (const tag of input.candidate.proposedTags ?? []) {
-    const item = registryItemFor(tag, registry.items);
-    if (item) addTag(item.tag, "Candidate proposed tag already exists in registry, so it is safe to suggest.");
-    else proposed.set(tag, { tag, confidence: "low", reason: "Candidate proposed tag is not in the registry yet.", registrySource: "candidate" });
+  if (normalizedClassification.authority === "bnl_source_file_classification") {
+    const blocked = new Set([
+      ...normalizedClassification.blockedPublicTags,
+      ...normalizedClassification.rejectedTags,
+      ...normalizedClassification.internalOnlyTags,
+      ...normalizedClassification.needsReviewTags,
+    ].map((tag) => tag.toLowerCase()));
+    for (const tag of normalizedClassification.publicSafeTags) {
+      if (!blocked.has(tag.toLowerCase())) addTag(tag, "BNL sourceFileClassificationV1 marked this as a public-safe tag candidate.", "high");
+    }
+    for (const tag of normalizedClassification.rejectedTags) rejected.push({ tag, reason: "BNL sourceFileClassificationV1 rejected this public tag candidate." });
+  } else {
+    for (const tag of input.candidate.recommendedTags ?? []) addTag(tag, "Existing candidate recommendation reused when present in registry.");
+    for (const tag of input.candidate.proposedTags ?? []) {
+      const item = registryItemFor(tag, registry.items);
+      if (item) addTag(item.tag, "Candidate proposed tag already exists in registry, so it is safe to suggest.");
+      else proposed.set(tag, { tag, confidence: "low", reason: "Candidate proposed tag is not in the registry yet.", registrySource: "candidate" });
+    }
   }
 
   return {
@@ -580,7 +706,11 @@ export function evaluateDossierReadiness(input: {
 
 export function createDossierDraftBlueprint(input: ClassificationInput): DossierDraftBlueprint {
   const publicDossiers = input.publicDossiers ?? databasePage.entries;
-  const classification = classifyDossierSourceFileSubject({ ...input, publicDossiers });
+  const normalizedClassification = normalizeBnlSourceFileClassification({ ...input, publicDossiers });
+  const fallbackClassification = classifyDossierSourceFileSubject({ ...input, publicDossiers });
+  const classification = normalizedClassification.authority === "bnl_source_file_classification"
+    ? { ...fallbackClassification, kind: (normalizedClassification.publicDossierType as PublicDossierKind) || fallbackClassification.kind, confidence: (normalizedClassification.confidence as DossierClassificationConfidence) || fallbackClassification.confidence, reasons: normalizedClassification.reasons.length ? normalizedClassification.reasons : fallbackClassification.reasons, blockers: uniqueStrings([...fallbackClassification.blockers, ...normalizedClassification.blockers], 8) }
+    : fallbackClassification;
   const suggestedTags = suggestDossierTags({ ...input, publicDossiers, classification });
   const evidence = distillDossierEvidence(input);
   const readiness = evaluateDossierReadiness({ classification, evidence, candidate: input.candidate });
@@ -592,6 +722,7 @@ export function createDossierDraftBlueprint(input: ClassificationInput): Dossier
     version: "1.0",
     subjectName: input.candidate.name,
     classification,
+    classificationProfile: normalizedClassification,
     suggestedTags,
     publicSafeFacts: evidence.publicSafe,
     safeRoleDirection: roleDirection,

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -31,6 +31,7 @@ import {
   type DossierSourceFileArchiveAttachStatus,
   type DossierSourceFileArchiveMetadata,
   type DossierSourceFileCaseReportV1,
+  type DossierSourceFileClassificationV1,
   type DossierSubjectAnalystReadV1,
   type DossierSourceFileEnrichmentArchive,
   type DossierRecommendationSourceLane,
@@ -562,6 +563,39 @@ function findSubjectAnalystReadV1(input: unknown) {
   return { read: undefined, path: undefined };
 }
 
+
+function isSourceFileClassificationV1Shape(value: unknown) {
+  const classification = sourceArchiveObject(value);
+  if (!classification) return false;
+  return [
+    "subjectType",
+    "publicDossierType",
+    "publicSafeTagCandidates",
+    "internalTags",
+    "needsReviewTagCandidates",
+    "rejectedTagCandidates",
+    "blockedPublicTags",
+    "sourceSafety",
+  ].some((key) => classification[key] !== undefined);
+}
+
+function findSourceFileClassificationV1(input: unknown) {
+  for (const candidate of sourceArchivePayloadCandidates(input)) {
+    const brief = sourceArchiveObject(candidate.value.sourceFileBriefV2);
+    const report = sourceArchiveObject(candidate.value.sourceFileCaseReportV1);
+    const nestedReport = sourceArchiveObject(brief?.sourceFileCaseReportV1);
+    const checks: Array<{ value: unknown; path: string }> = [
+      { value: candidate.value.sourceFileClassificationV1, path: `${candidate.path}.sourceFileClassificationV1` },
+      { value: report?.sourceFileClassificationV1, path: `${candidate.path}.sourceFileCaseReportV1.sourceFileClassificationV1` },
+      { value: nestedReport?.sourceFileClassificationV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1.sourceFileClassificationV1` },
+      { value: brief?.sourceFileClassificationV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileClassificationV1` },
+    ];
+    const match = checks.find((check) => isSourceFileClassificationV1Shape(check.value));
+    if (match) return { classification: match.value as DossierSourceFileClassificationV1, path: match.path };
+  }
+  return { classification: undefined, path: undefined };
+}
+
 function isSourceFileCaseReportShape(value: unknown) {
   const report = sourceArchiveObject(value);
   if (!report) return false;
@@ -659,6 +693,8 @@ function normalizeSourceFileArchiveInput(
       caseReportExtractedFrom?: string;
       sourceFileBriefExtractedFrom?: string;
       subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
+      sourceFileClassificationV1?: DossierSourceFileClassificationV1;
+      sourceFileClassificationExtractedFrom?: string;
     })
   | null {
   const subjectName = compactArchiveText(input.subjectName, 200);
@@ -666,6 +702,7 @@ function normalizeSourceFileArchiveInput(
   const caseReport = findSourceFileCaseReportV1(input);
   const sourceFileBrief = findSourceFileBriefV2(input);
   const analystRead = findSubjectAnalystReadV1(input);
+  const classification = findSourceFileClassificationV1(input);
   return {
     ...input,
     candidateId: compactArchiveText(input.candidateId, 200),
@@ -686,6 +723,8 @@ function normalizeSourceFileArchiveInput(
     sourceFileCaseReportV1: caseReport.report,
     sourceFileBriefV2: sourceFileBrief.brief,
     subjectAnalystReadV1: analystRead.read,
+    sourceFileClassificationV1: classification.classification,
+    sourceFileClassificationExtractedFrom: classification.path,
     caseReportPresent: Boolean(caseReport.report),
     subjectMemoryPacketPresent: sourceArchiveHasSubjectMemoryPacket(input),
     caseReportExtractedFrom: caseReport.path,
@@ -3049,6 +3088,7 @@ export async function ingestDossierSourceFileArchive(
       sourceFileCaseReportV1: normalized.sourceFileCaseReportV1,
       sourceFileBriefV2: normalized.sourceFileBriefV2,
       subjectAnalystReadV1: normalized.subjectAnalystReadV1,
+      sourceFileClassificationV1: normalized.sourceFileClassificationV1,
       caseReportPresent: normalized.caseReportPresent,
       subjectMemoryPacketPresent: normalized.subjectMemoryPacketPresent,
       caseReportExtractedFrom: normalized.caseReportExtractedFrom,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -189,6 +189,27 @@ export type DossierReadinessQuestionV1 = {
   relatedReviewClaimIds?: string[] | string;
 };
 
+
+export type DossierSourceFileClassificationV1 = {
+  version?: string | number;
+  subjectType?: string;
+  publicDossierType?: string;
+  confidence?: "high" | "medium" | "low" | string;
+  primaryTags?: string[] | string;
+  secondaryTags?: string[] | string;
+  internalTags?: string[] | string;
+  doNotPubliclyTagAs?: string[] | string;
+  routingTags?: string[] | string;
+  evidenceSignals?: unknown;
+  publicSafeTagCandidates?: string[] | string;
+  needsReviewTagCandidates?: string[] | string;
+  rejectedTagCandidates?: string[] | string;
+  classificationReasons?: string[] | string;
+  blockedPublicTags?: string[] | string;
+  sourceSafety?: string;
+  classificationBlockedBy?: string[] | string;
+};
+
 export type DossierSubjectAnalystReadV1 = DossierSourceFileHumanDisplayFields & {
   subjectName?: string;
   internalRead?: string;
@@ -274,6 +295,7 @@ export type DossierSourceFileCaseReportV1 = {
   memoryCoverage?: string | string[];
   subjectIntelligenceBriefV1?: DossierSubjectIntelligenceBriefV1;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
+  sourceFileClassificationV1?: DossierSourceFileClassificationV1;
 };
 
 export type DossierSourceFileBriefV2 = {
@@ -295,6 +317,7 @@ export type DossierSourceFileArchiveCompactReadout = {
   sourceFileCaseReportV1?: DossierSourceFileCaseReportV1;
   sourceFileBriefV2?: DossierSourceFileBriefV2;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
+  sourceFileClassificationV1?: DossierSourceFileClassificationV1;
   archivePayload?: unknown;
   archive?: unknown;
   payload?: unknown;
@@ -518,6 +541,7 @@ export type DossierCandidate = {
   latestSourceFileArchiveDigest?: string;
   latestSourceFileArchiveUpdatedAt?: string;
   latestSourceFileArchive?: DossierSourceFileArchiveMetadata;
+  sourceFileClassificationV1?: DossierSourceFileClassificationV1;
   sourceFileSummary?: DossierSourceFileOperatorSummary;
   sourceFileNotes?: DossierSourceFileNote[];
   sourceFileClaimReviews?: DossierSourceFileClaimReview[];

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -353,6 +353,102 @@ test("Dossier taxonomy expansion supports first-class artist, collaborator, and 
   assert.equal(dossierClassification.routeDossierCandidateType("personnel").category, "Personnel");
 });
 
+
+test("BNL sourceFileClassificationV1 drives classification tags while preserving safety buckets", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const candidate = {
+    id: "bnl-classification-fixture",
+    name: "BNL Classified Subject",
+    candidateType: "unknown",
+    source: "bnl_source_file_enrichment",
+    tier: "review_candidate",
+    score: 60,
+    whyNow: "BNL emitted canonical classification.",
+    reason: "BNL source file classification exists.",
+    evidenceSummary: "Public music context exists.",
+    knownFacts: ["Public artist page exists."],
+    recommendedTags: ["queue", "moderator"],
+    proposedTags: ["manual-private"],
+    sourceFileClassificationV1: {
+      version: "1",
+      subjectType: "artist",
+      publicDossierType: "artist",
+      confidence: "high",
+      publicSafeTagCandidates: ["artist", "radio", "queue"],
+      internalTags: ["internal-alias", "moderator", "team"],
+      needsReviewTagCandidates: ["role"],
+      rejectedTagCandidates: ["payment-customer"],
+      doNotPubliclyTagAs: ["moderator"],
+      blockedPublicTags: ["team"],
+      routingTags: ["queue_submission"],
+      classificationReasons: ["BNL canonical classification supplied."],
+      classificationBlockedBy: ["Owner review remains required."],
+      sourceSafety: "public_safe",
+    },
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const profile = dossierClassification.normalizeBnlSourceFileClassification({ candidate, recommendations: [] });
+  assert.equal(profile.authority, "bnl_source_file_classification");
+  assert.deepEqual(profile.publicSafeTags, ["artist", "radio", "queue"]);
+  assert.ok(profile.internalOnlyTags.includes("moderator"));
+  assert.ok(profile.needsReviewTags.includes("role"));
+  assert.ok(profile.rejectedTags.includes("payment-customer"));
+  assert.ok(profile.blockedPublicTags.includes("team"));
+
+  const blueprint = dossierClassification.createDossierDraftBlueprint({ candidate, recommendations: [] });
+  assert.equal(blueprint.classificationProfile.authority, "bnl_source_file_classification");
+  assert.equal(blueprint.classification.kind, "artist");
+  const publicTags = new Set([
+    ...blueprint.suggestedTags.tags.map((tag) => tag.tag),
+    ...blueprint.suggestedTags.proposedTags.map((tag) => tag.tag),
+  ]);
+  assert.equal(publicTags.has("artist"), true);
+  assert.equal(publicTags.has("radio"), true);
+  assert.equal(publicTags.has("moderator"), false);
+  assert.equal(publicTags.has("team"), false);
+  assert.equal(publicTags.has("role"), false);
+  assert.equal(publicTags.has("payment-customer"), false);
+});
+
+test("BNL source-blind classification prevents public tag promotion and fallback remains labeled", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const base = {
+    id: "source-blind-classification-fixture",
+    name: "Source Blind Subject",
+    candidateType: "artist",
+    source: "manual",
+    tier: "review_candidate",
+    score: 60,
+    whyNow: "Fixture.",
+    reason: "Fixture.",
+    evidenceSummary: "Artist music signal.",
+    status: "active_source_file",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const sourceBlind = dossierClassification.createDossierDraftBlueprint({
+    candidate: {
+      ...base,
+      sourceFileClassificationV1: {
+        publicDossierType: "artist",
+        publicSafeTagCandidates: ["artist", "radio"],
+        sourceSafety: "source_blind",
+      },
+    },
+    recommendations: [],
+  });
+  assert.equal(sourceBlind.classificationProfile.authority, "bnl_source_file_classification");
+  assert.deepEqual(sourceBlind.classificationProfile.publicSafeTags, []);
+  assert.equal(sourceBlind.suggestedTags.tags.some((tag) => tag.tag === "radio"), false);
+
+  const fallback = dossierClassification.normalizeBnlSourceFileClassification({ candidate: base, recommendations: [] });
+  assert.equal(fallback.authority, "site_fallback_classification");
+  assert.equal(fallback.publicDossierType, "artist");
+});
+
 test("Dossier classification blueprint separates category, evidence, readiness, and admin-only identity data", () => {
   const now = "2026-06-12T00:00:00.000Z";
   const base = {


### PR DESCRIPTION
### Motivation
- Integrate BNL’s canonical `sourceFileClassificationV1` into the site classification/tag/read-model path so Source Files, draft prep, and admin displays consume one authoritative profile. 
- Prefer BNL classification when present while preserving the existing site classification helpers as a safe fallback and clearly labeling fallback authority. 
- Enforce public/private safety rules so only BNL-marked public-safe candidates can feed public draft tags and all internal/rejected/blocked/source-blind signals remain admin-only.

### Description
- Added types and archive extraction to accept `sourceFileClassificationV1` (shape preserved and backward-compatible): new `DossierSourceFileClassificationV1` in `src/lib/dossier-workflow.ts` and archive plumbing in `src/lib/dossier-workflow-store.ts` so BNL classification is preserved on Source File archives. (changed files: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`)
- Introduced a normalized read model `DossierSourceFileClassificationReadModel` and `normalizeBnlSourceFileClassification` in `src/lib/dossier-classification.ts` that outputs fields: `subjectType`, `publicDossierType`, `confidence`, `publicSafeTags`, `needsReviewTags`, `internalOnlyTags`, `rejectedTags`, `routingTags`, `blockedPublicTags`, `sourceSafety`, `reasons`, `blockers`, and `authority` (`"bnl_source_file_classification" | "site_fallback_classification"`). (changed file: `src/lib/dossier-classification.ts`)
- Extended tag suggestion and draft blueprint flow to prefer BNL when present and label fallback otherwise; BNL `publicSafeTagCandidates` are promoted into the existing suggestion path while `internalTags`, `rejectedTagCandidates`, `doNotPubliclyTagAs`, `blockedPublicTags`, `needsReviewTagCandidates`, and `source_blind` protections are never promoted to public tags. The normalized profile is attached to the existing `DossierDraftBlueprint` as `classificationProfile`. (changed file: `src/lib/dossier-classification.ts`)
- Surface a compact, admin-only classification summary in the existing Source File blueprint view (no new dashboard/panel), showing authority, subject type, public dossier type, source safety, public-safe tags, needs-review tags, internal-only tags, and rejected/blocked tags. (changed file: `src/components/DossierSourceFileSummaryPanel.tsx`)
- Tests: added coverage for BNL authority preference, fallback behavior, public-safe tag promotion, source-blind behavior, and separation of internal/rejected/blocked/needs-review tag buckets; the new/updated test cases are in `tests/admin-dossiers.test.mjs`. (changed file: `tests/admin-dossiers.test.mjs`)

### Testing
- `npx tsc --noEmit` — passed.
- `node --test tests/admin-dossiers.test.mjs` — passed (all tests that exercise the new normalization and blueprint behavior succeeded).
- `node --test tests/bnl-read-model.test.mjs` — ran for context; the suite still reports 3 pre-existing assertion failures about dossier page rendering helper strings (`// DOSSIER`, `entry.tags.map`, `getDossierPrimaryLink(entry)`) that are unrelated to the classification integration.
- Summary of files changed: `src/lib/dossier-workflow.ts`, `src/lib/dossier-workflow-store.ts`, `src/lib/dossier-classification.ts`, `src/components/DossierSourceFileSummaryPanel.tsx`, `tests/admin-dossiers.test.mjs` (see diff for details).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33c32ee3748321a85aad9ab8ec9d39)