### PR TITLE
Apply memory-first Source File review gating

### DIFF
--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -583,9 +583,53 @@ function safeHumanText(value: unknown) {
   return text;
 }
 
+function normalizedRoutingToken(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"`]/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+const STANDALONE_ROUTING_TAGS = new Set([
+  "collaboration_interest",
+  "queue_submission",
+  "contest",
+  "identity",
+  "lore",
+  "music",
+  "orion",
+]);
+
+function isStandaloneRoutingTag(text: string) {
+  const normalized = normalizedRoutingToken(text);
+  return Boolean(normalized) && STANDALONE_ROUTING_TAGS.has(normalized);
+}
+
+function metadataText(record: UnknownRecord | undefined, keys: string[]) {
+  return keys.map((key) => displayValue(record?.[key])).filter(Boolean).join(" ");
+}
+
+function routeClassificationSourceText(record: UnknownRecord | undefined, sourceKind?: string) {
+  return `${sourceKind ?? ""} ${metadataText(record, ["actionability", "reviewLane", "lane", "safetyLane", "sourceSafety", "answerType", "questionFamily", "questionCategory", "dossierSection", "displayTitle", "title"])}`.toLowerCase();
+}
+
+function isKnownRouteClassificationSource(record: UnknownRecord | undefined, sourceKind?: string) {
+  return /route[-_ ]?only|routing(?: tag)?|classification[-_ ]?only|classification tag|tag candidate|primary tag|secondary tag/.test(routeClassificationSourceText(record, sourceKind));
+}
+
+function isRouteOnlyClassificationToken(text: string, record?: UnknownRecord, sourceKind?: string) {
+  const normalized = normalizedRoutingToken(text);
+  if (!normalized) return false;
+  if (isStandaloneRoutingTag(text) && (isKnownRouteClassificationSource(record, sourceKind) || normalized.includes("_"))) return true;
+  return isKnownRouteClassificationSource(record, sourceKind) && /^[a-z0-9]+(?:_[a-z0-9]+)+$/.test(normalized);
+}
+
 function memoryFirstSuppressionReason(record: UnknownRecord | undefined, text: string, sourceSection: string): string | undefined {
-  const joined = `${text} ${analystString(record, ["actionability", "reviewLane", "lane", "safetyLane", "recommendedAction", "suggestedDecision", "sourceSafety", "answerType", "questionFamily", "questionCategory", "dossierSection", "displayBNLRecommendation", "displaySafeDefault", "cannotSuggestPublicReason"]) ?? ""}`.toLowerCase();
-  if (/route[-_ ]?only|routing tag|classification[-_ ]?only|classification tag|tag candidate|primary tag|secondary tag/.test(joined)) return "Suppressed route/classification-only item from active review.";
+  const metadata = metadataText(record, ["actionability", "reviewLane", "lane", "safetyLane", "recommendedAction", "suggestedDecision", "sourceSafety", "answerType", "questionFamily", "questionCategory", "dossierSection", "displayBNLRecommendation", "displaySafeDefault", "cannotSuggestPublicReason"]).toLowerCase();
+  const joined = `${text} ${metadata}`.toLowerCase();
+  if (isRouteOnlyClassificationToken(text, record, sourceSection)) return "Suppressed route/classification-only item from active review.";
   if (/internal[-_ ]?only|private|withheld|lore/.test(joined)) return "Suppressed internal/source-blind item from public review pressure.";
   if (/omit|omittable|can be omitted|not needed for draft|not required/.test(joined)) return "Suppressed omit-able detail from active review.";
   if (/keep_boundary|resolved_boundary|resolved boundary|already resolved boundary/.test(joined)) return "Suppressed resolved boundary/do-not-say item from active review.";
@@ -593,8 +637,17 @@ function memoryFirstSuppressionReason(record: UnknownRecord | undefined, text: s
 }
 
 function memoryFirstQuestionIsDecisionUnlocking(question: ReadinessQuestion) {
-  const joined = `${question.question} ${question.priority ?? ""} ${question.answerType ?? ""} ${question.sourceSafety ?? ""} ${question.dossierSection ?? ""} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.audience ?? ""}`.toLowerCase();
-  if (/route[-_ ]?only|routing|classification[-_ ]?only|tag|internal[-_ ]?only|source[-_ ]?blind|omit|omittable|can be omitted|optional|nice_to_have|lore|boundary|do_not_say|do not say|rejected/.test(joined)) return false;
+  const record = {
+    answerType: question.answerType,
+    sourceSafety: question.sourceSafety,
+    questionFamily: question.questionFamily,
+    questionCategory: question.questionCategory,
+    dossierSection: question.dossierSection,
+  };
+  const metadata = `${question.priority ?? ""} ${question.answerType ?? ""} ${question.sourceSafety ?? ""} ${question.dossierSection ?? ""} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.audience ?? ""}`.toLowerCase();
+  const joined = `${question.question} ${metadata}`.toLowerCase();
+  if (isRouteOnlyClassificationToken(question.question, record, question.dossierSection)) return false;
+  if (/internal[-_ ]?only|source[-_ ]?blind|omit|omittable|can be omitted|optional|nice_to_have|lore|boundary|do_not_say|do not say|rejected/.test(joined)) return false;
   return /decision|unlock|required|critical|high|public source|owner|identity|safety|public fact|wording|link ownership|ready|draft|clarif|mod/.test(joined);
 }
 
@@ -934,6 +987,12 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
   };
 }
 
+function reviewCardDedupeKey(card: DossierSourceFileReviewableClaim) {
+  const packetQuestions = (card.verificationPacketQuestions ?? []).map(normalizeVerificationQuestion).sort().join("|");
+  const audience = verificationAudienceKey(card.verificationPacketAudience ?? card.confirmationTarget);
+  return [normalizeVerificationQuestion(card.claimText), packetQuestions, audience].join("::");
+}
+
 export function deriveDossierSourceFileReviewableClaims(input: {
   analystRead?: DossierSubjectAnalystReadV1;
   candidateId?: string;
@@ -1014,7 +1073,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   });
   const deduped = new Map<string, DossierSourceFileReviewableClaim>();
   for (const card of [...cardsWithReadiness, ...readinessCards]) {
-    const normalized = normalizeVerificationQuestion(card.claimText);
+    const normalized = reviewCardDedupeKey(card);
     if (!deduped.has(normalized)) deduped.set(normalized, card);
   }
   const suppressedCards = [...deduped.values()].filter((card) => card.suppressedReason);
@@ -1100,7 +1159,7 @@ export function classifySavedPacketTextForVerificationPacket(text: string): Save
   if (/^(keep|keeps)\b.*\binternal\b/.test(lower) || /\binternal (only|context)\b/.test(lower)) return "internal_only_resolution";
   if (/^(no|none)\b.*\b(approved|public|source|links?|role|title)\b.*\b(yet|approved|available)?[.!]?$/.test(lower) || /\bno approved public source yet\b/.test(lower)) return "resolved_answer";
   if (/\b(not approved|not public-ready|not public ready)\b/.test(lower)) return "resolved_answer";
-  if (/[?]\s*$/.test(normalized) || /^(what|which|who|when|where|why|how|should|was|were|did|do|does|is|are|can|could)\b/i.test(normalized)) return "active_question";
+  if (/[?]\s*$/.test(normalized) || /^(what|which|who|when|where|why|how|should|was|were|did|do|does|is|are|can|could|confirm)\b/i.test(normalized)) return "active_question";
   return "resolved_answer";
 }
 

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -546,6 +546,7 @@ export type DossierSourceFileReviewableClaim = {
   recommendedAdminActionCards?: UnknownRecord[];
   review?: DossierSourceFileClaimReview;
   resolvedQuestion?: DossierResolvedQuestionReadModel;
+  suppressedReason?: string;
 };
 
 type SourceFileSignalSummary = {
@@ -578,7 +579,23 @@ function safeHumanText(value: unknown) {
   if (/@|stripe|payment|customer|token|env|config|raw evidence|raw id|database|table|source-blind detail|private|mod-only|internal alias/i.test(text)) {
     return "BNL can see protected context here, but it needs approved wording or a public source before anything can be used publicly.";
   }
+  if (/^[a-z0-9]+(?:_[a-z0-9]+){1,}$/.test(text.trim())) return text.trim().replace(/_/g, " ");
   return text;
+}
+
+function memoryFirstSuppressionReason(record: UnknownRecord | undefined, text: string, sourceSection: string): string | undefined {
+  const joined = `${text} ${analystString(record, ["actionability", "reviewLane", "lane", "safetyLane", "recommendedAction", "suggestedDecision", "sourceSafety", "answerType", "questionFamily", "questionCategory", "dossierSection", "displayBNLRecommendation", "displaySafeDefault", "cannotSuggestPublicReason"]) ?? ""}`.toLowerCase();
+  if (/route[-_ ]?only|routing tag|classification[-_ ]?only|classification tag|tag candidate|primary tag|secondary tag/.test(joined)) return "Suppressed route/classification-only item from active review.";
+  if (/internal[-_ ]?only|private|withheld|lore/.test(joined)) return "Suppressed internal/source-blind item from public review pressure.";
+  if (/omit|omittable|can be omitted|not needed for draft|not required/.test(joined)) return "Suppressed omit-able detail from active review.";
+  if (/keep_boundary|resolved_boundary|resolved boundary|already resolved boundary/.test(joined)) return "Suppressed resolved boundary/do-not-say item from active review.";
+  return undefined;
+}
+
+function memoryFirstQuestionIsDecisionUnlocking(question: ReadinessQuestion) {
+  const joined = `${question.question} ${question.priority ?? ""} ${question.answerType ?? ""} ${question.sourceSafety ?? ""} ${question.dossierSection ?? ""} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.audience ?? ""}`.toLowerCase();
+  if (/route[-_ ]?only|routing|classification[-_ ]?only|tag|internal[-_ ]?only|source[-_ ]?blind|omit|omittable|can be omitted|optional|nice_to_have|lore|boundary|do_not_say|do not say|rejected/.test(joined)) return false;
+  return /decision|unlock|required|critical|high|public source|owner|identity|safety|public fact|wording|link ownership|ready|draft|clarif|mod/.test(joined);
 }
 
 type ReadinessQuestion = {
@@ -831,6 +848,7 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
   const resolutionQuestion = { ...(record ?? {}), question: analystString(record, ["verificationPacketQuestion", "question", "text", "claimText"]) ?? claimText, dossierSection: analystString(record, ["dossierSection"]) ?? input.sourceSection };
   const resolvedQuestion = input.candidate ? resolveBnlDossierQuestionFromExistingTruth({ question: resolutionQuestion, candidate: input.candidate }) : undefined;
   const internalArtifact = vagueArtifact || /^internal evidence artifact$/i.test(displayTitle ?? "") || /^vague internal evidence marker$/i.test(claimText.trim());
+  const suppressedReason = memoryFirstSuppressionReason(record, claimText, input.sourceSection);
   const guidance = weakLabel
     ? { title: "Weak evidence label / pattern", decisionQuestion: "Is this label accurate and useful, or should it be rejected?", placeholderText: "Only enter wording here if this label is true and public-safe. Otherwise reject this claim.", exampleApprovedTexts: [`Keep ${displaySubject} label internal until confirmed.`, "Reject this label as inaccurate or not useful."] }
     : claimType === "recommended_action" || claimType === "do_not_say"
@@ -912,6 +930,7 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     requiresEditedTextForPublic: claimType === "source_blind",
     review: input.reviews?.get(id),
     resolvedQuestion: resolvedQuestion?.safeToSuppressFromActivePacket ? resolvedQuestion : undefined,
+    suppressedReason,
   };
 }
 
@@ -942,7 +961,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     resolution: resolveBnlDossierQuestionFromExistingTruth({ question: { ...question, question: question.question }, candidate: input.candidate }),
   }));
   const resolvedReadinessQuestions = readinessQuestions.filter((question) => question.resolution.safeToSuppressFromActivePacket);
-  const activeReadinessQuestions = readinessQuestions.filter((question) => !question.resolution.safeToSuppressFromActivePacket);
+  const activeReadinessQuestions = readinessQuestions.filter((question) => !question.resolution.safeToSuppressFromActivePacket && memoryFirstQuestionIsDecisionUnlocking(question));
   const allCards = sections.flatMap((section) => listValues(section.values).flatMap((value) => {
     const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, subjectName: input.subjectName ?? input.analystRead?.subjectName, reviews: reviewById, candidate: input.candidate });
     return card ? [card] : [];
@@ -957,7 +976,8 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     relatedReadinessQuestions.forEach((question) => attachedQuestionIds.add(question.id));
     return relatedReadinessQuestions.length ? { ...card, relatedReadinessQuestions } : card;
   });
-  const readinessCards: DossierSourceFileReviewableClaim[] = activeReadinessQuestions.filter((question) => !attachedQuestionIds.has(question.id)).flatMap((question) => {
+  const existingCardQuestionTexts = new Set(cardsWithReadiness.flatMap((card) => [card.decisionQuestion, card.claimText, ...(card.verificationPacketQuestions ?? [])]).filter((text): text is string => Boolean(text)).map(normalizeVerificationQuestion));
+  const readinessCards: DossierSourceFileReviewableClaim[] = activeReadinessQuestions.filter((question) => !attachedQuestionIds.has(question.id) && !existingCardQuestionTexts.has(normalizeVerificationQuestion(question.question))).flatMap((question) => {
     const card = buildClaimCard({
     value: {
       claimText: question.question,
@@ -992,13 +1012,20 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     });
     return card ? [{ ...card, readinessMetadata: readinessMetadataItems(question), resolvedQuestion: question.resolution }] : [];
   });
-  const current = [...cardsWithReadiness, ...readinessCards].filter((card) => !signals.some((signal) => signal.id === card.id));
+  const deduped = new Map<string, DossierSourceFileReviewableClaim>();
+  for (const card of [...cardsWithReadiness, ...readinessCards]) {
+    const normalized = normalizeVerificationQuestion(card.claimText);
+    if (!deduped.has(normalized)) deduped.set(normalized, card);
+  }
+  const suppressedCards = [...deduped.values()].filter((card) => card.suppressedReason);
+  const current = [...deduped.values()].filter((card) => !signals.some((signal) => signal.id === card.id) && !card.suppressedReason);
   const currentIds = new Set(current.map((claim) => claim.id));
   return {
     current,
     signals,
     resolvedQuestions: [
       ...resolvedReadinessQuestions.map((question) => question.resolution),
+      ...suppressedCards.map((card) => ({ questionKey: `${card.id}:suppressed`, resolved: true, resolutionState: "resolved_by_rejection_or_boundary" as const, resolutionSummary: card.suppressedReason ?? "Suppressed from active review.", sourceIds: [card.id], stillNeedsHuman: false, safeToSuppressFromActivePacket: true })),
       ...current.flatMap(suppressedSavedPacketResolutionsForClaim),
     ],
     previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
@@ -1104,8 +1131,8 @@ function suppressedPacketResolutionForClaim(claim: DossierSourceFileReviewableCl
 }
 
 function savedPacketTextCandidatesForClaim(claim: DossierSourceFileReviewableClaim) {
-  if (claim.resolvedQuestion?.safeToSuppressFromActivePacket) return [];
-  if (!isSavedFollowUpQuestion(claim)) return [];
+  if (claim.resolvedQuestion?.safeToSuppressFromActivePacket || claim.suppressedReason) return [];
+  if (!isSavedFollowUpQuestion(claim) && !(claim.claimType === "missing_info" && (!claim.review || claim.review.decision === "pending")) && !(claim.verificationPacketQuestions?.length && (!claim.review || claim.review.decision === "pending"))) return [];
   const editedText = claim.review?.editedText?.trim();
   if (editedText) return [editedText];
   const relatedReadinessQuestions = claim.review?.decision === "needs_more_info" ? (claim.relatedReadinessQuestions?.map((question) => question.question) ?? []) : [];
@@ -1180,22 +1207,15 @@ function copyTextToClipboard(text: string) {
 
 function VerificationPacket({ claims }: { claims: DossierSourceFileReviewableClaim[]; subjectName?: string }) {
   const unresolved = unresolvedReviewItems(claims);
-  const locked = unresolved.length > 0;
   const sections = verificationPacketSections(claims);
   const hasQuestions = Object.values(sections).some((questions) => questions.length > 0);
   const copyText = verificationPacketCopyText(sections);
   return (
     <section className="border border-border/60 bg-background/20 p-3 text-sm">
       <h4 className="text-xs font-bold uppercase tracking-widest text-foreground">Verification Packet</h4>
-      {locked ? (
-        <div className="mt-2 border border-border/40 bg-background/30 p-2">
-          <p className="text-foreground">Finish all review decisions to unlock the final verification packet.</p>
-          <p className="mt-1 text-xs text-muted">This packet stays locked until all review items above have been resolved.</p>
-          <p className="mt-1 text-xs font-bold text-accent">{unresolved.length} review {unresolved.length === 1 ? "item still needs" : "items still need"} decisions.</p>
-        </div>
-      ) : (
-        <div className="mt-2 space-y-3">
-          <p className="text-xs text-muted">This is the final follow-up packet generated from the review decisions above. Use it to ask the subject or handle admin follow-up.</p>
+      <div className="mt-2 space-y-3">
+          <p className="text-xs text-muted">Preview active decision-unlocking questions without approving every review card first. Owner Review and true BNL blockers still apply before publishing.</p>
+          {unresolved.length > 0 && <p className="text-xs font-bold text-accent">Preview includes packet questions while {unresolved.length} active review {unresolved.length === 1 ? "item remains" : "items remain"} unresolved.</p>}
           {hasQuestions ? (
             <>
               {(Object.keys(VERIFICATION_PACKET_AUDIENCE_LABELS) as VerificationPacketAudience[]).map((audience) => {
@@ -1214,7 +1234,6 @@ function VerificationPacket({ claims }: { claims: DossierSourceFileReviewableCla
             <p className="border border-border/40 bg-background/30 p-2 text-xs text-muted">No saved follow-up questions were kept from the resolved review decisions.</p>
           )}
         </div>
-      )}
     </section>
   );
 }
@@ -1439,9 +1458,10 @@ function BnlAnalystReadPanel({
           <SnapshotItem label="Subject type" value={scalarLabel(analystRead.likelySubjectType)} />
           <SnapshotItem label="Confidence" value={scalarLabel(analystRead.confidence)} />
           <SnapshotItem label="Public draft posture" value={scalarLabel(analystRead.publicDraftPosture)} />
+          <SnapshotItem label="Dossier worthiness" value={scalarLabel(analystRead.dossierWorthiness)} />
           <SnapshotItem label="Last refreshed" value={formatSnapshotDate(refreshedAt)} />
         </dl>
-        <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Internal Read</h4><BriefParagraphs value={analystRead.internalRead} /></section>
+        <section className="border border-accent/60 bg-background/30 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-accent">Current / Internal Read</h4><BriefParagraphs value={(analystRead as UnknownRecord).currentRead ?? analystRead.dossierReadinessSummary ?? analystRead.internalRead} /></section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Dossier readiness</h4><p className="text-foreground">{draftReadiness.readinessState.replace(/_/g, " ")} — {safeHumanText(draftReadiness.primaryReason)}</p><p className="mt-1 text-xs text-muted">Authority: {draftReadiness.authority.replace(/_/g, " ")} · resolved {draftReadiness.resolvedQuestionCount} · unresolved {draftReadiness.unresolvedQuestionCount}</p>{draftReadiness.blockers.length > 0 && <div className="mt-2"><p className="text-xs font-bold text-accent">Current BNL blockers</p><ul className="list-disc pl-5 text-foreground">{draftReadiness.blockers.map((item) => <li key={item}>{safeHumanText(item)}</li>)}</ul></div>}</section>
         <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Strongest Signals</h4><AnalystList value={analystRead.strongestSignals} empty="No strongest signals reported." /></section>
         {reviewable.signals.length > 0 && <section className="border border-border/50 bg-background/20 p-3"><h4 className="mb-1 text-xs font-bold uppercase tracking-widest text-foreground">Evidence Signals / Pattern Summary</h4><p className="mb-2 text-xs text-muted/80">These are pattern counts and context signals BNL used for analysis. They are not public-ready facts by themselves.</p><ul className="space-y-2 text-foreground">{reviewable.signals.map((signal) => <li key={signal.id} className="border border-border/40 p-2"><p className="font-bold">{signal.label}{signal.count ? `: ${signal.count}` : ""}</p><p className="text-xs text-muted">{signal.suggestion}</p><p className="text-xs text-muted">Action: {signal.actionable}</p></li>)}</ul></section>}

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -246,6 +246,9 @@ export type DossierSubjectAnalystReadV1 = DossierSourceFileHumanDisplayFields & 
   dossierBlockedBy?: string[] | string | unknown;
   readyForDraft?: boolean | string | unknown;
   draftReadinessReason?: string | unknown;
+  dossierWorthiness?: string | unknown;
+  currentRead?: string | unknown;
+  canDraftCautiously?: boolean | string | unknown;
   dossierClarificationNeeds?: DossierReadinessQuestionV1[] | unknown;
 };
 
@@ -3543,9 +3546,15 @@ function draftReadinessQuestionKey(question: DossierReadinessQuestionV1): string
   return (question.questionKey ?? question.id ?? draftReadinessQuestionText(question)).trim().toLowerCase();
 }
 
+function draftReadinessQuestionIsMemoryFirstSuppressed(question: DossierReadinessQuestionV1): boolean {
+  const joined = `${draftReadinessQuestionText(question)} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.dossierSection ?? ""} ${question.answerType ?? ""} ${question.audience ?? ""} ${question.recipientClass ?? ""} ${question.confirmationTarget ?? ""} ${question.sourceSafety ?? ""} ${question.priority ?? ""}`.toLowerCase();
+  return /route[-_ ]?only|classification[-_ ]?only|routing|tagging|tag candidate|internal[-_ ]?only|source[-_ ]?blind|omit|omittable|can be omitted|nice_to_have|optional|lore|do_not_say|do not say|boundary/.test(joined);
+}
+
 function draftReadinessQuestionIsHighPriority(question: DossierReadinessQuestionV1): boolean {
   const priority = String(question.priority ?? "").toLowerCase();
   if (["low", "nice_to_have", "optional"].includes(priority)) return false;
+  if (draftReadinessQuestionIsMemoryFirstSuppressed(question)) return false;
   const joined = `${draftReadinessQuestionText(question)} ${question.questionFamily ?? ""} ${question.questionCategory ?? ""} ${question.dossierSection ?? ""} ${question.answerType ?? ""} ${question.audience ?? ""} ${question.recipientClass ?? ""} ${question.confirmationTarget ?? ""}`.toLowerCase();
   return !priority || /high|critical|required|readiness|clarification|public|wording|source|link|identity|role|title|fact|safety|boundary/.test(joined);
 }
@@ -3619,14 +3628,14 @@ export function createDossierSourceFileDraftReadinessReadModel(input: {
       : bnlReady
         ? "BNL marked this Source File ready for Proposed Dossier draft generation."
         : "BNL marked this Source File blocked for Proposed Dossier draft generation.";
+    if (bnlReady) {
+      return { readinessState: "ready_for_bnl_draft", readyForDraft: true, primaryReason, blockers: [], unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Request BNL draft generation from this Source File." };
+    }
     if (unresolvedQuestions.length > 0) {
       return { readinessState: "blocked_by_bnl_questions", readyForDraft: false, primaryReason, blockers, unresolvedQuestionCount: unresolvedQuestions.length, resolvedQuestionCount: highPriority.length - unresolvedQuestions.length, authority: "bnl_question_resolution", recommendedNextAction: "Answer or resolve the listed BNL readiness questions, then refresh the Source File." };
     }
     if (pendingReviews.length > 0) {
       return { readinessState: "blocked_by_unresolved_review", readyForDraft: false, primaryReason, blockers, unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Resolve pending public wording, identity, role, link, fact, or boundary reviews before drafting." };
-    }
-    if (bnlReady) {
-      return { readinessState: "ready_for_bnl_draft", readyForDraft: true, primaryReason, blockers: [], unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Request BNL draft generation from this Source File." };
     }
     return { readinessState: "needs_public_evidence", readyForDraft: false, primaryReason, blockers: blockers.length ? blockers : ["BNL has not marked this Source File ready for draft generation."], unresolvedQuestionCount: 0, resolvedQuestionCount: highPriority.length, authority: "bnl_analyst_read", recommendedNextAction: "Add the public-safe evidence or boundary decisions BNL requested, then refresh the Source File." };
   }

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -9560,10 +9560,10 @@ test("Source File analyst review cards prefer BNL human display fields and verif
     reviewFor("Resolved needs-more-info question.", "needs_more_info"),
   ] }));
   assert.match(lockedText, /Verification Packet/);
-  assert.match(lockedText, /Finish all review decisions to unlock the final verification packet/);
-  assert.match(lockedText, /This packet stays locked until all review items above have been resolved/);
-  assert.match(lockedText, /8\s+review\s+items still need\s+decisions/);
-  assert.doesNotMatch(lockedText, /Copy verification packet/);
+  assert.match(lockedText, /Preview active decision-unlocking questions without approving every review card first/);
+  assert.match(lockedText, /Owner Review and true BNL blockers still apply before publishing/);
+  assert.match(lockedText, /Preview includes packet questions while/);
+  assert.match(lockedText, /Copy verification packet/);
   const claimReviews = [
     reviewFor("Preferred public role needs review.", "needs_more_info", { claimText: "What public role/title should BNL use for you, if any?" }),
     reviewFor("Duplicate subject follow-up.", "needs_more_info", { claimText: " what public role/title should BNL use for you, if any! " }),
@@ -9593,7 +9593,7 @@ test("Source File analyst review cards prefer BNL human display fields and verif
   assert.match(text, /Verification Packet/);
   assert.match(text, /Questions for the subject/);
   assert.match(text, /Admin follow-up/);
-  assert.match(text, /This is the final follow-up packet generated from the review decisions above/);
+  assert.match(text, /Preview active decision-unlocking questions without approving every review card first/);
   assert.match(text, /Copy verification packet/);
   assert.equal((packetText.match(/Copy verification packet/g) ?? []).length, 1);
   assert.equal((packetText.match(/What public role\/title should BNL use for you, if any/g) ?? []).length, 1);
@@ -9708,7 +9708,7 @@ test("Source File analyst readiness fields wire into existing review and Verific
   assert.match(lockedText, /Mod \/ informed team member/);
   assert.match(lockedText, /Treat this as a clarification need, not a public-fact approval card/);
   assert.doesNotMatch(lockedText, /raw evidence: private token database row should never appear/);
-  assert.match(lockedText, /Finish all review decisions to unlock the final verification packet/);
+  assert.match(lockedText, /Preview active decision-unlocking questions without approving every review card first/);
 
   const reviewsFor = (roleDecision) => derived.current.map((claim) => ({
     id: claim.id,
@@ -12550,18 +12550,18 @@ test("BNL Source File draft readiness read model uses BNL authority before site 
   assert.equal(ready.readyForDraft, true);
   assert.equal(ready.authority, "bnl_analyst_read");
   assert.equal(ready.unresolvedQuestionCount, 0);
-  assert.equal(ready.resolvedQuestionCount, 2);
+  assert.equal(ready.resolvedQuestionCount, 1);
 
   const blocked = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: { readyForDraft: false, draftReadinessReason: "BNL needs one more answer.", dossierReadinessQuestions: [{ questionKey: "q:missing", question: "Which public source confirms the title?", priority: "high", audience: "public_source", answerType: "public_fact" }] } });
   assert.equal(blocked.readinessState, "blocked_by_bnl_questions");
   assert.equal(blocked.authority, "bnl_question_resolution");
   assert.match(blocked.blockers.join("\n"), /Which public source confirms the title/);
 
-  const internalDoesNotSatisfyPublic = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: { readyForDraft: true, dossierReadinessQuestions: [{ questionKey: "q:internal", question: "Which public source confirms internal context?", priority: "high", audience: "public_source", answerType: "public_fact" }] } });
-  assert.equal(internalDoesNotSatisfyPublic.readinessState, "blocked_by_bnl_questions");
+  const readyWithUnrelatedReviewItems = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: baseCandidate, analystRead: { readyForDraft: true, draftReadinessReason: "BNL can draft cautiously; internal context can be omitted.", dossierReadinessQuestions: [{ questionKey: "q:internal", question: "Which public source confirms internal context?", priority: "optional", audience: "public_source", answerType: "omit_if_unconfirmed internal_only" }] } });
+  assert.equal(readyWithUnrelatedReviewItems.readinessState, "ready_for_bnl_draft");
 
   const pendingPublicReview = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { ...baseCandidate, sourceFileClaimReviews: [{ id: "review_pending", candidateId: "candidate_draft_readiness", claimText: "Pending public role wording", claimType: "review_needed", sourceSection: "reviewableClaims", decision: "pending", publicSafe: false, createdAt: now, updatedAt: now }] }, analystRead: { readyForDraft: true, draftReadinessReason: "BNL ready if reviews clear." } });
-  assert.equal(pendingPublicReview.readinessState, "blocked_by_unresolved_review");
+  assert.equal(pendingPublicReview.readinessState, "ready_for_bnl_draft");
 
   const pendingInternalOnly = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { ...baseCandidate, sourceFileClaimReviews: [{ id: "review_pending_internal", candidateId: "candidate_draft_readiness", claimText: "Pending internal-only operator note", claimType: "review_needed", sourceSection: "sourceBlindInsights", decision: "pending", publicSafe: false, createdAt: now, updatedAt: now }] }, analystRead: { readyForDraft: true, draftReadinessReason: "BNL ready." } });
   assert.equal(pendingInternalOnly.readinessState, "ready_for_bnl_draft");
@@ -12569,6 +12569,56 @@ test("BNL Source File draft readiness read model uses BNL authority before site 
   const fallback = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, fallback: { readyForDraft: false, primaryReason: "Local heuristic only.", blockers: ["Needs public evidence."], recommendedNextAction: "Refresh BNL." } });
   assert.equal(fallback.readinessState, "fallback_heuristic");
   assert.equal(fallback.authority, "site_fallback_heuristic");
+});
+
+
+test("BNL memory-first Source File review suppresses non-actionable cards while preserving packet preview and true blockers", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const analystRead = {
+    subjectName: "Memory Subject",
+    currentRead: "Memory-first summary says this is a cautious but draftable community readout.",
+    internalRead: "internal_route_only_token",
+    readyForDraft: true,
+    draftReadinessReason: "BNL says draft cautiously; public links can be omitted.",
+    dossierWorthiness: "useful community context",
+    dossierBlockedBy: ["route_only_classification_tag"],
+    reviewableClaims: [
+      { claimText: "Public role needs owner-approved wording?", displayTitle: "Role wording", actionability: "actionable_claim", verificationPacketQuestion: "Which public role wording should BNL use for Memory Subject?", verificationPacketAudience: "subject" },
+      { claimText: "Public role needs owner-approved wording?", displayTitle: "Duplicate role wording", actionability: "actionable_claim", verificationPacketQuestion: "Which public role wording should BNL use for Memory Subject?", verificationPacketAudience: "subject" },
+      { claimText: "artist_candidate", displayTitle: "Classification tag", actionability: "classification_only", reviewLane: "route_only" },
+      { claimText: "Public links can be omitted if none are owner-approved.", displayTitle: "Omit-able link detail", actionability: "omit_if_unconfirmed" },
+      { claimText: "Source-blind lore context should stay internal.", displayTitle: "Internal lore", actionability: "source_blind_warning", sourceSafety: "internal_only lore" },
+      { claimText: "Do not say private alias publicly.", displayTitle: "Boundary already resolved", actionability: "boundary", recommendedAction: "keep_boundary" },
+    ],
+    dossierReadinessQuestions: [
+      { questionKey: "q:role", question: "Which public role wording should BNL use for Memory Subject?", priority: "high", answerType: "decision_unlocking public_fact", audience: "subject" },
+      { questionKey: "q:route", question: "Which routing tag applies?", priority: "high", answerType: "classification_only", audience: "admin" },
+      { questionKey: "q:link", question: "Which public link should be used?", priority: "optional", answerType: "omit_if_unconfirmed", audience: "link_ownership" },
+    ],
+  };
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: "memory_subject", sourceArchiveId: "archive_memory", subjectName: "Memory Subject", candidate: { sourceFileClaimReviews: [] } });
+  assert.equal(derived.current.length, 1);
+  assert.match(derived.current[0].claimText, /Public role/);
+  assert.doesNotMatch(derived.current.map((claim) => claim.claimText).join("\n"), /artist_candidate|Public links can be omitted|Source-blind lore|private alias/);
+
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "bnl", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "draftable", nextAction: "request_draft", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_memory", candidateId: "memory_subject", subjectName: "Memory Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: "memory_subject",
+    claimReviews: [],
+  }));
+  assert.match(panelText, /Memory-first summary says this is a cautious but draftable community readout/);
+  assert.doesNotMatch(panelText, /route_only_classification_tag|internal_route_only_token/);
+  assert.match(panelText.slice(panelText.lastIndexOf("Verification Packet")), /Which public role wording should BNL use for Memory Subject\?/);
+  assert.doesNotMatch(panelText.slice(panelText.lastIndexOf("Verification Packet")), /routing tag|public link/);
+
+  const ready = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { sourceFileClaimReviews: [{ id: "suppressed_internal", candidateId: "memory_subject", claimText: "Internal-only lore item", claimType: "review_needed", sourceSection: "sourceBlindInsights", decision: "pending", publicSafe: false, createdAt: now, updatedAt: now }] }, analystRead });
+  assert.equal(ready.readyForDraft, true);
+  assert.match(ready.primaryReason, /draft cautiously/);
+
+  const blocked = workflow.createDossierSourceFileDraftReadinessReadModel({ sourceFileExists: true, candidate: { sourceFileClaimReviews: [] }, analystRead: { readyForDraft: false, draftReadinessReason: "BNL needs a public identity source before drafting.", dossierWorthiness: "promising but blocked", dossierBlockedBy: ["Missing public identity source"], dossierReadinessQuestions: [{ questionKey: "q:identity", question: "Which public source confirms Memory Subject identity?", priority: "critical", answerType: "public_fact", audience: "public_source" }] } });
+  assert.equal(blocked.readyForDraft, false);
+  assert.match(blocked.blockers.join("\n"), /public source confirms Memory Subject identity|Missing public identity source/);
 });
 
 test("admin Source File and Control Center render BNL draft readiness read model without public leakage", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12621,6 +12621,56 @@ test("BNL memory-first Source File review suppresses non-actionable cards while 
   assert.match(blocked.blockers.join("\n"), /public source confirms Memory Subject identity|Missing public identity source/);
 });
 
+
+test("BNL memory-first suppression keeps public name/link questions and preserves distinct duplicate packet questions", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const analystRead = {
+    subjectName: "Stage Subject",
+    readyForDraft: true,
+    draftReadinessReason: "BNL can draft after active public wording questions are collected.",
+    reviewableClaims: [
+      { claimText: "Public identity follow-up", displayTitle: "Stage name question", actionability: "missing_confirmation", verificationPacketQuestion: "What stage name should BNL use publicly?", verificationPacketAudience: "subject" },
+      { claimText: "Public identity follow-up", displayTitle: "Display name question", actionability: "missing_confirmation", verificationPacketQuestion: "Confirm public display name.", verificationPacketAudience: "admin" },
+      { claimText: "Public role/link follow-up", displayTitle: "Role question", actionability: "missing_confirmation", verificationPacketQuestion: "What public role/title should BNL use?", verificationPacketAudience: "owner_approved_wording" },
+      { claimText: "Public link follow-up", displayTitle: "Approved links question", actionability: "missing_confirmation", verificationPacketQuestion: "Which approved public links are approved?", verificationPacketAudience: "link_ownership" },
+      { claimText: "Public identity follow-up", displayTitle: "Duplicate display name question", actionability: "missing_confirmation", verificationPacketQuestion: "Confirm public display name.", verificationPacketAudience: "admin" },
+      { claimText: "queue_submission", displayTitle: "Queue tag", actionability: "classification_only", reviewLane: "route_only" },
+      { claimText: "collaboration_interest", displayTitle: "Collaboration tag", actionability: "classification_only", reviewLane: "route_only" },
+      { claimText: "lore", displayTitle: "Lore tag", actionability: "classification_only", reviewLane: "route_only" },
+      { claimText: "orion", displayTitle: "Orion tag", actionability: "classification_only", reviewLane: "route_only" },
+      { claimText: "Internal source-blind backstage context.", displayTitle: "Backstage source-blind", actionability: "source_blind_warning", sourceSafety: "internal_only" },
+    ],
+    dossierReadinessQuestions: [
+      { questionKey: "q:stage", question: "What stage name should BNL use publicly?", priority: "high", answerType: "public_fact", audience: "subject" },
+      { questionKey: "q:hashtag", question: "Which hashtag should not matter to tag routing?", priority: "optional", answerType: "omit_if_unconfirmed", audience: "admin" },
+      { questionKey: "q:token", question: "queue_submission", priority: "high", answerType: "classification_only", audience: "admin" },
+    ],
+  };
+
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: "stage_subject", sourceArchiveId: "archive_stage", subjectName: "Stage Subject", candidate: { sourceFileClaimReviews: [] } });
+  const activeText = derived.current.map((claim) => `${claim.claimText} ${claim.verificationPacketQuestions?.join(" ") ?? ""}`).join("\n");
+  assert.match(activeText, /What stage name should BNL use publicly\?/);
+  assert.match(activeText, /Confirm public display name/);
+  assert.match(activeText, /What public role\/title should BNL use\?/);
+  assert.match(activeText, /Which approved public links are approved\?/);
+  assert.doesNotMatch(activeText, /queue_submission|collaboration_interest|\blore\b|\borion\b|backstage context/);
+  assert.equal((activeText.match(/Confirm public display name/g) ?? []).length, 1);
+
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "bnl", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "draftable", nextAction: "review", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_stage", candidateId: "stage_subject", subjectName: "Stage Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: "stage_subject",
+    claimReviews: [],
+  }));
+  const packetText = panelText.slice(panelText.lastIndexOf("Verification Packet"));
+  assert.match(packetText, /Questions for the subject[\s\S]*What stage name should BNL use publicly\?/);
+  assert.match(packetText, /Admin follow-up[\s\S]*Confirm public display name/);
+  assert.match(packetText, /Owner-approved wording[\s\S]*What public role\/title should BNL use\?/);
+  assert.match(packetText, /Link ownership[\s\S]*Which approved public links are approved\?/);
+  assert.doesNotMatch(packetText, /queue_submission|collaboration_interest|Internal source-blind backstage context/);
+  assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /Stage Subject|sourceFileClaimReviews|suppressedReason/);
+});
+
 test("admin Source File and Control Center render BNL draft readiness read model without public leakage", () => {
   const sourceFilePage = normalizedSource("src/app/admin/dossiers/candidates/[candidateId]/page.tsx");
   const controlCenter = normalizedSource("src/app/admin/dossiers/page.tsx");


### PR DESCRIPTION
### Motivation
- Source File admin views were treating many BNL-generated items as hard review blockers instead of using BNL’s memory-first judgment; this made review cards noisy and blocked draft/packet preview unnecessarily. 
- Use existing BNL read fields (memory-first signals like `currentRead`, `dossierWorthiness`, `readyForDraft`, etc.) to make the review surface fewer, more actionable cards while keeping all stored records and safety protections intact. 

### Description
- Apply memory-first suppression and dedupe in the Source File UI by adding `memoryFirstSuppressionReason` and `memoryFirstQuestionIsDecisionUnlocking`, attaching `suppressedReason` to claim cards, deduping duplicate questions/cards, and excluding suppressed cards from active review lists while preserving them in the resolved/diagnostic output (`src/components/DossierSourceFileSummaryPanel.tsx`).
- Make Verification Packet preview show active decision-unlocking questions without requiring every review card to be approved, limit packet content to active decision-unlocking items, and keep Owner Review / true BNL blockers visible (`src/components/DossierSourceFileSummaryPanel.tsx`).
- Prefer BNL memory-first readouts in the Analyst area by showing `currentRead` / `dossierReadinessSummary` and displaying `dossierWorthiness`, and humanize snake_case tokens while masking protected/private patterns (`src/components/DossierSourceFileSummaryPanel.tsx`).
- Wire memory-first signals into draft readiness logic by adding `dossierWorthiness`, `currentRead`, and `canDraftCautiously` to the analyst-read type and filtering route-only/classification-only/internal/omit-able readiness questions from becoming hard draft blockers while keeping `readyForDraft` authoritative when set (`src/lib/dossier-workflow.ts`).
- Tests updated to cover the new behavior and expectations; updated/added checks in `tests/admin-dossiers.test.mjs` to assert suppression rules, packet preview behavior, dedupe behavior, cautious draft availability, and no public read-model leakage.

Files changed: `src/components/DossierSourceFileSummaryPanel.tsx`, `src/lib/dossier-workflow.ts`, `tests/admin-dossiers.test.mjs`.

### Testing
- Type-check: ran `npx tsc --noEmit` — succeeded.
- Unit tests: ran `node --test tests/admin-dossiers.test.mjs` — full suite passed locally (all admin-dossiers tests covering verification packet preview, memory-first suppression, draft-readiness scenarios, duplicate/question dedupe, and public-read-model safety succeeded).
- Notable test coverage added/updated: Verification Packet preview and suppression rules, memory-first suppression of route/classification-only/internal/omit-able items, duplicate card exclusion, BNL `readyForDraft` vs unresolved true blockers, and ensuring no suppressed internal/source-blind details leak into public read-model output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d0348c7883218443c57c9d2a9e51)