### PR TITLE
Apply BNL memory-first defaults to Verification Packet and readiness gating

### DIFF
--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -546,7 +546,21 @@ export type DossierSourceFileReviewableClaim = {
   recommendedAdminActionCards?: UnknownRecord[];
   review?: DossierSourceFileClaimReview;
   resolvedQuestion?: DossierResolvedQuestionReadModel;
+  memoryFirstDefaultState?: MemoryFirstPacketDefaultState;
 };
+
+export type MemoryFirstPacketDefaultState =
+  | "active_question"
+  | "answered_by_bnl"
+  | "default_keep_internal"
+  | "default_omit_from_public"
+  | "default_use_cautious_wording"
+  | "already_rejected"
+  | "resolved_by_boundary"
+  | "resolved_by_existing_truth"
+  | "needs_owner_override"
+  | "needs_public_source"
+  | "needs_identity_confirmation";
 
 type SourceFileSignalSummary = {
   id: string;
@@ -940,9 +954,10 @@ export function deriveDossierSourceFileReviewableClaims(input: {
   const readinessQuestions = analystReadinessQuestions(input.analystRead).map((question) => ({
     ...question,
     resolution: resolveBnlDossierQuestionFromExistingTruth({ question: { ...question, question: question.question }, candidate: input.candidate }),
+    memoryFirstResolution: resolveVerificationPacketQuestionWithBnlJudgment({ text: question.question, audience: question.audience, answerType: question.answerType, dossierSection: question.dossierSection, questionKey: question.questionKey, candidate: input.candidate, analystRead: input.analystRead }),
   }));
-  const resolvedReadinessQuestions = readinessQuestions.filter((question) => question.resolution.safeToSuppressFromActivePacket);
-  const activeReadinessQuestions = readinessQuestions.filter((question) => !question.resolution.safeToSuppressFromActivePacket);
+  const resolvedReadinessQuestions = readinessQuestions.filter((question) => question.resolution.safeToSuppressFromActivePacket || question.memoryFirstResolution?.safeToSuppressFromActivePacket);
+  const activeReadinessQuestions = readinessQuestions.filter((question) => !question.resolution.safeToSuppressFromActivePacket && !question.memoryFirstResolution?.safeToSuppressFromActivePacket);
   const allCards = sections.flatMap((section) => listValues(section.values).flatMap((value) => {
     const card = buildClaimCard({ value, sourceSection: section.sourceSection, claimType: section.claimType, candidateId: input.candidateId, sourceArchiveId: input.sourceArchiveId, subjectName: input.subjectName ?? input.analystRead?.subjectName, reviews: reviewById, candidate: input.candidate });
     return card ? [card] : [];
@@ -990,7 +1005,9 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     reviews: reviewById,
     candidate: input.candidate,
     });
-    return card ? [{ ...card, readinessMetadata: readinessMetadataItems(question), resolvedQuestion: question.resolution }] : [];
+    if (!card) return [];
+    const memoryFirstState = question.memoryFirstResolution?.resolutionSummary.match(/\(([^)]+)\)/)?.[1]?.replace(/ /g, "_") as MemoryFirstPacketDefaultState | undefined;
+    return [{ ...card, readinessMetadata: readinessMetadataItems(question), resolvedQuestion: question.memoryFirstResolution ?? question.resolution, memoryFirstDefaultState: memoryFirstState ?? "active_question" }];
   });
   const current = [...cardsWithReadiness, ...readinessCards].filter((card) => !signals.some((signal) => signal.id === card.id));
   const currentIds = new Set(current.map((claim) => claim.id));
@@ -998,7 +1015,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     current,
     signals,
     resolvedQuestions: [
-      ...resolvedReadinessQuestions.map((question) => question.resolution),
+      ...resolvedReadinessQuestions.map((question) => question.memoryFirstResolution ?? question.resolution),
       ...current.flatMap(suppressedSavedPacketResolutionsForClaim),
     ],
     previous: (input.reviews ?? []).filter((review) => !currentIds.has(review.id)).map((review) => ({
@@ -1046,8 +1063,75 @@ function normalizeVerificationQuestion(question: string) {
   return question.trim().replace(/\s+/g, " ").replace(/[?.!;:]+$/g, "").toLowerCase();
 }
 
+function reviewMatchesPacketQuestion(review: DossierSourceFileClaimReview, text: string, questionKey?: string) {
+  const normalized = normalizeVerificationQuestion(text);
+  const reviewKey = textValue((review as unknown as UnknownRecord).questionKey);
+  if (questionKey && reviewKey === questionKey) return true;
+  return [review.claimText, review.editedText].some((value) => value && normalizeVerificationQuestion(value).includes(normalized));
+}
+
+function hasExplicitNewEvidence(record: UnknownRecord | undefined, text: string) {
+  const joined = `${text} ${analystString(record, ["newEvidence", "newOwnerApprovedEvidence", "ownerApprovedEvidence", "evidenceSummary", "publicSource", "suggestedPublicWording"]) ?? ""}`.toLowerCase();
+  return /\b(new|owner-approved|owner approved|public-safe|public source|confirmed)\b.*\b(evidence|source|wording|approval)\b/.test(joined);
+}
+
+export function memoryFirstDefaultForPacketQuestion(input: {
+  text: string;
+  audience?: unknown;
+  answerType?: unknown;
+  dossierSection?: unknown;
+  questionKey?: string;
+  record?: UnknownRecord;
+  candidate?: Partial<DossierCandidate>;
+  analystRead?: DossierSubjectAnalystReadV1;
+}): MemoryFirstPacketDefaultState {
+  const text = input.text.trim();
+  const lower = text.toLowerCase();
+  const joined = `${lower} ${textValue(input.audience) ?? ""} ${textValue(input.answerType) ?? ""} ${textValue(input.dossierSection) ?? ""} ${analystString(input.record, ["claimType", "type", "reviewLane", "actionability", "displayTitle", "title"]) ?? ""}`.toLowerCase();
+  const reviews = input.candidate?.sourceFileClaimReviews ?? [];
+  if (reviews.some((review) => review.decision === "rejected" && reviewMatchesPacketQuestion(review, text, input.questionKey)) && !hasExplicitNewEvidence(input.record, text)) return "already_rejected";
+  if (/route|routing|classification|classify|tag\b|candidate type|needs routing|which lane|what lane/.test(joined)) return "answered_by_bnl";
+  if (/protected context|protected|source-blind|source blind|private|internal context|rules\/instructions|rules|instructions/.test(joined)) return "default_keep_internal";
+  if (/orion|lore|persona|ai\/persona|ai persona|project connection|internal context/.test(joined) && !/approved public wording|required for the dossier|public mention is required/.test(joined)) return "default_keep_internal";
+  if (/queue|submission|submitted|radio history/.test(joined) && !/public-safe and necessary|public safe and necessary|required for the dossier/.test(joined)) return "default_keep_internal";
+  if (/public links?|links? (are )?(missing|unconfirmed)|which public links?|link ownership/.test(joined) && !/identity depends|identity confirmation|safe identity/.test(joined)) return "default_omit_from_public";
+  if (/public role|role\/title|role|title|label/.test(joined) && ((input.analystRead as UnknownRecord | undefined)?.canDraftCautiously || input.analystRead?.readyForDraft)) return "default_use_cautious_wording";
+  if (/contest|event/.test(joined) && !/reason the dossier exists|required for the dossier/.test(joined)) return "default_omit_from_public";
+  if (/collaboration|collab/.test(joined)) return "default_omit_from_public";
+  if (/boundary|do not say|public safety|unsafe/.test(joined)) return "resolved_by_boundary";
+  const existing = input.candidate ? resolveBnlDossierQuestionFromExistingTruth({ question: { question: text, audience: input.audience, answerType: input.answerType, dossierSection: input.dossierSection, questionKey: input.questionKey }, candidate: input.candidate }) : undefined;
+  if (existing?.safeToSuppressFromActivePacket) return "resolved_by_existing_truth";
+  if (/identity|display name|public name|safe name/.test(joined)) return "needs_identity_confirmation";
+  if (/public source|unsupported evidence|requires unsupported|public claim requires/.test(joined)) return "needs_public_source";
+  if (/owner override|owner-approved|owner approved/.test(joined)) return "needs_owner_override";
+  return "active_question";
+}
+
+export function resolveVerificationPacketQuestionWithBnlJudgment(input: Parameters<typeof memoryFirstDefaultForPacketQuestion>[0]): DossierResolvedQuestionReadModel | undefined {
+  const state = memoryFirstDefaultForPacketQuestion(input);
+  if (state === "active_question" || state === "needs_owner_override" || state === "needs_public_source" || state === "needs_identity_confirmation") return undefined;
+  return {
+    questionKey: input.questionKey ?? `memory_first:${normalizeVerificationQuestion(input.text).slice(0, 80)}`,
+    resolved: true,
+    resolutionState: state === "already_rejected" || state === "resolved_by_boundary" ? "resolved_by_rejection_or_boundary" : state === "resolved_by_existing_truth" ? "resolved_by_existing_public_fact" : "resolved_by_claim_review",
+    resolutionSummary: `BNL memory-first default (${state.replace(/_/g, " ")}): ${input.text.trim().replace(/\s+/g, " ")}`,
+    sourceIds: [],
+    stillNeedsHuman: false,
+    safeToSuppressFromActivePacket: true,
+  };
+}
+
+function classifyMemoryFirstReviewActionability(claim: DossierSourceFileReviewableClaim) {
+  if (claim.review && claim.review.decision !== "pending") return "active_question";
+  return claim.memoryFirstDefaultState ?? "active_question";
+}
+
+function memoryFirstDefaultIsActionable(state: MemoryFirstPacketDefaultState | undefined) {
+  return !state || state === "active_question" || state === "needs_owner_override" || state === "needs_public_source" || state === "needs_identity_confirmation";
+}
+
 function unresolvedReviewItems(claims: DossierSourceFileReviewableClaim[]) {
-  return claims.filter((claim) => !claim.review?.decision || claim.review.decision === "pending");
+  return claims.filter((claim) => memoryFirstDefaultIsActionable(classifyMemoryFirstReviewActionability(claim)) && (!claim.review?.decision || claim.review.decision === "pending"));
 }
 
 function isSavedFollowUpQuestion(claim: DossierSourceFileReviewableClaim) {
@@ -1105,6 +1189,9 @@ function suppressedPacketResolutionForClaim(claim: DossierSourceFileReviewableCl
 
 function savedPacketTextCandidatesForClaim(claim: DossierSourceFileReviewableClaim) {
   if (claim.resolvedQuestion?.safeToSuppressFromActivePacket) return [];
+  if ((!claim.review?.decision || claim.review.decision === "pending") && claim.claimType === "missing_info" && !claim.isVagueArtifact && !claim.isInternalAuditArtifact) {
+    return claim.verificationPacketQuestions?.length ? claim.verificationPacketQuestions : [claim.claimText];
+  }
   if (!isSavedFollowUpQuestion(claim)) return [];
   const editedText = claim.review?.editedText?.trim();
   if (editedText) return [editedText];
@@ -1121,12 +1208,14 @@ function savedPacketTextCandidatesForClaim(claim: DossierSourceFileReviewableCla
 }
 
 function savedFollowUpQuestionsForClaim(claim: DossierSourceFileReviewableClaim) {
-  return safeActivePacketQuestions(savedPacketTextCandidatesForClaim(claim));
+  return safeActivePacketQuestions(savedPacketTextCandidatesForClaim(claim))
+    .filter((text) => memoryFirstDefaultIsActionable(memoryFirstDefaultForPacketQuestion({ text, audience: claim.verificationPacketAudience ?? claim.confirmationTarget, answerType: claim.claimType, dossierSection: claim.sourceSection })));
 }
 
 function suppressedSavedPacketResolutionsForClaim(claim: DossierSourceFileReviewableClaim) {
   return safeCopyQuestions(savedPacketTextCandidatesForClaim(claim)).flatMap((text) => {
-    const resolution = suppressedPacketResolutionForClaim(claim, text);
+    const memoryResolution = resolveVerificationPacketQuestionWithBnlJudgment({ text, audience: claim.verificationPacketAudience ?? claim.confirmationTarget, answerType: claim.claimType, dossierSection: claim.sourceSection });
+    const resolution = memoryResolution ?? suppressedPacketResolutionForClaim(claim, text);
     return resolution ? [resolution] : [];
   });
 }
@@ -1189,9 +1278,22 @@ function VerificationPacket({ claims }: { claims: DossierSourceFileReviewableCla
       <h4 className="text-xs font-bold uppercase tracking-widest text-foreground">Verification Packet</h4>
       {locked ? (
         <div className="mt-2 border border-border/40 bg-background/30 p-2">
-          <p className="text-foreground">Finish all review decisions to unlock the final verification packet.</p>
-          <p className="mt-1 text-xs text-muted">This packet stays locked until all review items above have been resolved.</p>
+          <p className="text-foreground">Previewing active BNL decision-unlocking questions.</p>
+          <p className="mt-1 text-xs text-muted">Defaulted/internal/omitted questions are suppressed from this packet; unresolved actionable review items still need decisions before final use.</p>
           <p className="mt-1 text-xs font-bold text-accent">{unresolved.length} review {unresolved.length === 1 ? "item still needs" : "items still need"} decisions.</p>
+          {hasQuestions ? <div className="mt-2 space-y-2">
+            {(Object.keys(VERIFICATION_PACKET_AUDIENCE_LABELS) as VerificationPacketAudience[]).map((audience) => {
+              const questions = sections[audience];
+              if (!questions.length) return null;
+              return (
+                <div key={audience} className="border border-border/40 bg-background/30 p-2">
+                  <p className="text-xs font-bold text-accent">{VERIFICATION_PACKET_AUDIENCE_LABELS[audience]}</p>
+                  <ol className="mt-1 list-decimal space-y-1 pl-5 text-foreground">{questions.map((question) => <li key={question.text}>{question.text}{question.sourceCount > 1 ? <span className="ml-2 text-[11px] text-muted">Used by {question.sourceCount} review items</span> : null}</li>)}</ol>
+                </div>
+              );
+            })}
+            <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => copyTextToClipboard(copyText)}>Copy verification packet</button>
+          </div> : <p className="mt-2 text-xs text-muted">No active packet questions remain after BNL memory-first defaults.</p>}
         </div>
       ) : (
         <div className="mt-2 space-y-3">

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -570,8 +570,8 @@ type SourceFileSignalSummary = {
   actionable: string;
 };
 
-function stableClaimId(input: { candidateId?: string; sourceSection: string; claimText: string; sourceArchiveId?: string }) {
-  const normalized = `${input.candidateId ?? "candidate"}|${input.sourceSection}|${input.claimText.trim().toLowerCase().replace(/\s+/g, " ")}|${input.sourceArchiveId ?? ""}`;
+function stableClaimId(input: { candidateId?: string; sourceSection: string; claimText: string; sourceArchiveId?: string; packetSignature?: string }) {
+  const normalized = `${input.candidateId ?? "candidate"}|${input.sourceSection}|${input.claimText.trim().toLowerCase().replace(/\s+/g, " ")}|${input.packetSignature ?? ""}|${input.sourceArchiveId ?? ""}`;
   let hash = 0;
   for (let index = 0; index < normalized.length; index += 1) hash = (hash * 31 + normalized.charCodeAt(index)) >>> 0;
   return `source_file_claim_${hash.toString(36)}`;
@@ -852,7 +852,14 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
       : buildCardGuidance(claimText, claimType, record, displaySubject);
   const suggested = suggestedTextsForClaim({ claimText, claimType, record, subjectName: displaySubject, weakLabel, vagueArtifact });
   const rawSuggestedDecision = analystString(record, ["recommendedAction", "suggestedDecision", "recommendation"]);
-  const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId });
+  const verificationPacketQuestions = stringListFromRecord(record, "verificationPacketQuestion");
+  const verificationPacketAudience = analystString(record, ["verificationPacketAudience"]);
+  const packetSignature = [
+    ...verificationPacketQuestions.map(normalizeVerificationQuestion),
+    verificationPacketAudience ? `audience:${verificationPacketAudience}` : undefined,
+    analystString(record, ["suggestedMissingInfoQuestion", "suggestedAnswer", "suggestedAnswerText", "answer"]) ? `followup:${normalizeVerificationQuestion(analystString(record, ["suggestedMissingInfoQuestion", "suggestedAnswer", "suggestedAnswerText", "answer"]) ?? "")}` : undefined,
+  ].filter(Boolean).join("|");
+  const id = stableClaimId({ candidateId: input.candidateId, sourceSection: input.sourceSection, claimText, sourceArchiveId: input.sourceArchiveId, packetSignature });
   const blockedBy = stringItems(record?.blockedBy);
   return {
     id,
@@ -905,8 +912,8 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     confirmationTarget: analystString(record, ["confirmationTarget"]),
     primaryActionLabel: displayField(record, "primaryActionLabel"),
     secondaryActionLabels: stringListFromRecord(record, "secondaryActionLabels"),
-    verificationPacketQuestions: stringListFromRecord(record, "verificationPacketQuestion"),
-    verificationPacketAudience: analystString(record, ["verificationPacketAudience"]),
+    verificationPacketQuestions,
+    verificationPacketAudience,
     recommendedAdminActionCards: listRecords(record?.recommendedAdminActionCards),
     whatYouAreApproving: claimType === "recommended_action" ? "An admin task state, not a public claim approval." : claimType === "do_not_say" ? "A public-copy boundary that protects against unsupported claims." : claimType === "source_blind" ? "Only a separately confirmed public-safe replacement, not the source-blind text itself." : "A Source File review decision. Confirming public-ready does not publish a dossier.",
     whatToEnter: claimType === "recommended_action" ? "No public-safe text is required unless this task explicitly creates a Source File note." : claimType === "do_not_say" ? "No public-ready wording should be entered for boundaries." : claimType === "source_blind" ? "Add public-safe replacement text, if owner/admin confirms it elsewhere." : "Enter the exact sentence BNL may use as a Source File fact.",
@@ -927,6 +934,26 @@ function buildClaimCard(input: { value: unknown; sourceSection: string; claimTyp
     review: input.reviews?.get(id),
     resolvedQuestion: resolvedQuestion?.safeToSuppressFromActivePacket ? resolvedQuestion : undefined,
   };
+}
+
+function reviewCardDedupeKey(claim: DossierSourceFileReviewableClaim) {
+  return [
+    claim.sourceSection,
+    normalizeVerificationQuestion(claim.claimText),
+    (claim.verificationPacketQuestions ?? []).map(normalizeVerificationQuestion).sort().join("|"),
+    claim.verificationPacketAudience ?? claim.confirmationTarget ?? "",
+    claim.suggestedAnswerText ? normalizeVerificationQuestion(claim.suggestedAnswerText) : "",
+  ].join("::");
+}
+
+function dedupeReviewableClaimCards(claims: DossierSourceFileReviewableClaim[]) {
+  const seen = new Set<string>();
+  return claims.filter((claim) => {
+    const key = reviewCardDedupeKey(claim);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 export function deriveDossierSourceFileReviewableClaims(input: {
@@ -1009,7 +1036,7 @@ export function deriveDossierSourceFileReviewableClaims(input: {
     const memoryFirstState = question.memoryFirstResolution?.resolutionSummary.match(/\(([^)]+)\)/)?.[1]?.replace(/ /g, "_") as MemoryFirstPacketDefaultState | undefined;
     return [{ ...card, readinessMetadata: readinessMetadataItems(question), resolvedQuestion: question.memoryFirstResolution ?? question.resolution, memoryFirstDefaultState: memoryFirstState ?? "active_question" }];
   });
-  const current = [...cardsWithReadiness, ...readinessCards].filter((card) => !signals.some((signal) => signal.id === card.id));
+  const current = dedupeReviewableClaimCards([...cardsWithReadiness, ...readinessCards].filter((card) => !signals.some((signal) => signal.id === card.id)));
   const currentIds = new Set(current.map((claim) => claim.id));
   return {
     current,
@@ -1075,6 +1102,18 @@ function hasExplicitNewEvidence(record: UnknownRecord | undefined, text: string)
   return /\b(new|owner-approved|owner approved|public-safe|public source|confirmed)\b.*\b(evidence|source|wording|approval)\b/.test(joined);
 }
 
+function isStandaloneRoutingTag(text: string) {
+  const normalized = text.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_/-]+/g, "");
+  return /^(collaboration_interest|queue_submission|contest|identity|lore|music|orion|route|routing|classification|candidate_type|source_type|tag|[_a-z0-9/-]+_tag)$/.test(normalized);
+}
+
+function isRouteOnlyClassificationToken(text: string, sourceKind?: string) {
+  const source = (sourceKind ?? "").toLowerCase();
+  if (isStandaloneRoutingTag(text)) return true;
+  if (!/route|routing|classification|classify|tag|taxonomy|candidate_type|source_type/.test(source)) return false;
+  return /^[\s`"'*_/-]*[a-z0-9]+(?:[_/-][a-z0-9]+)*[\s`"'*_/-]*$/i.test(text.trim());
+}
+
 export function memoryFirstDefaultForPacketQuestion(input: {
   text: string;
   audience?: unknown;
@@ -1088,13 +1127,14 @@ export function memoryFirstDefaultForPacketQuestion(input: {
   const text = input.text.trim();
   const lower = text.toLowerCase();
   const joined = `${lower} ${textValue(input.audience) ?? ""} ${textValue(input.answerType) ?? ""} ${textValue(input.dossierSection) ?? ""} ${analystString(input.record, ["claimType", "type", "reviewLane", "actionability", "displayTitle", "title"]) ?? ""}`.toLowerCase();
+  const routeSourceKind = `${textValue(input.answerType) ?? ""} ${textValue(input.dossierSection) ?? ""} ${analystString(input.record, ["claimType", "type", "reviewLane", "actionability", "displayTitle", "title"]) ?? ""}`;
   const reviews = input.candidate?.sourceFileClaimReviews ?? [];
   if (reviews.some((review) => review.decision === "rejected" && reviewMatchesPacketQuestion(review, text, input.questionKey)) && !hasExplicitNewEvidence(input.record, text)) return "already_rejected";
-  if (/route|routing|classification|classify|tag\b|candidate type|needs routing|which lane|what lane/.test(joined)) return "answered_by_bnl";
+  if (isRouteOnlyClassificationToken(text, routeSourceKind)) return "answered_by_bnl";
   if (/protected context|protected|source-blind|source blind|private|internal context|rules\/instructions|rules|instructions/.test(joined)) return "default_keep_internal";
   if (/orion|lore|persona|ai\/persona|ai persona|project connection|internal context/.test(joined) && !/approved public wording|required for the dossier|public mention is required/.test(joined)) return "default_keep_internal";
   if (/queue|submission|submitted|radio history/.test(joined) && !/public-safe and necessary|public safe and necessary|required for the dossier/.test(joined)) return "default_keep_internal";
-  if (/public links?|links? (are )?(missing|unconfirmed)|which public links?|link ownership/.test(joined) && !/identity depends|identity confirmation|safe identity/.test(joined)) return "default_omit_from_public";
+  if (/(links? (are )?(missing|unconfirmed)|missing public links?|unconfirmed public links?|link ownership)/.test(joined) && !/approved|identity depends|identity confirmation|safe identity/.test(joined)) return "default_omit_from_public";
   if (/public role|role\/title|role|title|label/.test(joined) && ((input.analystRead as UnknownRecord | undefined)?.canDraftCautiously || input.analystRead?.readyForDraft)) return "default_use_cautious_wording";
   if (/contest|event/.test(joined) && !/reason the dossier exists|required for the dossier/.test(joined)) return "default_omit_from_public";
   if (/collaboration|collab/.test(joined)) return "default_omit_from_public";
@@ -1162,7 +1202,7 @@ export function classifySavedPacketTextForVerificationPacket(text: string): Save
 }
 
 function isActiveVerificationPacketQuestion(text: string) {
-  return classifySavedPacketTextForVerificationPacket(text) === "active_question";
+  return classifySavedPacketTextForVerificationPacket(text) === "active_question" || /^(confirm|verify|approve|choose)\b/i.test(text.trim());
 }
 
 function safeActivePacketQuestions(questions: string[]) {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -3594,10 +3594,17 @@ function draftReadinessTextIsMemoryFirstOmittable(text: string, context = "") {
   if (/public_source|public source|public_fact|public fact/.test(joined) && /which|confirm|source/.test(joined)) return false;
   if (/protected context|source-blind|source blind|private|internal context|orion|lore|ai\/persona|ai persona|project connection|rules\/instructions|rules|instructions/.test(joined)) return true;
   if (/queue|submission|submitted|radio history/.test(joined) && !/public-safe and necessary|public safe and necessary|required for the dossier/.test(joined)) return true;
-  if (/public links?|links? (are )?(missing|unconfirmed)|which public links?|link ownership/.test(joined) && !/identity depends|identity confirmation|safe identity/.test(joined)) return true;
+  if (/(links? (are )?(missing|unconfirmed)|missing public links?|unconfirmed public links?|link ownership)/.test(joined) && !/approved|identity depends|identity confirmation|safe identity/.test(joined)) return true;
   if (/contest|event/.test(joined) && !/reason the dossier exists|required for the dossier/.test(joined)) return true;
-  if (/collaboration|collab|route|routing|classification|classify|tag\b|candidate type|needs routing|which lane|what lane/.test(joined)) return true;
+  if (/collaboration|collab/.test(joined) || draftReadinessIsRouteOnlyClassificationToken(text, context)) return true;
   return false;
+}
+
+function draftReadinessIsRouteOnlyClassificationToken(text: string, context = "") {
+  const normalized = text.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_/-]+/g, "");
+  if (/^(collaboration_interest|queue_submission|contest|identity|lore|music|orion|route|routing|classification|candidate_type|source_type|tag|[_a-z0-9/-]+_tag)$/.test(normalized)) return true;
+  if (!/route|routing|classification|classify|tag|taxonomy|candidate_type|source_type/.test(context.toLowerCase())) return false;
+  return /^[\s`"'*_/-]*[a-z0-9]+(?:[_/-][a-z0-9]+)*[\s`"'*_/-]*$/i.test(text.trim());
 }
 
 function draftReadinessHasBnlReadiness(analystRead: DossierSubjectAnalystReadV1 | undefined): analystRead is DossierSubjectAnalystReadV1 {

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -3584,8 +3584,20 @@ function draftReadinessPendingPublicReviews(candidate: Partial<DossierCandidate>
   return (candidate.sourceFileClaimReviews ?? [])
     .filter((review) => review.decision === "pending" || review.decision === "needs_more_info")
     .filter((review) => /public|wording|identity|role|title|link|fact|safety|boundary/i.test(`${review.claimText} ${review.sourceSection} ${review.claimType}`))
+    .filter((review) => !draftReadinessTextIsMemoryFirstOmittable(review.claimText, `${review.sourceSection} ${review.claimType}`))
     .map((review) => review.claimText.trim())
     .filter(Boolean);
+}
+
+function draftReadinessTextIsMemoryFirstOmittable(text: string, context = "") {
+  const joined = `${text} ${context}`.toLowerCase();
+  if (/public_source|public source|public_fact|public fact/.test(joined) && /which|confirm|source/.test(joined)) return false;
+  if (/protected context|source-blind|source blind|private|internal context|orion|lore|ai\/persona|ai persona|project connection|rules\/instructions|rules|instructions/.test(joined)) return true;
+  if (/queue|submission|submitted|radio history/.test(joined) && !/public-safe and necessary|public safe and necessary|required for the dossier/.test(joined)) return true;
+  if (/public links?|links? (are )?(missing|unconfirmed)|which public links?|link ownership/.test(joined) && !/identity depends|identity confirmation|safe identity/.test(joined)) return true;
+  if (/contest|event/.test(joined) && !/reason the dossier exists|required for the dossier/.test(joined)) return true;
+  if (/collaboration|collab|route|routing|classification|classify|tag\b|candidate type|needs routing|which lane|what lane/.test(joined)) return true;
+  return false;
 }
 
 function draftReadinessHasBnlReadiness(analystRead: DossierSubjectAnalystReadV1 | undefined): analystRead is DossierSubjectAnalystReadV1 {
@@ -3609,7 +3621,7 @@ export function createDossierSourceFileDraftReadinessReadModel(input: {
       ...(Array.isArray(analystRead.dossierClarificationNeeds) ? analystRead.dossierClarificationNeeds : []),
     ] as DossierReadinessQuestionV1[];
     const highPriority = questions.filter(draftReadinessQuestionIsHighPriority);
-    const unresolvedQuestions = highPriority.filter((question) => !draftReadinessQuestionResolvedByReview(candidate, question));
+    const unresolvedQuestions = highPriority.filter((question) => !draftReadinessQuestionResolvedByReview(candidate, question) && !draftReadinessTextIsMemoryFirstOmittable(draftReadinessQuestionText(question), `${question.audience ?? ""} ${question.answerType ?? ""} ${question.dossierSection ?? ""}`));
     const pendingReviews = draftReadinessPendingPublicReviews(candidate);
     const bnlReady = draftReadinessBool(analystRead.readyForDraft) === true;
     const explicitBlockers = draftReadinessStringItems(analystRead.dossierBlockedBy);

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -9560,8 +9560,8 @@ test("Source File analyst review cards prefer BNL human display fields and verif
     reviewFor("Resolved needs-more-info question.", "needs_more_info"),
   ] }));
   assert.match(lockedText, /Verification Packet/);
-  assert.match(lockedText, /Finish all review decisions to unlock the final verification packet/);
-  assert.match(lockedText, /This packet stays locked until all review items above have been resolved/);
+  assert.match(lockedText, /Previewing active BNL decision-unlocking questions/);
+  assert.match(lockedText, /Defaulted\/internal\/omitted questions are suppressed from this packet/);
   assert.match(lockedText, /8\s+review\s+items still need\s+decisions/);
   assert.doesNotMatch(lockedText, /Copy verification packet/);
   const claimReviews = [
@@ -9708,7 +9708,7 @@ test("Source File analyst readiness fields wire into existing review and Verific
   assert.match(lockedText, /Mod \/ informed team member/);
   assert.match(lockedText, /Treat this as a clarification need, not a public-fact approval card/);
   assert.doesNotMatch(lockedText, /raw evidence: private token database row should never appear/);
-  assert.match(lockedText, /Finish all review decisions to unlock the final verification packet/);
+  assert.match(lockedText, /Previewing active BNL decision-unlocking questions/);
 
   const reviewsFor = (roleDecision) => derived.current.map((claim) => ({
     id: claim.id,
@@ -12519,11 +12519,68 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
     assert.doesNotMatch(packetText, new RegExp(suppressed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
   assert.match(packetText, /What exact public name may BNL use for Crow\?/);
-  assert.match(packetText, /What AI\/persona\/project connection is this referring to\?/);
-  assert.match(packetText, /Which public links, if any, may BNL associate with Crow\?/);
+  assert.doesNotMatch(packetText, /What AI\/persona\/project connection is this referring to\?/);
+  assert.doesNotMatch(packetText, /Which public links, if any, may BNL associate with Crow\?/);
   assert.match(text, /Automatically resolved BNL questions/);
   assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /Suppressed saved/);
   assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /classifySavedPacketTextForVerificationPacket|safeToSuppressFromActivePacket|resolutionState/);
+});
+
+test("BNL memory-first packet defaults suppress checklist-only questions without relying on review count", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const candidate = {
+    id: "candidate_memory_first_defaults",
+    name: "Memory First Subject",
+    sourceFileClaimReviews: [
+      { id: "review_rejected_label", candidateId: "candidate_memory_first_defaults", questionKey: "q:rejected_label", claimText: "Admin previously rejected this label. Is there new owner-approved evidence that changes it?", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "rejected", publicSafe: false, createdAt: now, updatedAt: now },
+      { id: "review_manual_before_preview", candidateId: "candidate_memory_first_defaults", questionKey: "q:manual_before", claimText: "Previously reviewed admin question", claimType: "review_needed", sourceSection: "dossierReadinessQuestions", decision: "confirmed_internal", publicSafe: false, createdAt: now, updatedAt: now },
+    ],
+  };
+  const analystRead = {
+    subjectName: "Memory First Subject",
+    readyForDraft: true,
+    canDraftCautiously: true,
+    draftReadinessReason: "BNL can draft cautiously if unsafe details are omitted or kept internal.",
+    dossierReadinessQuestions: [
+      { questionKey: "q:rejected_label", question: "Admin previously rejected this label. Is there new owner-approved evidence that changes it?", audience: "subject", answerType: "label" },
+      { questionKey: "q:protected", question: "Should protected context stay internal?", audience: "admin", answerType: "protected context" },
+      { questionKey: "q:orion", question: "Can BNL mention Orion/lore/internal context publicly?", audience: "admin", answerType: "lore" },
+      { questionKey: "q:queue", question: "Can BNL mention queue/submission history publicly?", audience: "subject", answerType: "queue history" },
+      { questionKey: "q:links", question: "Which public links are missing or unconfirmed?", audience: "link_ownership", answerType: "link" },
+      { questionKey: "q:role", question: "Which public role/title should BNL use?", audience: "owner_approved_wording", answerType: "role" },
+      { questionKey: "q:contest", question: "Which contest/event context is unclear?", audience: "admin", answerType: "event" },
+      { questionKey: "q:collab", question: "Should BNL claim collaboration?", audience: "admin", answerType: "collaboration" },
+      { questionKey: "q:ai", question: "What AI/persona/project/lore connection should be public?", audience: "admin", answerType: "persona" },
+      { questionKey: "q:route", question: "Needs routing: which classification tag applies?", audience: "unknown", answerType: "route/classification tag" },
+      { questionKey: "q:blocker", question: "Which public source confirms the legal-name identity?", audience: "public_source", answerType: "public_fact" },
+    ],
+  };
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: candidate.id, sourceArchiveId: "archive_memory_first", subjectName: "Memory First Subject", candidate, reviews: candidate.sourceFileClaimReviews });
+  const activeText = derived.current.map((claim) => claim.claimText).join("\n");
+  assert.doesNotMatch(activeText, /Admin previously rejected this label/);
+  assert.doesNotMatch(activeText, /protected context/i);
+  assert.doesNotMatch(activeText, /Orion\/lore/i);
+  assert.doesNotMatch(activeText, /queue\/submission/i);
+  assert.doesNotMatch(activeText, /public links are missing/i);
+  assert.doesNotMatch(activeText, /public role\/title/i);
+  assert.doesNotMatch(activeText, /contest\/event/i);
+  assert.doesNotMatch(activeText, /claim collaboration/i);
+  assert.doesNotMatch(activeText, /AI\/persona\/project/i);
+  assert.doesNotMatch(activeText, /classification tag/i);
+  assert.match(activeText, /Which public source confirms the legal-name identity/);
+  assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /already rejected|default keep internal|default omit from public|default use cautious wording|answered by bnl/);
+
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "manual", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "needs_review", nextAction: "review", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_memory_first", candidateId: candidate.id, subjectName: "Memory First Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: candidate.id,
+    candidate,
+    claimReviews: candidate.sourceFileClaimReviews,
+  }));
+  const packetText = panelText.slice(panelText.lastIndexOf("Verification Packet"));
+  assert.match(packetText, /Which public source confirms the legal-name identity/);
+  assert.doesNotMatch(packetText, /Admin previously rejected this label|protected context|Orion\/lore|queue\/submission|classification tag/);
+  assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /MemoryFirstPacketDefaultState|memoryFirstDefaultForPacketQuestion|sourceFileClaimReviews/);
 });
 
 test("BNL Source File draft readiness read model uses BNL authority before site fallback", () => {

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12520,7 +12520,7 @@ test("Verification Packet suppresses saved answer and boundary text while keepin
   }
   assert.match(packetText, /What exact public name may BNL use for Crow\?/);
   assert.doesNotMatch(packetText, /What AI\/persona\/project connection is this referring to\?/);
-  assert.doesNotMatch(packetText, /Which public links, if any, may BNL associate with Crow\?/);
+  assert.match(packetText, /Which public links, if any, may BNL associate with Crow\?/);
   assert.match(text, /Automatically resolved BNL questions/);
   assert.match(derived.resolvedQuestions.map((question) => question.resolutionSummary).join("\n"), /Suppressed saved/);
   assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /classifySavedPacketTextForVerificationPacket|safeToSuppressFromActivePacket|resolutionState/);
@@ -12551,7 +12551,7 @@ test("BNL memory-first packet defaults suppress checklist-only questions without
       { questionKey: "q:contest", question: "Which contest/event context is unclear?", audience: "admin", answerType: "event" },
       { questionKey: "q:collab", question: "Should BNL claim collaboration?", audience: "admin", answerType: "collaboration" },
       { questionKey: "q:ai", question: "What AI/persona/project/lore connection should be public?", audience: "admin", answerType: "persona" },
-      { questionKey: "q:route", question: "Needs routing: which classification tag applies?", audience: "unknown", answerType: "route/classification tag" },
+      { questionKey: "q:route", question: "classification", audience: "unknown", answerType: "route/classification tag" },
       { questionKey: "q:blocker", question: "Which public source confirms the legal-name identity?", audience: "public_source", answerType: "public_fact" },
     ],
   };
@@ -12581,6 +12581,65 @@ test("BNL memory-first packet defaults suppress checklist-only questions without
   assert.match(packetText, /Which public source confirms the legal-name identity/);
   assert.doesNotMatch(packetText, /Admin previously rejected this label|protected context|Orion\/lore|queue\/submission|classification tag/);
   assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /MemoryFirstPacketDefaultState|memoryFirstDefaultForPacketQuestion|sourceFileClaimReviews/);
+});
+
+test("memory-first routing tag suppression preserves real stage/name/link questions and distinct duplicate packet questions", () => {
+  const analystRead = {
+    subjectName: "Stage Subject",
+    readyForDraft: false,
+    reviewableClaims: [
+      { claimText: "Shared evidence", displayTitle: "Name packet", verificationPacketQuestion: "What stage name should BNL use publicly?", verificationPacketAudience: "subject" },
+      { claimText: "Shared evidence", displayTitle: "Role packet", verificationPacketQuestion: "What public role/title should BNL use?", verificationPacketAudience: "owner_approved_wording" },
+      { claimText: "Shared evidence", displayTitle: "Role packet duplicate", verificationPacketQuestion: "What public role/title should BNL use?", verificationPacketAudience: "owner_approved_wording" },
+      { claimText: "Display fixture", verificationPacketQuestion: "Confirm public display name.", verificationPacketAudience: "admin" },
+      { claimText: "Links fixture", verificationPacketQuestion: "Which public links are approved?", verificationPacketAudience: "link_ownership" },
+    ],
+    dossierReadinessQuestions: [
+      { questionKey: "q:queue_token", question: "queue_submission", audience: "unknown", answerType: "classification" },
+      { questionKey: "q:collab_token", question: "collaboration_interest", audience: "unknown", answerType: "classification" },
+      { questionKey: "q:lore_token", question: "lore", audience: "unknown", answerType: "classification" },
+      { questionKey: "q:orion_token", question: "orion", audience: "unknown", answerType: "classification" },
+      { questionKey: "q:stage_name", question: "What stage name should BNL use publicly?", audience: "subject", answerType: "identity" },
+    ],
+  };
+  const derived = sourceSummaryPanelComponent.deriveDossierSourceFileReviewableClaims({ analystRead, candidateId: "candidate_stage_tags", sourceArchiveId: "archive_stage_tags", subjectName: "Stage Subject" });
+  const activeText = derived.current.map((claim) => `${claim.claimText} ${(claim.verificationPacketQuestions ?? []).join(" ")} ${claim.verificationPacketAudience ?? ""}`).join("\n");
+  assert.match(activeText, /What stage name should BNL use publicly/);
+  assert.match(activeText, /Confirm public display name/);
+  assert.match(activeText, /What public role\/title should BNL use/);
+  assert.match(activeText, /Which public links are approved/);
+  assert.doesNotMatch(activeText, /queue_submission|collaboration_interest|\blore\b|\borion\b/);
+  assert.equal(derived.current.filter((claim) => claim.claimText === "Shared evidence").length, 2);
+
+  const now = "2026-06-18T00:00:00.000Z";
+  const reviews = derived.current.map((claim) => ({
+    id: claim.id,
+    candidateId: "candidate_stage_tags",
+    claimText: claim.claimText,
+    claimType: claim.claimType,
+    sourceSection: claim.sourceSection,
+    decision: "needs_more_info",
+    publicSafe: false,
+    createdAt: now,
+    updatedAt: now,
+  }));
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: { summarySource: "manual", lastUpdatedAt: now, substanceLevel: "useful", publicReadiness: "needs_review", nextAction: "review", existingPublicDossier: "no" },
+    latestSourceFileArchive: { id: "archive_stage_tags", candidateId: "candidate_stage_tags", subjectName: "Stage Subject", sourceDigest: "digest", createdAt: now, updatedAt: now, archiveSize: 1, chunkCount: 1, reviewOnly: true, subjectAnalystReadV1: analystRead },
+    candidateId: "candidate_stage_tags",
+    claimReviews: reviews,
+  }));
+  const packetText = panelText.slice(panelText.lastIndexOf("Verification Packet"));
+  assert.equal((packetText.match(/What stage name should BNL use publicly/g) ?? []).length, 1);
+  assert.equal((packetText.match(/What public role\/title should BNL use/g) ?? []).length, 1);
+  assert.match(packetText, /Questions for the subject/);
+  assert.match(packetText, /Owner-approved wording/);
+  assert.match(packetText, /Admin follow-up/);
+  assert.match(packetText, /Link ownership/);
+  assert.match(packetText, /Confirm public display name/);
+  assert.match(packetText, /Which public links are approved/);
+  assert.doesNotMatch(packetText, /queue_submission|collaboration_interest|\blore\b|\borion\b/);
+  assert.doesNotMatch(normalizedSource("src/app/api/bnl/read-model/route.ts"), /isStandaloneRoutingTag|isRouteOnlyClassificationToken|sourceFileClaimReviews/);
 });
 
 test("BNL Source File draft readiness read model uses BNL authority before site fallback", () => {


### PR DESCRIPTION
### Motivation
- Reduce noisy checklist questions in the Verification Packet by letting BNL’s memory-first judgement and existing Source File truth answer/suppress items that don't need human decisions. 
- Ensure previews and gating do not depend on prior manual-review counts and that only true decision-unlocking items remain active.
- Preserve safety: keep internal/protected items out of public output, keep true blockers (identity, owner, public-source) active, and do not change publish behavior or delete review records.

### Description
- Added a memory-first default layer and state enum (`MemoryFirstPacketDefaultState`) and functions `memoryFirstDefaultForPacketQuestion` and `resolveVerificationPacketQuestionWithBnlJudgment` to classify and resolve packet questions from BNL context and Source File truth. (src/components/DossierSourceFileSummaryPanel.tsx)
- Integrated memory-first resolution into reviewable-claim derivation so readiness questions and claim cards use BNL defaults to suppress or resolve packet items before building active review cards. (src/components/DossierSourceFileSummaryPanel.tsx)
- Modified saved-packet resolution and follow-up extraction so only memory-first actionable questions remain active and suppressed/defaulted items are recorded as resolved diagnostics (safeToSuppressFromActivePacket). (src/components/DossierSourceFileSummaryPanel.tsx)
- Updated the Verification Packet rendering to preview BNL decision-unlocking questions (without adding UI surfaces) and to copy only active packet questions. (src/components/DossierSourceFileSummaryPanel.tsx)
- Added memory-first omit rules into draft-readiness gating so omit-able/default-internal questions do not block `bnl` readiness while keeping identity/public-source/owner overrides as true blockers. (src/lib/dossier-workflow.ts)
- Extended/updated tests and added a regression test covering:
  - suppression of already-rejected labels,
  - defaults to keep protected/Orion/queue/link/collab/AI/persona/context internal or omitted,
  - cautious/default wording for unclear role/title when BNL allows cautious draft,
  - route/classification-only items suppressed,
  - Verification Packet preview behavior on unreviewed and previously-reviewed Source Files, and
  - ensuring no internal resolver metadata leaks into public read models. (tests/admin-dossiers.test.mjs)
- Files changed: `src/components/DossierSourceFileSummaryPanel.tsx` (memory-first resolver, claim/card integration, Verification Packet UI tweaks), `src/lib/dossier-workflow.ts` (draft readiness gating rules), and `tests/admin-dossiers.test.mjs` (test adjustments + new test coverage).

### Testing
- Type-check: ran `npx tsc --noEmit` and it succeeded.
- Regression tests: ran `node --test tests/admin-dossiers.test.mjs`; all tests passed (`227` tests, `0` failures).
- Verified the new test asserting memory-first suppression and the existing suite for Verification Packet and draft readiness all succeed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d7d2c0648321a4b6f954280fb41b)