### PR TITLE
Render BNL-authored Source File surface

### DIFF
--- a/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
+++ b/src/app/admin/dossiers/candidates/[candidateId]/page.tsx
@@ -2645,6 +2645,8 @@ export default function CandidateReviewPage() {
               claimReviews={candidate.sourceFileClaimReviews ?? []}
               onReviewClaim={reviewSourceFileClaim}
               candidate={candidate}
+              onCreateDraft={() => void createDraft()}
+              onRequestBnlDraft={() => void requestBnlDraft()}
               sourceFileTargetStatus={
                 isExistingDossierUpdate
                   ? "existing dossier update"

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1570,8 +1570,6 @@ function BnlAnalystReadPanel({
   claimReviews,
   onReviewClaim,
   candidate,
-  onCreateDraft,
-  onRequestBnlDraft,
 }: {
   analystRead?: DossierSubjectAnalystReadV1;
   refreshedAt?: string;
@@ -1581,8 +1579,6 @@ function BnlAnalystReadPanel({
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
   candidate?: Partial<DossierCandidate>;
-  onCreateDraft?: () => void;
-  onRequestBnlDraft?: () => void;
 }) {
   if (!analystRead) {
     return (
@@ -1740,6 +1736,17 @@ function normalizeSubjectDossierStateV1(latestSourceFileArchive?: DossierSourceF
   return undefined;
 }
 
+function normalizeReviewActionabilityV1(latestSourceFileArchive?: DossierSourceFileArchiveMetadata): UnknownRecord | undefined {
+  for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
+    const analyst = asRecord(candidate.subjectAnalystReadV1);
+    const report = asRecord(candidate.sourceFileCaseReportV1);
+    const nestedAnalyst = asRecord(report?.subjectAnalystReadV1);
+    const read = [candidate.reviewActionabilityV1, analyst?.reviewActionabilityV1, report?.reviewActionabilityV1, nestedAnalyst?.reviewActionabilityV1].map(asRecord).find(Boolean);
+    if (read) return read;
+  }
+  return undefined;
+}
+
 function humanizeDossierState(value?: string) {
   const raw = value?.trim();
   if (!raw) return "BNL guided Source File";
@@ -1762,35 +1769,177 @@ function sourceFileSurfaceQuestions(surface?: DossierSourceFileSurfaceV1): Readi
   return readinessQuestionsFrom(questions).filter((question) => memoryFirstQuestionIsDecisionUnlocking(question));
 }
 
-function BnlSurfaceControl({ control, blocked, onCreateDraft, onRequestBnlDraft }: { control?: UnknownRecord; blocked: boolean; onCreateDraft?: () => void; onRequestBnlDraft?: () => void }) {
-  const actionKey = textValue(control?.actionKey) ?? textValue(control?.controlType);
-  const label = textValue(control?.label) ?? humanizeDossierState(actionKey);
-  const inputHint = textValue(control?.inputHint);
-  const copyText = textValue(control?.copyText) ?? inputHint;
-  const choices = listValues(control?.choices).flatMap((choice) => {
-    const record = asRecord(choice);
-    return [textValue(record?.label) ?? textValue(record?.value) ?? textValue(choice)].filter(Boolean) as string[];
-  });
-  if (actionKey === "create_draft" && !blocked && onCreateDraft) return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onCreateDraft}>{label === "create draft" ? "Create Proposed Dossier Draft" : label}</button>;
-  if ((actionKey === "create_draft" || actionKey === "request_bnl_draft") && !blocked && onRequestBnlDraft) return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onRequestBnlDraft}>{label}</button>;
-  if (actionKey === "open_update_plan") return <a href="#dossier-update-workspace" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
-  if (textValue(control?.href)) return <a href={textValue(control?.href)} className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
-  return <div className="space-y-2"><button type="button" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent" onClick={() => copyText && copyTextToClipboard(copyText)}>{/ask_owner|ask_admin|copy|confirm_wording/i.test(actionKey ?? "") ? `Copy / focus: ${label}` : label}</button>{inputHint && <p className="text-[11px] text-muted">Input focus: {safeHumanText(inputHint)}</p>}{choices.length > 0 && <div className="flex flex-wrap gap-2 text-[11px] text-muted">{choices.map((choice) => <span key={choice} className="border border-border/50 px-2 py-1">{choice}</span>)}</div>}</div>;
+function firstQuestionForAction(questions: ReadinessQuestion[], actionKey?: string) {
+  const target = (actionKey ?? "").toLowerCase();
+  if (/owner/.test(target)) return questions.find((question) => /owner|wording|subject/.test(`${question.audience} ${question.question}`.toLowerCase()));
+  if (/admin/.test(target)) return questions.find((question) => /admin|confirm/.test(`${question.audience} ${question.question}`.toLowerCase()));
+  return questions[0];
 }
 
-function BnlSourceFileSurfacePanel({ surface, state, blocked, onCreateDraft, onRequestBnlDraft }: { surface: DossierSourceFileSurfaceV1; state?: DossierSubjectDossierStateV1; blocked: boolean; onCreateDraft?: () => void; onRequestBnlDraft?: () => void }) {
-  const stateLabel = humanizeDossierState(textValue(state?.state) ?? textValue(state?.status) ?? textValue(state?.label));
+function bnlStateGuidance(stateKey?: string) {
+  const state = stateKey?.trim();
+  const guidance: Record<string, string> = {
+    ready_for_cautious_draft: "BNL is draft-focused: use public-safe material and omit unconfirmed role, link, lore, queue, and internal details.",
+    needs_owner_wording: "BNL needs owner-approved wording before this can become better public dossier copy.",
+    needs_admin_confirmation: "BNL needs an admin confirmation before it can safely advance this dossier surface.",
+    update_existing_public_dossier: "BNL found an existing public dossier target; prepare an update plan instead of starting a parallel new dossier.",
+    candidate_new: "BNL is still building enough context to decide whether this should become a public dossier.",
+    source_file_building: "BNL is gathering context; keep pressure low until the Source File has enough public-safe material.",
+    watch_only: "BNL recommends watching and refreshing rather than forcing public review cards.",
+    internal_only: "BNL recommends an internal hold; do not create public review pressure from this surface.",
+    blocked: "BNL says a blocker must be resolved before drafting or public-copy approval.",
+  };
+  return state ? guidance[state] : undefined;
+}
+
+function BnlSurfaceControl({
+  control,
+  blocked,
+  packetQuestions,
+  onCreateDraft,
+  onRequestBnlDraft,
+}: {
+  control?: UnknownRecord;
+  blocked: boolean;
+  packetQuestions: ReadinessQuestion[];
+  onCreateDraft?: () => void;
+  onRequestBnlDraft?: () => void;
+}) {
+  const actionKey = (textValue(control?.actionKey) ?? textValue(control?.controlType) ?? "").toLowerCase();
+  const label = textValue(control?.label) ?? humanizeDossierState(actionKey);
+  const inputHint = safeHumanText(control?.inputHint);
+  const explicitCopy = safeHumanText(control?.copyText);
+  const routedQuestion = firstQuestionForAction(packetQuestions, actionKey);
+  const copyText = explicitCopy ?? routedQuestion?.question;
+  const choices = listValues(control?.choices).flatMap((choice) => {
+    const record = asRecord(choice);
+    return [safeHumanText(record?.label) ?? safeHumanText(record?.value) ?? safeHumanText(choice)].filter(Boolean) as string[];
+  });
+
+  if ((actionKey === "create_draft" || actionKey === "create_proposed_dossier") && !blocked && onCreateDraft) {
+    return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onCreateDraft}>{label === "create draft" ? "Create Proposed Dossier Draft" : label}</button>;
+  }
+  if ((actionKey === "request_bnl_draft" || actionKey === "create_bnl_draft") && !blocked && onRequestBnlDraft) {
+    return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onRequestBnlDraft}>{label}</button>;
+  }
+  if ((actionKey === "create_draft" || actionKey === "create_proposed_dossier" || actionKey === "request_bnl_draft" || actionKey === "create_bnl_draft") && blocked) {
+    return <p className="border border-accent/60 bg-accent/10 p-2 text-xs text-foreground">Draft action blocked by BNL until the blocker is resolved.</p>;
+  }
+  if (actionKey === "open_update_plan") {
+    return <a href="#dossier-update-workspace" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
+  }
+  if (textValue(control?.href)) {
+    return <a href={textValue(control?.href)} className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
+  }
+  if (/ask_owner|owner_wording/.test(actionKey) && copyText) {
+    return <button type="button" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent" onClick={() => copyTextToClipboard(copyText)}>Copy owner question</button>;
+  }
+  if (/ask_admin|admin_confirmation/.test(actionKey) && copyText) {
+    return <button type="button" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent" onClick={() => copyTextToClipboard(copyText)}>Copy admin question</button>;
+  }
+  if (/copy/.test(actionKey) && copyText) {
+    return <button type="button" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent" onClick={() => copyTextToClipboard(copyText)}>Copy question</button>;
+  }
+
+  const recommendedDefault = /keep_internal|internal_only/.test(actionKey)
+    ? "Recommended default: keep internal."
+    : /omit|omit_from_public/.test(actionKey)
+      ? "Recommended default: omit from public draft."
+      : /ask_owner|owner_wording/.test(actionKey)
+        ? "Next step: ask owner for approved public wording."
+        : /ask_admin|admin_confirmation/.test(actionKey)
+          ? "Next step: ask admin for confirmation."
+          : /reject_claim/.test(actionKey)
+            ? "Recommended default: reject or dismiss this claim in legacy diagnostics only if it is tied to a real review item."
+            : /approve_public_copy/.test(actionKey)
+              ? "Public copy approval requires a tied review claim and Owner Review; no direct action is available from this card."
+              : label;
+  return (
+    <div className="space-y-2 border border-border/50 bg-background/20 p-2 text-xs text-muted">
+      <p className="font-semibold text-foreground">{recommendedDefault}</p>
+      {inputHint && <p>Suggested wording focus: {inputHint}</p>}
+      {choices.length > 0 && <p>BNL choices: {choices.join(" / ")}</p>}
+    </div>
+  );
+}
+
+function BnlSourceFileSurfacePanel({
+  surface,
+  state,
+  blocked,
+  packetQuestions,
+  onCreateDraft,
+  onRequestBnlDraft,
+}: {
+  surface: DossierSourceFileSurfaceV1;
+  state?: DossierSubjectDossierStateV1;
+  blocked: boolean;
+  packetQuestions: ReadinessQuestion[];
+  onCreateDraft?: () => void;
+  onRequestBnlDraft?: () => void;
+}) {
+  const stateKey = textValue(state?.state) ?? textValue(state?.status);
+  const stateLabel = humanizeDossierState(stateKey ?? textValue(state?.label));
   const summary = safeHumanText(surface.statusSummary ?? surface.summary ?? surface.bnlTake ?? state?.summary) ?? "BNL has authored the operating surface for this Source File.";
   const action = typeof surface.primaryAction === "string" ? { label: surface.primaryAction, actionKey: surface.primaryAction } : asRecord(surface.primaryAction);
   const secondary = typeof surface.secondaryAction === "string" ? { label: surface.secondaryAction, actionKey: surface.secondaryAction } : asRecord(surface.secondaryAction);
   const cards = (surface.activeCards ?? []).filter((card) => asRecord(card));
-  return <div className="space-y-4"><Section title="BNL Source File Surface / BNL Take" tone={blocked ? "caution" : "review"} helper="BNL-authored operating surface. Raw read models are preserved below as diagnostics."><div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest"><StatusBadge>{stateLabel}</StatusBadge>{blocked && <StatusBadge>Draft blocked</StatusBadge>}</div><p className="mt-3 text-base text-foreground">{summary}</p><div className="mt-4 flex flex-wrap gap-3"><BnlSurfaceControl control={action} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />{secondary && <BnlSurfaceControl control={secondary} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />}</div></Section><Section title="BNL Active Cards" helper="Compact cards selected by BNL for the current dossier state.">{cards.length ? <ul className="grid gap-3 lg:grid-cols-2">{cards.map((card, index) => { const record = asRecord(card) ?? {}; const control = asRecord(record.control) ?? { actionKey: record.actionKey, controlType: record.controlType, label: record.controlLabel, inputHint: record.inputHint, choices: record.choices }; const title = safeHumanText(record.title ?? record.decision) ?? `BNL card ${index + 1}`; const subtitle = safeHumanText(record.subtitle ?? record.reason ?? record.bnlReason); return <li key={textValue(record.id) ?? `${index}-${title}`} className="border border-border bg-background/30 p-3"><h4 className="font-bold text-foreground">{title}</h4>{subtitle && <p className="mt-2 text-sm text-muted">{subtitle}</p>}<div className="mt-3"><BnlSurfaceControl control={control} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} /></div></li>; })}</ul> : <p className="text-muted">BNL did not select active cards for this state.</p>}</Section></div>;
+  const stateGuidance = bnlStateGuidance(stateKey);
+  return (
+    <div className="space-y-4">
+      <Section title="BNL Source File Surface / BNL Take" tone={blocked ? "caution" : "review"} helper="BNL-authored operating surface. Raw read models are preserved below as diagnostics.">
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest"><StatusBadge>{stateLabel}</StatusBadge>{blocked && <StatusBadge>Draft blocked</StatusBadge>}</div>
+        <p className="mt-3 text-base text-foreground">{summary}</p>
+        {stateGuidance && <p className="mt-2 text-sm text-muted">{stateGuidance}</p>}
+        <div className="mt-4 flex flex-wrap gap-3">
+          <BnlSurfaceControl control={action} blocked={blocked} packetQuestions={packetQuestions} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />
+          {secondary && <BnlSurfaceControl control={secondary} blocked={blocked} packetQuestions={packetQuestions} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />}
+        </div>
+      </Section>
+      <Section title="BNL Active Cards" helper="Compact cards selected by BNL for the current dossier state.">
+        {cards.length ? (
+          <ul className="grid gap-3 lg:grid-cols-2">
+            {cards.map((card, index) => {
+              const record = asRecord(card) ?? {};
+              const control = asRecord(record.control) ?? { actionKey: record.actionKey, controlType: record.controlType, label: record.controlLabel, inputHint: record.inputHint, choices: record.choices, copyText: record.copyText };
+              const title = safeHumanText(record.title ?? record.decision) ?? `BNL card ${index + 1}`;
+              const subtitle = safeHumanText(record.subtitle ?? record.reason ?? record.bnlReason);
+              return (
+                <li key={textValue(record.id) ?? `${index}-${title}`} className="border border-border bg-background/30 p-3">
+                  <h4 className="font-bold text-foreground">{title}</h4>
+                  {subtitle && <p className="mt-2 text-sm text-muted">{subtitle}</p>}
+                  <div className="mt-3"><BnlSurfaceControl control={control} blocked={blocked} packetQuestions={packetQuestions} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} /></div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : <p className="text-muted">BNL did not select active cards for this state.</p>}
+      </Section>
+    </div>
+  );
 }
 
 function BnlSurfaceVerificationPacket({ questions }: { questions: ReadinessQuestion[] }) {
   const sections = dedupeVerificationQuestions(questions.map((question) => ({ text: question.question, audience: verificationAudienceKey(question.audience) })));
   const hasQuestions = Object.values(sections).some((items) => items.length > 0);
-  return <section className="border border-border/60 bg-background/20 p-3 text-sm"><h4 className="text-xs font-bold uppercase tracking-widest text-foreground">BNL Verification Packet</h4><p className="mt-2 text-xs text-muted">BNL-selected questions that unlock a better dossier.</p>{hasQuestions ? <div className="mt-3 space-y-3">{(Object.keys(VERIFICATION_PACKET_AUDIENCE_LABELS) as VerificationPacketAudience[]).map((audience) => sections[audience].length ? <div key={audience} className="border border-border/40 bg-background/30 p-2"><p className="text-xs font-bold text-accent">{VERIFICATION_PACKET_AUDIENCE_LABELS[audience]}</p><ol className="mt-1 list-decimal space-y-1 pl-5 text-foreground">{sections[audience].map((question) => <li key={question.text}>{question.text}</li>)}</ol></div> : null)}</div> : <p className="mt-3 border border-border/40 bg-background/30 p-2 text-xs text-muted">BNL did not select packet questions for this surface.</p>}</section>;
+  const copyText = verificationPacketCopyText(sections);
+  return (
+    <section className="border border-border/60 bg-background/20 p-3 text-sm">
+      <h4 className="text-xs font-bold uppercase tracking-widest text-foreground">BNL Verification Packet</h4>
+      <p className="mt-2 text-xs text-muted">BNL-selected questions that unlock a better dossier.</p>
+      {hasQuestions ? (
+        <div className="mt-3 space-y-3">
+          {(Object.keys(VERIFICATION_PACKET_AUDIENCE_LABELS) as VerificationPacketAudience[]).map((audience) => sections[audience].length ? (
+            <div key={audience} className="border border-border/40 bg-background/30 p-2">
+              <p className="text-xs font-bold text-accent">{VERIFICATION_PACKET_AUDIENCE_LABELS[audience]}</p>
+              <ol className="mt-1 list-decimal space-y-1 pl-5 text-foreground">{sections[audience].map((question) => <li key={question.text}>{question.text}</li>)}</ol>
+            </div>
+          ) : null)}
+          <button type="button" className="border border-border px-2 py-1 text-xs text-foreground hover:border-accent" onClick={() => copyTextToClipboard(copyText)}>Copy BNL verification packet</button>
+        </div>
+      ) : <p className="mt-3 border border-border/40 bg-background/30 p-2 text-xs text-muted">BNL did not select packet questions for this surface.</p>}
+    </section>
+  );
 }
 
 export function DossierSourceFileArchiveRawData({ latestSourceFileArchive }: { latestSourceFileArchive?: DossierSourceFileArchiveMetadata }) {
@@ -2053,16 +2202,25 @@ export function DossierSourceFileSummaryPanel({
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
   const analystRead = normalizeSubjectAnalystReadV1(latestSourceFileArchive);
   const dossierCompletionRead = normalizeDossierCompletionReadV1(latestSourceFileArchive);
+  const reviewActionability = normalizeReviewActionabilityV1(latestSourceFileArchive);
   const sourceFileSurface = normalizeSourceFileSurfaceV1(latestSourceFileArchive, candidate);
   const subjectDossierState = normalizeSubjectDossierStateV1(latestSourceFileArchive, candidate);
   const surfaceStateKey = textValue(subjectDossierState?.state) ?? textValue(subjectDossierState?.status);
   const trueBlockerState = surfaceStateKey === "blocked";
   const surfaceQuestions = sourceFileSurface ? sourceFileSurfaceQuestions(sourceFileSurface) : [];
+  const fallbackSurfaceQuestions = readinessQuestionsFrom(reviewActionability?.verificationPacketQuestions).filter((question) => memoryFirstQuestionIsDecisionUnlocking(question));
+  const visibleSurfaceQuestions = surfaceQuestions.length ? surfaceQuestions : fallbackSurfaceQuestions;
   const latestArchiveMissingReport = Boolean(latestSourceFileArchive && !report);
   const hasArchiveDiagnostics =
     latestSourceFileArchive?.caseReportPresent !== undefined ||
     latestSourceFileArchive?.caseReportExtractedFrom !== undefined;
-  const snapshotItems = [
+  const surfacePrimaryAction = asRecord(sourceFileSurface?.primaryAction);
+  const snapshotItems = sourceFileSurface ? [
+    ["Subject", subjectName ?? latestSourceFileArchive?.subjectName ?? "Unknown subject"],
+    ["BNL state", humanizeDossierState(surfaceStateKey ?? textValue(subjectDossierState?.label))],
+    ["Last refresh", latestArchiveMissingReport ? "Report backfill required" : formatSnapshotDate(latestRecommendationTimestamp ?? summary.lastUpdatedAt)],
+    ["Main action", textValue(surfacePrimaryAction?.label) ?? textValue(surfacePrimaryAction?.actionKey) ?? (typeof sourceFileSurface.primaryAction === "string" ? sourceFileSurface.primaryAction : "BNL guidance")],
+  ] : [
     ["Subject", subjectName ?? latestSourceFileArchive?.subjectName ?? "Unknown subject"],
     ["Current state", humanStatus(currentLane ?? summary.nextAction)],
     ["Refresh status", latestArchiveMissingReport ? "Case report missing" : formatSnapshotDate(summary.lastUpdatedAt)],
@@ -2097,7 +2255,7 @@ export function DossierSourceFileSummaryPanel({
         </div>
       </div>
 
-      <Section title="Source File header / refresh status" helper="Status only. This section does not create dossier copy.">
+      <Section title={sourceFileSurface ? "Compact Source File status" : "Source File header / refresh status"} helper={sourceFileSurface ? "Secondary status only. BNL state and action below control the page." : "Status only. This section does not create dossier copy."}>
         <dl className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
           {snapshotItems.map(([label, value]) => (
             <SnapshotItem key={label} label={label} value={value} />
@@ -2110,12 +2268,18 @@ export function DossierSourceFileSummaryPanel({
 
       {sourceFileSurface ? (
         <>
-          <BnlSourceFileSurfacePanel surface={sourceFileSurface} state={subjectDossierState} blocked={trueBlockerState} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />
-          <BnlSurfaceVerificationPacket questions={surfaceQuestions.length ? surfaceQuestions : readinessQuestionsFrom((asRecord((latestSourceFileArchive as unknown as UnknownRecord)?.reviewActionabilityV1)?.verificationPacketQuestions))} />
+          <BnlSourceFileSurfacePanel surface={sourceFileSurface} state={subjectDossierState} blocked={trueBlockerState} packetQuestions={visibleSurfaceQuestions} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />
+          <BnlSurfaceVerificationPacket questions={visibleSurfaceQuestions} />
           <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
             <summary className="cursor-pointer font-semibold text-foreground">Support / Diagnostics</summary>
             <div className="mt-4 space-y-4">
               <DossierCompletionReadout completionRead={dossierCompletionRead} analystRead={analystRead} report={report} interimBrief={interimBrief} />
+              <details className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
+                <summary className="cursor-pointer font-semibold text-foreground">Legacy claim review diagnostics</summary>
+                <div className="mt-4">
+                  <BnlAnalystReadPanel analystRead={analystRead} refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt} candidateId={candidateId} sourceArchiveId={latestSourceFileArchive?.id} subjectName={subjectName ?? latestSourceFileArchive?.subjectName} claimReviews={claimReviews} onReviewClaim={onReviewClaim} candidate={candidate} />
+                </div>
+              </details>
             </div>
           </details>
         </>
@@ -2128,16 +2292,18 @@ export function DossierSourceFileSummaryPanel({
         />
       )}
 
-      <BnlAnalystReadPanel
-        analystRead={analystRead}
-        refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
-        candidateId={candidateId}
-        sourceArchiveId={latestSourceFileArchive?.id}
-        subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
-        claimReviews={claimReviews}
-        onReviewClaim={onReviewClaim}
-        candidate={candidate}
-      />
+      {!sourceFileSurface && (
+        <BnlAnalystReadPanel
+          analystRead={analystRead}
+          refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
+          candidateId={candidateId}
+          sourceArchiveId={latestSourceFileArchive?.id}
+          subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
+          claimReviews={claimReviews}
+          onReviewClaim={onReviewClaim}
+          candidate={candidate}
+        />
+      )}
 
       {blueprint && <DossierBlueprintView blueprint={blueprint} />}
 

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1712,13 +1712,28 @@ function InterimBriefView({ brief, hasReport }: { brief?: UnknownRecord; hasRepo
 }
 
 
+function surfaceLookupRecords(root: UnknownRecord) {
+  const brief = asRecord(root.sourceFileBriefV2);
+  const report = asRecord(root.sourceFileCaseReportV1);
+  const reportAnalyst = asRecord(report?.subjectAnalystReadV1);
+  const briefReport = asRecord(brief?.sourceFileCaseReportV1);
+  const briefReportAnalyst = asRecord(briefReport?.subjectAnalystReadV1);
+  return [
+    root,
+    asRecord(root.subjectAnalystReadV1),
+    report,
+    reportAnalyst,
+    brief,
+    briefReport,
+    briefReportAnalyst,
+  ].filter((record): record is UnknownRecord => Boolean(record));
+}
+
 function normalizeSourceFileSurfaceV1(latestSourceFileArchive?: DossierSourceFileArchiveMetadata, candidate?: Partial<DossierCandidate>): DossierSourceFileSurfaceV1 | undefined {
   const candidateArchive = asRecord(candidate?.latestSourceFileArchive);
   const roots = [latestSourceFileArchive, candidateArchive].filter(Boolean) as UnknownRecord[];
   for (const root of roots.flatMap((archive) => archivePayloadCandidates(archive as DossierSourceFileArchiveMetadata))) {
-    const analyst = asRecord(root.subjectAnalystReadV1);
-    const report = asRecord(root.sourceFileCaseReportV1);
-    const surface = [root.sourceFileSurfaceV1, analyst?.sourceFileSurfaceV1, report?.sourceFileSurfaceV1].map(asRecord).find(Boolean);
+    const surface = surfaceLookupRecords(root).map((record) => record.sourceFileSurfaceV1).map(asRecord).find(Boolean);
     if (surface) return surface as DossierSourceFileSurfaceV1;
   }
   return undefined;
@@ -1728,9 +1743,7 @@ function normalizeSubjectDossierStateV1(latestSourceFileArchive?: DossierSourceF
   const candidateArchive = asRecord(candidate?.latestSourceFileArchive);
   const roots = [latestSourceFileArchive, candidateArchive].filter(Boolean) as UnknownRecord[];
   for (const root of roots.flatMap((archive) => archivePayloadCandidates(archive as DossierSourceFileArchiveMetadata))) {
-    const analyst = asRecord(root.subjectAnalystReadV1);
-    const report = asRecord(root.sourceFileCaseReportV1);
-    const state = [root.subjectDossierStateV1, analyst?.subjectDossierStateV1, report?.subjectDossierStateV1].map(asRecord).find(Boolean);
+    const state = surfaceLookupRecords(root).map((record) => record.subjectDossierStateV1).map(asRecord).find(Boolean);
     if (state) return state as DossierSubjectDossierStateV1;
   }
   return undefined;
@@ -1738,10 +1751,7 @@ function normalizeSubjectDossierStateV1(latestSourceFileArchive?: DossierSourceF
 
 function normalizeReviewActionabilityV1(latestSourceFileArchive?: DossierSourceFileArchiveMetadata): UnknownRecord | undefined {
   for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
-    const analyst = asRecord(candidate.subjectAnalystReadV1);
-    const report = asRecord(candidate.sourceFileCaseReportV1);
-    const nestedAnalyst = asRecord(report?.subjectAnalystReadV1);
-    const read = [candidate.reviewActionabilityV1, analyst?.reviewActionabilityV1, report?.reviewActionabilityV1, nestedAnalyst?.reviewActionabilityV1].map(asRecord).find(Boolean);
+    const read = surfaceLookupRecords(candidate).map((record) => record.reviewActionabilityV1).map(asRecord).find(Boolean);
     if (read) return read;
   }
   return undefined;
@@ -1762,6 +1772,11 @@ function humanizeDossierState(value?: string) {
     blocked: "Blocked",
   };
   return labels[raw] ?? raw.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function sourceFileSurfaceHasVerificationPacket(surface?: DossierSourceFileSurfaceV1) {
+  const record = asRecord(surface);
+  return Boolean(record && (Object.prototype.hasOwnProperty.call(record, "verificationQuestions") || Object.prototype.hasOwnProperty.call(record, "verificationPacketQuestions")));
 }
 
 function sourceFileSurfaceQuestions(surface?: DossierSourceFileSurfaceV1): ReadinessQuestion[] {
@@ -2208,8 +2223,9 @@ export function DossierSourceFileSummaryPanel({
   const surfaceStateKey = textValue(subjectDossierState?.state) ?? textValue(subjectDossierState?.status);
   const trueBlockerState = surfaceStateKey === "blocked";
   const surfaceQuestions = sourceFileSurface ? sourceFileSurfaceQuestions(sourceFileSurface) : [];
+  const surfaceOwnsVerificationPacket = sourceFileSurfaceHasVerificationPacket(sourceFileSurface);
   const fallbackSurfaceQuestions = readinessQuestionsFrom(reviewActionability?.verificationPacketQuestions).filter((question) => memoryFirstQuestionIsDecisionUnlocking(question));
-  const visibleSurfaceQuestions = surfaceQuestions.length ? surfaceQuestions : fallbackSurfaceQuestions;
+  const visibleSurfaceQuestions = surfaceOwnsVerificationPacket ? surfaceQuestions : fallbackSurfaceQuestions;
   const latestArchiveMissingReport = Boolean(latestSourceFileArchive && !report);
   const hasArchiveDiagnostics =
     latestSourceFileArchive?.caseReportPresent !== undefined ||

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -15,6 +15,8 @@ import type {
   DossierSourceFileConfirmationTarget,
   DossierSourceFileVerificationPacketAudience,
   DossierCandidate,
+  DossierSourceFileSurfaceV1,
+  DossierSubjectDossierStateV1,
 } from "@/lib/dossier-workflow";
 import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
 import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
@@ -1568,6 +1570,8 @@ function BnlAnalystReadPanel({
   claimReviews,
   onReviewClaim,
   candidate,
+  onCreateDraft,
+  onRequestBnlDraft,
 }: {
   analystRead?: DossierSubjectAnalystReadV1;
   refreshedAt?: string;
@@ -1577,6 +1581,8 @@ function BnlAnalystReadPanel({
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
   candidate?: Partial<DossierCandidate>;
+  onCreateDraft?: () => void;
+  onRequestBnlDraft?: () => void;
 }) {
   if (!analystRead) {
     return (
@@ -1707,6 +1713,84 @@ function InterimBriefView({ brief, hasReport }: { brief?: UnknownRecord; hasRepo
       </dl>
     </Section>
   );
+}
+
+
+function normalizeSourceFileSurfaceV1(latestSourceFileArchive?: DossierSourceFileArchiveMetadata, candidate?: Partial<DossierCandidate>): DossierSourceFileSurfaceV1 | undefined {
+  const candidateArchive = asRecord(candidate?.latestSourceFileArchive);
+  const roots = [latestSourceFileArchive, candidateArchive].filter(Boolean) as UnknownRecord[];
+  for (const root of roots.flatMap((archive) => archivePayloadCandidates(archive as DossierSourceFileArchiveMetadata))) {
+    const analyst = asRecord(root.subjectAnalystReadV1);
+    const report = asRecord(root.sourceFileCaseReportV1);
+    const surface = [root.sourceFileSurfaceV1, analyst?.sourceFileSurfaceV1, report?.sourceFileSurfaceV1].map(asRecord).find(Boolean);
+    if (surface) return surface as DossierSourceFileSurfaceV1;
+  }
+  return undefined;
+}
+
+function normalizeSubjectDossierStateV1(latestSourceFileArchive?: DossierSourceFileArchiveMetadata, candidate?: Partial<DossierCandidate>): DossierSubjectDossierStateV1 | undefined {
+  const candidateArchive = asRecord(candidate?.latestSourceFileArchive);
+  const roots = [latestSourceFileArchive, candidateArchive].filter(Boolean) as UnknownRecord[];
+  for (const root of roots.flatMap((archive) => archivePayloadCandidates(archive as DossierSourceFileArchiveMetadata))) {
+    const analyst = asRecord(root.subjectAnalystReadV1);
+    const report = asRecord(root.sourceFileCaseReportV1);
+    const state = [root.subjectDossierStateV1, analyst?.subjectDossierStateV1, report?.subjectDossierStateV1].map(asRecord).find(Boolean);
+    if (state) return state as DossierSubjectDossierStateV1;
+  }
+  return undefined;
+}
+
+function humanizeDossierState(value?: string) {
+  const raw = value?.trim();
+  if (!raw) return "BNL guided Source File";
+  const labels: Record<string, string> = {
+    ready_for_cautious_draft: "Ready for cautious draft",
+    needs_owner_wording: "Needs owner-approved wording",
+    needs_admin_confirmation: "Needs admin confirmation",
+    update_existing_public_dossier: "Update existing dossier",
+    candidate_new: "New dossier candidate",
+    source_file_building: "Building Source File",
+    watch_only: "Watch only",
+    internal_only: "Internal only",
+    blocked: "Blocked",
+  };
+  return labels[raw] ?? raw.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function sourceFileSurfaceQuestions(surface?: DossierSourceFileSurfaceV1): ReadinessQuestion[] {
+  const questions = (surface?.verificationQuestions ?? surface?.verificationPacketQuestions) as unknown;
+  return readinessQuestionsFrom(questions).filter((question) => memoryFirstQuestionIsDecisionUnlocking(question));
+}
+
+function BnlSurfaceControl({ control, blocked, onCreateDraft, onRequestBnlDraft }: { control?: UnknownRecord; blocked: boolean; onCreateDraft?: () => void; onRequestBnlDraft?: () => void }) {
+  const actionKey = textValue(control?.actionKey) ?? textValue(control?.controlType);
+  const label = textValue(control?.label) ?? humanizeDossierState(actionKey);
+  const inputHint = textValue(control?.inputHint);
+  const copyText = textValue(control?.copyText) ?? inputHint;
+  const choices = listValues(control?.choices).flatMap((choice) => {
+    const record = asRecord(choice);
+    return [textValue(record?.label) ?? textValue(record?.value) ?? textValue(choice)].filter(Boolean) as string[];
+  });
+  if (actionKey === "create_draft" && !blocked && onCreateDraft) return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onCreateDraft}>{label === "create draft" ? "Create Proposed Dossier Draft" : label}</button>;
+  if ((actionKey === "create_draft" || actionKey === "request_bnl_draft") && !blocked && onRequestBnlDraft) return <button type="button" className="border border-accent px-3 py-2 text-xs text-accent hover:bg-accent hover:text-background" onClick={onRequestBnlDraft}>{label}</button>;
+  if (actionKey === "open_update_plan") return <a href="#dossier-update-workspace" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
+  if (textValue(control?.href)) return <a href={textValue(control?.href)} className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent">{label}</a>;
+  return <div className="space-y-2"><button type="button" className="border border-border px-3 py-2 text-xs text-foreground hover:border-accent" onClick={() => copyText && copyTextToClipboard(copyText)}>{/ask_owner|ask_admin|copy|confirm_wording/i.test(actionKey ?? "") ? `Copy / focus: ${label}` : label}</button>{inputHint && <p className="text-[11px] text-muted">Input focus: {safeHumanText(inputHint)}</p>}{choices.length > 0 && <div className="flex flex-wrap gap-2 text-[11px] text-muted">{choices.map((choice) => <span key={choice} className="border border-border/50 px-2 py-1">{choice}</span>)}</div>}</div>;
+}
+
+function BnlSourceFileSurfacePanel({ surface, state, blocked, onCreateDraft, onRequestBnlDraft }: { surface: DossierSourceFileSurfaceV1; state?: DossierSubjectDossierStateV1; blocked: boolean; onCreateDraft?: () => void; onRequestBnlDraft?: () => void }) {
+  const stateLabel = humanizeDossierState(textValue(state?.state) ?? textValue(state?.status) ?? textValue(state?.label));
+  const summary = safeHumanText(surface.statusSummary ?? surface.summary ?? surface.bnlTake ?? state?.summary) ?? "BNL has authored the operating surface for this Source File.";
+  const action = typeof surface.primaryAction === "string" ? { label: surface.primaryAction, actionKey: surface.primaryAction } : asRecord(surface.primaryAction);
+  const secondary = typeof surface.secondaryAction === "string" ? { label: surface.secondaryAction, actionKey: surface.secondaryAction } : asRecord(surface.secondaryAction);
+  const cards = (surface.activeCards ?? []).filter((card) => asRecord(card));
+  return <div className="space-y-4"><Section title="BNL Source File Surface / BNL Take" tone={blocked ? "caution" : "review"} helper="BNL-authored operating surface. Raw read models are preserved below as diagnostics."><div className="flex flex-wrap gap-2 text-xs uppercase tracking-widest"><StatusBadge>{stateLabel}</StatusBadge>{blocked && <StatusBadge>Draft blocked</StatusBadge>}</div><p className="mt-3 text-base text-foreground">{summary}</p><div className="mt-4 flex flex-wrap gap-3"><BnlSurfaceControl control={action} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />{secondary && <BnlSurfaceControl control={secondary} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />}</div></Section><Section title="BNL Active Cards" helper="Compact cards selected by BNL for the current dossier state.">{cards.length ? <ul className="grid gap-3 lg:grid-cols-2">{cards.map((card, index) => { const record = asRecord(card) ?? {}; const control = asRecord(record.control) ?? { actionKey: record.actionKey, controlType: record.controlType, label: record.controlLabel, inputHint: record.inputHint, choices: record.choices }; const title = safeHumanText(record.title ?? record.decision) ?? `BNL card ${index + 1}`; const subtitle = safeHumanText(record.subtitle ?? record.reason ?? record.bnlReason); return <li key={textValue(record.id) ?? `${index}-${title}`} className="border border-border bg-background/30 p-3"><h4 className="font-bold text-foreground">{title}</h4>{subtitle && <p className="mt-2 text-sm text-muted">{subtitle}</p>}<div className="mt-3"><BnlSurfaceControl control={control} blocked={blocked} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} /></div></li>; })}</ul> : <p className="text-muted">BNL did not select active cards for this state.</p>}</Section></div>;
+}
+
+function BnlSurfaceVerificationPacket({ questions }: { questions: ReadinessQuestion[] }) {
+  const sections = dedupeVerificationQuestions(questions.map((question) => ({ text: question.question, audience: verificationAudienceKey(question.audience) })));
+  const hasQuestions = Object.values(sections).some((items) => items.length > 0);
+  return <section className="border border-border/60 bg-background/20 p-3 text-sm"><h4 className="text-xs font-bold uppercase tracking-widest text-foreground">BNL Verification Packet</h4><p className="mt-2 text-xs text-muted">BNL-selected questions that unlock a better dossier.</p>{hasQuestions ? <div className="mt-3 space-y-3">{(Object.keys(VERIFICATION_PACKET_AUDIENCE_LABELS) as VerificationPacketAudience[]).map((audience) => sections[audience].length ? <div key={audience} className="border border-border/40 bg-background/30 p-2"><p className="text-xs font-bold text-accent">{VERIFICATION_PACKET_AUDIENCE_LABELS[audience]}</p><ol className="mt-1 list-decimal space-y-1 pl-5 text-foreground">{sections[audience].map((question) => <li key={question.text}>{question.text}</li>)}</ol></div> : null)}</div> : <p className="mt-3 border border-border/40 bg-background/30 p-2 text-xs text-muted">BNL did not select packet questions for this surface.</p>}</section>;
 }
 
 export function DossierSourceFileArchiveRawData({ latestSourceFileArchive }: { latestSourceFileArchive?: DossierSourceFileArchiveMetadata }) {
@@ -1944,6 +2028,8 @@ export function DossierSourceFileSummaryPanel({
   claimReviews = [],
   onReviewClaim,
   candidate,
+  onCreateDraft,
+  onRequestBnlDraft,
 }: {
   summary: DossierSourceFileSummary;
   entityReadout?: DossierEntityActivityReadout | null;
@@ -1960,11 +2046,18 @@ export function DossierSourceFileSummaryPanel({
   claimReviews?: DossierSourceFileClaimReview[];
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
   candidate?: Partial<DossierCandidate>;
+  onCreateDraft?: () => void;
+  onRequestBnlDraft?: () => void;
 }) {
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
   const analystRead = normalizeSubjectAnalystReadV1(latestSourceFileArchive);
   const dossierCompletionRead = normalizeDossierCompletionReadV1(latestSourceFileArchive);
+  const sourceFileSurface = normalizeSourceFileSurfaceV1(latestSourceFileArchive, candidate);
+  const subjectDossierState = normalizeSubjectDossierStateV1(latestSourceFileArchive, candidate);
+  const surfaceStateKey = textValue(subjectDossierState?.state) ?? textValue(subjectDossierState?.status);
+  const trueBlockerState = surfaceStateKey === "blocked";
+  const surfaceQuestions = sourceFileSurface ? sourceFileSurfaceQuestions(sourceFileSurface) : [];
   const latestArchiveMissingReport = Boolean(latestSourceFileArchive && !report);
   const hasArchiveDiagnostics =
     latestSourceFileArchive?.caseReportPresent !== undefined ||
@@ -2015,12 +2108,25 @@ export function DossierSourceFileSummaryPanel({
         </p>
       </Section>
 
-      <DossierCompletionReadout
-        completionRead={dossierCompletionRead}
-        analystRead={analystRead}
-        report={report}
-        interimBrief={interimBrief}
-      />
+      {sourceFileSurface ? (
+        <>
+          <BnlSourceFileSurfacePanel surface={sourceFileSurface} state={subjectDossierState} blocked={trueBlockerState} onCreateDraft={onCreateDraft} onRequestBnlDraft={onRequestBnlDraft} />
+          <BnlSurfaceVerificationPacket questions={surfaceQuestions.length ? surfaceQuestions : readinessQuestionsFrom((asRecord((latestSourceFileArchive as unknown as UnknownRecord)?.reviewActionabilityV1)?.verificationPacketQuestions))} />
+          <details className="border border-border/70 bg-background/20 p-3 text-sm text-muted">
+            <summary className="cursor-pointer font-semibold text-foreground">Support / Diagnostics</summary>
+            <div className="mt-4 space-y-4">
+              <DossierCompletionReadout completionRead={dossierCompletionRead} analystRead={analystRead} report={report} interimBrief={interimBrief} />
+            </div>
+          </details>
+        </>
+      ) : (
+        <DossierCompletionReadout
+          completionRead={dossierCompletionRead}
+          analystRead={analystRead}
+          report={report}
+          interimBrief={interimBrief}
+        />
+      )}
 
       <BnlAnalystReadPanel
         analystRead={analystRead}

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -276,6 +276,57 @@ export type DossierSourceFileDraftReadinessReadModel = {
   recommendedNextAction: string;
 };
 
+
+export type DossierSourceFileSurfaceControlV1 = {
+  controlType?: string;
+  actionKey?: string;
+  label?: string;
+  choices?: string[] | Array<{ label?: string; value?: string; description?: string }>;
+  defaultChoice?: string;
+  inputHint?: string;
+  href?: string;
+  copyText?: string;
+};
+
+export type DossierSourceFileSurfaceActionV1 = {
+  label?: string;
+  title?: string;
+  actionKey?: string;
+  controlType?: string;
+  href?: string;
+  copyText?: string;
+  inputHint?: string;
+};
+
+export type DossierSourceFileSurfaceCardV1 = {
+  id?: string;
+  title?: string;
+  decision?: string;
+  subtitle?: string;
+  reason?: string;
+  bnlReason?: string;
+  control?: DossierSourceFileSurfaceControlV1;
+};
+
+export type DossierSourceFileSurfaceV1 = {
+  version?: string | number;
+  statusSummary?: string;
+  summary?: string;
+  bnlTake?: string;
+  primaryAction?: DossierSourceFileSurfaceActionV1 | string;
+  secondaryAction?: DossierSourceFileSurfaceActionV1 | string;
+  activeCards?: DossierSourceFileSurfaceCardV1[];
+  verificationQuestions?: unknown;
+  verificationPacketQuestions?: unknown;
+};
+
+export type DossierSubjectDossierStateV1 = {
+  state?: string;
+  status?: string;
+  label?: string;
+  summary?: string;
+};
+
 export type DossierSourceFileCaseReportV1 = {
   version?: string;
   generatedAt?: string;
@@ -299,6 +350,8 @@ export type DossierSourceFileCaseReportV1 = {
   subjectIntelligenceBriefV1?: DossierSubjectIntelligenceBriefV1;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   sourceFileClassificationV1?: DossierSourceFileClassificationV1;
+  sourceFileSurfaceV1?: DossierSourceFileSurfaceV1;
+  subjectDossierStateV1?: DossierSubjectDossierStateV1;
 };
 
 export type DossierSourceFileBriefV2 = {
@@ -321,6 +374,8 @@ export type DossierSourceFileArchiveCompactReadout = {
   sourceFileBriefV2?: DossierSourceFileBriefV2;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   sourceFileClassificationV1?: DossierSourceFileClassificationV1;
+  sourceFileSurfaceV1?: DossierSourceFileSurfaceV1;
+  subjectDossierStateV1?: DossierSubjectDossierStateV1;
   archivePayload?: unknown;
   archive?: unknown;
   payload?: unknown;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12742,3 +12742,68 @@ test("admin Source File and Control Center render BNL draft readiness read model
   assert.match(controlCenter, /createDossierSourceFileDraftReadinessReadModel/);
   assert.doesNotMatch(publicReadModel, /sourceFileResolutionAudit|resolvedQuestionAudit|DossierSourceFileDraftReadinessReadModel|sourceFileClaimReviews/);
 });
+
+test("sourceFileSurfaceV1 drives primary Source File surface, compact cards, controls, and packet", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: { id: "surface_candidate", name: "Surface Subject", candidateType: "artist", source: "manual", tier: "draft_ready", score: 80, status: "active_source_file", createdAt: now, updatedAt: now },
+    recommendations: [],
+  });
+  const archive = {
+    id: "archive_surface",
+    candidateId: "surface_candidate",
+    subjectName: "Surface Subject",
+    sourceDigest: "abcdef1234567890",
+    createdAt: now,
+    updatedAt: now,
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileSurfaceV1: {
+      statusSummary: "BNL can fill a truthful short public dossier with safe omissions.",
+      primaryAction: { actionKey: "create_draft", label: "Draft from public-safe material" },
+      secondaryAction: { actionKey: "ask_owner", label: "Ask owner", inputHint: "owner-approved wording" },
+      activeCards: [
+        { title: "Draft from public-safe material", subtitle: "BNL can fill a truthful short public dossier with safe omissions.", control: { actionKey: "create_draft", label: "Create draft" } },
+        { title: "Owner wording needed", reason: "Only ask for wording that unlocks the dossier.", control: { actionKey: "ask_owner", label: "Copy owner question", inputHint: "owner-approved wording" } },
+        { title: "Internal-only Source File", subtitle: "Keep review pressure low.", control: { actionKey: "keep_internal", label: "Keep internal" } },
+      ],
+      verificationQuestions: [
+        { question: "Which public role wording should BNL use?", audience: "owner_approved_wording", priority: "high" },
+        { question: "Optional internal note?", audience: "admin", priority: "optional", sourceSafety: "internal_only" },
+      ],
+    },
+    subjectDossierStateV1: { state: "ready_for_cautious_draft" },
+    dossierCompletionReadV1: { bnlAssessment: "Legacy completion read should be diagnostic." },
+    reviewActionabilityV1: { verificationPacketQuestions: ["Fallback question should not be primary."] },
+    sourceFileClassificationV1: { internalTags: ["source_blind"] },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    subjectName: "Surface Subject",
+    latestSourceFileArchive: archive,
+    candidateId: "surface_candidate",
+    onCreateDraft: () => {},
+  }));
+  assert.match(text, /BNL Source File Surface \/ BNL Take/);
+  assert.match(text, /Ready for cautious draft/);
+  assert.match(text, /Draft from public-safe material/);
+  assert.match(text, /Owner wording needed/);
+  assert.match(text, /Copy \/ focus: Ask owner/);
+  assert.match(text, /owner-approved wording/);
+  assert.match(text, /Which public role wording should BNL use\?/);
+  assert.doesNotMatch(text, /Fallback question should not be primary/);
+  assert.doesNotMatch(text, /actionability|publicUse|blocksDraft|safeDefault|dossierImpact|sourceFileCaseReportV1|subjectAnalystReadV1|reviewActionabilityV1/);
+});
+
+test("sourceFileSurfaceV1 blocker state is prominent and prevents wired draft action", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const summary = sourceFileSummary.createDossierSourceFileSummary({ candidate: { id: "blocked_surface", name: "Blocked Surface", candidateType: "artist", source: "manual", tier: "draft_ready", score: 80, status: "active_source_file", createdAt: now, updatedAt: now }, recommendations: [] });
+  const archive = { id: "archive_blocked", candidateId: "blocked_surface", subjectName: "Blocked Surface", sourceDigest: "abcdef1234567890", createdAt: now, updatedAt: now, archiveSize: 123, chunkCount: 1, reviewOnly: true, sourceFileSurfaceV1: { statusSummary: "BNL needs a hard blocker resolved first.", primaryAction: { actionKey: "create_draft", label: "Create draft" }, activeCards: [{ title: "Blocked until admin confirms source", subtitle: "Do not draft yet.", control: { actionKey: "ask_admin", label: "Ask admin" } }] }, subjectDossierStateV1: { state: "blocked" } };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive, onCreateDraft: () => {} }));
+  assert.match(text, /Blocked/);
+  assert.match(text, /Draft blocked/);
+  assert.doesNotMatch(text, /Create Proposed Dossier Draft/);
+  assert.match(text, /Copy \/ focus: Ask admin/);
+});
+

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12819,3 +12819,94 @@ test("sourceFileSurfaceV1 blocker state is prominent and prevents wired draft ac
   assert.match(text, /Next step: ask admin for confirmation/);
 });
 
+
+test("sourceFileSurfaceV1 and state nested under sourceFileBriefV2 case report drive primary UI", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: { id: "nested_surface_candidate", name: "Nested Surface", candidateType: "artist", source: "manual", tier: "draft_ready", score: 80, status: "active_source_file", createdAt: now, updatedAt: now },
+    recommendations: [],
+  });
+  const archive = {
+    id: "archive_nested_surface",
+    candidateId: "nested_surface_candidate",
+    subjectName: "Nested Surface",
+    sourceDigest: "abcdef1234567890",
+    createdAt: now,
+    updatedAt: now,
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileBriefV2: {
+      sourceFileCaseReportV1: {
+        sourceFileSurfaceV1: {
+          statusSummary: "Nested BNL surface should be primary.",
+          primaryAction: { actionKey: "ask_owner", label: "Ask owner for wording" },
+          activeCards: [{ title: "Owner wording needed", subtitle: "Nested surface card wins.", control: { actionKey: "ask_owner", label: "Ask owner" } }],
+          verificationQuestions: [{ question: "Which owner-approved wording unlocks Nested Surface?", audience: "owner_approved_wording", priority: "high" }],
+        },
+        subjectDossierStateV1: { state: "needs_owner_wording" },
+        reviewActionabilityV1: { verificationPacketQuestions: ["Legacy nested packet question should not win."] },
+      },
+    },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /BNL Source File Surface \/ BNL Take/);
+  assert.match(text, /Needs owner-approved wording/);
+  assert.match(text, /Nested BNL surface should be primary/);
+  assert.match(text, /Owner wording needed/);
+  assert.match(text, /Which owner-approved wording unlocks Nested Surface\?/);
+  assert.doesNotMatch(text, /Legacy nested packet question should not win|sourceFileBriefV2|sourceFileCaseReportV1|reviewActionabilityV1/);
+});
+
+test("reviewActionabilityV1 nested under sourceFileBriefV2 case report backs missing surface packet but not an empty one", () => {
+  const now = "2026-06-18T00:00:00.000Z";
+  const summary = sourceFileSummary.createDossierSourceFileSummary({
+    candidate: { id: "nested_packet_candidate", name: "Nested Packet", candidateType: "artist", source: "manual", tier: "review_candidate", score: 60, status: "active_source_file", createdAt: now, updatedAt: now },
+    recommendations: [],
+  });
+  const baseArchive = {
+    id: "archive_nested_packet",
+    candidateId: "nested_packet_candidate",
+    subjectName: "Nested Packet",
+    sourceDigest: "abcdef1234567890",
+    createdAt: now,
+    updatedAt: now,
+    archiveSize: 123,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileBriefV2: {
+      sourceFileCaseReportV1: {
+        subjectDossierStateV1: { state: "needs_admin_confirmation" },
+        reviewActionabilityV1: { verificationPacketQuestions: [{ question: "Which admin confirms Nested Packet?", audience: "admin", priority: "high" }] },
+      },
+    },
+  };
+  const fallbackText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: {
+      ...baseArchive,
+      sourceFileBriefV2: {
+        sourceFileCaseReportV1: {
+          ...baseArchive.sourceFileBriefV2.sourceFileCaseReportV1,
+          sourceFileSurfaceV1: { statusSummary: "Surface without a packet uses legacy packet fallback.", primaryAction: { actionKey: "ask_admin", label: "Ask admin" }, activeCards: [] },
+        },
+      },
+    },
+  }));
+  assert.match(fallbackText, /Which admin confirms Nested Packet\?/);
+
+  const emptyPacketText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: {
+      ...baseArchive,
+      sourceFileBriefV2: {
+        sourceFileCaseReportV1: {
+          ...baseArchive.sourceFileBriefV2.sourceFileCaseReportV1,
+          sourceFileSurfaceV1: { statusSummary: "Surface intentionally has no packet questions.", primaryAction: { actionKey: "ask_admin", label: "Ask admin" }, activeCards: [], verificationQuestions: [] },
+        },
+      },
+    },
+  }));
+  assert.match(emptyPacketText, /BNL did not select packet questions/);
+  assert.doesNotMatch(emptyPacketText, /Which admin confirms Nested Packet\?/);
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12774,25 +12774,36 @@ test("sourceFileSurfaceV1 drives primary Source File surface, compact cards, con
       ],
     },
     subjectDossierStateV1: { state: "ready_for_cautious_draft" },
+    subjectAnalystReadV1: {
+      subjectName: "Surface Subject",
+      reviewableClaims: [{ title: "Old Source File Claim Decisions wall", claimText: "Legacy giant review claim should not dominate." }],
+    },
     dossierCompletionReadV1: { bnlAssessment: "Legacy completion read should be diagnostic." },
     reviewActionabilityV1: { verificationPacketQuestions: ["Fallback question should not be primary."] },
     sourceFileClassificationV1: { internalTags: ["source_blind"] },
   };
-  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+  const element = sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
     summary,
     subjectName: "Surface Subject",
     latestSourceFileArchive: archive,
     candidateId: "surface_candidate",
     onCreateDraft: () => {},
-  }));
+  });
+  const text = collectDefaultVisibleText(element);
+  const fullText = collectReactText(element);
   assert.match(text, /BNL Source File Surface \/ BNL Take/);
   assert.match(text, /Ready for cautious draft/);
   assert.match(text, /Draft from public-safe material/);
   assert.match(text, /Owner wording needed/);
-  assert.match(text, /Copy \/ focus: Ask owner/);
-  assert.match(text, /owner-approved wording/);
+  assert.match(text, /Copy owner question/);
+  assert.doesNotMatch(text, /Copy \/ focus/);
   assert.match(text, /Which public role wording should BNL use\?/);
   assert.doesNotMatch(text, /Fallback question should not be primary/);
+  assert.doesNotMatch(text, /Source File Claim Decisions|Legacy giant review claim should not dominate/);
+  assert.match(text, /Compact Source File status/);
+  assert.doesNotMatch(text, /Evidence depth|Public readiness|Identity certainty|BNL recommendation cards/);
+  assert.match(fullText, /Legacy claim review diagnostics/);
+  assert.match(fullText, /Source File Claim Decisions/);
   assert.doesNotMatch(text, /actionability|publicUse|blocksDraft|safeDefault|dossierImpact|sourceFileCaseReportV1|subjectAnalystReadV1|reviewActionabilityV1/);
 });
 
@@ -12804,6 +12815,7 @@ test("sourceFileSurfaceV1 blocker state is prominent and prevents wired draft ac
   assert.match(text, /Blocked/);
   assert.match(text, /Draft blocked/);
   assert.doesNotMatch(text, /Create Proposed Dossier Draft/);
-  assert.match(text, /Copy \/ focus: Ask admin/);
+  assert.doesNotMatch(text, /Copy \/ focus/);
+  assert.match(text, /Next step: ask admin for confirmation/);
 });
 


### PR DESCRIPTION
### Motivation
- Make the Source File page render the BNL-authored operating surface (`sourceFileSurfaceV1` / `subjectDossierStateV1`) as the primary UI so BNL controls state, main action, visible cards, and verification questions instead of exposing raw read-model fields. 
- Preserve existing diagnostics and fallback behavior so legacy read models remain available but collapsed, and ensure no new routes/workflows or public-publishing/identity changes are introduced.

### Description
- Add typed support for `sourceFileSurfaceV1` and `subjectDossierStateV1` on archive/case-report payloads and defensive lookup helpers to locate them in archive, analyst-read, case-report, or candidate archive locations.  
- Render a compact BNL Source File Surface panel (humanized state badge, short BNL status summary, one primary action, optional secondary action) and a compact list of BNL active cards with lightweight dynamic controls driven by card control metadata; advisory controls copy/focus instead of faking unimplemented actions.  
- Use BNL surface verification questions first (falling back to `reviewActionabilityV1`), move `dossierCompletionReadV1` / related read-model output into collapsed Support / Diagnostics when the surface is present, and preserve full fallback to the original behavior when the surface is absent.  
- Wire BNL surface draft controls to existing candidate handlers (`createDraftFromCandidate` / `requestBnlDraftFromCandidate`) and block the wired draft action when the surface `state` is a true `blocked` state; do not add routes, change publishing, or expose private evidence.

Files changed
- `src/lib/dossier-workflow.ts` — added types for `DossierSourceFileSurfaceV1` and `DossierSubjectDossierStateV1` and surfaced them on archive/case-report types.  
- `src/components/DossierSourceFileSummaryPanel.tsx` — added normalization helpers, BNL surface and verification packet components, dynamic control rendering, surface-first rendering logic and collapsed diagnostics fallback.  
- `src/app/admin/dossiers/candidates/[candidateId]/page.tsx` — passed existing draft/BND request handlers into the summary panel so surfaced `create_draft` / BNL draft actions wire to current flows.  
- `tests/admin-dossiers.test.mjs` — added tests asserting: surface becomes primary UI, state is humanized, primaryAction and activeCards render compactly, controls behave as advisory or wired where appropriate, verification questions prioritize BNL surface, diagnostics collapse, and blocker state prevents wired draft.

What changed and why
- Primary visible Source File UI now reflects BNL intent when `sourceFileSurfaceV1` exists so admins see a BNL-authored operating surface rather than raw schema/readouts.  
- Diagnostics and legacy read models are preserved but collapsed to avoid leaking raw/internal fields into the primary experience.  
- Existing draft and BNL-draft request flows are reused to avoid creating new workflows.

Anything intentionally left untouched
- No public publishing, owner review, identity merge, alias exposure, new routes, or removal of stored review records were changed.  
- Raw archive JSON, classification buckets, and withheld evidence remain available only in collapsed admin diagnostics.

Follow-up risks / manual checks
- Manual QA on staging should verify that UX wiring (Create Proposed Dossier Draft and Request BNL Draft buttons) behave correctly in the interactive app and that blocked surfaces prevent draft runs as intended.  
- Confirm downstream consumer code that reads archive shapes tolerates the new optional `sourceFileSurfaceV1` / `subjectDossierStateV1` fields.

### Testing
- Ran TypeScript check: `npx tsc --noEmit`, which passed.  
- Ran unit/integration test suite: `node --test tests/admin-dossiers.test.mjs`, which passed (all tests green; new surface-focused tests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3468491c9c83218c7968360769e374)