### PR TITLE
Render sourceFilePagePlanV1 as primary Source File page

### DIFF
--- a/src/app/api/bnl/source-file-enrichments/route.ts
+++ b/src/app/api/bnl/source-file-enrichments/route.ts
@@ -88,6 +88,7 @@ function normalizePayload(value: unknown): CreateDossierSourceFileArchiveInput {
     ),
     sourceFileCaseReportV1: payload.sourceFileCaseReportV1 as CreateDossierSourceFileArchiveInput["sourceFileCaseReportV1"],
     sourceFileBriefV2: payload.sourceFileBriefV2 as CreateDossierSourceFileArchiveInput["sourceFileBriefV2"],
+    sourceFilePagePlanV1: payload.sourceFilePagePlanV1 as CreateDossierSourceFileArchiveInput["sourceFilePagePlanV1"],
     archivePayload: payload.archivePayload,
     archive: payload.archive,
     payload: payload.payload,

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1922,6 +1922,7 @@ export function normalizeSourceFilePagePlanV1(
     const report = asRecord(candidate.sourceFileCaseReportV1);
     const reportAnalyst = asRecord(report?.subjectAnalystReadV1);
     const brief = asRecord(candidate.sourceFileBriefV2);
+    const briefAnalyst = asRecord(brief?.subjectAnalystReadV1);
     const briefReport = asRecord(brief?.sourceFileCaseReportV1);
     const briefReportAnalyst = asRecord(briefReport?.subjectAnalystReadV1);
     const match = [
@@ -1930,6 +1931,7 @@ export function normalizeSourceFilePagePlanV1(
       report?.sourceFilePagePlanV1,
       reportAnalyst?.sourceFilePagePlanV1,
       brief?.sourceFilePagePlanV1,
+      briefAnalyst?.sourceFilePagePlanV1,
       briefReport?.sourceFilePagePlanV1,
       briefReportAnalyst?.sourceFilePagePlanV1,
     ].find(hasPagePlanShape);

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -15,6 +15,8 @@ import type {
   DossierSourceFileConfirmationTarget,
   DossierSourceFileVerificationPacketAudience,
   DossierCandidate,
+  DossierSourceFilePagePlanV1,
+  DossierSourceFilePagePlanSuggestedControl,
 } from "@/lib/dossier-workflow";
 import type { DossierDraftBlueprint } from "@/lib/dossier-classification";
 import { buildDossierStylePacket, DOSSIER_DRAFT_CONTRACT_REQUIRED_FIELDS } from "@/lib/dossier-style-packet";
@@ -1894,6 +1896,113 @@ function DossierBlueprintView({ blueprint }: { blueprint: DossierDraftBlueprint 
   );
 }
 
+
+function hasPagePlanShape(value: unknown): value is DossierSourceFilePagePlanV1 {
+  const plan = asRecord(value);
+  if (!plan) return false;
+  return [
+    "header",
+    "analystRead",
+    "whatBnlNeeds",
+    "publicSafeMaterial",
+    "bnlReviewGuidance",
+    "questionsToAsk",
+    "worthDecision",
+    "internalOmitHold",
+    "draftOrUpdatePlan",
+    "diagnosticsSummary",
+  ].some((key) => plan[key] !== undefined);
+}
+
+export function normalizeSourceFilePagePlanV1(
+  latestSourceFileArchive?: DossierSourceFileArchiveMetadata,
+): DossierSourceFilePagePlanV1 | undefined {
+  for (const candidate of archivePayloadCandidates(latestSourceFileArchive)) {
+    const rootAnalyst = asRecord(candidate.subjectAnalystReadV1);
+    const report = asRecord(candidate.sourceFileCaseReportV1);
+    const reportAnalyst = asRecord(report?.subjectAnalystReadV1);
+    const brief = asRecord(candidate.sourceFileBriefV2);
+    const briefReport = asRecord(brief?.sourceFileCaseReportV1);
+    const briefReportAnalyst = asRecord(briefReport?.subjectAnalystReadV1);
+    const match = [
+      candidate.sourceFilePagePlanV1,
+      rootAnalyst?.sourceFilePagePlanV1,
+      report?.sourceFilePagePlanV1,
+      reportAnalyst?.sourceFilePagePlanV1,
+      brief?.sourceFilePagePlanV1,
+      briefReport?.sourceFilePagePlanV1,
+      briefReportAnalyst?.sourceFilePagePlanV1,
+    ].find(hasPagePlanShape);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function renderPlanField(label: string, value: unknown) {
+  return <div><dt className="text-xs uppercase tracking-widest text-accent">{label}</dt><dd className="mt-1 text-foreground"><BriefParagraphs value={value} /></dd></div>;
+}
+
+function SuggestedControlView({ control }: { control?: DossierSourceFilePagePlanSuggestedControl }) {
+  if (!control?.kind || control.kind === "none") return null;
+  if ((control.kind === "ask_owner" || control.kind === "ask_admin") && control.questionToCopy) {
+    return <button type="button" className="mt-2 border border-accent px-3 py-1 text-xs font-bold uppercase tracking-widest text-accent" onClick={() => void navigator.clipboard?.writeText(control.questionToCopy ?? "")}>{control.label ?? `Copy ${control.kind === "ask_owner" ? "owner" : "admin"} question`}</button>;
+  }
+  const text = control.guidance ?? control.recommendation ?? control.label ?? humanStatus(control.kind);
+  return <p className="mt-2 text-xs text-muted">{control.kind === "refresh" ? `Refresh guidance: ${text}` : text}</p>;
+}
+
+function PlanItems({ items, empty, render }: { items?: unknown[]; empty: string; render: (item: UnknownRecord, index: number) => React.ReactNode }) {
+  const records = (items ?? []).flatMap((item) => asRecord(item) ? [asRecord(item) as UnknownRecord] : []);
+  if (!records.length) return <p className="text-muted">{empty}</p>;
+  return <ul className="space-y-3">{records.map((item, index) => <li key={index} className="border border-border/50 bg-background/30 p-3">{render(item, index)}</li>)}</ul>;
+}
+
+function SourceFilePagePlanView({
+  plan,
+  summary,
+  latestSourceFileArchive,
+  subjectName,
+  currentLane,
+  latestRecommendationTimestamp,
+  sourceFileTargetStatus,
+}: {
+  plan: DossierSourceFilePagePlanV1;
+  summary: DossierSourceFileSummary;
+  latestSourceFileArchive?: DossierSourceFileArchiveMetadata;
+  subjectName?: string;
+  currentLane?: string;
+  latestRecommendationTimestamp?: string;
+  sourceFileTargetStatus?: string;
+}) {
+  const header = plan.header ?? {};
+  const analyst = plan.analystRead ?? {};
+  const internal = plan.internalOmitHold ?? {};
+  const draft = plan.draftOrUpdatePlan ?? {};
+  const diagnostics = plan.diagnosticsSummary ?? {};
+  const canDraft = draft.canDraft === true || String(draft.canDraft).toLowerCase() === "true";
+  return <div className="space-y-4" data-source-file-page-plan="primary">
+    <Section title="Compact Source File Header" helper="BNL-filled status summary only; draft controls live in the draft plan when available.">
+      <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <SnapshotItem label="Subject" value={scalarLabel(header.subject ?? subjectName ?? latestSourceFileArchive?.subjectName)} />
+        <SnapshotItem label="Source File status" value={scalarLabel(header.sourceFileStatus ?? sourceFileTargetStatus ?? summary.nextAction)} />
+        <SnapshotItem label="BNL state" value={scalarLabel(header.bnlState ?? summary.publicReadiness)} />
+        <SnapshotItem label="Current lane" value={scalarLabel(header.currentLane ?? currentLane)} />
+        <SnapshotItem label="Last refresh" value={formatSnapshotDate(String(header.lastRefresh ?? latestRecommendationTimestamp ?? latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt ?? ""))} />
+        <SnapshotItem label="Existing public dossier" value={scalarLabel(header.existingPublicDossier ?? summary.existingPublicDossier)} />
+      </dl>
+    </Section>
+    <Section title="BNL Analyst Read" tone="caution"><dl className="space-y-3">{renderPlanField("Overall read", analyst.overallRead)}{renderPlanField("What BNL thinks this is", analyst.whatBnlThinksThisIs)}{renderPlanField("Why this Source File exists", analyst.whyThisSourceFileExists)}{renderPlanField("What seems useful", analyst.whatSeemsUseful)}{renderPlanField("What seems weak", analyst.whatSeemsWeak)}{renderPlanField("What is uncertain", analyst.whatIsUncertain)}{renderPlanField("What BNL is watching", analyst.whatBnlIsWatching)}{renderPlanField("Confidence", analyst.confidence)}</dl></Section>
+    <Section title="What BNL Needs"><PlanItems items={plan.whatBnlNeeds} empty="BNL did not list any current needs." render={(item) => <><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Needed item", item.neededItem)}{renderPlanField("Why needed", item.whyNeeded)}{renderPlanField("Who can answer", item.whoCanAnswer)}{renderPlanField("Required or optional", item.requiredOrOptional)}{renderPlanField("What it unlocks", item.whatItUnlocks)}{renderPlanField("Current status", item.currentStatus)}</dl><SuggestedControlView control={asRecord(item.suggestedControl) as DossierSourceFilePagePlanSuggestedControl | undefined} /></>} /></Section>
+    <Section title="Public-Safe Material BNL Can Use"><PlanItems items={plan.publicSafeMaterial} empty={plan.noPublicSafeMaterialReadyText ?? "BNL says no material is ready for public use yet."} render={(item) => <dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Material", item.material)}{renderPlanField("How BNL would use it", item.howBnlWouldUseIt)}{renderPlanField("Why safe enough", item.whySafeEnough)}{renderPlanField("Confidence", item.confidence)}{renderPlanField("Needs approval", item.needsApproval)}</dl>} /></Section>
+    <Section title="BNL Review Guidance"><PlanItems items={plan.bnlReviewGuidance} empty="BNL did not add review guidance." render={(item) => <><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Review issue", item.reviewIssue)}{renderPlanField("BNL decision", item.bnlDecision)}{renderPlanField("BNL explanation", item.bnlExplanation)}{renderPlanField("Recommended default", item.recommendedDefault)}{renderPlanField("Still active", item.stillActive)}{renderPlanField("Needed to finish", item.neededToFinish)}</dl><SuggestedControlView control={asRecord(item.suggestedControl) as DossierSourceFilePagePlanSuggestedControl | undefined} /></>} /></Section>
+    <Section title="Questions To Ask"><PlanItems items={plan.questionsToAsk} empty={plan.noDecisionUnlockingQuestionsText ?? "BNL says no decision-unlocking questions exist."} render={(item) => <dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Question", item.question)}{renderPlanField("Audience", item.audience)}{renderPlanField("Why BNL is asking", item.whyBnlIsAsking)}{renderPlanField("What answer would unlock", item.whatAnswerWouldUnlock)}{renderPlanField("Required or optional", item.requiredOrOptional)}</dl>} /></Section>
+    <Section title="Dossier Worth-It Decision" tone="caution"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Worth a dossier", plan.worthDecision?.worthADossier)}{renderPlanField("Decision", plan.worthDecision?.decision)}{renderPlanField("Why", plan.worthDecision?.why)}{renderPlanField("Possible dossier type", plan.worthDecision?.possibleDossierType)}{renderPlanField("Draft readiness", plan.worthDecision?.draftReadiness)}{renderPlanField("What would change the decision", plan.worthDecision?.whatWouldChangeTheDecision)}</dl></Section>
+    <Section title="Internal / Omit / Hold"><div className="grid grid-cols-1 gap-3 lg:grid-cols-2"><div><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Keep internal</h4><PlanItems items={internal.keepInternal} empty="No keep-internal material listed." render={(item) => <dl className="space-y-2">{renderPlanField("Material", item.material)}{renderPlanField("Why internal", item.whyInternal)}{renderPlanField("Could become public later", item.couldBecomePublicLater)}{renderPlanField("What would make it usable", item.whatWouldMakeItUsable)}</dl>} /></div><div><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Omit from public draft</h4><PlanItems items={internal.omitFromPublicDraft} empty="No omit-from-public-draft material listed." render={(item) => <dl className="space-y-2">{renderPlanField("Material", item.material)}{renderPlanField("Why omitted", item.whyOmitted)}{renderPlanField("Could become public later", item.couldBecomePublicLater)}{renderPlanField("What would make it usable", item.whatWouldMakeItUsable)}</dl>} /></div></div></Section>
+    <Section title="Draft / Update Plan"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Can draft", draft.canDraft)}{renderPlanField("Draft type", draft.draftType)}{renderPlanField("Suggested angle", draft.suggestedAngle)}{renderPlanField("Use these materials", draft.useTheseMaterials)}{renderPlanField("Omit these materials", draft.omitTheseMaterials)}{renderPlanField("Owner Review warnings", draft.ownerReviewWarnings)}{!canDraft && renderPlanField("Why not", draft.whyNot)}</dl>{canDraft && <p className="mt-3 text-xs text-muted">Draft controls remain available only where existing handlers provide them; Owner Review is still required.</p>}</Section>
+    <Section title="Diagnostics Summary"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-4">{renderPlanField("Raw archive available", diagnostics.rawArchiveAvailable)}{renderPlanField("Case report available", diagnostics.caseReportAvailable)}{renderPlanField("Interim brief available", diagnostics.interimBriefAvailable)}{renderPlanField("Blueprint available", diagnostics.blueprintAvailable)}{renderPlanField("Legacy claim review count", diagnostics.legacyClaimReviewCount)}{renderPlanField("Absorbed review count", diagnostics.absorbedReviewCount)}{renderPlanField("Hidden diagnostic count", diagnostics.hiddenDiagnosticCount)}{renderPlanField("Safety notes", diagnostics.safetyNotes)}</dl></Section>
+  </div>;
+}
+
 function formatSnapshotDate(value?: string) {
   if (!value) return "—";
   const parsed = new Date(value);
@@ -1961,6 +2070,7 @@ export function DossierSourceFileSummaryPanel({
   onReviewClaim?: (claim: DossierSourceFileReviewableClaim, decision: DossierSourceFileClaimReviewDecision, options?: { publicSafe?: boolean; editedText?: string; decisionNote?: string }) => void;
   candidate?: Partial<DossierCandidate>;
 }) {
+  const sourceFilePagePlan = normalizeSourceFilePagePlanV1(latestSourceFileArchive);
   const report = normalizeCaseReport(latestSourceFileArchive);
   const interimBrief = normalizeInterimBrief(latestSourceFileArchive);
   const analystRead = normalizeSubjectAnalystReadV1(latestSourceFileArchive);
@@ -2015,43 +2125,85 @@ export function DossierSourceFileSummaryPanel({
         </p>
       </Section>
 
-      <DossierCompletionReadout
-        completionRead={dossierCompletionRead}
-        analystRead={analystRead}
-        report={report}
-        interimBrief={interimBrief}
-      />
+      {sourceFilePagePlan ? (
+        <>
+          <SourceFilePagePlanView
+            plan={sourceFilePagePlan}
+            summary={summary}
+            latestSourceFileArchive={latestSourceFileArchive}
+            subjectName={subjectName}
+            currentLane={currentLane}
+            latestRecommendationTimestamp={latestRecommendationTimestamp}
+            sourceFileTargetStatus={sourceFileTargetStatus}
+          />
+          <details className="border border-border/60 bg-background/20 p-3 text-sm text-muted">
+            <summary className="cursor-pointer font-semibold text-foreground">Support / Diagnostics</summary>
+            <div className="mt-3 space-y-4">
+              <DossierCompletionReadout
+                completionRead={dossierCompletionRead}
+                analystRead={analystRead}
+                report={report}
+                interimBrief={interimBrief}
+              />
+              <BnlAnalystReadPanel
+                analystRead={analystRead}
+                refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
+                candidateId={candidateId}
+                sourceArchiveId={latestSourceFileArchive?.id}
+                subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
+                claimReviews={claimReviews}
+                onReviewClaim={onReviewClaim}
+                candidate={candidate}
+              />
+              {blueprint && <DossierBlueprintView blueprint={blueprint} />}
+              {hasArchiveDiagnostics && (
+                <Section title="Archive ingest diagnostics" helper="Admin-only preservation check. These fields are safe booleans and path labels, not raw archive secrets.">
+                  <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <SnapshotItem label="caseReportPresent" value={latestSourceFileArchive?.caseReportPresent ? "true" : "false"} />
+                    <SnapshotItem label="caseReportExtractedFrom" value={latestSourceFileArchive?.caseReportExtractedFrom ?? "—"} />
+                  </dl>
+                </Section>
+              )}
+              <CaseReportView report={report} />
+              <InterimBriefView brief={interimBrief} hasReport={Boolean(report)} />
+            </div>
+          </details>
+        </>
+      ) : (
+        <>
+          <DossierCompletionReadout
+            completionRead={dossierCompletionRead}
+            analystRead={analystRead}
+            report={report}
+            interimBrief={interimBrief}
+          />
 
-      <BnlAnalystReadPanel
-        analystRead={analystRead}
-        refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
-        candidateId={candidateId}
-        sourceArchiveId={latestSourceFileArchive?.id}
-        subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
-        claimReviews={claimReviews}
-        onReviewClaim={onReviewClaim}
-        candidate={candidate}
-      />
+          <BnlAnalystReadPanel
+            analystRead={analystRead}
+            refreshedAt={latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt}
+            candidateId={candidateId}
+            sourceArchiveId={latestSourceFileArchive?.id}
+            subjectName={subjectName ?? latestSourceFileArchive?.subjectName}
+            claimReviews={claimReviews}
+            onReviewClaim={onReviewClaim}
+            candidate={candidate}
+          />
 
-      {blueprint && <DossierBlueprintView blueprint={blueprint} />}
+          {blueprint && <DossierBlueprintView blueprint={blueprint} />}
 
-      {hasArchiveDiagnostics && (
-        <Section title="Archive ingest diagnostics" helper="Admin-only preservation check. These fields are safe booleans and path labels, not raw archive secrets.">
-          <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <SnapshotItem
-              label="caseReportPresent"
-              value={latestSourceFileArchive?.caseReportPresent ? "true" : "false"}
-            />
-            <SnapshotItem
-              label="caseReportExtractedFrom"
-              value={latestSourceFileArchive?.caseReportExtractedFrom ?? "—"}
-            />
-          </dl>
-        </Section>
+          {hasArchiveDiagnostics && (
+            <Section title="Archive ingest diagnostics" helper="Admin-only preservation check. These fields are safe booleans and path labels, not raw archive secrets.">
+              <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <SnapshotItem label="caseReportPresent" value={latestSourceFileArchive?.caseReportPresent ? "true" : "false"} />
+                <SnapshotItem label="caseReportExtractedFrom" value={latestSourceFileArchive?.caseReportExtractedFrom ?? "—"} />
+              </dl>
+            </Section>
+          )}
+
+          <CaseReportView report={report} />
+          <InterimBriefView brief={interimBrief} hasReport={Boolean(report)} />
+        </>
       )}
-
-      <CaseReportView report={report} />
-      <InterimBriefView brief={interimBrief} hasReport={Boolean(report)} />
     </section>
   );
 }

--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -1940,8 +1940,47 @@ export function normalizeSourceFilePagePlanV1(
   return undefined;
 }
 
-function renderPlanField(label: string, value: unknown) {
-  return <div><dt className="text-xs uppercase tracking-widest text-accent">{label}</dt><dd className="mt-1 text-foreground"><BriefParagraphs value={value} /></dd></div>;
+function planFieldHasValue(value: unknown) {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number" || typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.some(planFieldHasValue);
+  const record = asRecord(value);
+  return record ? Object.values(record).some(planFieldHasValue) : false;
+}
+
+function renderPlanField(label: string, value: unknown, fallback = "BNL did not provide this detail yet.") {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-widest text-accent">{label}</dt>
+      <dd className="mt-1 text-foreground">
+        {planFieldHasValue(value) ? <BriefParagraphs value={value} /> : <p>{fallback}</p>}
+      </dd>
+    </div>
+  );
+}
+
+function needPriority(item: UnknownRecord) {
+  const marker = `${scalarLabel(item.requiredOrOptional)} ${scalarLabel(item.currentStatus)}`.toLowerCase();
+  if (/required|blocker|must|needed/.test(marker)) return 0;
+  if (/optional|helpful|nice/.test(marker)) return 1;
+  if (/not[ _-]?needed|not needed|none|resolved|complete/.test(marker)) return 2;
+  return 1;
+}
+
+
+function planHeaderValue(value: unknown, fallback: string) {
+  const displayed = displayValue(value);
+  return displayed ?? fallback;
+}
+
+function unlockFallback(item: UnknownRecord) {
+  const control = asRecord(item.suggestedControl);
+  const marker = `${scalarLabel(item.neededItem)} ${scalarLabel(item.whyNeeded)} ${scalarLabel(control?.kind)}`.toLowerCase();
+  if (/owner|wording|copy|public/.test(marker)) return "Unlocks clearer public-safe dossier wording.";
+  if (/angle|classification|type/.test(marker)) return "Helps confirm dossier angle.";
+  if (/draft|worth|decision|dossier/.test(marker)) return "Helps determine whether the dossier should be drafted.";
+  if (/refresh|evidence|source|material/.test(marker)) return "Improves dossier readiness.";
+  return "BNL did not specify what this unlocks yet.";
 }
 
 function SuggestedControlView({ control }: { control?: DossierSourceFilePagePlanSuggestedControl }) {
@@ -1953,10 +1992,11 @@ function SuggestedControlView({ control }: { control?: DossierSourceFilePagePlan
   return <p className="mt-2 text-xs text-muted">{control.kind === "refresh" ? `Refresh guidance: ${text}` : text}</p>;
 }
 
-function PlanItems({ items, empty, render }: { items?: unknown[]; empty: string; render: (item: UnknownRecord, index: number) => React.ReactNode }) {
+function PlanItems({ items, empty, render, prioritizeNeeds = false }: { items?: unknown[]; empty: string; render: (item: UnknownRecord, index: number) => React.ReactNode; prioritizeNeeds?: boolean }) {
   const records = (items ?? []).flatMap((item) => asRecord(item) ? [asRecord(item) as UnknownRecord] : []);
-  if (!records.length) return <p className="text-muted">{empty}</p>;
-  return <ul className="space-y-3">{records.map((item, index) => <li key={index} className="border border-border/50 bg-background/30 p-3">{render(item, index)}</li>)}</ul>;
+  const displayRecords = prioritizeNeeds ? [...records].sort((a, b) => needPriority(a) - needPriority(b)) : records;
+  if (!displayRecords.length) return <p className="text-muted">{empty}</p>;
+  return <ul className="space-y-3">{displayRecords.map((item, index) => <li key={index} className={`border border-border/50 bg-background/30 p-3 ${prioritizeNeeds && needPriority(item) === 0 ? "border-accent/70" : ""}`}>{render(item, index)}</li>)}</ul>;
 }
 
 function SourceFilePagePlanView({
@@ -1983,22 +2023,22 @@ function SourceFilePagePlanView({
   const diagnostics = plan.diagnosticsSummary ?? {};
   const canDraft = draft.canDraft === true || String(draft.canDraft).toLowerCase() === "true";
   return <div className="space-y-4" data-source-file-page-plan="primary">
-    <Section title="Compact Source File Header" helper="BNL-filled status summary only; draft controls live in the draft plan when available.">
+    <Section title="Unified Source File Header" helper="Single BNL page-plan header. Page-plan values win; legacy values only fill missing status context.">
       <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        <SnapshotItem label="Subject" value={scalarLabel(header.subject ?? subjectName ?? latestSourceFileArchive?.subjectName)} />
-        <SnapshotItem label="Source File status" value={scalarLabel(header.sourceFileStatus ?? sourceFileTargetStatus ?? summary.nextAction)} />
-        <SnapshotItem label="BNL state" value={scalarLabel(header.bnlState ?? summary.publicReadiness)} />
-        <SnapshotItem label="Current lane" value={scalarLabel(header.currentLane ?? currentLane)} />
+        <SnapshotItem label="Subject" value={planHeaderValue(header.subject ?? subjectName ?? latestSourceFileArchive?.subjectName, "BNL did not name the subject yet.")} />
+        <SnapshotItem label="Source File status" value={planHeaderValue(header.sourceFileStatus ?? sourceFileTargetStatus ?? summary.nextAction, "BNL did not provide Source File status yet.")} />
+        <SnapshotItem label="BNL state" value={planHeaderValue(header.bnlState ?? summary.publicReadiness, "BNL did not provide a state yet.")} />
+        <SnapshotItem label="Current lane" value={planHeaderValue(header.currentLane ?? currentLane, "BNL did not provide the current lane yet.")} />
         <SnapshotItem label="Last refresh" value={formatSnapshotDate(String(header.lastRefresh ?? latestRecommendationTimestamp ?? latestSourceFileArchive?.updatedAt ?? summary.lastUpdatedAt ?? ""))} />
-        <SnapshotItem label="Existing public dossier" value={scalarLabel(header.existingPublicDossier ?? summary.existingPublicDossier)} />
+        <SnapshotItem label="Existing public dossier" value={planHeaderValue(header.existingPublicDossier ?? summary.existingPublicDossier, "BNL did not state whether a public dossier exists yet.")} />
       </dl>
     </Section>
-    <Section title="BNL Analyst Read" tone="caution"><dl className="space-y-3">{renderPlanField("Overall read", analyst.overallRead)}{renderPlanField("What BNL thinks this is", analyst.whatBnlThinksThisIs)}{renderPlanField("Why this Source File exists", analyst.whyThisSourceFileExists)}{renderPlanField("What seems useful", analyst.whatSeemsUseful)}{renderPlanField("What seems weak", analyst.whatSeemsWeak)}{renderPlanField("What is uncertain", analyst.whatIsUncertain)}{renderPlanField("What BNL is watching", analyst.whatBnlIsWatching)}{renderPlanField("Confidence", analyst.confidence)}</dl></Section>
-    <Section title="What BNL Needs"><PlanItems items={plan.whatBnlNeeds} empty="BNL did not list any current needs." render={(item) => <><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Needed item", item.neededItem)}{renderPlanField("Why needed", item.whyNeeded)}{renderPlanField("Who can answer", item.whoCanAnswer)}{renderPlanField("Required or optional", item.requiredOrOptional)}{renderPlanField("What it unlocks", item.whatItUnlocks)}{renderPlanField("Current status", item.currentStatus)}</dl><SuggestedControlView control={asRecord(item.suggestedControl) as DossierSourceFilePagePlanSuggestedControl | undefined} /></>} /></Section>
+    <Section title="BNL Analyst Read" tone="caution"><dl className="space-y-3">{renderPlanField("Overall read", analyst.overallRead, "BNL did not provide an overall read yet.")}{renderPlanField("What BNL thinks this is", analyst.whatBnlThinksThisIs, "BNL has not clearly classified this subject yet.")}{renderPlanField("Why this Source File exists", analyst.whyThisSourceFileExists, "BNL did not explain the Source File purpose yet.")}{renderPlanField("What seems useful", analyst.whatSeemsUseful, "BNL did not identify any clearly useful dossier material yet.")}{renderPlanField("What seems weak", analyst.whatSeemsWeak, "BNL did not identify any weak areas yet.")}{renderPlanField("What is uncertain", analyst.whatIsUncertain, "BNL did not specify the uncertain areas yet.")}{renderPlanField("What BNL is watching", analyst.whatBnlIsWatching, "BNL did not list any active watch items yet.")}{renderPlanField("Confidence", analyst.confidence, "BNL did not provide a confidence read yet.")}</dl></Section>
+    <Section title="What BNL Needs" helper="Only the things BNL still needs to build a stronger, safer, more solid dossier."><PlanItems items={plan.whatBnlNeeds} prioritizeNeeds empty="BNL did not list any dossier-completion needs." render={(item) => <><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Needed item", item.neededItem, "BNL did not name the needed dossier item yet.")}{renderPlanField("Why needed", item.whyNeeded, "BNL did not explain why this is needed yet.")}{renderPlanField("Who can answer", item.whoCanAnswer, "BNL did not specify who can answer this yet.")}{renderPlanField("Required or optional", item.requiredOrOptional, "BNL did not mark whether this is required or optional yet.")}{renderPlanField("What it unlocks", item.whatItUnlocks, unlockFallback(item))}{renderPlanField("Current status", item.currentStatus, "BNL did not provide a current status yet.")}</dl><SuggestedControlView control={asRecord(item.suggestedControl) as DossierSourceFilePagePlanSuggestedControl | undefined} /></>} /></Section>
     <Section title="Public-Safe Material BNL Can Use"><PlanItems items={plan.publicSafeMaterial} empty={plan.noPublicSafeMaterialReadyText ?? "BNL says no material is ready for public use yet."} render={(item) => <dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Material", item.material)}{renderPlanField("How BNL would use it", item.howBnlWouldUseIt)}{renderPlanField("Why safe enough", item.whySafeEnough)}{renderPlanField("Confidence", item.confidence)}{renderPlanField("Needs approval", item.needsApproval)}</dl>} /></Section>
     <Section title="BNL Review Guidance"><PlanItems items={plan.bnlReviewGuidance} empty="BNL did not add review guidance." render={(item) => <><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Review issue", item.reviewIssue)}{renderPlanField("BNL decision", item.bnlDecision)}{renderPlanField("BNL explanation", item.bnlExplanation)}{renderPlanField("Recommended default", item.recommendedDefault)}{renderPlanField("Still active", item.stillActive)}{renderPlanField("Needed to finish", item.neededToFinish)}</dl><SuggestedControlView control={asRecord(item.suggestedControl) as DossierSourceFilePagePlanSuggestedControl | undefined} /></>} /></Section>
     <Section title="Questions To Ask"><PlanItems items={plan.questionsToAsk} empty={plan.noDecisionUnlockingQuestionsText ?? "BNL says no decision-unlocking questions exist."} render={(item) => <dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Question", item.question)}{renderPlanField("Audience", item.audience)}{renderPlanField("Why BNL is asking", item.whyBnlIsAsking)}{renderPlanField("What answer would unlock", item.whatAnswerWouldUnlock)}{renderPlanField("Required or optional", item.requiredOrOptional)}</dl>} /></Section>
-    <Section title="Dossier Worth-It Decision" tone="caution"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Worth a dossier", plan.worthDecision?.worthADossier)}{renderPlanField("Decision", plan.worthDecision?.decision)}{renderPlanField("Why", plan.worthDecision?.why)}{renderPlanField("Possible dossier type", plan.worthDecision?.possibleDossierType)}{renderPlanField("Draft readiness", plan.worthDecision?.draftReadiness)}{renderPlanField("What would change the decision", plan.worthDecision?.whatWouldChangeTheDecision)}</dl></Section>
+    <Section title="Dossier Worth-It Decision" tone="caution"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Worth a dossier", plan.worthDecision?.worthADossier, "BNL did not state whether this is dossier-worthy yet.")}{renderPlanField("Decision", plan.worthDecision?.decision, "BNL did not provide a dossier decision yet.")}{renderPlanField("Why", plan.worthDecision?.why, "BNL did not explain the decision yet.")}{renderPlanField("Possible dossier type", plan.worthDecision?.possibleDossierType, "BNL did not suggest a dossier type yet.")}{renderPlanField("Draft readiness", plan.worthDecision?.draftReadiness, "BNL did not provide a draft-readiness assessment yet.")}{renderPlanField("What would change the decision", plan.worthDecision?.whatWouldChangeTheDecision, "BNL did not explain what would change the decision yet.")}</dl></Section>
     <Section title="Internal / Omit / Hold"><div className="grid grid-cols-1 gap-3 lg:grid-cols-2"><div><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Keep internal</h4><PlanItems items={internal.keepInternal} empty="No keep-internal material listed." render={(item) => <dl className="space-y-2">{renderPlanField("Material", item.material)}{renderPlanField("Why internal", item.whyInternal)}{renderPlanField("Could become public later", item.couldBecomePublicLater)}{renderPlanField("What would make it usable", item.whatWouldMakeItUsable)}</dl>} /></div><div><h4 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground">Omit from public draft</h4><PlanItems items={internal.omitFromPublicDraft} empty="No omit-from-public-draft material listed." render={(item) => <dl className="space-y-2">{renderPlanField("Material", item.material)}{renderPlanField("Why omitted", item.whyOmitted)}{renderPlanField("Could become public later", item.couldBecomePublicLater)}{renderPlanField("What would make it usable", item.whatWouldMakeItUsable)}</dl>} /></div></div></Section>
     <Section title="Draft / Update Plan"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2">{renderPlanField("Can draft", draft.canDraft)}{renderPlanField("Draft type", draft.draftType)}{renderPlanField("Suggested angle", draft.suggestedAngle)}{renderPlanField("Use these materials", draft.useTheseMaterials)}{renderPlanField("Omit these materials", draft.omitTheseMaterials)}{renderPlanField("Owner Review warnings", draft.ownerReviewWarnings)}{!canDraft && renderPlanField("Why not", draft.whyNot)}</dl>{canDraft && <p className="mt-3 text-xs text-muted">Draft controls remain available only where existing handlers provide them; Owner Review is still required.</p>}</Section>
     <Section title="Diagnostics Summary"><dl className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-4">{renderPlanField("Raw archive available", diagnostics.rawArchiveAvailable)}{renderPlanField("Case report available", diagnostics.caseReportAvailable)}{renderPlanField("Interim brief available", diagnostics.interimBriefAvailable)}{renderPlanField("Blueprint available", diagnostics.blueprintAvailable)}{renderPlanField("Legacy claim review count", diagnostics.legacyClaimReviewCount)}{renderPlanField("Absorbed review count", diagnostics.absorbedReviewCount)}{renderPlanField("Hidden diagnostic count", diagnostics.hiddenDiagnosticCount)}{renderPlanField("Safety notes", diagnostics.safetyNotes)}</dl></Section>
@@ -2116,16 +2156,18 @@ export function DossierSourceFileSummaryPanel({
         </div>
       </div>
 
-      <Section title="Source File header / refresh status" helper="Status only. This section does not create dossier copy.">
-        <dl className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
-          {snapshotItems.map(([label, value]) => (
-            <SnapshotItem key={label} label={label} value={value} />
-          ))}
-        </dl>
-        <p className="mt-3 text-xs text-muted">
-          Summary badge: {formatDossierSummaryBadge(summary.summarySource)}.
-        </p>
-      </Section>
+      {!sourceFilePagePlan && (
+        <Section title="Source File header / refresh status" helper="Status only. This section does not create dossier copy.">
+          <dl className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+            {snapshotItems.map(([label, value]) => (
+              <SnapshotItem key={label} label={label} value={value} />
+            ))}
+          </dl>
+          <p className="mt-3 text-xs text-muted">
+            Summary badge: {formatDossierSummaryBadge(summary.summarySource)}.
+          </p>
+        </Section>
+      )}
 
       {sourceFilePagePlan ? (
         <>

--- a/src/lib/dossier-workflow-store.ts
+++ b/src/lib/dossier-workflow-store.ts
@@ -32,6 +32,7 @@ import {
   type DossierSourceFileArchiveMetadata,
   type DossierSourceFileCaseReportV1,
   type DossierSourceFileClassificationV1,
+  type DossierSourceFilePagePlanV1,
   type DossierSubjectAnalystReadV1,
   type DossierSourceFileEnrichmentArchive,
   type DossierRecommendationSourceLane,
@@ -596,6 +597,49 @@ function findSourceFileClassificationV1(input: unknown) {
   return { classification: undefined, path: undefined };
 }
 
+
+function isSourceFilePagePlanV1Shape(value: unknown) {
+  const plan = sourceArchiveObject(value);
+  if (!plan) return false;
+  return [
+    "header",
+    "analystRead",
+    "whatBnlNeeds",
+    "publicSafeMaterial",
+    "bnlReviewGuidance",
+    "questionsToAsk",
+    "worthDecision",
+    "internalOmitHold",
+    "draftOrUpdatePlan",
+    "diagnosticsSummary",
+  ].some((key) => plan[key] !== undefined);
+}
+
+function findSourceFilePagePlanV1(input: unknown) {
+  for (const candidate of sourceArchivePayloadCandidates(input)) {
+    const brief = sourceArchiveObject(candidate.value.sourceFileBriefV2);
+    const rootAnalyst = sourceArchiveObject(candidate.value.subjectAnalystReadV1);
+    const report = sourceArchiveObject(candidate.value.sourceFileCaseReportV1);
+    const reportAnalyst = sourceArchiveObject(report?.subjectAnalystReadV1);
+    const briefAnalyst = sourceArchiveObject(brief?.subjectAnalystReadV1);
+    const nestedReport = sourceArchiveObject(brief?.sourceFileCaseReportV1);
+    const nestedReportAnalyst = sourceArchiveObject(nestedReport?.subjectAnalystReadV1);
+    const checks: Array<{ value: unknown; path: string }> = [
+      { value: candidate.value.sourceFilePagePlanV1, path: `${candidate.path}.sourceFilePagePlanV1` },
+      { value: rootAnalyst?.sourceFilePagePlanV1, path: `${candidate.path}.subjectAnalystReadV1.sourceFilePagePlanV1` },
+      { value: report?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileCaseReportV1.sourceFilePagePlanV1` },
+      { value: reportAnalyst?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileCaseReportV1.subjectAnalystReadV1.sourceFilePagePlanV1` },
+      { value: brief?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileBriefV2.sourceFilePagePlanV1` },
+      { value: briefAnalyst?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileBriefV2.subjectAnalystReadV1.sourceFilePagePlanV1` },
+      { value: nestedReport?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1.sourceFilePagePlanV1` },
+      { value: nestedReportAnalyst?.sourceFilePagePlanV1, path: `${candidate.path}.sourceFileBriefV2.sourceFileCaseReportV1.subjectAnalystReadV1.sourceFilePagePlanV1` },
+    ];
+    const match = checks.find((check) => isSourceFilePagePlanV1Shape(check.value));
+    if (match) return { pagePlan: match.value as DossierSourceFilePagePlanV1, path: match.path };
+  }
+  return { pagePlan: undefined, path: undefined };
+}
+
 function isSourceFileCaseReportShape(value: unknown) {
   const report = sourceArchiveObject(value);
   if (!report) return false;
@@ -695,6 +739,7 @@ function normalizeSourceFileArchiveInput(
       subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
       sourceFileClassificationV1?: DossierSourceFileClassificationV1;
       sourceFileClassificationExtractedFrom?: string;
+      sourceFilePagePlanV1?: DossierSourceFilePagePlanV1;
     })
   | null {
   const subjectName = compactArchiveText(input.subjectName, 200);
@@ -703,6 +748,7 @@ function normalizeSourceFileArchiveInput(
   const sourceFileBrief = findSourceFileBriefV2(input);
   const analystRead = findSubjectAnalystReadV1(input);
   const classification = findSourceFileClassificationV1(input);
+  const pagePlan = findSourceFilePagePlanV1(input);
   return {
     ...input,
     candidateId: compactArchiveText(input.candidateId, 200),
@@ -725,6 +771,7 @@ function normalizeSourceFileArchiveInput(
     subjectAnalystReadV1: analystRead.read,
     sourceFileClassificationV1: classification.classification,
     sourceFileClassificationExtractedFrom: classification.path,
+    sourceFilePagePlanV1: pagePlan.pagePlan,
     caseReportPresent: Boolean(caseReport.report),
     subjectMemoryPacketPresent: sourceArchiveHasSubjectMemoryPacket(input),
     caseReportExtractedFrom: caseReport.path,
@@ -3089,6 +3136,7 @@ export async function ingestDossierSourceFileArchive(
       sourceFileBriefV2: normalized.sourceFileBriefV2,
       subjectAnalystReadV1: normalized.subjectAnalystReadV1,
       sourceFileClassificationV1: normalized.sourceFileClassificationV1,
+      sourceFilePagePlanV1: normalized.sourceFilePagePlanV1,
       caseReportPresent: normalized.caseReportPresent,
       subjectMemoryPacketPresent: normalized.subjectMemoryPacketPresent,
       caseReportExtractedFrom: normalized.caseReportExtractedFrom,

--- a/src/lib/dossier-workflow.ts
+++ b/src/lib/dossier-workflow.ts
@@ -250,6 +250,7 @@ export type DossierSubjectAnalystReadV1 = DossierSourceFileHumanDisplayFields & 
   currentRead?: string | unknown;
   canDraftCautiously?: boolean | string | unknown;
   dossierClarificationNeeds?: DossierReadinessQuestionV1[] | unknown;
+  sourceFilePagePlanV1?: DossierSourceFilePagePlanV1;
 };
 
 export type DossierSourceFileDraftReadinessState =
@@ -276,6 +277,127 @@ export type DossierSourceFileDraftReadinessReadModel = {
   recommendedNextAction: string;
 };
 
+
+export type DossierSourceFilePagePlanSuggestedControl = {
+  kind?: "ask_owner" | "ask_admin" | "refresh" | "keep_internal" | "omit" | "none" | string;
+  label?: string;
+  recommendation?: string;
+  questionToCopy?: string;
+  guidance?: string;
+};
+
+export type DossierSourceFilePagePlanHeader = {
+  subject?: string;
+  sourceFileStatus?: string;
+  bnlState?: string;
+  currentLane?: string;
+  lastRefresh?: string;
+  existingPublicDossier?: string;
+};
+
+export type DossierSourceFilePagePlanAnalystRead = {
+  overallRead?: string;
+  whatBnlThinksThisIs?: string;
+  whyThisSourceFileExists?: string;
+  whatSeemsUseful?: string | string[];
+  whatSeemsWeak?: string | string[];
+  whatIsUncertain?: string | string[];
+  whatBnlIsWatching?: string | string[];
+  confidence?: string;
+};
+
+export type DossierSourceFilePagePlanNeed = {
+  neededItem?: string;
+  whyNeeded?: string;
+  whoCanAnswer?: string;
+  requiredOrOptional?: string;
+  whatItUnlocks?: string;
+  currentStatus?: string;
+  suggestedControl?: DossierSourceFilePagePlanSuggestedControl;
+};
+
+export type DossierSourceFilePagePlanPublicMaterial = {
+  material?: string;
+  howBnlWouldUseIt?: string;
+  whySafeEnough?: string;
+  confidence?: string;
+  needsApproval?: boolean | string;
+};
+
+export type DossierSourceFilePagePlanReviewGuidance = {
+  reviewIssue?: string;
+  bnlDecision?: string;
+  bnlExplanation?: string;
+  recommendedDefault?: string;
+  stillActive?: boolean | string;
+  neededToFinish?: string;
+  suggestedControl?: DossierSourceFilePagePlanSuggestedControl;
+};
+
+export type DossierSourceFilePagePlanQuestion = {
+  question?: string;
+  audience?: string;
+  whyBnlIsAsking?: string;
+  whatAnswerWouldUnlock?: string;
+  requiredOrOptional?: string;
+};
+
+export type DossierSourceFilePagePlanWorthDecision = {
+  worthADossier?: boolean | string;
+  decision?: string;
+  why?: string;
+  possibleDossierType?: string;
+  draftReadiness?: string;
+  whatWouldChangeTheDecision?: string;
+};
+
+export type DossierSourceFilePagePlanInternalOmitHold = {
+  material?: string;
+  whyInternal?: string;
+  whyOmitted?: string;
+  couldBecomePublicLater?: boolean | string;
+  whatWouldMakeItUsable?: string;
+};
+
+export type DossierSourceFilePagePlanDraftOrUpdatePlan = {
+  canDraft?: boolean | string;
+  draftType?: string;
+  suggestedAngle?: string;
+  useTheseMaterials?: string[] | string;
+  omitTheseMaterials?: string[] | string;
+  ownerReviewWarnings?: string[] | string;
+  whyNot?: string;
+};
+
+export type DossierSourceFilePagePlanDiagnosticsSummary = {
+  rawArchiveAvailable?: boolean | string;
+  caseReportAvailable?: boolean | string;
+  interimBriefAvailable?: boolean | string;
+  blueprintAvailable?: boolean | string;
+  legacyClaimReviewCount?: number | string;
+  absorbedReviewCount?: number | string;
+  hiddenDiagnosticCount?: number | string;
+  safetyNotes?: string[] | string;
+};
+
+export type DossierSourceFilePagePlanV1 = {
+  header?: DossierSourceFilePagePlanHeader;
+  analystRead?: DossierSourceFilePagePlanAnalystRead;
+  whatBnlNeeds?: DossierSourceFilePagePlanNeed[];
+  publicSafeMaterial?: DossierSourceFilePagePlanPublicMaterial[];
+  noPublicSafeMaterialReadyText?: string;
+  bnlReviewGuidance?: DossierSourceFilePagePlanReviewGuidance[];
+  questionsToAsk?: DossierSourceFilePagePlanQuestion[];
+  noDecisionUnlockingQuestionsText?: string;
+  worthDecision?: DossierSourceFilePagePlanWorthDecision;
+  internalOmitHold?: {
+    keepInternal?: DossierSourceFilePagePlanInternalOmitHold[];
+    omitFromPublicDraft?: DossierSourceFilePagePlanInternalOmitHold[];
+  };
+  draftOrUpdatePlan?: DossierSourceFilePagePlanDraftOrUpdatePlan;
+  diagnosticsSummary?: DossierSourceFilePagePlanDiagnosticsSummary;
+};
+
 export type DossierSourceFileCaseReportV1 = {
   version?: string;
   generatedAt?: string;
@@ -299,6 +421,7 @@ export type DossierSourceFileCaseReportV1 = {
   subjectIntelligenceBriefV1?: DossierSubjectIntelligenceBriefV1;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   sourceFileClassificationV1?: DossierSourceFileClassificationV1;
+  sourceFilePagePlanV1?: DossierSourceFilePagePlanV1;
 };
 
 export type DossierSourceFileBriefV2 = {
@@ -308,6 +431,7 @@ export type DossierSourceFileBriefV2 = {
   sourceFileCaseReportV1?: DossierSourceFileCaseReportV1;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   caseFileReport?: unknown;
+  sourceFilePagePlanV1?: DossierSourceFilePagePlanV1;
 };
 
 export type DossierSourceFileArchiveCompactReadout = {
@@ -321,6 +445,7 @@ export type DossierSourceFileArchiveCompactReadout = {
   sourceFileBriefV2?: DossierSourceFileBriefV2;
   subjectAnalystReadV1?: DossierSubjectAnalystReadV1;
   sourceFileClassificationV1?: DossierSourceFileClassificationV1;
+  sourceFilePagePlanV1?: DossierSourceFilePagePlanV1;
   archivePayload?: unknown;
   archive?: unknown;
   payload?: unknown;

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12742,3 +12742,151 @@ test("admin Source File and Control Center render BNL draft readiness read model
   assert.match(controlCenter, /createDossierSourceFileDraftReadinessReadModel/);
   assert.doesNotMatch(publicReadModel, /sourceFileResolutionAudit|resolvedQuestionAudit|DossierSourceFileDraftReadinessReadModel|sourceFileClaimReviews/);
 });
+
+test("sourceFilePagePlanV1 renders as primary fixed Source File page before fallbacks", () => {
+  const summary = sourceFileReportTestSummary();
+  const pagePlan = {
+    header: {
+      subject: "Plan Subject",
+      sourceFileStatus: "active",
+      bnlState: "needs_owner_review",
+      currentLane: "active_source_file",
+      lastRefresh: "2026-06-17T00:00:00.000Z",
+      existingPublicDossier: "no",
+    },
+    analystRead: {
+      overallRead: "BNL sees a cautious public dossier possibility.",
+      whatBnlThinksThisIs: "A public-facing community profile candidate.",
+      whyThisSourceFileExists: "To decide whether a safe dossier can be drafted.",
+      whatSeemsUseful: ["Approved public appearance context."],
+      whatSeemsWeak: ["Role wording is not owner-confirmed."],
+      whatIsUncertain: ["Preferred public name."],
+      whatBnlIsWatching: ["Whether owner approval changes the angle."],
+      confidence: "medium",
+    },
+    whatBnlNeeds: [{
+      neededItem: "Owner-approved role wording",
+      whyNeeded: "Prevents overclaiming.",
+      whoCanAnswer: "Owner",
+      requiredOrOptional: "required",
+      whatItUnlocks: "A safe draft angle.",
+      currentStatus: "open",
+      suggestedControl: { kind: "ask_owner", questionToCopy: "What public role wording should BNL use?" },
+    }],
+    publicSafeMaterial: [{
+      material: "Public BARCODE Radio appearance",
+      howBnlWouldUseIt: "As the only public-safe anchor.",
+      whySafeEnough: "Already public and non-private.",
+      confidence: "high",
+      needsApproval: "yes",
+    }],
+    bnlReviewGuidance: [{
+      reviewIssue: "Legacy claim card about collaborator wording",
+      bnlDecision: "Do not publish as a fact yet",
+      bnlExplanation: "It needs owner-approved wording.",
+      recommendedDefault: "Hold for Owner Review",
+      stillActive: "yes",
+      neededToFinish: "Owner answer",
+      suggestedControl: { kind: "keep_internal", recommendation: "Keep this as review guidance." },
+    }],
+    questionsToAsk: [{
+      question: "What public wording is approved?",
+      audience: "Owner",
+      whyBnlIsAsking: "It determines whether the dossier can be drafted.",
+      whatAnswerWouldUnlock: "Draft readiness.",
+      requiredOrOptional: "required",
+    }],
+    worthDecision: {
+      worthADossier: "maybe",
+      decision: "Hold until owner wording arrives.",
+      why: "There is useful public-safe material, but not enough approved framing.",
+      possibleDossierType: "Community",
+      draftReadiness: "blocked",
+      whatWouldChangeTheDecision: "Owner-approved role wording.",
+    },
+    internalOmitHold: {
+      keepInternal: [{ material: "Source-blind withheld item", whyInternal: "Source-blind/internal.", couldBecomePublicLater: "no", whatWouldMakeItUsable: "Separate public confirmation." }],
+      omitFromPublicDraft: [{ material: "Unapproved collaborator label", whyOmitted: "Not owner-approved.", couldBecomePublicLater: "yes", whatWouldMakeItUsable: "Owner approval." }],
+    },
+    draftOrUpdatePlan: {
+      canDraft: false,
+      draftType: "community update",
+      suggestedAngle: "Public appearance only.",
+      useTheseMaterials: ["Public BARCODE Radio appearance"],
+      omitTheseMaterials: ["Unapproved collaborator label"],
+      ownerReviewWarnings: ["Owner Review required before publishing."],
+      whyNot: "Required owner wording is still missing.",
+    },
+    diagnosticsSummary: {
+      rawArchiveAvailable: true,
+      caseReportAvailable: true,
+      interimBriefAvailable: true,
+      blueprintAvailable: false,
+      legacyClaimReviewCount: 1,
+      absorbedReviewCount: 1,
+      hiddenDiagnosticCount: 2,
+      safetyNotes: ["Private/source-blind evidence stays diagnostic only."],
+    },
+  };
+  const archive = {
+    id: "archive-page-plan",
+    candidateId: "candidate-page-plan",
+    subjectName: "Plan Subject",
+    sourceDigest: "digest",
+    createdAt: "2026-06-17T00:00:00.000Z",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+    archiveSize: 1,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFilePagePlanV1: pagePlan,
+    dossierCompletionReadV1: { bnlAssessment: "Fallback completion read should be diagnostic." },
+    subjectAnalystReadV1: { sourceBlindInsights: ["Source-blind withheld item"] },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  const sections = [
+    "Compact Source File Header",
+    "BNL Analyst Read",
+    "What BNL Needs",
+    "Public-Safe Material BNL Can Use",
+    "BNL Review Guidance",
+    "Questions To Ask",
+    "Dossier Worth-It Decision",
+    "Internal / Omit / Hold",
+    "Draft / Update Plan",
+    "Diagnostics Summary",
+  ];
+  for (const section of sections) assert.match(text, new RegExp(section.replace(/[\/]/g, "\\$&")));
+  for (let index = 0; index < sections.length - 1; index += 1) assert.ok(text.indexOf(sections[index]) < text.indexOf(sections[index + 1]), `${sections[index]} should render before ${sections[index + 1]}`);
+  assert.match(text, /Overall read[\s\S]*BNL sees a cautious public dossier possibility/);
+  assert.match(text, /Needed item[\s\S]*Owner-approved role wording/);
+  assert.ok(text.indexOf("Public-Safe Material BNL Can Use") < text.indexOf("Internal / Omit / Hold"));
+  assert.match(text, /BNL Review Guidance[\s\S]*Legacy claim card about collaborator wording[\s\S]*Do not publish as a fact yet/);
+  assert.ok(text.indexOf("Questions To Ask") < text.indexOf("Dossier Worth-It Decision"));
+  assert.match(text, /Draft \/ Update Plan[\s\S]*Can draft[\s\S]*false[\s\S]*Why not[\s\S]*Required owner wording is still missing/);
+  assert.match(text, /Support \/ Diagnostics/);
+  assert.doesNotMatch(text, /Main Action|sourceFilePagePlanV1|Fallback completion read should be diagnostic/);
+});
+
+test("sourceFilePagePlanV1 renders canDraft true without exposing draft controls in the header", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-page-plan-draftable",
+    candidateId: "candidate-page-plan-draftable",
+    subjectName: "Draftable Plan Subject",
+    sourceDigest: "digest",
+    createdAt: "2026-06-17T00:00:00.000Z",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+    archiveSize: 1,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileBriefV2: { sourceFileCaseReportV1: { subjectAnalystReadV1: { sourceFilePagePlanV1: {
+      header: { subject: "Draftable Plan Subject" },
+      analystRead: { overallRead: "BNL can draft cautiously." },
+      draftOrUpdatePlan: { canDraft: true, draftType: "new dossier", suggestedAngle: "Approved public signals." },
+      diagnosticsSummary: { rawArchiveAvailable: true },
+    } } } },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /Draft \/ Update Plan[\s\S]*Can draft[\s\S]*true[\s\S]*Draft controls remain available only where existing handlers provide them/);
+  assert.doesNotMatch(text.slice(0, text.indexOf("Draft / Update Plan")), /Create Draft|Request BNL Draft|Main Action/);
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12844,7 +12844,7 @@ test("sourceFilePagePlanV1 renders as primary fixed Source File page before fall
   };
   const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
   const sections = [
-    "Compact Source File Header",
+    "Unified Source File Header",
     "BNL Analyst Read",
     "What BNL Needs",
     "Public-Safe Material BNL Can Use",
@@ -12857,6 +12857,10 @@ test("sourceFilePagePlanV1 renders as primary fixed Source File page before fall
   ];
   for (const section of sections) assert.match(text, new RegExp(section.replace(/[\/]/g, "\\$&")));
   for (let index = 0; index < sections.length - 1; index += 1) assert.ok(text.indexOf(sections[index]) < text.indexOf(sections[index + 1]), `${sections[index]} should render before ${sections[index + 1]}`);
+  assert.doesNotMatch(text, /Source File header \/ refresh status/);
+  assert.doesNotMatch(text, /Compact Source File Header/);
+  assert.doesNotMatch(text, /BNL Dossier Intelligence/);
+  assert.match(text, /What BNL Needs[\s\S]*Only the things BNL still needs to build a stronger, safer, more solid dossier/);
   assert.match(text, /Overall read[\s\S]*BNL sees a cautious public dossier possibility/);
   assert.match(text, /Needed item[\s\S]*Owner-approved role wording/);
   assert.ok(text.indexOf("Public-Safe Material BNL Can Use") < text.indexOf("Internal / Omit / Hold"));
@@ -12865,6 +12869,41 @@ test("sourceFilePagePlanV1 renders as primary fixed Source File page before fall
   assert.match(text, /Draft \/ Update Plan[\s\S]*Can draft[\s\S]*false[\s\S]*Why not[\s\S]*Required owner wording is still missing/);
   assert.match(text, /Support \/ Diagnostics/);
   assert.doesNotMatch(text, /Main Action|sourceFilePagePlanV1|Fallback completion read should be diagnostic/);
+});
+
+
+test("sourceFilePagePlanV1 consolidates header, fills blank primary fields, and prioritizes required needs", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-page-plan-empty-fields",
+    candidateId: "candidate-page-plan-empty-fields",
+    subjectName: "Empty Field Plan Subject",
+    sourceDigest: "digest",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    updatedAt: "2026-06-18T00:00:00.000Z",
+    archiveSize: 1,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFilePagePlanV1: {
+      header: { subject: "Empty Field Plan Subject", sourceFileStatus: "active" },
+      analystRead: {},
+      whatBnlNeeds: [
+        { neededItem: "Optional polish", requiredOrOptional: "optional", currentStatus: "later" },
+        { neededItem: "Required owner wording", requiredOrOptional: "required", suggestedControl: { kind: "ask_owner" } },
+      ],
+      worthDecision: {},
+      diagnosticsSummary: { rawArchiveAvailable: true },
+    },
+  };
+  const text = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({ summary, latestSourceFileArchive: archive }));
+  assert.match(text, /Unified Source File Header[\s\S]*Empty Field Plan Subject/);
+  assert.doesNotMatch(text, /Source File header \/ refresh status|Compact Source File Header|BNL Dossier Intelligence/);
+  assert.match(text, /Overall read[\s\S]*BNL did not provide an overall read yet/);
+  assert.match(text, /What BNL thinks this is[\s\S]*BNL has not clearly classified this subject yet/);
+  assert.match(text, /Worth a dossier[\s\S]*BNL did not state whether this is dossier-worthy yet/);
+  assert.match(text, /What it unlocks[\s\S]*Unlocks clearer public-safe dossier wording/);
+  assert.ok(text.indexOf("Required owner wording") < text.indexOf("Optional polish"));
+  assert.doesNotMatch(text, /—/);
 });
 
 test("sourceFilePagePlanV1 renders canDraft true without exposing draft controls in the header", () => {
@@ -12932,9 +12971,11 @@ test("root sourceFilePagePlanV1 survives Source File archive ingest and renders 
     summary: sourceFileReportTestSummary(),
     latestSourceFileArchive: sourceFile.latestSourceFileArchive,
   }));
-  assert.match(panelText, /Compact Source File Header[\s\S]*Root Page Plan Subject/);
+  assert.match(panelText, /Unified Source File Header[\s\S]*Root Page Plan Subject/);
   assert.match(panelText, /BNL Analyst Read[\s\S]*Root page plan survived ingest/);
   assert.match(panelText, /What BNL Needs[\s\S]*Root owner answer/);
+  assert.match(panelText, /What it unlocks[\s\S]*Unlocks clearer public-safe dossier wording/);
+  assert.doesNotMatch(panelText, /—/);
 });
 
 test("sourceFileBriefV2.subjectAnalystReadV1.sourceFilePagePlanV1 renders primary UI", () => {
@@ -12966,8 +13007,9 @@ test("sourceFileBriefV2.subjectAnalystReadV1.sourceFilePagePlanV1 renders primar
     summary,
     latestSourceFileArchive: archive,
   }));
-  assert.match(panelText, /Compact Source File Header[\s\S]*Brief Analyst Plan Subject/);
+  assert.match(panelText, /Unified Source File Header[\s\S]*Brief Analyst Plan Subject/);
   assert.match(panelText, /BNL Analyst Read[\s\S]*Direct brief analyst page plan was found/);
   assert.match(panelText, /Public-Safe Material BNL Can Use[\s\S]*Approved public signal/);
+  assert.doesNotMatch(panelText, /—/);
   assert.doesNotMatch(panelText, /Legacy completion read should stay diagnostic/);
 });

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12890,3 +12890,79 @@ test("sourceFilePagePlanV1 renders canDraft true without exposing draft controls
   assert.match(text, /Draft \/ Update Plan[\s\S]*Can draft[\s\S]*true[\s\S]*Draft controls remain available only where existing handlers provide them/);
   assert.doesNotMatch(text.slice(0, text.indexOf("Draft / Update Plan")), /Create Draft|Request BNL Draft|Main Action/);
 });
+
+test("root sourceFilePagePlanV1 survives Source File archive ingest and renders primary UI", async () => {
+  await resetWorkflowStore();
+
+  const created = await (await authedPost({
+    action: "createManualCandidate",
+    input: {
+      name: "Root Page Plan Subject",
+      candidateType: "artist",
+      reason: "Operator wants root page-plan archive coverage.",
+      whyNow: "BNL emits sourceFilePagePlanV1 at the archive root.",
+      evidenceSummary: "Admin fixture evidence.",
+    },
+  })).json();
+  const pagePlan = {
+    header: { subject: "Root Page Plan Subject", sourceFileStatus: "active" },
+    analystRead: { overallRead: "Root page plan survived ingest." },
+    whatBnlNeeds: [{ neededItem: "Root owner answer", whyNeeded: "Confirms the page plan path." }],
+    diagnosticsSummary: { rawArchiveAvailable: true },
+  };
+
+  const result = await store.ingestDossierSourceFileArchive({
+    candidateId: created.candidate.id,
+    subjectName: "Root Page Plan Subject",
+    subjectKey: "root-page-plan-subject",
+    ingestKey: "root-page-plan-ingest",
+    sourcePackage: { archiveOrdinal: "root-page-plan" },
+    sourceFilePagePlanV1: pagePlan,
+  });
+
+  assert.equal(result.archive.sourceFilePagePlanV1?.analystRead?.overallRead, "Root page plan survived ingest.");
+  assert.equal(result.candidate.latestSourceFileArchive?.sourceFilePagePlanV1?.header?.subject, "Root Page Plan Subject");
+
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary: sourceFileReportTestSummary(),
+    latestSourceFileArchive: result.archive,
+  }));
+  assert.match(panelText, /Compact Source File Header[\s\S]*Root Page Plan Subject/);
+  assert.match(panelText, /BNL Analyst Read[\s\S]*Root page plan survived ingest/);
+  assert.match(panelText, /What BNL Needs[\s\S]*Root owner answer/);
+});
+
+test("sourceFileBriefV2.subjectAnalystReadV1.sourceFilePagePlanV1 renders primary UI", () => {
+  const summary = sourceFileReportTestSummary();
+  const archive = {
+    id: "archive-brief-analyst-page-plan",
+    candidateId: "candidate-brief-analyst-page-plan",
+    subjectName: "Brief Analyst Plan Subject",
+    sourceDigest: "digest",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    updatedAt: "2026-06-18T00:00:00.000Z",
+    archiveSize: 1,
+    chunkCount: 1,
+    reviewOnly: true,
+    sourceFileBriefV2: {
+      subjectAnalystReadV1: {
+        sourceFilePagePlanV1: {
+          header: { subject: "Brief Analyst Plan Subject", bnlState: "ready_for_review" },
+          analystRead: { overallRead: "Direct brief analyst page plan was found." },
+          publicSafeMaterial: [{ material: "Approved public signal", howBnlWouldUseIt: "As public-safe context." }],
+          diagnosticsSummary: { interimBriefAvailable: true },
+        },
+      },
+    },
+    dossierCompletionReadV1: { bnlAssessment: "Legacy completion read should stay diagnostic." },
+  };
+
+  const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: archive,
+  }));
+  assert.match(panelText, /Compact Source File Header[\s\S]*Brief Analyst Plan Subject/);
+  assert.match(panelText, /BNL Analyst Read[\s\S]*Direct brief analyst page plan was found/);
+  assert.match(panelText, /Public-Safe Material BNL Can Use[\s\S]*Approved public signal/);
+  assert.doesNotMatch(panelText, /Legacy completion read should stay diagnostic/);
+});

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12893,6 +12893,7 @@ test("sourceFilePagePlanV1 renders canDraft true without exposing draft controls
 
 test("root sourceFilePagePlanV1 survives Source File archive ingest and renders primary UI", async () => {
   await resetWorkflowStore();
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "test-bnl-ingest-token";
 
   const created = await (await authedPost({
     action: "createManualCandidate",
@@ -12911,21 +12912,25 @@ test("root sourceFilePagePlanV1 survives Source File archive ingest and renders 
     diagnosticsSummary: { rawArchiveAvailable: true },
   };
 
-  const result = await store.ingestDossierSourceFileArchive({
+  const result = await (await bnlArchivePost({
     candidateId: created.candidate.id,
     subjectName: "Root Page Plan Subject",
     subjectKey: "root-page-plan-subject",
     ingestKey: "root-page-plan-ingest",
     sourcePackage: { archiveOrdinal: "root-page-plan" },
     sourceFilePagePlanV1: pagePlan,
-  });
+  })).json();
 
+  assert.equal(result.ok, true);
   assert.equal(result.archive.sourceFilePagePlanV1?.analystRead?.overallRead, "Root page plan survived ingest.");
-  assert.equal(result.candidate.latestSourceFileArchive?.sourceFilePagePlanV1?.header?.subject, "Root Page Plan Subject");
+
+  const state = await store.getDossierWorkflowState();
+  const sourceFile = state.candidates.find((candidate) => candidate.id === created.candidate.id);
+  assert.equal(sourceFile.latestSourceFileArchive?.sourceFilePagePlanV1?.header?.subject, "Root Page Plan Subject");
 
   const panelText = collectDefaultVisibleText(sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
     summary: sourceFileReportTestSummary(),
-    latestSourceFileArchive: result.archive,
+    latestSourceFileArchive: sourceFile.latestSourceFileArchive,
   }));
   assert.match(panelText, /Compact Source File Header[\s\S]*Root Page Plan Subject/);
   assert.match(panelText, /BNL Analyst Read[\s\S]*Root page plan survived ingest/);


### PR DESCRIPTION
### Motivation
- Use the new BNL-emitted `sourceFilePagePlanV1` contract as the authoritative, fixed ten-section Source File page when present while preserving existing fallbacks and diagnostics.
- Keep primary UI safe: do not expose raw archive/schema fields, private/internal evidence, Owner Review bypass, or publish actions in the header.
- Ensure the site renders exactly what BNL filled (order and content) and avoids inventing meaning from raw fields.

### Description
- Added full TypeScript types for the page plan contract (`DossierSourceFilePagePlanV1` and all nested types and `SuggestedControl`) and made `sourceFilePagePlanV1` optional on archive/brief/case-report/analyst shapes. (src/lib/dossier-workflow.ts)
- Implemented `normalizeSourceFilePagePlanV1(...)` which searches the same archive payload and nested locations as other normalization helpers to find the page plan. (src/components/DossierSourceFileSummaryPanel.tsx)
- Added `SourceFilePagePlanView` and support helpers to render the exact ten-section BNL-filled layout in the required order, with suggested-control rendering rules (owner/admin copy button, refresh guidance text, no fake action buttons for omit/internal). (src/components/DossierSourceFileSummaryPanel.tsx)
- Updated `DossierSourceFileSummaryPanel` to prefer `sourceFilePagePlanV1` rendering first, and when present demote legacy surfaces (completion/readout/blueprint/case-report/interim/claim cards) into a collapsed "Support / Diagnostics" drawer; preserved the original fallback behavior when no page plan exists. (src/components/DossierSourceFileSummaryPanel.tsx)
- Tests were added/updated to validate priority, section ordering, draft plan states, diagnostics collapse, and safety (no main-action/header draft controls or raw schema leakage). (tests/admin-dossiers.test.mjs)

Files changed and why:
- `src/lib/dossier-workflow.ts` — added page-plan types and wired optional `sourceFilePagePlanV1` into existing archive/brief/case-report/analyst shapes so the contract is discoverable.
- `src/components/DossierSourceFileSummaryPanel.tsx` — added normalization, the `SourceFilePagePlanView`, rendering helpers, and logic to render the page plan first with diagnostics collapsed when present.
- `tests/admin-dossiers.test.mjs` — new tests to assert page-plan priority, section order, draft visibility constraints, diagnostics presence, and safety expectations.

### Testing
- Type-check: `npx tsc --noEmit` — succeeded.
- Unit tests: `node --test tests/admin-dossiers.test.mjs` — all tests passed (231 tests, 0 failures).
- Test coverage includes: page-plan primary rendering, ten-section order, compact header presence without page-level Main Action, BNL Analyst Read prominence, What BNL Needs list rendering (with suggested-control copy behavior), Public-Safe Material ordering, BNL Review Guidance replacing legacy card wall in primary UI, Questions before Worth-Decision ordering, Draft/Update Plan `canDraft` states and placement of draft controls, Diagnostics Summary rendering and collapse of legacy raw diagnostics, and assurances that no raw/archive/schema labels or private/source-blind content leak into the primary UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348331288c8321b3252a81a761ef8b)