### PR TITLE
Harden verification packet question filtering

### DIFF
--- a/src/components/DossierSourceFileSummaryPanel.tsx
+++ b/src/components/DossierSourceFileSummaryPanel.tsx
@@ -2143,23 +2143,57 @@ function verificationAudience(value: unknown, control?: UnknownRecord): Verifica
   return "general";
 }
 
+function isNonQuestionAssessmentMaterial(value: string) {
+  const text = value.trim();
+  if (!text) return true;
+  if (/does not have any decision-unlocking questions|no decision-unlocking questions/i.test(text)) return true;
+  if (/@|stripe|payment|customer|token|raw evidence|raw id|database row|source-blind detail|private evidence|internal raw/i.test(text)) return true;
+  if (/excluded\s+\d+\s+protected\/private/i.test(text)) return true;
+  if (/source-blind|internal context|raw details were withheld|no confirmed queue or submission|do not state|public-safe material|review-only evidence|unlocks\s*:\s*false/i.test(text)) return true;
+  if (/^(?:[a-z][a-z0-9 /_-]*):\s*\d+$/i.test(text)) return true;
+  if (/^(?:\d+|none|unknown|false|n\/?a|not applicable|placeholder|tbd)$/i.test(text)) return true;
+  if (/\b(?:count|counts|total|metric|metrics|warning|warnings|audit|diagnostic|diagnostics|withheld|protected|private|internal|boundary|summary|activity)\b[^?]*:?\s*\d+$/i.test(text)) return true;
+  if (/\b\d+\s+(?:item|items|record|records|mention|mentions|link|links|claim|claims|evidence|entries)\b/i.test(text)) return true;
+  return false;
+}
+
 function safeVerificationQuestionText(value: unknown) {
-  const text = displayValue(value);
+  const text = displayValue(value)?.trim();
   if (!text) return undefined;
-  if (/does not have any decision-unlocking questions|no decision-unlocking questions/i.test(text)) return undefined;
-  if (/@|stripe|payment|customer|token|raw evidence|raw id|database row|source-blind detail|private evidence|internal raw/i.test(text)) return undefined;
+  if (isNonQuestionAssessmentMaterial(text)) return undefined;
+  const hasQuestionMark = text.includes("?");
+  const startsWithQuestionIntent = /^(?:what|which|who|where|when|why|how|should|can|could|is|are|was|were|did|does|do)\b/i.test(text);
+  if (!hasQuestionMark && !startsWithQuestionIntent) return undefined;
+  if (!/[a-z]/i.test(text) || text.length < 8) return undefined;
+  if (!/(?:bnl|dossier|public|owner|admin|source|confirm|approve|use|wording|role|claim|draft|question|answer|subject|profile|evidence|decision|review|publish|associate|link|name)/i.test(text)) return undefined;
   return text;
+}
+
+function safeVerificationUnlockText(value: unknown) {
+  const text = safeHumanText(value)?.trim();
+  if (!text) return undefined;
+  if (/^(?:false|none|unknown|n\/?a|not applicable|placeholder|tbd|null|empty|—|-|no)$/i.test(text)) return undefined;
+  if (/^unlocks\s*:\s*false$/i.test(text)) return undefined;
+  return text;
+}
+
+function verificationWhyFallback(audience: VerificationQuestion["audience"]) {
+  if (audience === "owner") return "BNL needs owner-approved wording before using this publicly.";
+  if (audience === "admin") return "BNL needs an admin decision before this can shape the dossier.";
+  if (audience === "public-source") return "BNL needs a public source before using this as public dossier evidence.";
+  return "BNL needs this answered before deciding whether the dossier is solid.";
 }
 
 function questionFromRecord(record: UnknownRecord, fallbackAudience?: unknown): VerificationQuestion | undefined {
   const control = asRecord(record.suggestedControl);
   const question = safeVerificationQuestionText(record.question ?? control?.questionToCopy);
   if (!question) return undefined;
+  const audience = verificationAudience(record.audience ?? fallbackAudience, control);
   return {
     question,
-    audience: verificationAudience(record.audience ?? fallbackAudience, control),
-    why: safeHumanText(record.whyBnlIsAsking ?? record.whyNeeded ?? record.bnlExplanation),
-    unlocks: safeHumanText(record.whatAnswerWouldUnlock ?? record.whatItUnlocks ?? record.neededToFinish),
+    audience,
+    why: safeHumanText(record.whyBnlIsAsking ?? record.whyNeeded ?? record.bnlExplanation) ?? verificationWhyFallback(audience),
+    unlocks: safeVerificationUnlockText(record.whatAnswerWouldUnlock ?? record.whatItUnlocks ?? record.neededToFinish),
     requiredOrOptional: displayValue(record.requiredOrOptional),
   };
 }
@@ -2204,7 +2238,7 @@ function VerificationPacketSection({ questions, subject, empty }: { questions: V
   const adminQuestions = questions.filter((question) => question.audience === "admin");
   const publicSourceQuestions = questions.filter((question) => question.audience === "public-source");
   return (
-    <Section title="Verification Packet" helper="Operator-facing questions and clean copy controls. Private/source-blind/internal raw evidence is not copied.">
+    <Section title="Verification Packet" helper="Operator-facing questions and clean copy controls. Protected review material is not copied.">
       {questions.length ? (
         <div className="space-y-3">
           <div className="flex flex-wrap gap-2">

--- a/tests/admin-dossiers.test.mjs
+++ b/tests/admin-dossiers.test.mjs
@@ -12930,6 +12930,61 @@ test("sourceFilePagePlanV1 renders as primary fixed Source File page before fall
 });
 
 
+
+test("Verification Packet hardens copyable questions against metrics, warnings, boundaries, and false unlocks", () => {
+  const summary = sourceFileReportTestSummary();
+  const pagePlan = {
+    header: { subject: "Crow", sourceFileStatus: "active" },
+    analystRead: { overallRead: "BNL is checking whether Crow has enough public-safe dossier context." },
+    whatBnlNeeds: [{
+      neededItem: "Generic fallback bad item",
+      suggestedControl: { kind: "ask_owner", questionToCopy: "Music discussion only: 40" },
+      whatItUnlocks: "false",
+    }],
+    bnlReviewGuidance: [
+      { reviewIssue: "Protected warning", suggestedControl: { kind: "ask_admin", questionToCopy: "Excluded 204 protected/private memory item(s)" }, neededToFinish: "false" },
+      { reviewIssue: "Source-blind warning", suggestedControl: { kind: "ask_admin", questionToCopy: "Source-blind/internal context exists" } },
+      { reviewIssue: "Queue boundary", suggestedControl: { kind: "ask_admin", questionToCopy: "No confirmed queue or submission history is connected" } },
+      { reviewIssue: "Boundary note", suggestedControl: { kind: "ask_owner", questionToCopy: "Do not state artist/music role without owner-approved wording" } },
+      { reviewIssue: "Unlock false note", suggestedControl: { kind: "ask_admin", questionToCopy: "Which admin should decide whether Crow has enough public dossier support?" }, neededToFinish: false },
+    ],
+    questionsToAsk: [
+      { question: "Which owner-approved public wording should BNL use for Crow?", audience: "owner", whatAnswerWouldUnlock: "false" },
+      { question: "Which admin can confirm whether Crow is ready for a public dossier?", audience: "admin", whatAnswerWouldUnlock: "unknown" },
+      { question: "What public source confirms Crow's public role?", audience: "public-source", whatAnswerWouldUnlock: "none" },
+      { question: "contest/event activity", audience: "general" },
+      { question: "Generic links: 7", audience: "general" },
+      { question: "Collaboration offers: 9", audience: "general" },
+      { question: "public-safe material summary", audience: "general" },
+      { question: "review-only evidence", audience: "general" },
+      { question: "raw details were withheld", audience: "general" },
+      { question: "Unlocks: false", audience: "general" },
+    ],
+    worthDecision: {},
+    diagnosticsSummary: { rawArchiveAvailable: true },
+  };
+  const element = sourceSummaryPanelComponent.DossierSourceFileSummaryPanel({
+    summary,
+    latestSourceFileArchive: { id: "archive_crow_hardened_packet", candidateId: "candidate_crow_hardened_packet", subjectName: "Crow", sourceDigest: "digest", createdAt: "2026-06-19T00:00:00.000Z", updatedAt: "2026-06-19T00:00:00.000Z", archiveSize: 1, chunkCount: 1, reviewOnly: true, sourceFilePagePlanV1: pagePlan },
+  });
+  const text = collectDefaultVisibleText(element);
+  const packetText = text.slice(text.lastIndexOf("Verification Packet"), text.indexOf("Public-Safe Material BNL Can Use"));
+
+  assert.match(packetText, /Which owner-approved public wording should BNL use for Crow\?/);
+  assert.match(packetText, /Which admin can confirm whether Crow is ready for a public dossier\?/);
+  assert.match(packetText, /What public source confirms Crow's public role\?/);
+  assert.match(packetText, /BNL needs owner-approved wording before using this publicly/);
+  assert.match(packetText, /BNL needs an admin decision before this can shape the dossier/);
+  assert.match(packetText, /BNL needs a public source before using this as public dossier evidence/);
+  assert.doesNotMatch(packetText, /This question is included because it can unlock a safer dossier decision/);
+  assert.doesNotMatch(packetText, /GENERAL/);
+  assert.doesNotMatch(packetText, /Music discussion only: 40|Generic links: 7|Collaboration offers: 9/);
+  assert.doesNotMatch(packetText, /Excluded 204 protected\/private|Source-blind\/internal context exists|raw details were withheld|review-only evidence/i);
+  assert.doesNotMatch(packetText, /No confirmed queue or submission|Do not state artist\/music role|contest\/event activity|public-safe material summary/i);
+  assert.doesNotMatch(packetText, /Unlocks:\s*(false|unknown|none)|What answer unlocks\s*(false|unknown|none)/i);
+  assert.doesNotMatch(packetText, /private\/source-blind\/internal raw evidence|protected\/private memory item/i);
+});
+
 test("sourceFilePagePlanV1 consolidates header, fills blank primary fields, and prioritizes required needs", () => {
   const summary = sourceFileReportTestSummary();
   const archive = {


### PR DESCRIPTION
### Motivation
- Prevent non-actionable metrics, audit notes, internal/source-blind warnings, and other assessment text from being treated as copyable Verification Packet questions. 
- Ensure only human-readable, dossier-building questions appear in the Verification Packet and that false/placeholder unlock text is not copied. 
- Provide clearer audience-specific fallback guidance when a human `why` is not present and avoid leaking diagnostic/internal phrasing in the packet helper copy.

### Description
- Add stricter validation to `safeVerificationQuestionText` (moved into `isNonQuestionAssessmentMaterial` + additional intent checks) so only real questions (question mark or interrogative start, human-readable, dossier-focused) are accepted. (src/components/DossierSourceFileSummaryPanel.tsx)
- Add `safeVerificationUnlockText` to omit false/empty/placeholder/unhelpful unlock values and only include meaningful unlock text. (src/components/DossierSourceFileSummaryPanel.tsx)
- Add `verificationWhyFallback` to supply audience-specific fallback `why` copy for owner/admin/public-source/general contexts when no `why` is present. (src/components/DossierSourceFileSummaryPanel.tsx)
- Replace the Verification Packet helper copy to avoid repeating internal/raw evidence phrasing. (src/components/DossierSourceFileSummaryPanel.tsx)
- Add a regression test that exercises contaminated/metric-like inputs, protected/internal warnings, false unlocks, GENERAL suppression, and accepted owner/admin/public-source questions. (tests/admin-dossiers.test.mjs)
- No public routes, core navigation, or protected BNL artifacts were removed or modified; the change is focused on filtering/formatting of Verification Packet output only.

### Testing
- Ran type-check: `npx tsc --noEmit` and it succeeded. 
- Ran test suite: `node --test tests/admin-dossiers.test.mjs` and all tests passed (new regression included). 
- New/updated test: `Verification Packet hardens copyable questions against metrics, warnings, boundaries, and false unlocks` (added to `tests/admin-dossiers.test.mjs`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35a877cb688321ad3e5661f7970b4f)