### PR TITLE
Correct accepted-source panel grouping and provider list

### DIFF
--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -620,7 +620,7 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
               </div>
               <div className="space-y-1 leading-relaxed lg:self-end">
                 <p>Some accepted services currently open externally and may not provide automatic artwork, duration, or embedded playback. Expanded player and metadata support is planned.</p>
-                <p className="text-foreground">Send a direct song, track, or video link—not an artist profile, playlist, channel, album page, or general homepage.</p>
+                <p className="text-foreground">Send a direct song, track, or video link—not an artist profile, playlist, channel, general homepage, or album page that does not identify a specific track.</p>
               </div>
             </div>
             {mode === "link" ? (

--- a/src/components/RadioQueueForm.tsx
+++ b/src/components/RadioQueueForm.tsx
@@ -587,39 +587,40 @@ export function RadioQueueForm({ sessionId, onSubmitted, onCancel, onAcceptedRec
               <button type="button" onClick={() => setMode("link")} aria-pressed={mode === "link"} className={`flex min-h-[44px] items-center cursor-pointer border p-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${mode === "link" ? "border-accent bg-accent text-background" : "border-border hover:border-accent/50 hover:bg-accent/10"}`}><span className={`text-xs uppercase tracking-widest ${mode === "link" ? "text-background" : "text-muted"}`}>Use Track Link</span></button>
               <button type="button" onClick={() => setMode("upload")} aria-pressed={mode === "upload"} className={`flex min-h-[44px] items-center cursor-pointer border p-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${mode === "upload" ? "border-accent bg-accent text-background" : "border-border hover:border-accent/50 hover:bg-accent/10"}`}><span className={`text-xs uppercase tracking-widest ${mode === "upload" ? "text-background" : "text-muted"}`}>Upload MP3/WAV</span></button>
             </div>
-            <div className="grid gap-2 border border-border/70 bg-background/40 p-3 text-xs text-muted sm:grid-cols-[0.95fr_1.05fr]">
+            <div className="grid gap-3 border border-border/70 bg-background/40 p-3 text-xs text-muted lg:grid-cols-[1.45fr_1fr]">
               <div>
                 <p className="text-[10px] font-bold uppercase tracking-[0.28em] text-foreground">Accepted track sources</p>
-                <div className="mt-2 grid gap-2 sm:grid-cols-[0.6fr_1.4fr]">
-                  <div>
+                <div className="mt-2 grid gap-2 md:grid-cols-[0.65fr_1.2fr_1.35fr]">
+                  <div className="border border-border/60 bg-surface/50 p-2">
                     <p className="text-[10px] uppercase tracking-widest text-muted">Upload</p>
                     <ul className="mt-1 space-y-0.5 font-bold text-foreground">
                       <li>MP3</li>
                       <li>WAV</li>
                     </ul>
                   </div>
-                  <div>
-                    <p className="text-[10px] uppercase tracking-widest text-muted">Common track links</p>
-                    <ul className="mt-1 grid gap-x-3 gap-y-0.5 text-foreground sm:grid-cols-2">
+                  <div className="border border-accent/35 bg-accent/5 p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-accent">Built-in support</p>
+                    <ul className="mt-1 space-y-0.5 font-bold text-foreground">
                       <li>YouTube video, Short, or YouTube Music</li>
                       <li>Spotify</li>
-                      <li>SoundCloud track</li>
+                      <li>SoundCloud</li>
+                    </ul>
+                  </div>
+                  <div className="border border-border/60 bg-surface/50 p-2">
+                    <p className="text-[10px] uppercase tracking-widest text-muted">Also accepted</p>
+                    <ul className="mt-1 grid gap-x-3 gap-y-0.5 text-foreground sm:grid-cols-2 md:grid-cols-1 xl:grid-cols-2">
                       <li>Apple Music</li>
                       <li>Amazon Music</li>
                       <li>Suno</li>
                       <li>Bandcamp</li>
-                      <li>Audiomack</li>
-                      <li>BeatStars</li>
                       <li>TikTok video or Short</li>
-                      <li>Direct hosted audio or music-video link</li>
-                      <li>Other public direct song links</li>
                     </ul>
                   </div>
                 </div>
               </div>
-              <div className="space-y-1 leading-relaxed">
-                <p>Some services may not provide automatic artwork, duration, or embedded playback. Those links are still accepted and may be opened externally by the host.</p>
-                <p className="text-foreground">Send a direct song, track, or video link—not an artist profile, playlist, channel, album homepage, or general website page.</p>
+              <div className="space-y-1 leading-relaxed lg:self-end">
+                <p>Some accepted services currently open externally and may not provide automatic artwork, duration, or embedded playback. Expanded player and metadata support is planned.</p>
+                <p className="text-foreground">Send a direct song, track, or video link—not an artist profile, playlist, channel, album page, or general homepage.</p>
               </div>
             </div>
             {mode === "link" ? (


### PR DESCRIPTION
### Motivation
- Fix the public BARCODE Radio submission panel to match the operator-approved grouping and visible provider list from issue #242. 
- Remove incorrect or misleading visible entries (Audiomack, BeatStars, direct hosted links, and other public direct song links) while keeping all backend acceptance and validation unchanged. 
- Make the UI clearly distinguish current first-class built-in provider handling from accepted external-open links and keep the panel compact and responsive. 

### Description
- Updated `src/components/RadioQueueForm.tsx` to replace the previous single “Common track links” group with three visually distinct groups: `Upload`, `Built-in support`, and `Also accepted`. 
- Visible source list now exactly shows: `Upload: MP3, WAV`; `Built-in support: YouTube video, Short, or YouTube Music; Spotify; SoundCloud`; and `Also accepted: Apple Music; Amazon Music; Suno; Bandcamp; TikTok video or Short`. 
- Removed only the listed items from the visible featured panel (Audiomack, BeatStars, direct hosted audio/music-video link, other public direct song links) and updated supporting copy to state that some accepted services open externally and may not provide automatic artwork, duration, or embedded playback. 
- No backend, playback, synchronization, upload, validation, resolver, or overlay logic was changed, and PR #241 playback/YouTube synchronization behavior was left untouched; issues #240 and #243 remain separate for future work. 

### Testing
- Ran `npx tsc --noEmit` and it passed. 
- Ran `npx eslint src/components/RadioQueueForm.tsx` and it passed. 
- Ran `npm run test:queue` and the suite completed with known unrelated BNL read-model failures (3 failing tests): `dossier authoring guide matches sections rendered by the dossier page`, `dossier tag registry preserves raw entry tags and leaves database UI tag behavior freeform`, and `dossier page link rendering uses featured link helper and remains safe without links`. 
- Manual verification checklist (for Vercel preview): confirm the panel lists MP3, WAV, YouTube video/Short/YouTube Music, Spotify, SoundCloud, Apple Music, Amazon Music, Suno, Bandcamp, and TikTok video or Short; confirm Audiomack and BeatStars are not displayed; confirm direct hosted and “other public direct song links” are not displayed; confirm groups are visually distinct and responsive; confirm YouTube link submission and MP3/WAV upload still work; confirm `WATCH ON TIKTOK` behavior is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51555da444832190e256ee30dea714)