### PR TITLE
Add Apple Music queue recognition and optional catalog metadata

### DIFF
--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT, PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION, PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION, PUBLIC_QUEUE_LEGAL_TERMS_VERSION, detectQueueSourceType } from "@/lib/queue-types";
+import { PUBLIC_QUEUE_LEGAL_CHECKBOX_TEXT, PUBLIC_QUEUE_LEGAL_PRIVACY_VERSION, PUBLIC_QUEUE_LEGAL_QUEUE_TERMS_VERSION, PUBLIC_QUEUE_LEGAL_TERMS_VERSION, detectQueueSourceType, parseAppleMusicSongUrl } from "@/lib/queue-types";
 import { getPublicQueueSnapshot, getRadioQueueState, isTrackPersistedInSessionQueue, normalizeQueueSourceKey, requestPriorityUpgradePlaceholder, submitRadioTrack, toPublicQueueTrack } from "@/lib/queue";
 import type { QueueEntry } from "@/lib/queue-types";
 
@@ -67,6 +67,15 @@ function validateLegalAcceptance(body: Record<string, unknown>) {
 function parseBodyDuration(value: unknown): number | null {
   const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : null;
+}
+
+function isAppleMusicHostUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.hostname === "music.apple.com";
+  } catch {
+    return false;
+  }
 }
 
 function duplicateResponse(): NextResponse {
@@ -220,6 +229,7 @@ export async function submitTrackFromBody(body: Record<string, unknown>): Promis
   const link = cleanBodyText(body.link);
   if (!link) return NextResponse.json({ error: "Paste a track link." }, { status: 400 });
   try { new URL(link); } catch { return NextResponse.json({ error: "Enter a valid track URL." }, { status: 400 }); }
+  if (isAppleMusicHostUrl(link) && !parseAppleMusicSongUrl(link)) return NextResponse.json({ error: "Use a direct Apple Music song link. Album, artist, playlist, and station pages are not accepted.", code: "invalid_apple_music_song_url" }, { status: 400 });
   if (await hasDuplicateLinkSubmission(link)) return duplicateResponse();
 
   const sourceType = detectQueueSourceType(link);

--- a/src/components/AdminRadioQueueControl.tsx
+++ b/src/components/AdminRadioQueueControl.tsx
@@ -69,6 +69,7 @@ const SIMULATION_SPEEDS: Record<SimulationSpeed, { label: string; minDelayMs: nu
 
 function sourceLabel(entry: QueueEntry): string {
   if (entry.sourceType === "tiktok") return "TikTok";
+  if (entry.sourceType === "apple_music") return "Apple Music";
   return (entry.sourceType ?? "other").toUpperCase();
 }
 function formatPrice(cents = 0, currency = "usd"): string { return `${new Intl.NumberFormat("en-US", { style: "currency", currency: currency.toUpperCase() }).format(Math.max(0, cents) / 100)} ${currency.toUpperCase()}`; }
@@ -150,6 +151,7 @@ function embedUrl(entry: QueueEntry): string | null {
     }
     if (entry.sourceType === "spotify") return `https://open.spotify.com/embed${parsed.pathname}`;
     if (entry.sourceType === "soundcloud") return `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}`;
+    if (entry.sourceType === "apple_music") return null;
   } catch { return null; }
   return null;
 }

--- a/src/components/PublicQueueSession.tsx
+++ b/src/components/PublicQueueSession.tsx
@@ -194,6 +194,7 @@ function sourceTypeLabel(track: QueuePublicTrack): string {
   if (track.sourceType === "soundcloud") return "SoundCloud";
   if (track.sourceType === "youtube") return "YouTube";
   if (track.sourceType === "tiktok") return "TikTok";
+  if (track.sourceType === "apple_music") return "Apple Music";
   return track.sourceType ? track.sourceType.toUpperCase() : "Track link";
 }
 

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -3,11 +3,11 @@
 // ============================================================
 
 export type QueueTier = "free" | "featured" | "fastlane" | "frontrow";
-export type QueueSourceType = "upload" | "link" | "youtube" | "soundcloud" | "spotify" | "tiktok" | "other";
+export type QueueSourceType = "upload" | "link" | "youtube" | "soundcloud" | "spotify" | "tiktok" | "apple_music" | "other";
 export type QueueLane = "priority" | "wheel" | "regular";
 export type QueueNonPriorityLane = "wheel" | "regular";
 export type QueueTrackStatus = "queued" | "completed" | "removed" | "playing" | "next" | "pending" | "played" | "refunded" | "expired";
-export type QueueDurationSource = "upload_metadata" | "file_metadata" | "youtube" | "soundcloud" | "spotify" | "youtube_api" | "spotify_api" | "soundcloud_api" | "direct_metadata" | "provider_metadata" | "internal_estimate" | "estimated" | "unknown";
+export type QueueDurationSource = "upload_metadata" | "file_metadata" | "youtube" | "soundcloud" | "spotify" | "youtube_api" | "spotify_api" | "soundcloud_api" | "apple_music_api" | "direct_metadata" | "provider_metadata" | "internal_estimate" | "estimated" | "unknown";
 export type QueueSessionStatus = "prepared" | "open" | "closed" | "archived";
 export type QueueBroadcastPhase = "warmup" | "submission_window" | "broadcast_active" | "ended";
 export type PriorityUpgradeStatus = "none" | "requested" | "manual" | "checkout_pending" | "paid" | "paid_needs_attention" | "failed" | "refunded";
@@ -294,6 +294,41 @@ export function parseTikTokVideoUrl(value?: string | null): ParsedTikTokVideoUrl
     return null;
   }
 }
+export interface ParsedAppleMusicSongUrl {
+  storefront: string;
+  albumSlug: string;
+  albumId: string;
+  songId: string;
+  canonicalSourceUrl: string;
+  providerId: string;
+}
+
+const APPLE_MUSIC_ID_PATTERN = /^\d{1,32}$/;
+const APPLE_MUSIC_STOREFRONT_PATTERN = /^[a-z]{2}(?:-[a-z0-9]{2,8})?$/i;
+const APPLE_MUSIC_SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,199}$/;
+
+export function parseAppleMusicSongUrl(value?: string | null): ParsedAppleMusicSongUrl | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") return null;
+    if (url.hostname !== "music.apple.com") return null;
+    if (url.username || url.password || url.port) return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length !== 4) return null;
+    const [storefront, kind, albumSlug, albumId] = parts;
+    if (!APPLE_MUSIC_STOREFRONT_PATTERN.test(storefront)) return null;
+    if (kind !== "album") return null;
+    if (!APPLE_MUSIC_SLUG_PATTERN.test(albumSlug)) return null;
+    if (!APPLE_MUSIC_ID_PATTERN.test(albumId)) return null;
+    const songId = url.searchParams.get("i");
+    if (!songId || !APPLE_MUSIC_ID_PATTERN.test(songId)) return null;
+    const canonicalSourceUrl = `https://music.apple.com/${storefront}/album/${albumSlug}/${albumId}?i=${songId}`;
+    return { storefront, albumSlug, albumId, songId, canonicalSourceUrl, providerId: `apple_music:song:${songId}` };
+  } catch {
+    return null;
+  }
+}
 
 export function parseQueueYouTubeVideoId(link?: string | null): string | null {
   if (!link) return null;
@@ -323,7 +358,7 @@ export function getTrackArtworkUrl(track: Pick<QueueEntry, "sourceType" | "sourc
     const videoId = parseQueueYouTubeVideoId(track.link);
     if (videoId) return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
   }
-  if ((track.sourceType === "spotify" || track.sourceType === "soundcloud" || track.sourceType === "youtube" || track.sourceType === "tiktok") && isSafeHttpsArtworkUrl(track.sourceArtworkUrl)) return track.sourceArtworkUrl;
+  if ((track.sourceType === "spotify" || track.sourceType === "soundcloud" || track.sourceType === "youtube" || track.sourceType === "tiktok" || track.sourceType === "apple_music") && isSafeHttpsArtworkUrl(track.sourceArtworkUrl)) return track.sourceArtworkUrl;
   return null;
 }
 
@@ -377,6 +412,7 @@ export function formatRuntime(seconds: number): string {
 
 export function detectQueueSourceType(value: string): QueueSourceType {
   if (parseTikTokVideoUrl(value)) return "tiktok";
+  if (parseAppleMusicSongUrl(value)) return "apple_music";
   try {
     const url = new URL(value);
     const host = url.hostname.replace(/^www\./, "").toLowerCase();

--- a/src/lib/queue-types.ts
+++ b/src/lib/queue-types.ts
@@ -305,7 +305,21 @@ export interface ParsedAppleMusicSongUrl {
 
 const APPLE_MUSIC_ID_PATTERN = /^\d{1,32}$/;
 const APPLE_MUSIC_STOREFRONT_PATTERN = /^[a-z]{2}(?:-[a-z0-9]{2,8})?$/i;
-const APPLE_MUSIC_SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,199}$/;
+function normalizeAppleMusicAlbumSlug(value: string): string | null {
+  if (!value || value.length > 300) return null;
+  if (value === "." || value === "..") return null;
+  if (value.includes("/") || value.includes("\\") || value.includes("\0")) return null;
+  if (/%(?![0-9A-Fa-f]{2})/.test(value)) return null;
+  try {
+    const decoded = decodeURIComponent(value);
+    if (!decoded || decoded === "." || decoded === "..") return null;
+    if (decoded.includes("/") || decoded.includes("\\") || decoded.includes("\0")) return null;
+    if (/[\u0000-\u001F\u007F]/.test(decoded)) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
 
 export function parseAppleMusicSongUrl(value?: string | null): ParsedAppleMusicSongUrl | null {
   if (!value) return null;
@@ -316,12 +330,16 @@ export function parseAppleMusicSongUrl(value?: string | null): ParsedAppleMusicS
     if (url.username || url.password || url.port) return null;
     const parts = url.pathname.split("/").filter(Boolean);
     if (parts.length !== 4) return null;
-    const [storefront, kind, albumSlug, albumId] = parts;
-    if (!APPLE_MUSIC_STOREFRONT_PATTERN.test(storefront)) return null;
+    const [rawStorefront, kind, rawAlbumSlug, albumId] = parts;
+    if (!APPLE_MUSIC_STOREFRONT_PATTERN.test(rawStorefront)) return null;
+    const storefront = rawStorefront.toLowerCase();
     if (kind !== "album") return null;
-    if (!APPLE_MUSIC_SLUG_PATTERN.test(albumSlug)) return null;
+    const albumSlug = normalizeAppleMusicAlbumSlug(rawAlbumSlug);
+    if (!albumSlug) return null;
     if (!APPLE_MUSIC_ID_PATTERN.test(albumId)) return null;
-    const songId = url.searchParams.get("i");
+    const songIds = url.searchParams.getAll("i");
+    if (songIds.length !== 1) return null;
+    const songId = songIds[0];
     if (!songId || !APPLE_MUSIC_ID_PATTERN.test(songId)) return null;
     const canonicalSourceUrl = `https://music.apple.com/${storefront}/album/${albumSlug}/${albumId}?i=${songId}`;
     return { storefront, albumSlug, albumId, songId, canonicalSourceUrl, providerId: `apple_music:song:${songId}` };

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -14,6 +14,7 @@ import {
   getTrackDurationLabel,
   getTrackArtworkUrl,
   normalizeTier,
+  parseAppleMusicSongUrl,
   parseTikTokVideoUrl,
 } from "./queue-types";
 import type {
@@ -48,6 +49,8 @@ const PRE_SHOW_ROUTING_DELAY_MS = (20 * 60 + 15) * 1000;
 const UPLOADED_FILE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const TIKTOK_OEMBED_TIMEOUT_MS = 2500;
 const TIKTOK_OEMBED_MAX_BYTES = 256 * 1024;
+const APPLE_MUSIC_CATALOG_TIMEOUT_MS = 2500;
+const APPLE_MUSIC_CATALOG_MAX_BYTES = 256 * 1024;
 const BARCODE_QUEUE_UPLOAD_HOST_SUFFIX = ".private.blob.vercel-storage.com";
 const BARCODE_QUEUE_UPLOAD_PATH_PREFIX = "/barcode-radio-queue/";
 
@@ -761,6 +764,7 @@ function normalizeDurationSource(source: QueueDurationSource | string | undefine
   if (source === "browser-audio-metadata" || source === "upload_metadata") return "upload_metadata";
   if (source === "file-metadata" || source === "file_metadata") return "file_metadata";
   if (source === "provider-metadata" || source === "provider_metadata") return sourceType === "youtube" || sourceType === "soundcloud" || sourceType === "spotify" ? sourceType : "provider_metadata";
+  if (source === "apple_music_api") return "apple_music_api";
   if (source === "internal-estimate" || source === "internal_estimate" || source === "estimated") return source === "estimated" ? "estimated" : "internal_estimate";
   if (source === "youtube_api" || source === "spotify_api" || source === "soundcloud_api" || source === "direct_metadata") return source;
   if (source === "youtube" || source === "soundcloud" || source === "spotify" || source === "unknown") return source;
@@ -768,6 +772,7 @@ function normalizeDurationSource(source: QueueDurationSource | string | undefine
   if (detected && sourceType === "youtube") return "youtube_api";
   if (detected && sourceType === "spotify") return "spotify_api";
   if (detected && sourceType === "soundcloud") return "soundcloud_api";
+  if (detected && sourceType === "apple_music") return "apple_music_api";
   return detected ? "provider_metadata" : "internal_estimate";
 }
 
@@ -984,11 +989,11 @@ function safeHttpsPublicUrl(value: unknown): string | null {
   } catch { return null; }
 }
 
-async function readLimitedJson(res: Response): Promise<unknown | null> {
+async function readLimitedJson(res: Response, maxBytes = TIKTOK_OEMBED_MAX_BYTES): Promise<unknown | null> {
   const contentType = res.headers.get("content-type") || "";
   if (!/application\/(json|.*\+json)|text\/json/i.test(contentType)) return null;
   const length = Number(res.headers.get("content-length") || 0);
-  if (Number.isFinite(length) && length > TIKTOK_OEMBED_MAX_BYTES) return null;
+  if (Number.isFinite(length) && length > maxBytes) return null;
   const reader = res.body?.getReader();
   if (!reader) return null;
   const chunks: Uint8Array[] = [];
@@ -998,7 +1003,7 @@ async function readLimitedJson(res: Response): Promise<unknown | null> {
     if (done) break;
     if (value) {
       total += value.byteLength;
-      if (total > TIKTOK_OEMBED_MAX_BYTES) return null;
+      if (total > maxBytes) return null;
       chunks.push(value);
     }
   }
@@ -1037,6 +1042,44 @@ async function lookupTikTokMetadata(link: string): Promise<ProviderMetadata> {
   }
 }
 
+function safeAppleMusicArtworkUrl(value: unknown): string | null {
+  if (typeof value !== "string" || !value.includes("{w}") || !value.includes("{h}") || value.length > 500) return null;
+  const rendered = value.replace(/\{w\}/g, "600").replace(/\{h\}/g, "600");
+  return safeHttpsPublicUrl(rendered);
+}
+
+async function lookupAppleMusicMetadata(link: string): Promise<ProviderMetadata> {
+  const parsed = parseAppleMusicSongUrl(link);
+  const token = process.env.APPLE_MUSIC_DEVELOPER_TOKEN;
+  if (!parsed || !token) return blankProvider("internal_estimate");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), APPLE_MUSIC_CATALOG_TIMEOUT_MS);
+  try {
+    const endpoint = `https://api.music.apple.com/v1/catalog/${encodeURIComponent(parsed.storefront)}/songs/${encodeURIComponent(parsed.songId)}`;
+    const res = await fetch(endpoint, { cache: "no-store", signal: controller.signal, headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok || !(res.headers.get("content-type") ?? "").toLowerCase().includes("application/json")) return blankProvider("internal_estimate");
+    const payload = await readLimitedJson(res, APPLE_MUSIC_CATALOG_MAX_BYTES);
+    const first = Array.isArray((payload as { data?: unknown[] } | null)?.data) ? (payload as { data: Array<{ attributes?: Record<string, unknown> }> }).data[0] : null;
+    const attributes = first && typeof first.attributes === "object" ? first.attributes : null;
+    if (!attributes) return blankProvider("internal_estimate");
+    const durationMs = typeof attributes.durationInMillis === "number" ? attributes.durationInMillis : null;
+    const seconds = durationMs && Number.isFinite(durationMs) && durationMs > 0 ? Math.max(1, Math.round(durationMs / 1000)) : null;
+    const artwork = typeof attributes.artwork === "object" && attributes.artwork ? safeAppleMusicArtworkUrl((attributes.artwork as { url?: unknown }).url) : null;
+    return {
+      detectedArtistName: sanitizeProviderText(attributes.artistName, 160),
+      detectedSongTitle: sanitizeProviderText(attributes.name, 240),
+      providerTitle: sanitizeProviderText(attributes.name, 240),
+      detectedDurationSeconds: seconds,
+      durationSource: seconds ? "apple_music_api" : "internal_estimate",
+      artworkUrl: artwork,
+    };
+  } catch {
+    return blankProvider("internal_estimate");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function lookupSoundCloudMetadata(link: string): Promise<ProviderMetadata> {
   const clientId = process.env.SOUNDCLOUD_CLIENT_ID;
   if (!clientId) return lookupSoundCloudOEmbed(link).catch(() => blankProvider("internal_estimate"));
@@ -1059,9 +1102,10 @@ export async function detectProviderMetadata(sourceType: QueueSourceType, link: 
     else if (sourceType === "spotify") metadata = await lookupSpotifyMetadata(link);
     else if (sourceType === "soundcloud") metadata = await lookupSoundCloudMetadata(link);
     else if (sourceType === "tiktok") metadata = await lookupTikTokMetadata(link);
+    else if (sourceType === "apple_music") metadata = await lookupAppleMusicMetadata(link);
     else return metadata;
 
-    if (metadata.detectedDurationSeconds) return metadata;
+    if (metadata.detectedDurationSeconds || sourceType === "apple_music") return metadata;
 
     const duration = await detectTrackDurationFromLink(link);
     if (duration.durationSeconds && duration.durationIsEstimate === false) {
@@ -1096,6 +1140,8 @@ function normalizeEmail(value?: string | null): string {
 
 export function normalizeQueueSourceKey(value?: string | null): string | null {
   if (!value) return null;
+  const appleMusic = parseAppleMusicSongUrl(value);
+  if (appleMusic) return appleMusic.providerId;
   const tiktok = parseTikTokVideoUrl(value);
   if (tiktok) return `tiktok:video:${tiktok.postId}`;
   try {
@@ -1125,6 +1171,10 @@ function parseProviderId(sourceType: QueueSourceType, link: string): string | nu
   if (sourceType === "tiktok") {
     const parsed = parseTikTokVideoUrl(link);
     return parsed ? `tiktok:video:${parsed.postId}` : null;
+  }
+  if (sourceType === "apple_music") {
+    const parsed = parseAppleMusicSongUrl(link);
+    return parsed?.providerId ?? null;
   }
   return null;
 }
@@ -1243,7 +1293,7 @@ export async function createQueueTrack(input: {
   if (!normalizedTikTokHandle) throw new Error("TikTok handle is required.");
   const providerMetadata = sourceType === "upload" ? blankProvider() : await detectProviderMetadata(sourceType, input.link ?? "");
   const providerId = parseProviderId(sourceType, input.link ?? input.fileUrl ?? "");
-  const normalizedSourceKey = normalizeQueueSourceKey(input.fileUrl || input.link || "");
+  const normalizedSourceKey = providerId ?? normalizeQueueSourceKey(input.fileUrl || input.link || "");
   const fileMetadata = sourceType === "upload" ? parseFilenameMetadata(input.fileName) : { artist: null, title: null, providerTitle: null };
   const detectedDurationSeconds = typeof input.detectedDurationSeconds === "number" && Number.isFinite(input.detectedDurationSeconds)
     ? Math.max(1, Math.round(input.detectedDurationSeconds))

--- a/src/lib/track-duration.ts
+++ b/src/lib/track-duration.ts
@@ -1,12 +1,13 @@
-import { INTERNAL_BUFFER_DURATION_SECONDS, parseTikTokVideoUrl } from "./queue-types";
+import { INTERNAL_BUFFER_DURATION_SECONDS, parseAppleMusicSongUrl, parseTikTokVideoUrl } from "./queue-types";
 
-export type TrackDurationProvider = "youtube" | "spotify" | "soundcloud" | "tiktok" | "direct" | "other";
+export type TrackDurationProvider = "youtube" | "spotify" | "soundcloud" | "tiktok" | "apple_music" | "direct" | "other";
 
 export type TrackDurationSource =
   | "upload_metadata"
   | "youtube_api"
   | "spotify_api"
   | "soundcloud_api"
+  | "apple_music_api"
   | "direct_metadata"
   | "estimated"
   | "unknown";
@@ -126,6 +127,8 @@ export function parseSafeTrackProviderUrl(link?: string | null): ParsedTrackProv
   if (youtubeId) return { provider: "youtube", providerTrackId: youtubeId, normalizedUrl: `https://www.youtube.com/watch?v=${youtubeId}` };
   const spotifyId = parseSpotifyTrackId(link);
   if (spotifyId) return { provider: "spotify", providerTrackId: spotifyId, normalizedUrl: `https://open.spotify.com/track/${spotifyId}` };
+  const appleMusic = parseAppleMusicSongUrl(link);
+  if (appleMusic) return { provider: "apple_music", providerTrackId: appleMusic.songId, normalizedUrl: appleMusic.canonicalSourceUrl };
   const tiktok = parseTikTokVideoUrl(link);
   if (tiktok) return { provider: "tiktok", providerTrackId: tiktok.postId, normalizedUrl: tiktok.canonicalSourceUrl };
   const soundcloudUrl = parseSoundCloudPublicUrl(link);
@@ -196,6 +199,7 @@ export async function detectTrackDurationFromLink(link?: string | null): Promise
     if (parsed.provider === "youtube" && parsed.providerTrackId) return detectYouTubeDuration(parsed.providerTrackId);
     if (parsed.provider === "spotify" && parsed.providerTrackId) return detectSpotifyDuration(parsed.providerTrackId);
     if (parsed.provider === "soundcloud") return detectSoundCloudDuration(parsed.normalizedUrl);
+    if (parsed.provider === "apple_music") return unavailable("apple_music", ["Apple Music catalog duration is fetched during queue metadata lookup when configured."], parsed.providerTrackId);
     if (parsed.provider === "tiktok") return unavailable("tiktok", ["Official TikTok oEmbed does not document exact duration metadata; using the internal estimate."], parsed.providerTrackId);
     return unavailable(parsed.provider, ["Provider is parsed but duration fetching is not enabled."], parsed.providerTrackId);
   } catch (error) {

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -1607,6 +1607,26 @@ test("public POST rejects missing legal acceptance", async () => {
   assert.equal(payload.error, "Legal acceptance is required before submitting to the queue.");
 });
 
+test("public POST rejects invalid Apple Music host pages before creating tracks", async () => {
+  const sessionId = await freshOpenSession("invalid apple page");
+  const before = await queue.getRadioQueueState();
+  const response = await queueApi.submitTrackFromBody({
+    sessionId,
+    mode: "link",
+    artist: "Apple Artist",
+    title: "Album Page",
+    tiktokHandle: "@invalidapple",
+    link: "https://music.apple.com/us/album/example-album/123456789",
+    ...legalAcceptanceBody(),
+  });
+  const payload = await jsonOf(response);
+  const after = await queue.getRadioQueueState();
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, "invalid_apple_music_song_url");
+  assert.equal(payload.error, "Use a direct Apple Music song link. Album, artist, playlist, and station pages are not accepted.");
+  assert.equal(after.queue.length, before.queue.length);
+});
+
 test("public POST accepts current active sessionId", async () => {
   const sessionId = await freshOpenSession("current session");
   const response = await queueApi.submitTrackFromBody({
@@ -2058,4 +2078,106 @@ test("admin and public TikTok component source assertions remain scoped", () => 
   assert.match(adminSource, /function AdminYouTubePlayer/);
   assert.match(formSource, /TikTok video or Short/);
   assert.match(publicSource, /WATCH ON TIKTOK/);
+});
+
+const appleMusicUrl = "https://music.apple.com/us/album/example-album/123456789?i=987654321";
+
+function mockAppleMusicCatalog(body, init = {}) {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    if (init.throwAbort) throw new DOMException("aborted", "AbortError");
+    return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { "content-type": init.contentType ?? "application/json", ...(init.contentLength ? { "content-length": init.contentLength } : {}) },
+    });
+  };
+  return { calls, restore: () => { globalThis.fetch = originalFetch; } };
+}
+
+function withAppleToken(value, callback) {
+  const original = process.env.APPLE_MUSIC_DEVELOPER_TOKEN;
+  if (value === undefined) delete process.env.APPLE_MUSIC_DEVELOPER_TOKEN;
+  else process.env.APPLE_MUSIC_DEVELOPER_TOKEN = value;
+  return Promise.resolve(callback()).finally(() => {
+    if (original === undefined) delete process.env.APPLE_MUSIC_DEVELOPER_TOKEN;
+    else process.env.APPLE_MUSIC_DEVELOPER_TOKEN = original;
+  });
+}
+
+test("Apple Music direct song submissions use provider identity and duplicate-safe normalization", async () => withAppleToken(undefined, async () => {
+  await freshOpenSession("apple duplicate", { showStarted: false });
+  const first = await queue.submitRadioTrack({ artist: "Submitted Artist", title: "Submitted Song", tiktokHandle: "@appledup1", link: `${appleMusicUrl}&utm_source=x#frag` });
+  assert.equal(first.sourceType, "apple_music");
+  assert.equal(first.providerId, "apple_music:song:987654321");
+  assert.equal(first.normalizedSourceKey, "apple_music:song:987654321");
+  assert.equal(queue.normalizeQueueSourceKey("https://music.apple.com/gb/album/other-slug/123456789?i=987654321&utm_medium=y#x"), "apple_music:song:987654321");
+  assert.equal(first.submittedArtistName, "Submitted Artist");
+  assert.equal(first.submittedSongTitle, "Submitted Song");
+  assert.equal(first.detectedArtistName, null);
+  assert.equal(first.detectedSongTitle, null);
+  assert.equal(first.detectedDurationSeconds, null);
+  assert.equal(first.durationIsEstimate, true);
+  assert.equal(first.estimatedDurationSeconds, 300);
+  await withFakeNow(new Date(Date.now() + 301_000), async () => {
+    await assert.rejects(() => queue.submitRadioTrack({ artist: "Apple Artist", title: "Tracking", tiktokHandle: "@appledup2", link: `${appleMusicUrl}&utm_campaign=x` }), /Duplicate transmission/);
+    await assert.rejects(() => queue.submitRadioTrack({ artist: "Apple Artist", title: "Storefront", tiktokHandle: "@appledup3", link: "https://music.apple.com/gb/album/example-album/123456789?i=987654321" }), /Duplicate transmission/);
+    await assert.rejects(() => queue.submitRadioTrack({ artist: "Apple Artist", title: "Slug", tiktokHandle: "@appledup4", link: "https://music.apple.com/us/album/harmless-slug/123456789?i=987654321" }), /Duplicate transmission/);
+  });
+}));
+
+test("Apple Music catalog metadata is optional, supplemental, safe, and fetched once", async () => withAppleToken("secret-dev-token", async () => {
+  const mock = mockAppleMusicCatalog({ data: [{ attributes: { artistName: "Catalog Artist", name: "Catalog Song", durationInMillis: 201500, artwork: { url: "https://is1-ssl.mzstatic.com/image/thumb/Music/{w}x{h}bb.jpg" } } }] });
+  try {
+    const track = await queue.createQueueTrack({ artist: "Submitted Artist", title: "Submitted Song", tiktokHandle: "@applemeta", link: appleMusicUrl });
+    assert.equal(mock.calls.length, 1);
+    assert.match(mock.calls[0].url, /api\.music\.apple\.com\/v1\/catalog\/us\/songs\/987654321/);
+    assert.equal(mock.calls[0].options.headers.Authorization, "Bearer secret-dev-token");
+    assert.equal(JSON.stringify(track).includes("secret-dev-token"), false);
+    assert.equal(track.detectedArtistName, "Catalog Artist");
+    assert.equal(track.detectedSongTitle, "Catalog Song");
+    assert.equal(track.providerTitle, "Catalog Song");
+    assert.equal(track.detectedDurationSeconds, 202);
+    assert.equal(track.durationIsEstimate, false);
+    assert.equal(track.durationSource, "apple_music_api");
+    assert.equal(track.sourceArtworkUrl, "https://is1-ssl.mzstatic.com/image/thumb/Music/600x600bb.jpg");
+    assert.equal(track.submittedArtistName, "Submitted Artist");
+    assert.equal(track.submittedSongTitle, "Submitted Song");
+  } finally { mock.restore(); }
+}));
+
+test("Apple Music metadata failures accept track with internal estimate", async () => {
+  for (const scenario of [
+    { token: undefined, body: { data: [] }, expectCalls: 0 },
+    { token: "token", body: { errors: [{ detail: "missing" }] }, status: 404, expectCalls: 1 },
+    { token: "token", body: "{bad json", expectCalls: 1 },
+    { token: "token", body: { data: [{ attributes: { name: "Oversize" } }] }, contentLength: String(300 * 1024), expectCalls: 1 },
+    { token: "token", body: { data: [] }, expectCalls: 1 },
+    { token: "token", body: {}, throwAbort: true, expectCalls: 1 },
+    { token: "token", body: { data: [{ attributes: { artwork: { url: "https://is1-ssl.mzstatic.com/image/thumb/Music/unbounded.jpg" } } }] }, expectCalls: 1 },
+  ]) {
+    await withAppleToken(scenario.token, async () => {
+      const mock = mockAppleMusicCatalog(scenario.body, scenario);
+      try {
+        const track = await queue.createQueueTrack({ artist: "Fallback Artist", title: "Fallback Song", tiktokHandle: `@applefallback${Math.random().toString(36).slice(2, 8)}`, link: appleMusicUrl });
+        assert.equal(mock.calls.length, scenario.expectCalls);
+        assert.equal(track.detectedDurationSeconds, null);
+        assert.equal(track.durationIsEstimate, true);
+        assert.equal(track.estimatedDurationSeconds, 300);
+        if (scenario.body?.data?.[0]?.attributes?.artwork) assert.equal(track.sourceArtworkUrl, null);
+      } finally { mock.restore(); }
+    });
+  }
+});
+
+test("admin and public Apple Music component source assertions remain external-open only", () => {
+  const adminSource = fs.readFileSync(path.join(projectRoot, "src/components/AdminRadioQueueControl.tsx"), "utf8");
+  const publicSource = fs.readFileSync(path.join(projectRoot, "src/components/PublicQueueSession.tsx"), "utf8");
+  const overlayFiles = ["src/components/LiveOverlayReceiver.tsx", "src/lib/live-overlay.ts", "src/lib/live-overlay-resolver.ts", "src/app/api/admin/overlay/live/route.ts", "src/app/api/overlay/live/route.ts", "src/app/overlay/live/overlay-live.css"];
+  assert.match(adminSource, /entry\.sourceType === "apple_music"\) return "Apple Music"/);
+  assert.match(publicSource, /track\.sourceType === "apple_music"\) return "Apple Music"/);
+  assert.match(adminSource, /entry\.sourceType === "apple_music"\) return null/);
+  assert.doesNotMatch(adminSource, /AppleMusicPlayer|music\.apple\.com\/embed/);
+  for (const file of overlayFiles) assert.doesNotMatch(fs.readFileSync(path.join(projectRoot, file), "utf8"), /apple_music|Apple Music|music\.apple\.com/);
 });

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -2081,6 +2081,7 @@ test("admin and public TikTok component source assertions remain scoped", () => 
 });
 
 const appleMusicUrl = "https://music.apple.com/us/album/example-album/123456789?i=987654321";
+const uppercaseStorefrontAppleMusicUrl = "https://music.apple.com/US/album/caf%C3%A9-del-mar/123456789?i=987654321";
 
 function mockAppleMusicCatalog(body, init = {}) {
   const originalFetch = globalThis.fetch;
@@ -2130,7 +2131,7 @@ test("Apple Music direct song submissions use provider identity and duplicate-sa
 test("Apple Music catalog metadata is optional, supplemental, safe, and fetched once", async () => withAppleToken("secret-dev-token", async () => {
   const mock = mockAppleMusicCatalog({ data: [{ attributes: { artistName: "Catalog Artist", name: "Catalog Song", durationInMillis: 201500, artwork: { url: "https://is1-ssl.mzstatic.com/image/thumb/Music/{w}x{h}bb.jpg" } } }] });
   try {
-    const track = await queue.createQueueTrack({ artist: "Submitted Artist", title: "Submitted Song", tiktokHandle: "@applemeta", link: appleMusicUrl });
+    const track = await queue.createQueueTrack({ artist: "Submitted Artist", title: "Submitted Song", tiktokHandle: "@applemeta", link: uppercaseStorefrontAppleMusicUrl });
     assert.equal(mock.calls.length, 1);
     assert.match(mock.calls[0].url, /api\.music\.apple\.com\/v1\/catalog\/us\/songs\/987654321/);
     assert.equal(mock.calls[0].options.headers.Authorization, "Bearer secret-dev-token");
@@ -2141,6 +2142,7 @@ test("Apple Music catalog metadata is optional, supplemental, safe, and fetched 
     assert.equal(track.detectedDurationSeconds, 202);
     assert.equal(track.durationIsEstimate, false);
     assert.equal(track.durationSource, "apple_music_api");
+    assert.equal(track.link, uppercaseStorefrontAppleMusicUrl);
     assert.equal(track.sourceArtworkUrl, "https://is1-ssl.mzstatic.com/image/thumb/Music/600x600bb.jpg");
     assert.equal(track.submittedArtistName, "Submitted Artist");
     assert.equal(track.submittedSongTitle, "Submitted Song");

--- a/tests/track-duration.test.mjs
+++ b/tests/track-duration.test.mjs
@@ -263,3 +263,46 @@ test("TikTok duration parsing returns unavailable and stores 300 second estimate
   assert.match(result.notes.join(" "), /does not document exact duration/);
   assert.deepEqual(duration.trackDurationStorageFields(result), { detectedDurationSeconds: null, estimatedDurationSeconds: 300, durationIsEstimate: true, durationSource: "estimated" });
 });
+
+const appleUrl = "https://music.apple.com/us/album/example-album/123456789?i=987654321&utm_source=x#frag";
+
+test("parses Apple Music direct song URLs and canonicalizes identity", () => {
+  const parsed = queueTypes.parseAppleMusicSongUrl(appleUrl);
+  assert.ok(parsed);
+  assert.equal(parsed.storefront, "us");
+  assert.equal(parsed.albumId, "123456789");
+  assert.equal(parsed.songId, "987654321");
+  assert.equal(parsed.providerId, "apple_music:song:987654321");
+  assert.equal(parsed.canonicalSourceUrl, "https://music.apple.com/us/album/example-album/123456789?i=987654321");
+  assert.equal(queueTypes.detectQueueSourceType(appleUrl), "apple_music");
+  const durationParsed = duration.parseSafeTrackProviderUrl(appleUrl);
+  assert.deepEqual(durationParsed, { provider: "apple_music", providerTrackId: "987654321", normalizedUrl: "https://music.apple.com/us/album/example-album/123456789?i=987654321" });
+});
+
+test("rejects unsupported Apple Music URL forms", () => {
+  for (const value of [
+    "https://music.apple.com/us/album/example-album/123456789",
+    "https://music.apple.com/us/artist/example/123456789",
+    "https://music.apple.com/us/playlist/example/pl.123",
+    "https://music.apple.com/us/station/example/ra.123",
+    "https://music.apple.com/us/radio",
+    "https://music.apple.com/",
+    "http://music.apple.com/us/album/example-album/123456789?i=987654321",
+    "https://music.apple.com.evil.test/us/album/example-album/123456789?i=987654321",
+    "https://user:pass@music.apple.com/us/album/example-album/123456789?i=987654321",
+    "https://music.apple.com:444/us/album/example-album/123456789?i=987654321",
+    "https://music.apple.com/us/album/example-album/notnumeric?i=987654321",
+    "https://music.apple.com/us/album/example-album/123456789?i=notnumeric",
+    "https://music.apple.com/us/album//123456789?i=987654321",
+  ]) {
+    assert.equal(queueTypes.parseAppleMusicSongUrl(value), null, value);
+    assert.notEqual(queueTypes.detectQueueSourceType(value), "apple_music", value);
+    assert.equal(duration.parseSafeTrackProviderUrl(value)?.provider === "apple_music", false, value);
+  }
+});
+
+test("permits only safe HTTPS Apple Music artwork passthrough", () => {
+  assert.equal(queueTypes.getTrackArtworkUrl({ sourceType: "apple_music", sourceArtworkUrl: "https://is1-ssl.mzstatic.com/image/thumb/Music/art.jpg" }), "https://is1-ssl.mzstatic.com/image/thumb/Music/art.jpg");
+  assert.equal(queueTypes.getTrackArtworkUrl({ sourceType: "apple_music", sourceArtworkUrl: "http://is1-ssl.mzstatic.com/art.jpg" }), null);
+  assert.equal(queueTypes.getTrackArtworkUrl({ sourceType: "apple_music", sourceArtworkUrl: "https://user@is1-ssl.mzstatic.com/art.jpg" }), null);
+});

--- a/tests/track-duration.test.mjs
+++ b/tests/track-duration.test.mjs
@@ -301,6 +301,49 @@ test("rejects unsupported Apple Music URL forms", () => {
   }
 });
 
+
+test("accepts safe international Apple Music album slug segments", () => {
+  const cases = [
+    ["example-album", "us"],
+    ["caf%C3%A9-del-mar", "us"],
+    ["%E6%9D%B1%E4%BA%AC", "jp"],
+    ["rock-%26-roll", "us"],
+    ["album_name", "us"],
+  ];
+  for (const [slug, storefront] of cases) {
+    const parsed = queueTypes.parseAppleMusicSongUrl(`https://music.apple.com/${storefront}/album/${slug}/123456789?i=987654321&utm_source=x#frag`);
+    assert.ok(parsed, slug);
+    assert.equal(parsed.albumSlug, slug);
+    assert.equal(parsed.canonicalSourceUrl, `https://music.apple.com/${storefront}/album/${slug}/123456789?i=987654321`);
+    assert.equal(parsed.providerId, "apple_music:song:987654321");
+  }
+});
+
+test("normalizes Apple Music storefront casing and preserves encoded slug", () => {
+  const parsed = queueTypes.parseAppleMusicSongUrl("https://music.apple.com/US/album/caf%C3%A9-del-mar/123456789?i=987654321");
+  assert.ok(parsed);
+  assert.equal(parsed.storefront, "us");
+  assert.equal(parsed.albumSlug, "caf%C3%A9-del-mar");
+  assert.equal(parsed.canonicalSourceUrl, "https://music.apple.com/us/album/caf%C3%A9-del-mar/123456789?i=987654321");
+});
+
+test("rejects unsafe Apple Music encoded slug and ambiguous song parameter variants", () => {
+  const overlong = "a".repeat(301);
+  for (const value of [
+    "https://music.apple.com/us/album/bad%ZZslug/123456789?i=987654321",
+    "https://music.apple.com/us/album/%2F/123456789?i=987654321",
+    "https://music.apple.com/us/album/%5C/123456789?i=987654321",
+    "https://music.apple.com/us/album/bad%00slug/123456789?i=987654321",
+    "https://music.apple.com/us/album/bad%1Fslug/123456789?i=987654321",
+    "https://music.apple.com/us/album/./123456789?i=987654321",
+    "https://music.apple.com/us/album/../123456789?i=987654321",
+    `https://music.apple.com/us/album/${overlong}/123456789?i=987654321`,
+    "https://music.apple.com/us/album/example-album/123456789?i=987654321&i=123456789",
+  ]) {
+    assert.equal(queueTypes.parseAppleMusicSongUrl(value), null, value);
+  }
+});
+
 test("permits only safe HTTPS Apple Music artwork passthrough", () => {
   assert.equal(queueTypes.getTrackArtworkUrl({ sourceType: "apple_music", sourceArtworkUrl: "https://is1-ssl.mzstatic.com/image/thumb/Music/art.jpg" }), "https://is1-ssl.mzstatic.com/image/thumb/Music/art.jpg");
   assert.equal(queueTypes.getTrackArtworkUrl({ sourceType: "apple_music", sourceArtworkUrl: "http://is1-ssl.mzstatic.com/art.jpg" }), null);


### PR DESCRIPTION
### Motivation

- Promote direct Apple Music song links to a first-class queue provider so canonical song identity and optional official metadata can be used during queue ingestion. 
- Provide an optional Level 2 path to fetch official Apple Music catalog metadata (title, artist, artwork, exact duration) when a server-only `APPLE_MUSIC_DEVELOPER_TOKEN` is configured while keeping a graceful fallback to the internal estimate. 
- Require a strict, narrow direct-song URL form and explicit host validation to avoid accepting album/artist/playlist/station pages and to preserve duplicate-safety across storefront/slug/tracking variants.

### Description

- Add `apple_music` to `QueueSourceType` and `apple_music_api` to duration/source enums, and extend safe artwork passthrough to permit Apple Music HTTPS artwork URLs (`src/lib/queue-types.ts`).
- Implement `parseAppleMusicSongUrl()` with strict validation and canonicalization, return a stable provider identity `apple_music:song:{songId}`, and detect Apple Music before generic fallback in `detectQueueSourceType()` (`src/lib/queue-types.ts`).
- Parse Apple Music as a duration provider in `parseSafeTrackProviderUrl()` and make duration handling return a note that exact duration is provided by the catalog metadata flow (`src/lib/track-duration.ts`).
- Add an optional server-side Apple catalog lookup using `APPLE_MUSIC_DEVELOPER_TOKEN` with `no-store`, timeout (~2500ms), limited JSON body, safe first-resource parsing, artwork template rendering to bounded sizes, and graceful fallbacks; map `artistName -> detectedArtistName`, `name -> detectedSongTitle/providerTitle`, `durationInMillis -> detectedDurationSeconds` (`src/lib/queue.ts`).
- Normalize duplicates by preferring provider identity (providerId) and use that as the normalized source key when available so fragments/tracking/storefront/harmless-slug variants are duplicate-equivalent (`src/lib/queue.ts`).
- Add narrow API validation to reject invalid Apple Music host pages (album/artist/playlist/station) preflight with HTTP 400 and code `invalid_apple_music_song_url` (`src/app/api/queue/route.ts`).
- Add admin/public source labels for Apple Music and ensure admin embed/preview explicitly returns `null` for Apple Music (external-open only; no iframe/embed or MusicKit) (`src/components/AdminRadioQueueControl.tsx`, `src/components/PublicQueueSession.tsx`).
- Add focused unit/integration tests covering parser behavior, provider identity normalization, duplicate blocking, artwork handling, metadata mapping, single-catalog-request behavior, and failure fallbacks (`tests/track-duration.test.mjs`, `tests/queue-playback.test.mjs`).
- Files changed: `src/lib/queue-types.ts`, `src/lib/track-duration.ts`, `src/lib/queue.ts`, `src/app/api/queue/route.ts`, `src/components/AdminRadioQueueControl.tsx`, `src/components/PublicQueueSession.tsx`, `tests/track-duration.test.mjs`, `tests/queue-playback.test.mjs`.

### Testing

- `npm run build` completed successfully and produced a successful Next build. 
- `npx tsc --noEmit` passed with no type errors. 
- `npx eslint` on the changed files passed with one pre-existing `react-hooks/exhaustive-deps` warning in `AdminRadioQueueControl.tsx`. 
- `node --test tests/track-duration.test.mjs tests/queue-playback.test.mjs tests/live-overlay-resolver.test.mjs` passed (new Apple Music parser, provider/duration plumbing, metadata mapping, and live-overlay regressions covered). 
- `npm run test:queue` ran but surfaced three known, unrelated BNL read-model assertions (dossier authoring guide / tag registry / page link helper); queue-specific suites and Apple Music-focused tests passed and metadata-failure scenarios are asserted in the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52e64c6ccc8321865e0dd5998e3d7a)