### PR TITLE
Reset homepage around music, Radio, and public identity

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     default: "BARCODE Network",
     template: "%s | BARCODE Network",
   },
-  description: "An interdimensional broadcast station. Programs: 6 Bit • BARCODE Radio • Database • Releases • Transmissions.",
+  description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
   keywords: ["BARCODE Network", "6 Bit", "BARCODE Radio", "hip hop", "live broadcast", "music submissions"],
   icons: {
     icon: [
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "BARCODE Network",
-    description: "An interdimensional broadcast station. Signal over noise.",
+    description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
     siteName: "BARCODE Network",
     images: [{ url: "/og-image.png", width: 1200, height: 630 }],
     type: "website",
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary",
     title: "BARCODE Network",
-    description: "An interdimensional broadcast station. Signal over noise.",
+    description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
   },
   robots: {
     index: true,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { LiveBanner } from "@/components/LiveBanner";
-import { HeroHeading, StatusBadge, SectionDot } from "@/components/LiveEffects";
+import { StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
 import { BNLRelayModule } from "@/components/BNLRelay";
 
@@ -13,16 +14,44 @@ function resolveHref(href: string): string {
   return href;
 }
 
+function RouteLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className: string;
+  children: ReactNode;
+}) {
+  const resolved = resolveHref(href);
+  const isExternal = href.startsWith("EXTERNAL:");
+
+  return isExternal ? (
+    <a
+      href={resolved}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      {children}
+    </a>
+  ) : (
+    <Link href={resolved} className={className}>
+      {children}
+    </Link>
+  );
+}
+
 export default function Home() {
   return (
     <div className="pt-14">
       {/* Live Banner */}
       <LiveBanner />
 
-      {/* Hero Section */}
+      {/* Public-access Hero */}
       <section className="relative noise-bg border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-24 sm:py-32">
-          <div className="max-w-3xl">
+          <div className="max-w-4xl">
             <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6 mb-6">
               <Image
                 src={siteConfig.logo}
@@ -33,13 +62,17 @@ export default function Home() {
                 unoptimized
                 priority
               />
-              <HeroHeading
-                heading1={homePage.hero.heading1}
-                heading2={homePage.hero.heading2}
-                label={homePage.hero.label}
-              />
+              <div>
+                <p className="text-xs uppercase tracking-[0.45em] text-muted mb-3 animate-flicker">
+                  {homePage.hero.label}
+                </p>
+                <h1 className="text-[clamp(2.35rem,14vw,5rem)] sm:text-[clamp(3.75rem,9vw,7rem)] font-black uppercase leading-[0.9] tracking-[-0.08em] text-foreground break-words">
+                  <span className="block">{homePage.hero.heading1}</span>
+                  <span className="block text-accent">{homePage.hero.heading2}</span>
+                </h1>
+              </div>
             </div>
-            <p className="text-base sm:text-lg text-muted leading-relaxed max-w-xl mb-8">
+            <p className="text-base sm:text-lg text-muted leading-relaxed max-w-2xl mb-8">
               {homePage.hero.description}
             </p>
             <div className="flex flex-wrap gap-3">
@@ -60,31 +93,49 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Latest Network Relay */}
+      {/* Plain-language orientation */}
       <section className="border-b border-border">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10">
-          <BNLRelayModule title="Latest Network Relay" />
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
+          <div className="max-w-3xl">
+            <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-4 animate-flicker">
+              {homePage.orientation.label}
+            </p>
+            <h2 className="text-2xl sm:text-4xl font-black tracking-tight text-foreground mb-6">
+              {homePage.orientation.heading}
+            </h2>
+            <div className="space-y-5 text-base sm:text-lg text-muted leading-relaxed">
+              {homePage.orientation.paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* Active Programs */}
+      {/* Listen / Watch / Enter / Investigate routes */}
       <section className="border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="flex items-center gap-3 mb-10">
+          <div className="flex items-center gap-3 mb-4">
             <SectionDot />
-            <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-              Active Programs
-            </h2>
+            <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
+              {homePage.routeSection.label}
+            </p>
           </div>
+          <h2 className="text-2xl sm:text-4xl font-black tracking-tight text-foreground mb-4">
+            {homePage.routeSection.heading}
+          </h2>
+          <p className="text-base text-muted leading-relaxed max-w-2xl mb-10">
+            {homePage.routeSection.introduction}
+          </p>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {homePage.programs.map((program) => (
-              <Link
+              <RouteLink
                 key={program.href}
                 href={program.href}
                 className="group border border-border hover:border-accent/30 bg-surface p-6 transition-all hover:bg-surface-light"
               >
-                <div className="flex items-start justify-between mb-3">
+                <div className="flex items-start justify-between gap-4 mb-3">
                   <h3 className="text-lg font-bold tracking-wide text-foreground group-hover:text-accent transition-colors">
                     {program.title}
                   </h3>
@@ -96,61 +147,81 @@ export default function Home() {
                 <div className="mt-4 text-xs text-muted/50 uppercase tracking-wider group-hover:text-accent/50 transition-colors">
                   Enter →
                 </div>
-              </Link>
+              </RouteLink>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Network Statement */}
+      {/* Why BARCODE exists */}
       <section className="border-b border-border noise-bg">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
           <div className="max-w-2xl mx-auto text-center">
             <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-6 animate-flicker">
               {homePage.mission.label}
             </p>
+            <h2 className="text-2xl sm:text-4xl font-black tracking-tight text-foreground mb-6">
+              {homePage.mission.heading}
+            </h2>
             <blockquote className="text-xl sm:text-2xl text-foreground/80 leading-relaxed font-light italic">
-              &ldquo;{homePage.mission.quote}&rdquo;
+              &ldquo;{homePage.mission.statement}&rdquo;
             </blockquote>
+            <p className="mt-6 text-base text-muted leading-relaxed">
+              {homePage.mission.body}
+            </p>
             <div className="mt-8 w-12 h-px bg-accent mx-auto" />
           </div>
         </div>
       </section>
 
-      {/* Quick Links / Status Grid */}
+      {/* Latest Network Relay */}
+      <section className="border-b border-border">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10">
+          <BNLRelayModule title="Latest Network Relay" />
+        </div>
+      </section>
+
+      {/* Deeper transmission and return actions */}
       <section>
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
-            {homePage.quickLinks.map((link) => {
-              const resolved = resolveHref(link.href);
-              const isExternal = link.href.startsWith("EXTERNAL:");
-              const className = "border border-border p-4 text-center hover:border-accent/30 transition-colors group";
-              const inner = (
+          <div className="max-w-3xl mb-12">
+            <p className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted mb-4 animate-flicker">
+              {homePage.deeperTransmission.label}
+            </p>
+            <h2 className="text-2xl sm:text-4xl font-black tracking-tight text-foreground mb-6">
+              {homePage.deeperTransmission.heading}
+            </h2>
+            <p className="text-base sm:text-lg text-muted leading-relaxed mb-8">
+              {homePage.deeperTransmission.body}
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href={homePage.deeperTransmission.ctaPrimary.href}
+                className="inline-flex items-center px-6 py-3 text-sm uppercase tracking-widest border border-accent text-accent hover:bg-accent hover:text-background transition-all"
+              >
+                {homePage.deeperTransmission.ctaPrimary.text}
+              </Link>
+              <Link
+                href={homePage.deeperTransmission.ctaSecondary.href}
+                className="inline-flex items-center px-6 py-3 text-sm uppercase tracking-widest border border-border-light text-muted hover:border-foreground hover:text-foreground transition-all"
+              >
+                {homePage.deeperTransmission.ctaSecondary.text}
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {homePage.quickLinks.map((link) => (
+              <RouteLink
+                key={link.label}
+                href={link.href}
+                className="border border-border p-4 text-center hover:border-accent/30 transition-colors group"
+              >
                 <span className="text-sm text-muted group-hover:text-accent transition-colors uppercase tracking-wider">
                   {link.label}
                 </span>
-              );
-
-              return isExternal ? (
-                <a
-                  key={link.label}
-                  href={resolved}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={className}
-                >
-                  {inner}
-                </a>
-              ) : (
-                <Link
-                  key={link.label}
-                  href={resolved}
-                  className={className}
-                >
-                  {inner}
-                </Link>
-              );
-            })}
+              </RouteLink>
+            ))}
           </div>
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,13 +62,13 @@ export default function Home() {
                 unoptimized
                 priority
               />
-              <div>
+              <div className="min-w-0">
                 <p className="text-xs uppercase tracking-[0.45em] text-muted mb-3 animate-flicker">
                   {homePage.hero.label}
                 </p>
-                <h1 className="text-[clamp(2.35rem,14vw,5rem)] sm:text-[clamp(3.75rem,9vw,7rem)] font-black uppercase leading-[0.9] tracking-[-0.08em] text-foreground break-words">
-                  <span className="block">{homePage.hero.heading1}</span>
-                  <span className="block text-accent">{homePage.hero.heading2}</span>
+                <h1 className="text-[clamp(1.9rem,9vw,4.5rem)] sm:text-[clamp(2.75rem,6vw,4.75rem)] font-black uppercase leading-[0.9] tracking-[-0.08em] text-foreground">
+                  <span className="block whitespace-nowrap">{homePage.hero.heading1}</span>
+                  <span className="block whitespace-nowrap text-accent">{homePage.hero.heading2}</span>
                 </h1>
               </div>
             </div>
@@ -145,7 +145,7 @@ export default function Home() {
                   {program.description}
                 </p>
                 <div className="mt-4 text-xs text-muted/50 uppercase tracking-wider group-hover:text-accent/50 transition-colors">
-                  Enter →
+                  {program.status} →
                 </div>
               </RouteLink>
             ))}

--- a/src/content.ts
+++ b/src/content.ts
@@ -11,7 +11,7 @@
 
 export const siteConfig = {
   name: "BARCODE Network",
-  tagline: "Interdimensional broadcast infrastructure. Signal over noise.",
+  tagline: "Every fragment carries a signal.",
   domain: "https://barcode-network.com",
   logo: "/logos/emblem.png",
 };
@@ -29,46 +29,65 @@ export const externalLinks = {
 
 export const homePage = {
   hero: {
-    label: "// NETWORK UPLINK: UNKNOWN ORIGIN",
-    heading1: "BARCODE",
-    heading2: "NETWORK",
+    label: "BARCODE NETWORK // PUBLIC ACCESS",
+    heading1: "EVERY FRAGMENT",
+    heading2: "CARRIES A SIGNAL.",
     description:
-      "An interdimensional broadcast station routing programs, signals, and transmissions across unknown channels. This is not an artist page. This is infrastructure.",
-    ctaPrimary: { text: "Access Terminal →", href: "/terminal" },
-    ctaSecondary: { text: "BARCODE Radio", href: "/radio" },
+      "BARCODE is a living hip-hop broadcast universe built from broken technology, human memory, and creative outsiders. Music, live broadcasts, community, and interdimensional story meet here. Traditional, AI-assisted, and hybrid artists share the same signal.",
+    ctaPrimary: { text: "HEAR THE MUSIC →", href: "/releases" },
+    ctaSecondary: { text: "ENTER BARCODE RADIO", href: "/radio" },
+  },
+
+  orientation: {
+    label: "// START HERE",
+    heading: "THE CREW CAME FIRST. THE NETWORK GREW AROUND IT.",
+    paragraphs: [
+      "BARCODE began as a four-member digital hip-hop collective: 6 Bit, DJ Floppydisc, Cache Back, and Mac Modem. BARCODE Network grew around that original signal, connecting the music to live broadcasts, community, characters, software, and story.",
+      "6 Bit is the artist, producer, and host at the center of the public transmission. BARCODE Radio is the live public square, where artists submit original music and the audience responds in real time. The people, work, and events are real; the interdimensional mythology gives what happens a larger place to live.",
+    ],
+  },
+
+  routeSection: {
+    label: "// CHOOSE YOUR ROUTE",
+    heading: "THE MUSIC COMES FIRST. THE WORLD OPENS FROM THERE.",
+    introduction:
+      "Start with the catalog or the live show. Then enter the community or investigate the deeper system.",
   },
 
   programs: [
     {
-      title: "6 Bit",
-      description: "Host entity. Live transmissions. Music analytics.",
-      href: "/terminal",
-      status: "ACTIVE",
-    },
-    {
-      title: "BARCODE Radio",
-      description: "Open frequency. Real-time engagement. Real reactions.",
-      href: "/radio",
-      status: "ACTIVE",
-    },
-    {
-      title: "Database",
-      description: "Dossier system. Entities, partners, sponsors, anomalies.",
-      href: "/database",
-      status: "ACTIVE",
-    },
-    {
-      title: "Releases",
-      description: "Official transmissions. Cataloged audio artifacts.",
+      title: "RELEASES",
+      description: "Hear official releases from 6 Bit and BARCODE.",
       href: "/releases",
-      status: "ACTIVE",
+      status: "LISTEN",
+    },
+    {
+      title: "BARCODE RADIO",
+      description: "Enter the live broadcast for original submissions, reactions, and conversation.",
+      href: "/radio",
+      status: "WATCH",
+    },
+    {
+      title: "COMMUNITY",
+      description: "Join the Discord and meet the artists, listeners, collaborators, and recurring characters around the project.",
+      href: "EXTERNAL:discord",
+      status: "ENTER",
+    },
+    {
+      title: "DATABASE",
+      description: "Open dossiers, transmissions, recurring characters, and deeper continuity.",
+      href: "/database",
+      status: "INVESTIGATE",
     },
   ],
 
   mission: {
-    label: "// MISSION",
-    quote:
-      "BARCODE Network exists to move signal through realities that don’t want it. Every program is a relay. Every transmission is evidence.",
+    label: "// WHY BARCODE EXISTS",
+    heading: "CRAFT BEFORE CATEGORY.",
+    statement:
+      "The work is work. The person is a person. The future is built from what survived.",
+    body:
+      "BARCODE makes room for traditional, AI-assisted, and hybrid creators without reducing their work or their existence to an argument about tools.",
   },
   // Intro video embedded from Google Drive.
   // To use a local file instead, drop it at /public/video/intro.mp4 and set src to "/video/intro.mp4"
@@ -80,12 +99,19 @@ export const homePage = {
     transcript:
       "Hi I'm 6 Bit, and this is The B-B-B-Barcode Network. This is a broadcast station oper-operating out of [redacted]. We value the opportunity to share your-share your music across multiple known and unknown broadcast fre-frequencies.",
   },
+  deeperTransmission: {
+    label: "// DEEPER TRANSMISSION",
+    heading: "THE PEOPLE ARE REAL. THE MYTHOLOGY REMEMBERS.",
+    body:
+      "The releases, broadcasts, collaborations, and community moments happen first. BARCODE’s interdimensional story gives them continuity, turning recurring people, characters, and events into a world you can investigate without losing the truth underneath it.",
+    ctaPrimary: { text: "ENTER THE DATABASE", href: "/database" },
+    ctaSecondary: { text: "VIEW TRANSMISSIONS", href: "/transmissions" },
+  },
   quickLinks: [
-    { label: "Discord", href: "EXTERNAL:discord" },
-    { label: "TikTok", href: "EXTERNAL:tiktok" },
-    { label: "Releases", href: "/releases" },
-    { label: "Database", href: "/database" },
-    { label: "Submit Music", href: "/radio" },
+    { label: "JOIN DISCORD", href: "EXTERNAL:discord" },
+    { label: "SUBMIT MUSIC", href: "/radio" },
+    { label: "OPEN TERMINAL", href: "/terminal" },
+    { label: "FOLLOW ON TIKTOK", href: "EXTERNAL:tiktok" },
   ],
 };
 


### PR DESCRIPTION
### Motivation
- Reorder the homepage so first-time visitors encounter BARCODE as a music-led, participatory world before network machinery, following the hierarchy: reality first, meaning second, mythology third. 
- Make the origin and public identity explicit by naming the original four-member collective and describing 6 Bit as the artist, producer, and host with BARCODE Radio as the live public square. 
- Preserve live surfaces and system layers; this is a content/composition change only and does not attempt layout or ticker positioning fixes.

### Description
- Updated `src/content.ts` to set `siteConfig.tagline` to the exact tagline and replace homepage-only fields under `homePage` with the new hero copy, `orientation`, `routeSection`, repurposed `programs` (route cards), `mission` (Why BARCODE Exists), `deeperTransmission`, and the four return `quickLinks`, while leaving the `broadcast` object functionally unchanged. 
- Rewrote `src/app/page.tsx` to render the required section order (LiveBanner, public-access hero, plain-language orientation, route cards, Why BARCODE exists, live `BNLRelayModule`, deeper transmission, and return actions), replaced the homepage `HeroHeading` usage with a local responsive two-line semantic `<h1>`, added a `RouteLink` resolver that renders `EXTERNAL:` links as safe new-tab anchors and internal routes with Next `Link`, preserved `pt-14`, emblem image, and `LiveBanner`, and moved the homepage `BNLRelayModule` lower on the page. 
- Changed only the three allowed strings in `src/app/layout.tsx` (root `description`, `openGraph.description`, and `twitter.description`) to the requested metadata string. 
- Kept the scope strictly to the three allowed files and removed now-unused imports from the homepage file.

### Testing
- `git fetch origin main` failed in this environment because no `origin` remote is configured. 
- `git diff --check` passed for the modified files. 
- `npm run check` failed due to pre-existing lint/test errors located outside the three allowed files (existing archived JSX comment and hook-lint issues), which are unrelated to the homepage changes. 
- `npm run build` completed successfully (Next compiled and static pages were generated), and additional `rg` checks confirmed the old sentence was removed, both `LiveBanner` and `BNLRelayModule` remain, and the homepage contains exactly one semantic `<h1>`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55a60f40908321a1a02bba07b0843b)