### PR TITLE
Repair global live-state layout stack

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,9 +70,9 @@ export default function RootLayout({
       >
         <LiveStatusProvider>
           <DataStream />
-          <LiveBanner />
           <Header />
           <BNLNetworkRelayShell />
+          <LiveBanner />
           <main className="min-h-screen animate-interference overflow-x-hidden">
             {children}
           </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { LiveBanner } from "@/components/LiveBanner";
 import { StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
 import { BNLRelayModule } from "@/components/BNLRelay";
@@ -45,9 +44,6 @@ function RouteLink({
 export default function Home() {
   return (
     <div className="pt-14">
-      {/* Live Banner */}
-      <LiveBanner />
-
       {/* Public-access Hero */}
       <section className="relative noise-bg border-b border-border">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-24 sm:py-32">

--- a/src/components/BNLRelay.tsx
+++ b/src/components/BNLRelay.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { externalLinks } from "@/content";
 import { useBNLStatus } from "@/components/useBNLStatus";
+import { useLiveStatus } from "./LiveStatusProvider";
 
 function bnlTone(online: boolean) {
   return online ? "text-foreground" : "text-foreground/70";
@@ -60,6 +61,7 @@ function BNLRelayExplainer() {
   const [dismissed, setDismissed] = useState(false);
   const [glitchingOut, setGlitchingOut] = useState(false);
   const pathname = usePathname();
+  const { siteShowMode } = useLiveStatus();
 
   useEffect(() => {
     if (pathname === "/queue" || pathname.startsWith("/queue/")) return;
@@ -82,9 +84,11 @@ function BNLRelayExplainer() {
 
   if (pathname === "/queue" || pathname.startsWith("/queue/") || dismissed) return null;
 
+  const desktopTopClass = siteShowMode === "offline" ? "sm:top-24" : "sm:top-[9rem]";
+
   return (
     <div
-      className={`fixed inset-x-3 bottom-16 z-30 sm:top-24 sm:bottom-auto border border-accent/30 bg-black/95 p-3 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[2600ms] ease-out sm:inset-x-auto sm:right-6 sm:w-[calc(100vw-1.5rem)] sm:max-w-sm sm:p-4 ${
+      className={`fixed inset-x-3 bottom-16 z-30 ${desktopTopClass} sm:bottom-auto border border-accent/30 bg-black/95 p-3 font-mono text-white shadow-[0_0_35px_rgba(255,0,0,0.16)] transition-opacity duration-[2600ms] ease-out sm:inset-x-auto sm:right-6 sm:w-[calc(100vw-1.5rem)] sm:max-w-sm sm:p-4 ${
         visible ? "opacity-100" : "opacity-0 pointer-events-none"
       } ${glitchingOut ? "animate-[bnl-relay-glitch-out_520ms_steps(2,end)_forwards]" : ""}`}
     >
@@ -179,8 +183,8 @@ export function BNLNetworkRelayTicker() {
   return (
     <>
       <div aria-hidden className="h-8" />
-      <div className="fixed left-0 right-0 top-14 z-40 border-b border-border/80 bg-black px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white sm:px-4 sm:text-[11px] sm:tracking-[0.2em]">
-        <div className="mx-auto flex max-w-7xl items-center gap-2 overflow-hidden sm:gap-3">
+      <div className="fixed left-0 right-0 top-14 z-40 h-8 border-b border-border/80 bg-black px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white sm:px-4 sm:text-[11px] sm:tracking-[0.2em]">
+        <div className="mx-auto flex h-full max-w-7xl items-center gap-2 overflow-hidden sm:gap-3">
           <span className="hidden shrink-0 text-white/85 sm:inline">&gt; NETWORK RELAY // BNL-01</span>
           <span className="shrink-0 text-white/85 sm:hidden">&gt; BNL-01 //</span>
           <div className="bnl-relay-scroll min-w-0 flex-1">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { useLiveStatus } from "./LiveStatusProvider";
 import { GlitchText } from "./GlitchText";
 import { siteConfig } from "@/content";
 
@@ -20,12 +19,6 @@ const navItems = [
 
 export function Header() {
   const pathname = usePathname();
-  const { siteShowMode, queueHref, streamUrl } = useLiveStatus();
-
-  const liveHref = queueHref ?? (siteShowMode === "broadcast_live" ? streamUrl || "/radio" : null);
-  const liveLabel = siteShowMode === "broadcast_live" ? "BARCODE RADIO LIVE" : siteShowMode === "intake_open" ? "SUBMISSIONS OPEN" : null;
-  const isExternalLiveHref = Boolean(liveHref && liveHref.startsWith("http"));
-
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b border-border bg-background/95 backdrop-blur-sm">
       <div className="mx-auto max-w-7xl px-4 sm:px-6">
@@ -71,18 +64,6 @@ export function Header() {
           </nav>
 
           <div className="flex items-center gap-4">
-            {liveHref && liveLabel && (
-              <a
-                href={liveHref}
-                target={isExternalLiveHref ? "_blank" : undefined}
-                rel={isExternalLiveHref ? "noopener noreferrer" : undefined}
-                className="flex items-center gap-2 px-3 py-1 border border-danger rounded text-sm uppercase tracking-wider text-danger live-indicator hover:bg-danger/10 transition-colors"
-              >
-                <span className="w-2 h-2 rounded-full bg-danger" />
-                {liveLabel}
-              </a>
-            )}
-
             <MobileMenu pathname={pathname} />
           </div>
         </div>

--- a/src/components/LiveBanner.tsx
+++ b/src/components/LiveBanner.tsx
@@ -10,43 +10,61 @@ export function LiveBanner() {
   if (pathname === "/queue" || pathname.startsWith("/queue/")) return null;
   if (siteShowMode === "offline") return null;
 
+  const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/");
+
   let text = "BARCODE RADIO IS LIVE";
+  let mobileText = "RADIO LIVE";
   let cta = "WATCH LIVE";
+  let mobileCta = "WATCH";
   let href = streamUrl;
 
   if (siteShowMode === "intake_open" && queueHref) {
     text = "BARCODE RADIO SUBMISSIONS ARE OPEN";
+    mobileText = "SUBMISSIONS OPEN";
     cta = "SUBMIT A TRACK";
+    mobileCta = "SUBMIT";
     href = queueHref;
   }
 
   if (siteShowMode === "broadcast_live") {
     text = "BARCODE RADIO IS LIVE";
+    mobileText = "RADIO LIVE";
     if (hasActiveQueueSession && queueHref) {
       cta = "JOIN THE SHOW";
+      mobileCta = "JOIN SHOW";
       href = queueHref;
     }
   }
 
   const external = href.startsWith("http");
+  const topClass = isAdminRoute ? "top-14" : "top-[5.5rem]";
 
   return (
-    <div className="bg-danger/10 border-b border-danger/30">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6">
-        <a
-          href={href}
-          target={external ? "_blank" : undefined}
-          rel={external ? "noopener noreferrer" : undefined}
-          className="flex items-center justify-center gap-3 py-3 group"
-        >
-          <span className="relative flex h-3 w-3">
-            <span className="absolute inline-flex h-full w-full rounded-full bg-danger opacity-75 animate-ping" />
-            <span className="relative inline-flex rounded-full h-3 w-3 bg-danger" />
-          </span>
-          <span className="text-sm uppercase tracking-[0.3em] text-danger font-bold text-glow-red">{text}</span>
-          <span className="text-sm text-danger/60 uppercase tracking-wider group-hover:text-danger transition-colors">{cta}</span>
-        </a>
+    <>
+      <div aria-hidden className="h-12" />
+      <div className={`fixed left-0 right-0 ${topClass} z-40 h-12 border-b border-danger/30 bg-danger/10 backdrop-blur-sm`}>
+        <div className="mx-auto h-full max-w-7xl px-3 sm:px-6">
+          <a
+            href={href}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noopener noreferrer" : undefined}
+            className="group flex h-full min-w-0 items-center justify-center gap-2 overflow-hidden sm:gap-3"
+          >
+            <span className="relative flex h-2.5 w-2.5 shrink-0 sm:h-3 sm:w-3">
+              <span className="absolute inline-flex h-full w-full rounded-full bg-danger opacity-75 animate-ping" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-danger sm:h-3 sm:w-3" />
+            </span>
+            <span className="min-w-0 whitespace-nowrap text-[11px] font-bold uppercase tracking-[0.12em] text-danger text-glow-red sm:text-sm sm:tracking-[0.3em]">
+              <span className="sm:hidden">{mobileText}</span>
+              <span className="hidden sm:inline">{text}</span>
+            </span>
+            <span className="shrink-0 whitespace-nowrap text-[10px] uppercase tracking-[0.08em] text-danger/70 transition-colors group-hover:text-danger sm:text-sm sm:tracking-wider">
+              <span className="sm:hidden">{mobileCta}</span>
+              <span className="hidden sm:inline">{cta}</span>
+            </span>
+          </a>
+        </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
### Motivation

- Ensure a single, reliable site-wide BARCODE Radio live banner and a deterministic fixed vertical stack so fixed surfaces never cover each other or the start of page content.
- Remove the homepage duplicate live banner that was visually covered but still occupying normal-flow height, which caused state-dependent blank gaps.
- Preserve all existing Radio/queue/BNL behavior and page copy while fixing only layout surface ordering and geometry.

### Description

- Changed files: `src/app/layout.tsx`, `src/app/page.tsx`, `src/components/Header.tsx`, `src/components/LiveBanner.tsx`, and `src/components/BNLRelay.tsx`.
- `src/app/layout.tsx`: moved the global `<LiveBanner />` to render after `<Header />` and `<BNLNetworkRelayShell />` so the root stack is `DataStream`, `Header`, `BNLNetworkRelayShell`, `LiveBanner`, then page content.
- `src/app/page.tsx`: removed the homepage `LiveBanner` import and instance while preserving the root `pt-14` offset and all homepage copy and structure.
- `src/components/Header.tsx`: removed the redundant live-status pill and its `useLiveStatus` import while keeping logo, nav, and mobile menu unchanged.
- `src/components/LiveBanner.tsx`: rebuilt the banner layout to return an `aria-hidden` spacer of `h-12` plus a fixed `h-12` banner, to suppress itself on `/queue*`, to use `top-[5.5rem]` on public routes and `top-14` on admin routes, and to provide compact mobile labels plus full desktop labels without wrapping while preserving existing CTA text and safe external-link attributes.
- `src/components/BNLRelay.tsx`: made the fixed BNL ticker wrapper match its `h-8` spacer exactly, removed vertical padding from the fixed wrapper, vertically centered inner contents, and updated `BNLRelayExplainer` to read `siteShowMode` and shift its desktop `top` to `sm:top-24` when offline or `sm:top-[9rem]` when active so it clears the live banner.

### Testing

- `git diff --check` passed with no new whitespace or diff-check violations introduced by these five-file changes.
- `npm run check` failed due to pre-existing repository lint/type/test issues in archived and unrelated files outside the five changed files, and none of the reported failures pointed to the modified files in this PR.
- `npm run build` (Next build) completed successfully and produced the expected route manifest without build-time errors.
- Focused source checks confirmed only the five allowed files changed, there is exactly one remaining `<LiveBanner />` usage (in `src/app/layout.tsx`), and `LiveStatusProvider`, `BNLNetworkRelayShell`, `useBNLStatus`, `globals.css`, APIs, and content data were not modified.
- Could not complete browser-based responsive visual smoke tests at 320px/390px/768px/1440px or exercise live-state toggles in this environment because no safe local/mock show-state override was available and production show state was not mutated; visual verification of responsive spacing and single-line banner at narrow widths is requested in review.

This PR does not change Radio state authority, queue logic, BNL data/status logic, APIs, Footer/SystemTicker, homepage copy, or introduce new dependencies or routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a579a46ff648321b177fdb8ff497dc3)