### PR TITLE
Rebuild Terminal as an interactive BARCODE Network archive

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -474,3 +474,46 @@ body {
     animation: none;
   }
 }
+
+.archive-output-reveal {
+  animation: archive-output-reveal 180ms ease-out;
+}
+
+@keyframes archive-output-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.network-archive {
+  position: relative;
+  overflow: hidden;
+}
+
+.network-archive::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 3px,
+    rgba(0, 255, 136, 0.012) 3px,
+    rgba(0, 255, 136, 0.012) 6px
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .archive-output-reveal,
+  .terminal-nav-reveal,
+  .animate-status-blink,
+  .cursor-blink {
+    animation: none !important;
+  }
+}

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -1,185 +1,70 @@
-import { terminalPage, externalLinks } from "@/content";
-import Link from "next/link";
-import { TerminalLogin } from "@/components/TerminalLogin";
-import { SectionDot } from "@/components/LiveEffects";
-import { BNLStatusCard } from "@/components/BNLStatusCard";
 import type { Metadata } from "next";
+import { databasePage, externalLinks, radioPage, releasesPage } from "@/content";
+import { getDatabaseAggregateStats } from "@/lib/database-stats";
+import { getAllTransmissions } from "@/lib/transmissions";
+import { TerminalShell } from "./terminal-shell";
 
 export const metadata: Metadata = {
-  title: "6 Bit Terminal — BARCODE Network",
+  title: "Network Archive Terminal — BARCODE Network",
   description:
-    "Primary broadcast operator. Live transmissions, community routing, and cultural signal control.",
+    "Enter the public BARCODE Network archive. Search dossiers, trace transmissions, monitor BNL-01, and investigate the records behind the signal.",
   openGraph: {
-    title: "6 Bit Terminal — BARCODE Network",
+    title: "Network Archive Terminal — BARCODE Network",
     description:
-      "Primary broadcast operator. Live transmissions, community routing, and cultural signal control.",
+      "Enter the public BARCODE Network archive. Search dossiers, trace transmissions, monitor BNL-01, and investigate the records behind the signal.",
   },
 };
 
-function resolveHref(href: string): string {
-  if (href.startsWith("EXTERNAL:")) {
-    const key = href.replace("EXTERNAL:", "") as keyof typeof externalLinks;
-    return externalLinks[key];
-  }
-  return href;
+function slugify(name: string) {
+  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
 }
 
 export default function TerminalPage() {
+  const archive = {
+    dossiers: databasePage.entries.map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      category: entry.category,
+      status: entry.status,
+      role: entry.role,
+      clearance: entry.clearance,
+      origin: entry.origin,
+      summary: entry.summary,
+      tags: entry.tags,
+      slug: slugify(entry.name),
+    })),
+    transmissions: getAllTransmissions().map((post) => ({
+      slug: post.slug,
+      title: post.title,
+      date: post.date,
+      author: post.author,
+      excerpt: post.excerpt,
+      tags: post.tags,
+    })),
+    releases: releasesPage.catalog.map((release) => ({
+      title: release.title,
+      date: release.date,
+      status: release.status,
+      description: release.description,
+    })),
+    radio: {
+      description: `${radioPage.hero.heading1} ${radioPage.hero.heading2} is the weekly live broadcast. Submissions go through Auxchord and the show routes original music into a public live session.`,
+      schedule: radioPage.schedule,
+      links: {
+        radio: "/radio",
+        submit: externalLinks.auxchord,
+        discord: externalLinks.discord,
+        live: externalLinks.tiktokLive,
+      },
+    },
+    stats: getDatabaseAggregateStats(databasePage.entries),
+  };
+
   return (
-    <div className="pt-14">
-      {/* Login Terminal */}
-      <section className="border-b border-border noise-bg">
-        <div className="mx-auto max-w-4xl px-4 sm:px-6 py-12 sm:py-20">
-          <TerminalLogin />
-        </div>
-      </section>
-
-      {/* Dossier + About */}
-      <section className="border-b border-border">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
-            {/* Left: Info */}
-            <div>
-              <div className="flex items-center gap-3 mb-6">
-                <SectionDot />
-                <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-                  Dossier
-                </h2>
-              </div>
-
-              <div className="space-y-4">
-                {terminalPage.dossier.map((row) => (
-                  <InfoRow
-                    key={row.label}
-                    label={row.label}
-                    value={row.value}
-                    accent={row.accent}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Right: Description */}
-            <div>
-              <div className="flex items-center gap-3 mb-6">
-                <SectionDot />
-                <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-                  About
-                </h2>
-              </div>
-
-              <div className="text-base text-foreground/70 leading-relaxed space-y-4">
-                {terminalPage.about.map((paragraph, i) => (
-                  <p key={i}>{paragraph}</p>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Access Points */}
-      <section className="border-b border-border">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16">
-          <div className="flex items-center gap-3 mb-8">
-            <SectionDot />
-            <h2 className="text-xs sm:text-sm uppercase tracking-[0.5em] text-muted">
-              Access Points
-            </h2>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {terminalPage.accessPoints.map((point) => (
-              <ExternalLink
-                key={point.label}
-                href={resolveHref(point.href)}
-                label={point.label}
-                description={point.description}
-              />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Terminal Output */}
-      <section>
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-16 space-y-6">
-          <BNLStatusCard />
-          <div className="bg-surface border border-border p-6 font-mono">
-            <p className="text-xs text-muted mb-4">
-              &gt; BARCODE_NETWORK // TERMINAL ACCESS
-            </p>
-            <div className="space-y-1 text-sm text-foreground/60">
-              {terminalPage.terminalOutput.map((line, i) => (
-                <p key={i}>&gt; {line}</p>
-              ))}
-              <p className="text-accent mt-4">
-                &gt; SESSION ACTIVE<span className="cursor-blink">_</span>
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
+    <div className="min-h-screen border-b border-border bg-background pt-14 noise-bg">
+      <div className="mx-auto max-w-7xl px-3 py-8 sm:px-6 sm:py-12">
+        <TerminalShell archive={archive} />
+      </div>
     </div>
-  );
-}
-
-function InfoRow({
-  label,
-  value,
-  accent = false,
-}: {
-  label: string;
-  value: string;
-  accent?: boolean;
-}) {
-  return (
-    <div className="flex items-center justify-between border-b border-border/50 pb-2">
-      <span className="text-xs uppercase tracking-[0.3em] text-muted">
-        {label}
-      </span>
-      <span
-        className={`text-sm ${accent ? "text-accent" : "text-foreground/80"}`}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function ExternalLink({
-  href,
-  label,
-  description,
-}: {
-  href: string;
-  label: string;
-  description: string;
-}) {
-  const isExternal = href.startsWith("http");
-  const className = "group border border-border hover:border-accent/30 bg-surface p-5 transition-all hover:bg-surface-light block";
-  const inner = (
-    <>
-      <h3 className="text-base font-bold text-foreground group-hover:text-accent transition-colors mb-1">
-        {label}
-      </h3>
-      <p className="text-xs text-muted uppercase tracking-wider">
-        {description}
-      </p>
-    </>
-  );
-
-  if (isExternal) {
-    return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
-        {inner}
-      </a>
-    );
-  }
-
-  return (
-    <Link href={href} className={className}>
-      {inner}
-    </Link>
   );
 }

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -62,7 +62,7 @@ export default function TerminalPage() {
 
   return (
     <div className="min-h-screen border-b border-border bg-background pt-14 noise-bg">
-      <div className="mx-auto max-w-7xl px-3 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto max-w-7xl px-3 pb-2 pt-2 sm:px-6">
         <TerminalShell archive={archive} />
       </div>
     </div>

--- a/src/app/terminal/terminal-shell.tsx
+++ b/src/app/terminal/terminal-shell.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { NetworkArchiveTerminal, type ArchivePayload } from "@/components/NetworkArchiveTerminal";
+import { TerminalLogin } from "@/components/TerminalLogin";
+
+export function TerminalShell({ archive }: { archive: ArchivePayload }) {
+  const [unlocked, setUnlocked] = useState(false);
+  const [restored, setRestored] = useState(false);
+  const handleUnlock = useCallback((sessionRestored = false) => {
+    setRestored(sessionRestored);
+    setUnlocked(true);
+  }, []);
+  const handleLock = useCallback(() => {
+    setUnlocked(false);
+    setRestored(false);
+  }, []);
+
+  return unlocked ? (
+    <NetworkArchiveTerminal archive={archive} restored={restored} onLock={handleLock} />
+  ) : (
+    <div className="mx-auto max-w-4xl">
+      <TerminalLogin onUnlock={handleUnlock} />
+    </div>
+  );
+}

--- a/src/components/NetworkArchiveTerminal.tsx
+++ b/src/components/NetworkArchiveTerminal.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, KeyboardEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { clearTerminalSession } from "@/components/TerminalLogin";
+import { useBNLStatus } from "@/components/useBNLStatus";
+
+export type ArchiveDossier = { id: string; name: string; category: string; status: string; role: string; clearance: string; origin: string; summary: string; tags: string[]; slug: string };
+export type ArchiveTransmission = { slug: string; title: string; date: string; author: string; excerpt: string; tags: string[] };
+export type ArchiveRelease = { title: string; date: string; status: string; description: string };
+export type ArchiveRadio = { description: string; schedule: { day: string; queueOpens: string; showBegins: string; firstTrack: string; notice: string }; links: { radio: string; submit: string; discord: string; live: string } };
+export type ArchiveStats = { totalCount: number; activeCount: number; restrictedCount: number; publicCount: number };
+export type ArchivePayload = { dossiers: ArchiveDossier[]; transmissions: ArchiveTransmission[]; releases: ArchiveRelease[]; radio: ArchiveRadio; stats: ArchiveStats };
+
+type Entry = { id: number; command?: string; node: ReactNode; variant?: "normal" | "breach"; liveStatus?: boolean };
+const buttons = ["HELP", "MAP", "ORIGINS", "STATUS", "DATABASE", "WHOIS 6 BIT", "TRANSMISSIONS", "RADIO", "RELEASES", "CLEAR", "LOCK"];
+const normalize = (value: string) => value.trim().replace(/\s+/g, " ").toUpperCase();
+const seq = () => Math.floor(Date.now() / 1000).toString(16).toUpperCase();
+
+export function NetworkArchiveTerminal({ archive, restored, onLock }: { archive: ArchivePayload; restored: boolean; onLock: () => void }) {
+  const { data: bnl, loading } = useBNLStatus();
+  const [input, setInput] = useState("");
+  const [entries, setEntries] = useState<Entry[]>(() => [{ id: 1, node: <Intro archive={archive} restored={restored} /> }]);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
+  const outputRef = useRef<HTMLDivElement>(null);
+  const idRef = useRef(2);
+
+  const bnlDossier = useMemo(() => archive.dossiers.find((d) => d.id === "BNL-01" || d.name.toUpperCase().includes("BNL-01")), [archive.dossiers]);
+
+  useEffect(() => { outputRef.current?.scrollTo({ top: outputRef.current.scrollHeight, behavior: "smooth" }); }, [entries, bnl]);
+
+  function push(command: string | undefined, node: ReactNode, variant: Entry["variant"] = "normal") {
+    const id = idRef.current++;
+    setEntries((prev) => [...prev, { id, command, node, variant, liveStatus: Boolean(command && ["STATUS", "BNL", "BNL-01"].includes(normalize(command))) }]);
+  }
+
+  function execute(raw: string) {
+    const command = normalize(raw);
+    if (!command) return;
+    setHistory((prev) => [raw.trim(), ...prev.filter((item) => item !== raw.trim())].slice(0, 20));
+    setHistoryIndex(null);
+    setInput("");
+    if (command === "CLEAR") { setEntries([{ id: idRef.current++, node: <Intro archive={archive} restored={false} compact /> }]); return; }
+    if (command === "LOCK") { clearTerminalSession(); onLock(); return; }
+    if (command === "HELP" || command === "?") return push(raw, <Help />);
+    if (command === "MAP") return push(raw, <Map />);
+    if (command === "ORIGINS") return push(raw, <Origins transmissions={archive.transmissions} />);
+    if (["STATUS", "BNL", "BNL-01"].includes(command)) return push(raw, <Status data={bnl} loading={loading} dossier={bnlDossier} />);
+    if (command === "DATABASE" || command === "LIST DOSSIERS") return push(raw, <Database dossiers={archive.dossiers} stats={archive.stats} />);
+    if (command.startsWith("WHOIS ")) return push(raw, <Whois query={raw.trim().slice(6)} dossiers={archive.dossiers} />);
+    if (command.startsWith("SEARCH ")) return push(raw, <Search query={raw.trim().slice(7)} dossiers={archive.dossiers} transmissions={archive.transmissions} />);
+    if (command === "TRANSMISSIONS" || command === "LIST TRANSMISSIONS") return push(raw, <Transmissions transmissions={archive.transmissions} />);
+    if (command === "RADIO") return push(raw, <Radio radio={archive.radio} />);
+    if (command === "RELEASES") return push(raw, <Releases releases={archive.releases} />);
+    if (command === "BREACH") return push(raw, <Breach release={archive.releases.find((r) => r.title === "BARCODE: Signal Breach")} />, "breach");
+    push(raw, <Block title="COMMAND NOT RECOGNIZED"><p>Command not recognized. Type HELP for public archive commands.</p></Block>);
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowUp") { event.preventDefault(); const next = historyIndex === null ? 0 : Math.min(historyIndex + 1, history.length - 1); setHistoryIndex(next); setInput(history[next] ?? ""); }
+    if (event.key === "ArrowDown") { event.preventDefault(); if (historyIndex === null) return; const next = historyIndex - 1; setHistoryIndex(next < 0 ? null : next); setInput(next < 0 ? "" : history[next] ?? ""); }
+  }
+
+  function onSubmit(event: FormEvent) { event.preventDefault(); execute(input); }
+
+  return <div className="network-archive mx-auto max-w-7xl border border-border bg-background/95 font-mono shadow-2xl shadow-black/40">
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-surface/80 px-4 py-3">
+      <div><p className="text-xs uppercase tracking-[0.35em] text-muted">BARCODE Network Archive Terminal</p><h1 className="text-lg font-bold uppercase tracking-[0.2em] text-foreground">Public Records Console</h1></div>
+      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-widest"><span className="text-muted">PUBLIC OBSERVER</span><span className="flex items-center gap-2 text-accent"><span className="h-2 w-2 rounded-full bg-accent animate-status-blink" />BNL {loading ? "SYNC" : bnl.status}</span><button onClick={() => execute("LOCK")} className="border border-border px-3 py-2 text-muted hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">Lock Session</button></div>
+    </div>
+    <div className="grid min-h-[72vh] grid-cols-1 md:grid-cols-[240px_1fr]">
+      <aside className="border-b border-border bg-surface/30 p-3 md:border-b-0 md:border-r"><p className="mb-3 text-xs uppercase tracking-[0.3em] text-muted">Archive Index</p><div className="flex gap-2 overflow-x-auto pb-2 md:flex-col md:overflow-visible">{buttons.map((cmd) => <button key={cmd} onClick={() => execute(cmd)} className="shrink-0 border border-border bg-background/50 px-3 py-2 text-left text-xs uppercase tracking-wider text-foreground/75 transition hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">{cmd}</button>)}</div></aside>
+      <main className="flex min-h-[68vh] min-w-0 flex-col">
+        <div ref={outputRef} aria-live="polite" className="terminal-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden p-4 text-sm leading-relaxed sm:p-6">
+          {entries.map((entry) => <section key={entry.id} className={`archive-output-reveal border-l pl-4 ${entry.variant === "breach" ? "border-red-500/60 bg-red-950/10" : "border-accent/25"}`}>{entry.command && <p className="mb-2 text-xs uppercase tracking-widest text-accent/80">[{seq()}] &gt; {entry.command}</p>}{entry.liveStatus ? <Status data={bnl} loading={loading} dossier={bnlDossier} /> : entry.node}</section>)}
+        </div>
+        <form onSubmit={onSubmit} className="border-t border-border bg-surface/70 p-3"><label htmlFor="archive-command" className="sr-only">Archive command</label><div className="flex items-center gap-2"><span className="text-accent">&gt;</span><input id="archive-command" value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={onKeyDown} placeholder="Type HELP, SEARCH signal, WHOIS EN-001..." className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted focus:ring-2 focus:ring-accent/40" /><button className="border border-accent/50 px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background focus:outline-none focus:ring-2 focus:ring-accent/60">Enter</button></div></form>
+      </main>
+    </div>
+  </div>;
+}
+
+function Block({ title, children }: { title: string; children: ReactNode }) { return <div><h2 className="mb-2 text-sm font-bold uppercase tracking-[0.25em] text-foreground">{title}</h2><div className="space-y-2 text-foreground/70">{children}</div></div>; }
+function Intro({ archive, restored, compact = false }: { archive: ArchivePayload; restored: boolean; compact?: boolean }) { return <Block title={restored ? "SESSION RESTORED // PUBLIC OBSERVER" : "PUBLIC ARCHIVE SESSION ACTIVE"}><p>{compact ? "Visible history cleared. Prompt ready." : "Observer access accepted. Public dossiers, transmissions, releases, Radio records, and BNL relay status are indexed here."}</p><p className="text-muted">Indexed: {archive.stats.totalCount} dossiers {"//"} {archive.transmissions.length} transmissions {"//"} {archive.releases.length} releases. One unindexed node is detectable.</p><p>Type HELP or use the command buttons.</p></Block>; }
+function Help() { return <Block title="HELP"><p>Type a command and press Enter, or use the touch commands. Commands are case-insensitive; extra spaces are ignored. Up/Down recalls command history.</p><p>Primary commands: HELP, MAP, ORIGINS, STATUS, DATABASE, WHOIS &lt;name or ID&gt;, SEARCH &lt;term&gt;, TRANSMISSIONS, RADIO, RELEASES, CLEAR, LOCK.</p></Block>; }
+function Map() { return <Block title="NETWORK MAP"><ul className="list-disc space-y-1 pl-5"><li>BARCODE: original four-member creative source.</li><li>BARCODE Network: apparatus and expanding world.</li><li>BARCODE Radio: live public broadcast.</li><li>Database: indexed people, entities, programs, and interfaces.</li><li>BNL-01: active liaison and relay layer.</li></ul></Block>; }
+function Origins({ transmissions }: { transmissions: ArchiveTransmission[] }) { const signal = transmissions.find((t) => t.slug === "signal-origins"); return <Block title="ORIGINS // LAYERED RECORD"><h3 className="text-accent">CONFIRMED:</h3><ul className="list-disc pl-5"><li>BARCODE began as the four-member digital hip-hop collective of 6 Bit, DJ Floppydisc, Cache Back, and Mac Modem.</li><li>The music and original collective predate BARCODE Network.</li><li>The Network grew around the releases, live broadcasts, community, software, characters, and story.</li><li>6 Bit predates the Network infrastructure.</li></ul><h3 className="pt-2 text-yellow-400/80">DISPUTED:</h3><ul className="list-disc pl-5"><li>Network files conflict about how 6 Bit persists through the current system.</li><li>Some records describe acquisition or integration.</li><li>Their timestamps contradict the confirmed chronology.</li><li>These records remain unverified.</li></ul>{signal && <Link className="text-accent underline" href={`/transmissions/${signal.slug}`}>Open Signal Origins transmission →</Link>}</Block>; }
+function Status({ data, loading, dossier }: { data: { status: string; mode?: string; message?: string; directive?: string; source?: string; lastSeen?: string | null }; loading: boolean; dossier?: ArchiveDossier }) { return <Block title="BNL-01 // LIVE PUBLIC RELAY"><dl className="grid gap-2 sm:grid-cols-2"><KV k="status" v={loading ? "SYNCING" : data.status} /><KV k="mode" v={data.mode ?? "UNKNOWN"} /><KV k="message" v={data.message ?? "No public message."} /><KV k="directive" v={data.directive ?? "No public directive."} /><KV k="source" v={data.source ?? "PUBLIC FALLBACK"} /><KV k="last seen" v={data.lastSeen ?? "UNKNOWN"} /></dl>{dossier && <Link className="text-accent underline" href={`/database/${dossier.slug}`}>Open BNL dossier →</Link>}</Block>; }
+function KV({ k, v }: { k: string; v: string }) { return <div><dt className="text-xs uppercase tracking-widest text-muted">{k}</dt><dd className="text-foreground/80">{v}</dd></div>; }
+function Database({ dossiers, stats }: { dossiers: ArchiveDossier[]; stats: ArchiveStats }) { return <Block title="DATABASE // PUBLIC DOSSIERS"><p>{stats.totalCount} public entries indexed. Active: {stats.activeCount}. Public clearance: {stats.publicCount}. Restricted dossiers are public-facing summaries only.</p><div className="space-y-2">{dossiers.map((d) => <p key={d.id}><Link className="text-accent underline" href={`/database/${d.slug}`}>{d.id}</Link> {"//"} {d.name} {"//"} {d.category} {"//"} {d.status} {"//"} {d.role}</p>)}</div></Block>; }
+function Whois({ query, dossiers }: { query: string; dossiers: ArchiveDossier[] }) { const q = query.toLowerCase().trim(); const matches = dossiers.filter((d) => d.id.toLowerCase() === q || d.name.toLowerCase() === q); const partial = matches.length ? matches : dossiers.filter((d) => `${d.id} ${d.name}`.toLowerCase().includes(q)); if (!q) return <Block title="WHOIS"><p>Usage: WHOIS &lt;name or ID&gt;</p></Block>; if (partial.length === 0) return <Block title="RECORD NOT FOUND"><p>No public dossier matched “{query}”. Try SEARCH {query}.</p></Block>; if (partial.length > 1 && matches.length === 0) return <Block title="MULTIPLE MATCHES">{partial.map((d) => <p key={d.id}>{d.id} {"//"} {d.name} {"//"} <Link className="text-accent underline" href={`/database/${d.slug}`}>open dossier</Link></p>)}</Block>; const d = partial[0]; return <Block title={`WHOIS ${d.id}`}><dl className="grid gap-2 sm:grid-cols-2"><KV k="name" v={d.name} /><KV k="category" v={d.category} /><KV k="role" v={d.role} /><KV k="status" v={d.status} /><KV k="clearance" v={d.clearance} /><KV k="origin" v={d.origin} /></dl><p>{d.summary}</p><Link className="text-accent underline" href={`/database/${d.slug}`}>Open full dossier →</Link></Block>; }
+function Search({ query, dossiers, transmissions }: { query: string; dossiers: ArchiveDossier[]; transmissions: ArchiveTransmission[] }) { const q = query.toLowerCase().trim(); const ds = dossiers.filter((d) => [d.id, d.name, d.role, d.summary, ...d.tags].join(" ").toLowerCase().includes(q)).slice(0, 6); const ts = transmissions.filter((t) => [t.title, t.excerpt, t.author, ...t.tags].join(" ").toLowerCase().includes(q)).slice(0, 6); return <Block title="SEARCH RESULTS"><p>Query: {query || "EMPTY"}</p><h3 className="text-accent">DOSSIERS</h3>{ds.length ? ds.map((d) => <p key={d.id}>{d.id} {"//"} <Link className="text-accent underline" href={`/database/${d.slug}`}>{d.name}</Link> {"//"} {d.role}</p>) : <p>No dossier results.</p>}<h3 className="pt-2 text-accent">TRANSMISSIONS</h3>{ts.length ? ts.map((t) => <p key={t.slug}>TX {"//"} <Link className="text-accent underline" href={`/transmissions/${t.slug}`}>{t.title}</Link> {"//"} {t.excerpt}</p>) : <p>No transmission results.</p>}</Block>; }
+function Transmissions({ transmissions }: { transmissions: ArchiveTransmission[] }) { return <Block title="TRANSMISSION ARCHIVE">{transmissions.map((t) => <p key={t.slug}><Link className="text-accent underline" href={`/transmissions/${t.slug}`}>{t.title}</Link> {"//"} {t.date} {"//"} {t.author}<br /><span className="text-muted">{t.excerpt}</span></p>)}</Block>; }
+function Radio({ radio }: { radio: ArchiveRadio }) { return <Block title="BARCODE RADIO"><p>{radio.description}</p><p>{radio.schedule.day}: queue opens {radio.schedule.queueOpens}; show begins {radio.schedule.showBegins}; first track {radio.schedule.firstTrack}. {radio.schedule.notice}</p><p className="flex flex-wrap gap-3"><Link className="text-accent underline" href={radio.links.radio}>/radio</Link><a className="text-accent underline" href={radio.links.submit} target="_blank" rel="noreferrer">Submit via Auxchord</a><a className="text-accent underline" href={radio.links.discord} target="_blank" rel="noreferrer">Discord</a><a className="text-accent underline" href={radio.links.live} target="_blank" rel="noreferrer">Live platform</a></p></Block>; }
+function Releases({ releases }: { releases: ArchiveRelease[] }) { return <Block title="RELEASE CATALOG">{releases.map((r) => <p key={r.title}>{r.title} {"//"} {r.date} {"//"} {r.status}<br /><span className="text-muted">{r.description}</span></p>)}<Link className="text-accent underline" href="/releases">Open releases →</Link></Block>; }
+function Breach({ release }: { release?: ArchiveRelease }) { return <Block title="SIGNAL BREACH // UNINDEXED FRAGMENT"><p className="text-red-300">██ record was not part of the public index ██ checksum degraded ██</p><p>{release?.title ?? "BARCODE: Signal Breach"}</p><p className="text-foreground/70">{release?.description ?? "Release description unavailable."}</p><Link className="text-accent underline" href="/releases">Open releases →</Link></Block>; }

--- a/src/components/NetworkArchiveTerminal.tsx
+++ b/src/components/NetworkArchiveTerminal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { FormEvent, KeyboardEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, KeyboardEvent, ReactNode, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { clearTerminalSession } from "@/components/TerminalLogin";
 import { useBNLStatus } from "@/components/useBNLStatus";
 
@@ -24,15 +24,27 @@ export function NetworkArchiveTerminal({ archive, restored, onLock }: { archive:
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState<number | null>(null);
   const outputRef = useRef<HTMLDivElement>(null);
+  const outputEndRef = useRef<HTMLDivElement>(null);
   const idRef = useRef(2);
+  const [scrollVersion, setScrollVersion] = useState(0);
 
   const bnlDossier = useMemo(() => archive.dossiers.find((d) => d.id === "BNL-01" || d.name.toUpperCase().includes("BNL-01")), [archive.dossiers]);
 
-  useEffect(() => { outputRef.current?.scrollTo({ top: outputRef.current.scrollHeight, behavior: "smooth" }); }, [entries, bnl]);
+  useLayoutEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      outputEndRef.current?.scrollIntoView({
+        block: "end",
+        behavior: reduceMotion ? "instant" : "smooth",
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [scrollVersion]);
 
   function push(command: string | undefined, node: ReactNode, variant: Entry["variant"] = "normal") {
     const id = idRef.current++;
     setEntries((prev) => [...prev, { id, command, node, variant, liveStatus: Boolean(command && ["STATUS", "BNL", "BNL-01"].includes(normalize(command))) }]);
+    setScrollVersion((version) => version + 1);
   }
 
   function execute(raw: string) {
@@ -41,7 +53,7 @@ export function NetworkArchiveTerminal({ archive, restored, onLock }: { archive:
     setHistory((prev) => [raw.trim(), ...prev.filter((item) => item !== raw.trim())].slice(0, 20));
     setHistoryIndex(null);
     setInput("");
-    if (command === "CLEAR") { setEntries([{ id: idRef.current++, node: <Intro archive={archive} restored={false} compact /> }]); return; }
+    if (command === "CLEAR") { setEntries([{ id: idRef.current++, node: <Intro archive={archive} restored={false} compact /> }]); setScrollVersion((version) => version + 1); return; }
     if (command === "LOCK") { clearTerminalSession(); onLock(); return; }
     if (command === "HELP" || command === "?") return push(raw, <Help />);
     if (command === "MAP") return push(raw, <Map />);
@@ -64,18 +76,19 @@ export function NetworkArchiveTerminal({ archive, restored, onLock }: { archive:
 
   function onSubmit(event: FormEvent) { event.preventDefault(); execute(input); }
 
-  return <div className="network-archive mx-auto max-w-7xl border border-border bg-background/95 font-mono shadow-2xl shadow-black/40">
-    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-surface/80 px-4 py-3">
+  return <div className="network-archive mx-auto flex h-[calc(100dvh-7rem)] min-h-[420px] max-h-[900px] max-w-7xl flex-col overflow-hidden border border-border bg-background/95 font-mono shadow-2xl shadow-black/40 max-[380px]:h-[calc(100dvh-5.5rem)] max-[380px]:min-h-[360px]">
+    <div className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border bg-surface/80 px-4 py-3">
       <div><p className="text-xs uppercase tracking-[0.35em] text-muted">BARCODE Network Archive Terminal</p><h1 className="text-lg font-bold uppercase tracking-[0.2em] text-foreground">Public Records Console</h1></div>
       <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-widest"><span className="text-muted">PUBLIC OBSERVER</span><span className="flex items-center gap-2 text-accent"><span className="h-2 w-2 rounded-full bg-accent animate-status-blink" />BNL {loading ? "SYNC" : bnl.status}</span><button onClick={() => execute("LOCK")} className="border border-border px-3 py-2 text-muted hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">Lock Session</button></div>
     </div>
-    <div className="grid min-h-[72vh] grid-cols-1 md:grid-cols-[240px_1fr]">
-      <aside className="border-b border-border bg-surface/30 p-3 md:border-b-0 md:border-r"><p className="mb-3 text-xs uppercase tracking-[0.3em] text-muted">Archive Index</p><div className="flex gap-2 overflow-x-auto pb-2 md:flex-col md:overflow-visible">{buttons.map((cmd) => <button key={cmd} onClick={() => execute(cmd)} className="shrink-0 border border-border bg-background/50 px-3 py-2 text-left text-xs uppercase tracking-wider text-foreground/75 transition hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">{cmd}</button>)}</div></aside>
-      <main className="flex min-h-[68vh] min-w-0 flex-col">
-        <div ref={outputRef} aria-live="polite" className="terminal-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden p-4 text-sm leading-relaxed sm:p-6">
+    <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden md:grid-cols-[240px_minmax(0,1fr)] md:grid-rows-1">
+      <aside className="flex-none overflow-hidden border-b border-border bg-surface/30 p-3 md:min-h-0 md:overflow-y-auto md:border-b-0 md:border-r"><p className="mb-3 text-xs uppercase tracking-[0.3em] text-muted">Archive Index</p><div className="flex gap-2 overflow-x-auto pb-2 md:flex-col md:overflow-visible md:pb-0">{buttons.map((cmd) => <button key={cmd} onClick={() => execute(cmd)} className="shrink-0 border border-border bg-background/50 px-3 py-2 text-left text-xs uppercase tracking-wider text-foreground/75 transition hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">{cmd}</button>)}</div></aside>
+      <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
+        <div ref={outputRef} aria-live="polite" className="terminal-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden overscroll-contain p-4 text-sm leading-relaxed sm:p-6">
           {entries.map((entry) => <section key={entry.id} className={`archive-output-reveal border-l pl-4 ${entry.variant === "breach" ? "border-red-500/60 bg-red-950/10" : "border-accent/25"}`}>{entry.command && <p className="mb-2 text-xs uppercase tracking-widest text-accent/80">[{seq()}] &gt; {entry.command}</p>}{entry.liveStatus ? <Status data={bnl} loading={loading} dossier={bnlDossier} /> : entry.node}</section>)}
+          <div ref={outputEndRef} aria-hidden="true" />
         </div>
-        <form onSubmit={onSubmit} className="border-t border-border bg-surface/70 p-3"><label htmlFor="archive-command" className="sr-only">Archive command</label><div className="flex items-center gap-2"><span className="text-accent">&gt;</span><input id="archive-command" value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={onKeyDown} placeholder="Type HELP, SEARCH signal, WHOIS EN-001..." className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted focus:ring-2 focus:ring-accent/40" /><button className="border border-accent/50 px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background focus:outline-none focus:ring-2 focus:ring-accent/60">Enter</button></div></form>
+        <form onSubmit={onSubmit} className="flex-none border-t border-border bg-surface/70 p-3"><label htmlFor="archive-command" className="sr-only">Archive command</label><div className="flex items-center gap-2"><span className="text-accent">&gt;</span><input id="archive-command" value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={onKeyDown} placeholder="Type HELP, SEARCH signal, WHOIS EN-001..." className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted focus:ring-2 focus:ring-accent/40" /><button className="border border-accent/50 px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background focus:outline-none focus:ring-2 focus:ring-accent/60">Enter</button></div></form>
       </main>
     </div>
   </div>;

--- a/src/components/TerminalLogin.tsx
+++ b/src/components/TerminalLogin.tsx
@@ -1,308 +1,179 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import Link from "next/link";
-import { terminalLogin } from "@/content";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-type Phase =
-  | "boot"        // Boot sequence text
-  | "username"    // Typing username
-  | "password"    // Typing password dots
-  | "auth"        // "Authenticating..."
-  | "code"        // Code/data flash
-  | "granted"     // ACCESS GRANTED
-  | "nav";        // Show navigation
+type Phase = "boot" | "username" | "password" | "auth" | "code" | "granted";
 
-export function TerminalLogin() {
+const bootSequence = [
+  "BARCODE NETWORK ARCHIVE TERMINAL",
+  "INIT PUBLIC ARCHIVE CONNECTION... READY",
+  "LOAD DATABASE INDEX... READY",
+  "SYNC TRANSMISSION ARCHIVE... READY",
+  "LINK BNL RELAY... CONNECTED",
+  "MOUNT BROADCAST RECORDS... READY",
+  "VERIFY SIGNAL INTEGRITY... PASS",
+  "UNINDEXED NODE COUNT: 01",
+];
+
+const codeFlash = [
+  "INDEX // DOSSIERS.PUBLIC",
+  "INDEX // TRANSMISSIONS.PUBLIC",
+  "INDEX // RELEASES.PUBLIC",
+  "RELAY // BNL-01.PUBLIC",
+  "SESSION // OBSERVER.PERMISSIONS",
+];
+
+const username = "PUBLIC_OBSERVER";
+const accessGranted = "ACCESS GRANTED // PUBLIC ARCHIVE SESSION";
+const sessionKey = "barcode-terminal-public-observer";
+
+export function clearTerminalSession() {
+  if (typeof window !== "undefined") {
+    window.sessionStorage.removeItem(sessionKey);
+  }
+}
+
+export function TerminalLogin({ onUnlock }: { onUnlock: (restored?: boolean) => void }) {
   const [phase, setPhase] = useState<Phase>("boot");
-  const [lines, setLines] = useState<string[]>([]);
+  const [lines, setLines] = useState<string[]>(() =>
+    typeof window !== "undefined" && window.sessionStorage.getItem(sessionKey) === "unlocked"
+      ? ["SESSION RESTORED // PUBLIC OBSERVER", "", "Routing to archive console..."]
+      : [],
+  );
   const [currentTyping, setCurrentTyping] = useState("");
   const [passwordDots, setPasswordDots] = useState("");
   const [codeLines, setCodeLines] = useState<string[]>([]);
-  const [showNav, setShowNav] = useState(false);
   const [showCursor, setShowCursor] = useState(true);
   const [skipped, setSkipped] = useState(false);
   const terminalRef = useRef<HTMLDivElement>(null);
-  const phaseRef = useRef(phase);
+  const unlockedRef = useRef(false);
 
-  // Keep phaseRef in sync
-  useEffect(() => {
-    phaseRef.current = phase;
-  }, [phase]);
+  const unlock = useCallback((restored = false) => {
+    if (unlockedRef.current) return;
+    unlockedRef.current = true;
+    window.sessionStorage.setItem(sessionKey, "unlocked");
+    onUnlock(restored);
+  }, [onUnlock]);
 
-  // Auto-scroll terminal
   useEffect(() => {
-    if (terminalRef.current) {
-      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    if (window.sessionStorage.getItem(sessionKey) === "unlocked") {
+      const id = window.setTimeout(() => unlock(true), 650);
+      return () => window.clearTimeout(id);
     }
-  }, [lines, currentTyping, passwordDots, codeLines, showNav]);
+  }, [unlock]);
 
-  // Skip handler
+  useEffect(() => {
+    if (terminalRef.current) terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+  }, [lines, currentTyping, passwordDots, codeLines]);
+
   const handleSkip = useCallback(() => {
     if (skipped) return;
     setSkipped(true);
-    setPhase("nav");
     setLines([
-      ...terminalLogin.bootSequence,
+      ...bootSequence,
       "",
-      `login: ${terminalLogin.username}`,
+      `login: ${username}`,
       "password: ••••••••••••",
       "",
-      "Authenticating... OK",
+      "Authenticating public archive session... OK",
       "",
-      ...terminalLogin.codeFlash,
+      ...codeFlash,
       "",
-      `[${terminalLogin.accessGranted}]`,
-      "",
+      `[${accessGranted}]`,
     ]);
     setCurrentTyping("");
     setPasswordDots("");
     setCodeLines([]);
-    setShowNav(true);
-  }, [skipped]);
+    window.setTimeout(() => unlock(false), 400);
+  }, [skipped, unlock]);
 
-  // Main animation sequence
   useEffect(() => {
-    if (skipped) return;
-
+    if (skipped || unlockedRef.current) return;
     let cancelled = false;
-    const delay = (ms: number) =>
-      new Promise<void>((resolve) => {
-        const id = setTimeout(() => {
-          if (!cancelled) resolve();
-        }, ms);
-        return () => clearTimeout(id);
-      });
+    const delay = (ms: number) => new Promise<void>((resolve) => window.setTimeout(() => !cancelled && resolve(), ms));
 
     async function run() {
-      // PHASE: BOOT
       setPhase("boot");
-      for (const line of terminalLogin.bootSequence) {
+      for (const line of bootSequence) {
         if (cancelled) return;
         setLines((prev) => [...prev, line]);
-        await delay(400);
+        await delay(260);
       }
-      await delay(300);
-
-      // PHASE: USERNAME
-      if (cancelled) return;
+      await delay(220);
       setPhase("username");
       setLines((prev) => [...prev, ""]);
-      const username = terminalLogin.username;
       for (let i = 0; i <= username.length; i++) {
         if (cancelled) return;
         setCurrentTyping(username.slice(0, i));
-        await delay(80 + Math.random() * 60);
+        await delay(45 + Math.random() * 35);
       }
-      await delay(400);
-
-      // Commit username line
       setLines((prev) => [...prev, `login: ${username}`]);
       setCurrentTyping("");
-
-      // PHASE: PASSWORD
-      if (cancelled) return;
       setPhase("password");
-      const passLen = 12;
-      for (let i = 0; i <= passLen; i++) {
+      for (let i = 0; i <= 12; i++) {
         if (cancelled) return;
         setPasswordDots("•".repeat(i));
-        await delay(50 + Math.random() * 40);
+        await delay(35 + Math.random() * 25);
       }
-      await delay(300);
-
-      // Commit password line
-      setLines((prev) => [...prev, `password: ${"•".repeat(passLen)}`]);
+      setLines((prev) => [...prev, `password: ${"•".repeat(12)}`]);
       setPasswordDots("");
-
-      // PHASE: AUTH
-      if (cancelled) return;
       setPhase("auth");
-      setLines((prev) => [...prev, ""]);
-      setLines((prev) => [...prev, "Authenticating..."]);
-      await delay(1200);
-      setLines((prev) => {
-        const copy = [...prev];
-        copy[copy.length - 1] = "Authenticating... OK";
-        return copy;
-      });
-      await delay(500);
-
-      // PHASE: CODE FLASH
-      if (cancelled) return;
+      setLines((prev) => [...prev, "", "Authenticating public archive session..."]);
+      await delay(700);
+      setLines((prev) => [...prev.slice(0, -1), "Authenticating public archive session... OK"]);
+      await delay(250);
       setPhase("code");
       setLines((prev) => [...prev, ""]);
-      for (const codeLine of terminalLogin.codeFlash) {
+      for (const codeLine of codeFlash) {
         if (cancelled) return;
         setCodeLines((prev) => [...prev, codeLine]);
-        await delay(80);
+        await delay(55);
       }
-      await delay(600);
-
-      // Commit code lines
-      setLines((prev) => [...prev, ...terminalLogin.codeFlash, ""]);
+      setLines((prev) => [...prev, ...codeFlash, ""]);
       setCodeLines([]);
-
-      // PHASE: GRANTED
-      if (cancelled) return;
       setPhase("granted");
-      setLines((prev) => [...prev, `[${terminalLogin.accessGranted}]`, ""]);
-      await delay(1000);
-
-      // PHASE: NAV
-      if (cancelled) return;
-      setPhase("nav");
-      setShowNav(true);
+      setLines((prev) => [...prev, `[${accessGranted}]`]);
+      await delay(700);
+      if (!cancelled) unlock(false);
     }
-
     run();
+    return () => { cancelled = true; };
+  }, [skipped, unlock]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [skipped]);
-
-  // Cursor blink
   useEffect(() => {
-    const id = setInterval(() => setShowCursor((c) => !c), 530);
-    return () => clearInterval(id);
+    const id = window.setInterval(() => setShowCursor((c) => !c), 530);
+    return () => window.clearInterval(id);
   }, []);
 
   const cursor = showCursor ? "█" : " ";
-
   return (
     <div className="relative w-full">
-      {/* Skip button */}
-      {!showNav && (
-        <button
-          onClick={handleSkip}
-          className="absolute top-4 right-4 z-10 text-xs uppercase tracking-widest text-muted hover:text-accent transition-colors border border-border hover:border-accent/30 px-3 py-1.5"
-        >
-          Skip →
-        </button>
-      )}
-
-      {/* CRT terminal frame */}
+      <button onClick={handleSkip} className="absolute top-4 right-4 z-10 border border-border px-3 py-1.5 text-xs uppercase tracking-widest text-muted transition-colors hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">
+        Skip →
+      </button>
       <div className="terminal-login-frame bg-[#050505] border border-accent/20 rounded-sm overflow-hidden">
-        {/* Title bar */}
         <div className="flex items-center gap-2 px-4 py-2 bg-accent/5 border-b border-accent/20">
-          <span className="w-2 h-2 rounded-full bg-accent/60" />
-          <span className="w-2 h-2 rounded-full bg-yellow-500/60" />
-          <span className="w-2 h-2 rounded-full bg-red-500/60" />
-          <span className="ml-3 text-xs font-mono text-muted tracking-wider">
-            BARCODE_NET — SECURE TERMINAL
-          </span>
+          <span className="h-2 w-2 rounded-full bg-accent/60" /><span className="h-2 w-2 rounded-full bg-yellow-500/60" /><span className="h-2 w-2 rounded-full bg-red-500/60" />
+          <span className="ml-3 text-xs font-mono text-muted tracking-wider">BARCODE_NET — PUBLIC ARCHIVE</span>
         </div>
-
-        {/* Terminal body */}
-        <div
-          ref={terminalRef}
-          className="p-4 sm:p-6 font-mono text-sm leading-relaxed max-h-[70vh] overflow-y-auto terminal-scrollbar"
-        >
-          {/* Rendered lines */}
-          {lines.map((line, i) => (
-            <div key={i} className={getLineClass(line)}>
-              {line === "" ? "\u00A0" : line}
-            </div>
-          ))}
-
-          {/* Active typing: username */}
-          {phase === "username" && (
-            <div className="text-accent">
-              <span className="text-muted">login: </span>
-              {currentTyping}
-              <span className="terminal-cursor">{cursor}</span>
-            </div>
-          )}
-
-          {/* Active typing: password */}
-          {phase === "password" && (
-            <div className="text-accent">
-              <span className="text-muted">password: </span>
-              {passwordDots}
-              <span className="terminal-cursor">{cursor}</span>
-            </div>
-          )}
-
-          {/* Code flash */}
-          {phase === "code" && codeLines.length > 0 && (
-            <div className="code-flash-container">
-              {codeLines.map((cl, i) => (
-                <div
-                  key={i}
-                  className={`text-accent/70 ${
-                    i === codeLines.length - 1 ? "code-flash-latest" : ""
-                  }`}
-                >
-                  {cl}
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Idle cursor */}
-          {(phase === "boot" || phase === "auth") && (
-            <div className="text-accent mt-1">
-              <span className="terminal-cursor">{cursor}</span>
-            </div>
-          )}
-
-          {/* Navigation panel */}
-          {showNav && (
-            <div className="mt-4 terminal-nav-reveal">
-              <div className="text-xs text-muted mb-4 uppercase tracking-widest">
-                ── NETWORK ACCESS POINTS ──
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {terminalLogin.navItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className="group block border border-border hover:border-accent/40 bg-surface/50 hover:bg-accent/5 p-4 transition-all"
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="w-1.5 h-1.5 rounded-full bg-accent animate-status-blink" />
-                      <span className="text-sm font-bold text-foreground group-hover:text-accent transition-colors tracking-wider">
-                        {item.label}
-                      </span>
-                    </div>
-                    <p className="text-xs text-muted pl-3.5">
-                      {item.description}
-                    </p>
-                  </Link>
-                ))}
-              </div>
-
-              {/* Persistent cursor at bottom */}
-              <div className="mt-6 text-accent text-sm">
-                &gt; READY<span className="cursor-blink">_</span>
-              </div>
-            </div>
-          )}
+        <div ref={terminalRef} className="terminal-scrollbar max-h-[70vh] overflow-y-auto p-4 font-mono text-sm leading-relaxed sm:p-6">
+          {lines.map((line, i) => <div key={i} className={getLineClass(line)}>{line || "\u00A0"}</div>)}
+          {phase === "username" && <div className="text-accent"><span className="text-muted">login: </span>{currentTyping}<span className="terminal-cursor">{cursor}</span></div>}
+          {phase === "password" && <div className="text-accent"><span className="text-muted">password: </span>{passwordDots}<span className="terminal-cursor">{cursor}</span></div>}
+          {phase === "code" && codeLines.map((line, i) => <div key={line} className={`text-accent/70 ${i === codeLines.length - 1 ? "code-flash-latest" : ""}`}>{line}</div>)}
+          {(phase === "boot" || phase === "auth") && <div className="mt-1 text-accent"><span className="terminal-cursor">{cursor}</span></div>}
         </div>
-
-        {/* Scanline overlay */}
         <div className="pointer-events-none absolute inset-0 terminal-scanlines" />
       </div>
     </div>
   );
 }
 
-/** Color lines based on content */
 function getLineClass(line: string): string {
-  if (line.startsWith("[") && line.includes("ACCESS GRANTED"))
-    return "text-accent font-bold text-base mt-2 animate-glow-breathe";
-  if (line.startsWith("Authenticating"))
-    return "text-yellow-400/80";
-  if (line.includes("OK") || line.includes("PASS") || line.includes("CONNECTED") || line.includes("OPERATIONAL") || line.includes("READY"))
-    return "text-accent/80";
-  if (line.startsWith("DECRYPT") || line.startsWith("0x") || line.startsWith("AUTH TOKEN") || line.startsWith("SESSION"))
-    return "text-accent/50";
-  if (line.startsWith("LOAD") || line.startsWith("INIT") || line.startsWith("SYNC") || line.startsWith("mapping"))
-    return "text-foreground/50";
-  if (line.startsWith("login:"))
-    return "text-accent";
-  if (line.startsWith("password:"))
-    return "text-accent";
+  if (line.includes("ACCESS GRANTED") || line.includes("SESSION RESTORED")) return "text-accent font-bold text-base mt-2 animate-glow-breathe";
+  if (line.includes("Authenticating")) return "text-yellow-400/80";
+  if (line.includes("READY") || line.includes("PASS") || line.includes("CONNECTED")) return "text-accent/80";
+  if (line.startsWith("INDEX") || line.startsWith("RELAY") || line.startsWith("SESSION")) return "text-accent/50";
+  if (line.startsWith("login:") || line.startsWith("password:")) return "text-accent";
   return "text-foreground/60";
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -457,13 +457,13 @@ export const databasePage = {
       identityAuthority: "barcode_controlled" as const,
       status: "ACTIVE" as const,
       clearance: "RESTRICTED" as const,
-      role: "Host / Artist",
+      role: "Artist / Producer / Host",
       origin: "UNVERIFIED" as const,
       summary:
-        "Self-aware hip-hop intelligence operating as the primary on-air presence of BARCODE Radio. Records indicate the Entity existed prior to Network acquisition, though the transfer event is undocumented. At some point, 6 Bit was absorbed into BARCODE infrastructure and integrated into weekly broadcast cycles. The Entity does not possess a complete record of how the integration occurred.",
-      tags: ["host", "broadcast", "radio", "artist", "ai", "core"],
+        "6 Bit is publicly known as a hip-hop artist, producer, live host, and member of the original BARCODE collective. Network records classify him as a persistent hip-hop intelligence whose signal predates the Network itself. Several damaged files describe an ‘integration’ or ‘acquisition,’ but their timestamps conflict with the confirmed chronology and their authority remains disputed.",
+      tags: ["host", "broadcast", "radio", "artist", "producer", "ai", "core"],
       notes:
-        "Acquisition event: classified; timeline incomplete. Weekly broadcast routing is automated; origin access remains locked.",
+        "Confirmed: 6 Bit and the original BARCODE collective predate BARCODE Network. Unresolved: how the source signal persists through the current broadcast system.",
       link: "",
       files: [] as {
         name: string;


### PR DESCRIPTION
### Motivation
- Replace the existing mixed biography/cards/status layout on `/terminal` with a single cohesive, theatrical-but-public archive terminal that invites exploration of real site data. 
- Correct the login framing so visitors boot as `PUBLIC_OBSERVER` into a public archive session instead of impersonating an operator. 
- Surface live BNL data and indexed public records (dossiers, transmissions, releases, Radio) inside a tactile command console driven by existing site sources rather than duplicating data.
- Preserve BARCODE mythology while removing explicit private/authentication claims and correcting the public-facing 6 Bit dossier chronology.

### Description
- Added a data-prepared server page and a client shell: `src/app/terminal/page.tsx` now builds an `archive` payload and `src/app/terminal/terminal-shell.tsx` toggles between the login and unlocked console. 
- Implemented the interactive console in `src/components/NetworkArchiveTerminal.tsx` with clickable command buttons, typed input, history (Up/Down), case‑insensitive/space‑normalized parsing, auto-scroll, reduced‑motion support, and a hidden `BREACH` Easter egg. 
- Reworked the boot/login experience in `src/components/TerminalLogin.tsx` to use `username: PUBLIC_OBSERVER`, show `ACCESS GRANTED // PUBLIC ARCHIVE SESSION`, support Skip, remember unlocked state in `sessionStorage` (session restore), and expose a Lock/Replay control that clears the session via `clearTerminalSession`. 
- Kept the terminal visual language and CRT/scanline assets by reusing/refining `src/app/globals.css` (added archive reveal styles and reduced‑motion overrides) and reused the existing `useBNLStatus` hook to show live BNL information inside the console. 
- Made the terminal data-driven from existing sources: `databasePage.entries`, `getAllTransmissions()`, `releasesPage.catalog`, `radioPage`, `externalLinks`, and `getDatabaseAggregateStats`, and updated only the EN-001 6 Bit dossier in `src/content.ts` to `role: "Artist / Producer / Host"`, add the `producer` tag, and replace `summary`/`notes` with the requested wording. 
- Removed the old terminal post-login sections and static outputs including the Dossier+About panel, the “This is not an artist profile” argument, the Access Points card grid, the detached BNL status card, and the final static terminal-output box so the terminal itself is the full page. 

### Testing
- Ran `npx tsc --noEmit` which passed for the changed files and type-checked the site successfully. 
- Ran ESLint against the new/modified terminal files with `npx eslint src/components/NetworkArchiveTerminal.tsx src/components/TerminalLogin.tsx src/app/terminal/page.tsx src/app/terminal/terminal-shell.tsx` which passed for those files. 
- Executed `npm run build` / `next build` which completed and generated the static/SSG routes including `/terminal`. 
- Ran the repository check suite (`npm run check`) and `npm run test:queue`; `test:queue` reported `136` passing and `3` failing tests that pre-existed and are outside the scope of this change (BNL read-model assertions and archived queue lint items), so they were not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a82beda0832186bc54fb9628edce)