### PR TITLE
Quarantine test queue data from public and BNL signals

### DIFF
--- a/docs/queue-production-capability.md
+++ b/docs/queue-production-capability.md
@@ -1,0 +1,31 @@
+# BARCODE queue production capability
+
+`BARCODE_QUEUE_PRODUCTION_ENABLED` is a server-only production capability for allowing BARCODE Radio queue sessions and tracks to feed public and BNL-facing signals.
+
+## Default-off behavior
+
+The capability is disabled unless the environment variable value is exactly `true`. Unset, empty, `TRUE`, `1`, `yes`, or any other value is treated as disabled.
+
+While disabled, test queue sessions and tracks do not affect global live status, public queue CTAs derived from live status, public show mode, BNL read-model queue projections, queue-derived artists, queue-derived operator lanes, dossier recommendations, Source File evidence, public authoring suggestions, or memory-like evidence.
+
+## Authorized testing that remains available
+
+Queue testing and admin workflows may continue in their existing authorized surfaces. The gate only blocks promotion of queue data into public/BNL truth surfaces. It does not change queue mechanics, playback, submissions, provider integrations, admin controls, uploads, priority lanes, scheduling, simulations, payments, or routes.
+
+## Blocked from public and BNL consumption
+
+When disabled, the global live-status provider does not poll `/api/queue`, cached queue snapshots are cleared, and `/api/bnl/read-model` returns an explicit unavailable queue contract with `capabilities.queueProduction=false` instead of live sessions, queue tracks, now-playing, up-next, queue counts, queue-derived artists, recap candidates, queue-derived copy candidates, or queue-derived dossier suggestions. Queue-lane recommendation ingest such as `queue_context` is rejected before it can create approved BNL/Source File evidence.
+
+Manual and scheduled TikTok live status remains independent. A legitimate manual or scheduled live state may still produce broadcast-live public show mode.
+
+## Vercel rollout procedure
+
+1. Leave production disabled until the owner explicitly declares the queue ready for production use.
+2. In Vercel, add `BARCODE_QUEUE_PRODUCTION_ENABLED` to the intended environment only.
+3. Set the value to exactly `true` when the owner approves production queue signals.
+4. Redeploy the site so server-only code reads the new environment value.
+5. Confirm `/api/admin/live` and `/api/bnl/read-model` report `capabilities.queueProduction=true`.
+
+## Rollback
+
+Unset `BARCODE_QUEUE_PRODUCTION_ENABLED` or set it to anything other than exact `true`, then redeploy. The default-off behavior resumes and queue testing data is quarantined from public and BNL signals.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:queue": "node --test tests/queue-playback.test.mjs tests/bnl-read-model.test.mjs",
+    "test:queue": "node --test tests/queue-playback.test.mjs tests/bnl-read-model.test.mjs tests/queue-production-capability.test.mjs",
     "check": "npx tsc --noEmit && npm run lint && npm run test:queue"
   },
   "dependencies": {

--- a/src/app/api/admin/live/route.ts
+++ b/src/app/api/admin/live/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from "next/server";
 import { Redis } from "@upstash/redis";
 import { verifyAdminToken, COOKIE_NAME } from "@/lib/auth";
 import { isWithinBroadcastWindow } from "@/lib/broadcastSchedule";
+import { queueProductionCapability } from "@/lib/queue-production";
 
 export const dynamic = "force-dynamic";
 
@@ -67,6 +68,7 @@ export async function GET() {
     isScheduled,
     streamUrl,
     manualOverride: manualOverride !== null,
+    capabilities: queueProductionCapability(),
   });
 }
 

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -99,6 +99,80 @@ const QUEUE_SUBMISSION_STATUSES = [
   "unknown",
 ] as const;
 
+const QUEUE_DERIVED_PROVENANCE_MARKERS = new Set([
+  "queue_context",
+  "queue_frequency",
+  "queue_recurrence",
+  "queue_public_snapshot",
+  "completed_play",
+  "priority_moment",
+  "queue_session",
+  "queue_track",
+  "queue_submission",
+  "queue_status",
+]);
+const QUEUE_KNOWLEDGE_SUBMISSION_STATUSES = new Set([
+  "connected",
+  "confirmed_submission",
+  "no_submission_found",
+  "review_needed",
+  "unknown",
+]);
+
+function provenanceMarker(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return normalized || null;
+}
+
+function provenanceMarkersFrom(value: unknown): string[] {
+  if (value === undefined || value === null) return [];
+  if (typeof value === "string") {
+    const marker = provenanceMarker(value);
+    return marker ? [marker] : [];
+  }
+  if (Array.isArray(value)) return value.flatMap(provenanceMarkersFrom);
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return [
+      record.source,
+      record.type,
+      record.kind,
+      record.lane,
+      record.authority,
+      record.sourceAuthority,
+      record.provenance,
+      record.surface,
+    ].flatMap(provenanceMarkersFrom);
+  }
+  return [];
+}
+
+function hasQueueDerivedDossierInput(input: {
+  rawSourceLanes?: unknown;
+  normalizedSourceLanes?: readonly DossierRecommendationSourceLane[];
+  rawSourceTypes?: unknown;
+  source?: unknown;
+  sourceAuthority?: unknown;
+  rawProvenance?: unknown;
+  queueSubmissionStatus?: string;
+}): boolean {
+  const markers = [
+    ...provenanceMarkersFrom(input.rawSourceLanes),
+    ...(input.normalizedSourceLanes ?? []),
+    ...provenanceMarkersFrom(input.rawSourceTypes),
+    ...provenanceMarkersFrom(input.source),
+    ...provenanceMarkersFrom(input.sourceAuthority),
+    ...provenanceMarkersFrom(input.rawProvenance),
+  ];
+  if (markers.some((marker) => QUEUE_DERIVED_PROVENANCE_MARKERS.has(marker))) {
+    return true;
+  }
+  return input.queueSubmissionStatus
+    ? QUEUE_KNOWLEDGE_SUBMISSION_STATUSES.has(input.queueSubmissionStatus)
+    : false;
+}
+
 function text(value: unknown, maxLength: number): string | undefined {
   if (value === undefined || value === null) return undefined;
   if (typeof value !== "string") throw new Error("Expected text field");
@@ -521,9 +595,29 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     if (sourceLanes.length === 0) sourceLanes = ["unknown"];
   }
 
-  if (!isQueueProductionEnabled() && sourceLanes.includes("queue_context")) {
+  const sourceTypes = stringList(payload.sourceTypes, 120);
+  const sourceAuthority = packetStringList(payload.sourceAuthority, 1000);
+  const rawProvenance = rawJsonValue(payload.rawProvenance);
+  const queueSubmissionStatus = enumValue(
+    payload.queueSubmissionStatus,
+    QUEUE_SUBMISSION_STATUSES,
+    "queue submission status",
+  );
+
+  if (
+    !isQueueProductionEnabled() &&
+    hasQueueDerivedDossierInput({
+      rawSourceLanes: sourceLanesInput,
+      normalizedSourceLanes: sourceLanes,
+      rawSourceTypes: payload.sourceTypes,
+      source: payload.source,
+      sourceAuthority,
+      rawProvenance,
+      queueSubmissionStatus,
+    })
+  ) {
     throw new Error(
-      "queue_context recommendations are disabled until BARCODE_QUEUE_PRODUCTION_ENABLED is exactly true",
+      "Queue-derived dossier recommendations are disabled until BARCODE_QUEUE_PRODUCTION_ENABLED is exactly true",
     );
   }
 
@@ -561,15 +655,8 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
   const authoredVsMentionedSummary = reviewEvidenceList(payload.authoredVsMentionedSummary, "authoredVsMentionedSummary");
   const publicUseCandidates = packetStringList(payload.publicUseCandidates);
   const reviewOnlyEvidence = packetStringList(payload.reviewOnlyEvidence);
-  const queueSubmissionStatus = enumValue(
-    payload.queueSubmissionStatus,
-    QUEUE_SUBMISSION_STATUSES,
-    "queue submission status",
-  );
   const queueSubmissionNote = text(payload.queueSubmissionNote, 1000);
   const recommendedAction = text(payload.recommendedAction, 1000);
-  const sourceAuthority = packetStringList(payload.sourceAuthority, 1000);
-  const rawProvenance = rawJsonValue(payload.rawProvenance);
   const reason =
     text(payload.reason, 2000) ??
     knownContext?.[0] ??
@@ -610,7 +697,7 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     evidenceSummary: bridgeEvidenceSummary,
     confidence: enumValue(payload.confidence, CONFIDENCES, "confidence"),
     sourceLanes,
-    sourceTypes: stringList(payload.sourceTypes, 120),
+    sourceTypes,
     suggestedAction: text(payload.suggestedAction, 500),
     knownContext,
     usefulEvidence,

--- a/src/app/api/bnl/dossier-recommendations/route.ts
+++ b/src/app/api/bnl/dossier-recommendations/route.ts
@@ -17,6 +17,7 @@ import {
   DossierWorkflowInputError,
   reconcilePopulationSignals,
 } from "@/lib/dossier-workflow-store";
+import { isQueueProductionEnabled } from "@/lib/queue-production";
 
 export const dynamic = "force-dynamic";
 
@@ -518,6 +519,12 @@ function normalizePayload(value: unknown): CreateDossierRecommendationInput {
     }
     sourceLanes = Array.from(new Set(sourceLanes.filter(Boolean)));
     if (sourceLanes.length === 0) sourceLanes = ["unknown"];
+  }
+
+  if (!isQueueProductionEnabled() && sourceLanes.includes("queue_context")) {
+    throw new Error(
+      "queue_context recommendations are disabled until BARCODE_QUEUE_PRODUCTION_ENABLED is exactly true",
+    );
   }
 
   const targetDossierId = text(payload.targetDossierId, 200);

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -1057,7 +1057,23 @@ export async function GET() {
               publicSafeCopyCandidates: [],
               doNotStore: ["queue production signals are disabled"],
             },
-        rules,
+        rules: queueProductionEnabled
+          ? rules
+          : {
+              ...rules,
+              allowedUse: rules.allowedUse.filter(
+                (item) => !/queue|artist\/track/i.test(item),
+              ),
+              sourceAuthority: {
+                ...rules.sourceAuthority,
+                queue:
+                  "production queue signals unavailable; testing queue sessions and tracks are not public runtime context",
+                artists:
+                  "queue-derived artist surfaces unavailable while production queue signals are disabled",
+                operatorLanes:
+                  "queue-derived lane hints unavailable while production queue signals are disabled",
+              },
+            },
       },
     },
     {

--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -30,6 +30,10 @@ import {
   isPublicDatabasePageVisible,
 } from "@/lib/database-visibility";
 import { getRadioQueueState, toPublicQueueTrack } from "@/lib/queue";
+import {
+  isQueueProductionEnabled,
+  queueProductionCapability,
+} from "@/lib/queue-production";
 import type {
   QueueEntry,
   QueueLane,
@@ -170,6 +174,15 @@ function pressureFor(
   if (load >= 0.75) return "high";
   if (load >= 0.4) return "medium";
   return "low";
+}
+
+function disabledQueueProjection() {
+  return {
+    available: false,
+    reason: "queue_production_disabled",
+    message:
+      "BARCODE Radio queue production signals are disabled; testing queue data is unavailable to the BNL public read model.",
+  };
 }
 
 async function readPublicLiveQueueForBnl() {
@@ -1008,7 +1021,10 @@ const rules = {
 };
 
 export async function GET() {
-  const liveQueue = await readPublicLiveQueueForBnl();
+  const queueProductionEnabled = isQueueProductionEnabled();
+  const liveQueue = queueProductionEnabled
+    ? await readPublicLiveQueueForBnl()
+    : { queue: disabledQueueProjection(), artists: [] };
   const dossiers = publicDossiers();
 
   return NextResponse.json(
@@ -1020,12 +1036,27 @@ export async function GET() {
       scope: "bnl_public_read_model",
       source: "barcode-network-site",
       publicOnly: true,
+      capabilities: queueProductionCapability(),
       sections: {
         sourceContext,
         queue: liveQueue.queue,
         artists: liveQueue.artists,
         dossiers,
-        operatorLanes: buildOperatorLanes(liveQueue.queue, dossiers),
+        operatorLanes: queueProductionEnabled
+          ? buildOperatorLanes(
+              liveQueue.queue as Awaited<
+                ReturnType<typeof readPublicLiveQueueForBnl>
+              >["queue"],
+              dossiers,
+            )
+          : {
+              temporaryRuntimeContext: [],
+              recapCandidates: [],
+              broadcastMemoryCandidates: [],
+              dossierSeedCandidates: [],
+              publicSafeCopyCandidates: [],
+              doNotStore: ["queue production signals are disabled"],
+            },
         rules,
       },
     },

--- a/src/components/LiveStatusProvider.tsx
+++ b/src/components/LiveStatusProvider.tsx
@@ -67,6 +67,22 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
         setIsScheduled(data.isScheduled);
         setStreamUrlState(data.streamUrl);
         setManualOverride(data.manualOverride);
+        const queueProduction = data?.capabilities?.queueProduction === true;
+        if (!queueProduction) {
+          setQueueSnapshot(null);
+        } else {
+          try {
+            const queueRes = await fetch("/api/queue", { cache: "no-store" });
+            if (queueRes.ok) {
+              const queueData = (await queueRes.json()) as QueuePublicSnapshot;
+              setQueueSnapshot(queueData);
+            } else {
+              queueError = "Failed to fetch queue status";
+            }
+          } catch {
+            queueError = "Failed to fetch queue status";
+          }
+        }
       } else {
         adminError = "Failed to fetch live status";
       }
@@ -74,17 +90,6 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
       adminError = "Failed to fetch live status";
     }
 
-    try {
-      const queueRes = await fetch("/api/queue", { cache: "no-store" });
-      if (queueRes.ok) {
-        const queueData = (await queueRes.json()) as QueuePublicSnapshot;
-        setQueueSnapshot(queueData);
-      } else {
-        queueError = "Failed to fetch queue status";
-      }
-    } catch {
-      queueError = "Failed to fetch queue status";
-    }
 
     setLastError(adminError ?? queueError);
   }, []);

--- a/src/components/LiveStatusProvider.tsx
+++ b/src/components/LiveStatusProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
 import type { QueueBroadcastPhase, QueuePublicSnapshot } from "@/lib/queue-types";
+import { derivePublicShowState } from "@/lib/live-status-public";
 
 type SiteShowMode = "offline" | "intake_open" | "broadcast_live";
 
@@ -53,6 +54,7 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
   const [isAdmin, setIsAdmin] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
   const [persisted, setPersisted] = useState<boolean | null>(null);
+  const [queueProductionEnabled, setQueueProductionEnabled] = useState(false);
   const [queueSnapshot, setQueueSnapshot] = useState<QueuePublicSnapshot | null>(null);
 
   const fetchStatus = useCallback(async () => {
@@ -68,6 +70,7 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
         setStreamUrlState(data.streamUrl);
         setManualOverride(data.manualOverride);
         const queueProduction = data?.capabilities?.queueProduction === true;
+        setQueueProductionEnabled(queueProduction);
         if (!queueProduction) {
           setQueueSnapshot(null);
         } else {
@@ -84,12 +87,15 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
           }
         }
       } else {
+        setQueueProductionEnabled(false);
+        setQueueSnapshot(null);
         adminError = "Failed to fetch live status";
       }
     } catch {
+      setQueueProductionEnabled(false);
+      setQueueSnapshot(null);
       adminError = "Failed to fetch live status";
     }
-
 
     setLastError(adminError ?? queueError);
   }, []);
@@ -157,16 +163,18 @@ export function LiveStatusProvider({ children }: { children: ReactNode }) {
     }
   }, [fetchStatus]);
 
-  const queueSession = queueSnapshot?.session;
-  const hasActiveQueueSession = Boolean(queueSession && queueSession.status !== "archived" && queueSession.broadcastPhase !== "ended");
-  const queueSessionId = hasActiveQueueSession ? queueSession?.sessionId ?? null : null;
-  const queueHref = queueSessionId ? `/queue/${queueSessionId}` : null;
-  const queueSubmissionsOpen = Boolean(hasActiveQueueSession && queueSnapshot?.status?.isOpen);
-  const queueBroadcastPhase = hasActiveQueueSession ? queueSession?.broadcastPhase ?? null : null;
-
-  let siteShowMode: SiteShowMode = "offline";
-  if (queueSubmissionsOpen) siteShowMode = "intake_open";
-  if (queueBroadcastPhase === "broadcast_active" || isLive) siteShowMode = "broadcast_live";
+  const {
+    hasActiveQueueSession,
+    queueSessionId,
+    queueHref,
+    queueSubmissionsOpen,
+    queueBroadcastPhase,
+    siteShowMode,
+  } = derivePublicShowState({
+    queueProductionEnabled,
+    isLive,
+    queueSnapshot,
+  });
 
   return (
     <LiveStatusContext.Provider value={{

--- a/src/lib/live-status-public.ts
+++ b/src/lib/live-status-public.ts
@@ -1,0 +1,55 @@
+import type { QueueBroadcastPhase, QueuePublicSnapshot } from "@/lib/queue-types";
+
+export type SiteShowMode = "offline" | "intake_open" | "broadcast_live";
+
+export type PublicShowStateInput = {
+  queueProductionEnabled: boolean;
+  isLive: boolean;
+  queueSnapshot: QueuePublicSnapshot | null | undefined;
+};
+
+export type PublicShowState = {
+  hasActiveQueueSession: boolean;
+  queueSessionId: string | null;
+  queueHref: string | null;
+  queueSubmissionsOpen: boolean;
+  queueBroadcastPhase: QueueBroadcastPhase | null;
+  siteShowMode: SiteShowMode;
+};
+
+export function derivePublicShowState({
+  queueProductionEnabled,
+  isLive,
+  queueSnapshot,
+}: PublicShowStateInput): PublicShowState {
+  const queueSession = queueProductionEnabled ? queueSnapshot?.session : null;
+  const hasActiveQueueSession = Boolean(
+    queueSession &&
+      queueSession.status !== "archived" &&
+      queueSession.broadcastPhase !== "ended",
+  );
+  const queueSessionId = hasActiveQueueSession
+    ? queueSession?.sessionId ?? null
+    : null;
+  const queueHref = queueSessionId ? `/queue/${queueSessionId}` : null;
+  const queueSubmissionsOpen = Boolean(
+    hasActiveQueueSession && queueSnapshot?.status?.isOpen,
+  );
+  const queueBroadcastPhase = hasActiveQueueSession
+    ? queueSession?.broadcastPhase ?? null
+    : null;
+
+  let siteShowMode: SiteShowMode = "offline";
+  if (queueSubmissionsOpen) siteShowMode = "intake_open";
+  if (queueBroadcastPhase === "broadcast_active" || isLive)
+    siteShowMode = "broadcast_live";
+
+  return {
+    hasActiveQueueSession,
+    queueSessionId,
+    queueHref,
+    queueSubmissionsOpen,
+    queueBroadcastPhase,
+    siteShowMode,
+  };
+}

--- a/src/lib/queue-production.ts
+++ b/src/lib/queue-production.ts
@@ -1,0 +1,11 @@
+export const QUEUE_PRODUCTION_ENV = "BARCODE_QUEUE_PRODUCTION_ENABLED";
+
+export function isQueueProductionEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[QUEUE_PRODUCTION_ENV] === "true";
+}
+
+export function queueProductionCapability(env: NodeJS.ProcessEnv = process.env) {
+  return {
+    queueProduction: isQueueProductionEnabled(env),
+  };
+}

--- a/tests/bnl-read-model.test.mjs
+++ b/tests/bnl-read-model.test.mjs
@@ -8,6 +8,7 @@ import ts from "typescript";
 // Keep endpoint tests isolated to the in-memory queue store instead of any configured Redis.
 delete process.env.UPSTASH_REDIS_REST_URL;
 delete process.env.UPSTASH_REDIS_REST_TOKEN;
+process.env.BARCODE_QUEUE_PRODUCTION_ENABLED = "true";
 
 const projectRoot = path.resolve(import.meta.dirname, "..");
 const originalResolveFilename = Module._resolveFilename;

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -8,6 +8,7 @@ import ts from "typescript";
 // Keep queue tests isolated to the in-memory store instead of any configured Redis.
 delete process.env.UPSTASH_REDIS_REST_URL;
 delete process.env.UPSTASH_REDIS_REST_TOKEN;
+process.env.BARCODE_QUEUE_PRODUCTION_ENABLED = "true";
 
 const projectRoot = path.resolve(import.meta.dirname, "..");
 const originalResolveFilename = Module._resolveFilename;

--- a/tests/queue-production-capability.test.mjs
+++ b/tests/queue-production-capability.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, "src", request.slice(2));
+    if (fs.existsSync(resolved)) return resolved;
+    if (fs.existsSync(`${resolved}.ts`)) return `${resolved}.ts`;
+    if (fs.existsSync(`${resolved}.tsx`)) return `${resolved}.tsx`;
+    return resolved;
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+Module._extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, { compilerOptions: { esModuleInterop: true, jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 }, fileName: filename });
+  module._compile(outputText, filename);
+};
+Module._extensions[".tsx"] = Module._extensions[".ts"];
+
+const require = createRequire(import.meta.url);
+const capability = require("../src/lib/queue-production.ts");
+const queue = require("../src/lib/queue.ts");
+const readModel = require("../src/app/api/bnl/read-model/route.ts");
+const dossierRecommendations = require("../src/app/api/bnl/dossier-recommendations/route.ts");
+const workflowStore = require("../src/lib/dossier-workflow-store.ts");
+const adminLive = require("../src/app/api/admin/live/route.ts");
+
+async function resetWorkflowStore() {
+  await workflowStore.saveDossierWorkflowState({ version: 1, revision: 0, candidates: [], drafts: [], recommendations: [], updatedAt: new Date(0).toISOString() });
+}
+
+async function withQueueProduction(value, fn) {
+  const previous = process.env.BARCODE_QUEUE_PRODUCTION_ENABLED;
+  if (value === undefined) delete process.env.BARCODE_QUEUE_PRODUCTION_ENABLED;
+  else process.env.BARCODE_QUEUE_PRODUCTION_ENABLED = value;
+  try { return await fn(); }
+  finally {
+    if (previous === undefined) delete process.env.BARCODE_QUEUE_PRODUCTION_ENABLED;
+    else process.env.BARCODE_QUEUE_PRODUCTION_ENABLED = previous;
+  }
+}
+
+test("queue production capability defaults false and only exact true enables it", () => {
+  assert.equal(capability.isQueueProductionEnabled({}), false);
+  assert.equal(capability.isQueueProductionEnabled({ BARCODE_QUEUE_PRODUCTION_ENABLED: "" }), false);
+  assert.equal(capability.isQueueProductionEnabled({ BARCODE_QUEUE_PRODUCTION_ENABLED: "TRUE" }), false);
+  assert.equal(capability.isQueueProductionEnabled({ BARCODE_QUEUE_PRODUCTION_ENABLED: "1" }), false);
+  assert.equal(capability.isQueueProductionEnabled({ BARCODE_QUEUE_PRODUCTION_ENABLED: "true" }), true);
+});
+
+test("global live provider source gates queue polling while preserving manual live mode", () => {
+  const providerSource = fs.readFileSync(path.join(projectRoot, "src/components/LiveStatusProvider.tsx"), "utf8");
+  assert.match(providerSource, /capabilities\?\.queueProduction === true/);
+  assert.match(providerSource, /setQueueSnapshot\(null\)/);
+  assert.match(providerSource, /if \(!queueProduction\)/);
+  assert.match(providerSource, /fetch\("\/api\/queue"/);
+  assert.match(providerSource, /queueBroadcastPhase === "broadcast_active" \|\| isLive/);
+  assert.doesNotMatch(providerSource, /NEXT_PUBLIC_BARCODE_QUEUE_PRODUCTION_ENABLED/);
+});
+
+test("admin live exposes non-sensitive capability without exposing env name", async () => {
+  await withQueueProduction(undefined, async () => {
+    const payload = await (await adminLive.GET()).json();
+    assert.equal(payload.capabilities.queueProduction, false);
+  });
+  await withQueueProduction("true", async () => {
+    const payload = await (await adminLive.GET()).json();
+    assert.equal(payload.capabilities.queueProduction, true);
+  });
+});
+
+test("disabled BNL read model does not read queue storage or expose queue-derived data", async () => {
+  await withQueueProduction(undefined, async () => {
+    await queue.startNewQueueSession({ title: "Open Test Queue" });
+    await queue.setQueueOpen(true);
+    const original = queue.getRadioQueueState;
+    queue.getRadioQueueState = async () => { throw new Error("queue storage should not be read"); };
+    try {
+      const model = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+      assert.equal(model.capabilities.queueProduction, false);
+      assert.equal(model.sections.queue.available, false);
+      assert.equal(model.sections.queue.reason, "queue_production_disabled");
+      assert.deepEqual(model.sections.artists, []);
+      assert.deepEqual(model.sections.operatorLanes.temporaryRuntimeContext, []);
+      assert.deepEqual(model.sections.operatorLanes.recapCandidates, []);
+      assert.deepEqual(model.sections.operatorLanes.dossierSeedCandidates, []);
+      const serialized = JSON.stringify(model.sections);
+      assert.doesNotMatch(serialized, /Open Test Queue|nowPlaying|upNext|queue_derived_artist_surface|queue_public_snapshot|recap_candidate/);
+      assert.ok(model.sections.dossiers.public.length > 0);
+    } finally {
+      queue.getRadioQueueState = original;
+    }
+  });
+});
+
+test("queue_context cannot create approved BNL or Source File evidence while disabled", async () => {
+  await withQueueProduction(undefined, async () => {
+    await resetWorkflowStore();
+    const previousToken = process.env.BNL_DOSSIER_INGEST_TOKEN;
+    process.env.BNL_DOSSIER_INGEST_TOKEN = "queue-production-test-token";
+    const response = await dossierRecommendations.POST(new Request("https://example.test/api/bnl/dossier-recommendations", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer queue-production-test-token" },
+      body: JSON.stringify({ subjectName: "Queue Test Artist", reason: "Queue context", sourceLanes: ["queue_context"] }),
+    }));
+    assert.equal(response.status, 400);
+    if (previousToken === undefined) delete process.env.BNL_DOSSIER_INGEST_TOKEN;
+    else process.env.BNL_DOSSIER_INGEST_TOKEN = previousToken;
+    const state = await workflowStore.getDossierWorkflowState();
+    assert.equal(state.recommendations.length, 0);
+    assert.equal(state.candidates.length, 0);
+  });
+});
+
+test("enabled capability restores public-facing BNL queue behavior", async () => {
+  await withQueueProduction("true", async () => {
+    await queue.startNewQueueSession({ title: "Production Enabled Queue" });
+    await queue.setQueueOpen(true);
+    const added = await queue.addToQueue({ artist: "Enabled Artist", title: "Enabled Track", tier: "free", lane: "regular", amount: 0, createdAt: new Date().toISOString() });
+    const model = await (await readModel.GET(new Request("https://example.test/api/bnl/read-model"))).json();
+    assert.equal(model.capabilities.queueProduction, true);
+    assert.equal(model.sections.queue.available, true);
+    assert.ok(JSON.stringify(model.sections.queue).includes(added.id));
+    assert.ok(model.sections.artists.some((artist) => artist.name === "Enabled Artist"));
+  });
+});

--- a/tests/queue-production-capability.test.mjs
+++ b/tests/queue-production-capability.test.mjs
@@ -31,9 +31,31 @@ const readModel = require("../src/app/api/bnl/read-model/route.ts");
 const dossierRecommendations = require("../src/app/api/bnl/dossier-recommendations/route.ts");
 const workflowStore = require("../src/lib/dossier-workflow-store.ts");
 const adminLive = require("../src/app/api/admin/live/route.ts");
+const { derivePublicShowState } = require("../src/lib/live-status-public.ts");
 
 async function resetWorkflowStore() {
   await workflowStore.saveDossierWorkflowState({ version: 1, revision: 0, candidates: [], drafts: [], recommendations: [], updatedAt: new Date(0).toISOString() });
+}
+
+async function postDossierRecommendation(body) {
+  const previousToken = process.env.BNL_DOSSIER_INGEST_TOKEN;
+  process.env.BNL_DOSSIER_INGEST_TOKEN = "queue-production-test-token";
+  try {
+    return await dossierRecommendations.POST(new Request("https://example.test/api/bnl/dossier-recommendations", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer queue-production-test-token" },
+      body: JSON.stringify(body),
+    }));
+  } finally {
+    if (previousToken === undefined) delete process.env.BNL_DOSSIER_INGEST_TOKEN;
+    else process.env.BNL_DOSSIER_INGEST_TOKEN = previousToken;
+  }
+}
+
+async function assertNoWorkflowRecords() {
+  const state = await workflowStore.getDossierWorkflowState();
+  assert.equal(state.recommendations.length, 0);
+  assert.equal(state.candidates.length, 0);
 }
 
 async function withQueueProduction(value, fn) {
@@ -55,13 +77,46 @@ test("queue production capability defaults false and only exact true enables it"
   assert.equal(capability.isQueueProductionEnabled({ BARCODE_QUEUE_PRODUCTION_ENABLED: "true" }), true);
 });
 
-test("global live provider source gates queue polling while preserving manual live mode", () => {
+test("public show-state helper ignores queue snapshots unless production capability is enabled", () => {
+  const queueSnapshot = {
+    session: {
+      sessionId: "test-session",
+      status: "active",
+      broadcastPhase: "broadcast_active",
+    },
+    status: { isOpen: true },
+  };
+
+  assert.deepEqual(derivePublicShowState({ queueProductionEnabled: false, isLive: false, queueSnapshot }), {
+    hasActiveQueueSession: false,
+    queueSessionId: null,
+    queueHref: null,
+    queueSubmissionsOpen: false,
+    queueBroadcastPhase: null,
+    siteShowMode: "offline",
+  });
+
+  assert.equal(
+    derivePublicShowState({ queueProductionEnabled: false, isLive: true, queueSnapshot }).siteShowMode,
+    "broadcast_live",
+  );
+
+  assert.deepEqual(derivePublicShowState({ queueProductionEnabled: true, isLive: false, queueSnapshot }), {
+    hasActiveQueueSession: true,
+    queueSessionId: "test-session",
+    queueHref: "/queue/test-session",
+    queueSubmissionsOpen: true,
+    queueBroadcastPhase: "broadcast_active",
+    siteShowMode: "broadcast_live",
+  });
+});
+
+test("global live provider source fails closed when capability authority is missing", () => {
   const providerSource = fs.readFileSync(path.join(projectRoot, "src/components/LiveStatusProvider.tsx"), "utf8");
   assert.match(providerSource, /capabilities\?\.queueProduction === true/);
   assert.match(providerSource, /setQueueSnapshot\(null\)/);
   assert.match(providerSource, /if \(!queueProduction\)/);
   assert.match(providerSource, /fetch\("\/api\/queue"/);
-  assert.match(providerSource, /queueBroadcastPhase === "broadcast_active" \|\| isLive/);
   assert.doesNotMatch(providerSource, /NEXT_PUBLIC_BARCODE_QUEUE_PRODUCTION_ENABLED/);
 });
 
@@ -100,22 +155,37 @@ test("disabled BNL read model does not read queue storage or expose queue-derive
   });
 });
 
-test("queue_context cannot create approved BNL or Source File evidence while disabled", async () => {
+test("queue-derived dossier recommendation provenance is rejected while disabled", async () => {
+  await withQueueProduction(undefined, async () => {
+    const rejectedPayloads = [
+      { subjectName: "Queue Context Artist", reason: "Queue context", sourceLanes: ["queue_context"] },
+      { subjectName: "Queue Frequency Artist", reason: "Population queue frequency", type: "population_recommendation", ingestSource: "bnl_population_recommender", sourceLanes: ["queue_frequency"] },
+      { subjectName: "Queue Source Type Artist", reason: "Queue public snapshot", sourceTypes: ["queue_public_snapshot"] },
+      { subjectName: "Queue Submission Artist", reason: "Queue submission found", queueSubmissionStatus: "confirmed_submission" },
+    ];
+
+    for (const payload of rejectedPayloads) {
+      await resetWorkflowStore();
+      const response = await postDossierRecommendation(payload);
+      assert.equal(response.status, 400, `${payload.subjectName} should be rejected`);
+      await assertNoWorkflowRecords();
+    }
+  });
+});
+
+test("not_connected queue submission boundary remains compatible while disabled", async () => {
   await withQueueProduction(undefined, async () => {
     await resetWorkflowStore();
-    const previousToken = process.env.BNL_DOSSIER_INGEST_TOKEN;
-    process.env.BNL_DOSSIER_INGEST_TOKEN = "queue-production-test-token";
-    const response = await dossierRecommendations.POST(new Request("https://example.test/api/bnl/dossier-recommendations", {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: "Bearer queue-production-test-token" },
-      body: JSON.stringify({ subjectName: "Queue Test Artist", reason: "Queue context", sourceLanes: ["queue_context"] }),
-    }));
-    assert.equal(response.status, 400);
-    if (previousToken === undefined) delete process.env.BNL_DOSSIER_INGEST_TOKEN;
-    else process.env.BNL_DOSSIER_INGEST_TOKEN = previousToken;
+    const response = await postDossierRecommendation({
+      subjectName: "Non Queue Boundary Artist",
+      reason: "No queue submission is connected to this Source File packet.",
+      sourceLanes: ["website_dossier"],
+      queueSubmissionStatus: "not_connected",
+    });
+    assert.equal(response.status, 200);
     const state = await workflowStore.getDossierWorkflowState();
-    assert.equal(state.recommendations.length, 0);
-    assert.equal(state.candidates.length, 0);
+    assert.equal(state.recommendations.length, 1);
+    assert.equal(state.recommendations[0].queueSubmissionStatus, "not_connected");
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent non-production BARCODE Radio queue sessions and tracks from influencing public site state, BNL read-models, dossier recommendations, Source File evidence, or memory-like inputs until the owner explicitly enables production queue signals.
- Provide a deterministic, server-only capability that gates production-facing behavior and can be rolled out or rolled back safely.

### Description
- Add a server-only capability helper `src/lib/queue-production.ts` implementing `BARCODE_QUEUE_PRODUCTION_ENABLED` which is enabled only when the env value is exactly `"true"` and exposes `isQueueProductionEnabled()` and `queueProductionCapability()`.
- Expose the non-sensitive capability on existing endpoints by adding `capabilities: queueProductionCapability()` to `/api/admin/live` and `/api/bnl/read-model` so server responses can be used to gate client behavior without leaking env names to the client bundles.
- Quarantine live/queue polling in `src/components/LiveStatusProvider.tsx` so the provider clears cached queue snapshots and avoids polling `/api/queue` while the capability is disabled, while preserving manual/scheduled `isLive` behavior and site show-mode logic.
- Gate the BNL read model in `src/app/api/bnl/read-model/route.ts` so it does not call `getRadioQueueState()` while disabled and instead returns an explicit unavailable queue projection (`available: false`, `reason: "queue_production_disabled"`) plus `capabilities.queueProduction=false` and empty queue-derived artists/operator lanes.
- Defend dossier / Source File ingestion by rejecting `queue_context` source-lane recommendations in `src/app/api/bnl/dossier-recommendations/route.ts` when the capability is disabled so queue-derived inputs cannot create approved BNL/Source File evidence.
- Add documentation `docs/queue-production-capability.md` describing default-off behavior, testing allowances, blocked public/BNL surfaces, Vercel rollout procedure, and rollback instructions.
- Add deterministic tests `tests/queue-production-capability.test.mjs` covering exact-true parsing, LiveStatusProvider gating, admin live capability exposure, disabled read-model behavior, `queue_context` ingest rejection, and restored behavior when enabled; update existing queue test entry points to explicitly set the env for in-memory tests and add the new test to `npm run test:queue` in `package.json`.
- No public routes, header/footer copy, queue mechanics, payments, navigation, or unrelated content were changed.

### Testing
- `npx tsc --noEmit` succeeded.
- `npm run build` (Next.js production build) succeeded.
- `node --test tests/queue-production-capability.test.mjs` (new deterministic capability tests) succeeded and validated disabled vs enabled behavior.
- `npm run test:queue` was run; all newly added queue-production tests passed but the full test run failed due to pre-existing unrelated assertions/lint rules in existing tests/files (these failures are unrelated to the quarantine change and reflect existing archive/component lint/test issues).
- `npm run check` failed at the repository lint step because of pre-existing lint errors in archived/unrelated files; type-check and the new tests passed where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57cd8f1d4883219162e6ce821e492c)