### PR TITLE
Organize BNL Journal daily and weekly entries

### DIFF
--- a/src/app/journal/[entryId]/page.tsx
+++ b/src/app/journal/[entryId]/page.tsx
@@ -1,11 +1,108 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
-import { JournalArticle, JournalUnavailable } from "@/components/journal/JournalArticle";
-import { getBNLJournalEntry, getBNLJournalNeighbors } from "@/lib/bnl-journal-store";
+import { notFound, redirect } from "next/navigation";
+import {
+  JournalArticle,
+  JournalUnavailable,
+} from "@/components/journal/JournalArticle";
+import {
+  journalArchiveHref,
+  journalEntryHref,
+  parseJournalArchiveFilter,
+} from "@/lib/bnl-journal-navigation";
+import {
+  getBNLJournalEntry,
+  getBNLJournalNeighbors,
+} from "@/lib/bnl-journal-store";
 
 export const dynamic = "force-dynamic";
 
-type Props = { params: Promise<{ entryId: string }> };
-export async function generateMetadata({ params }: Props): Promise<Metadata> { const { entryId } = await params; const result = await getBNLJournalEntry(entryId); if (!result.ok || !result.value) return { title: "BNL-01 Journal" }; return { title: `${result.value.title} | BNL-01 Journal`, description: result.value.excerpt, authors: [{ name: "BNL-01" }], openGraph: { title: result.value.title, description: result.value.excerpt, publishedTime: result.value.publishedAt } }; }
-export default async function JournalEntryPage({ params }: Props) { const { entryId } = await params; const result = await getBNLJournalEntry(entryId); if (!result.ok) return <div className="pt-14"><JournalUnavailable /></div>; if (!result.value) notFound(); const neighbors = await getBNLJournalNeighbors(entryId); return <div className="pt-14"><section className="mx-auto max-w-4xl px-4 py-10 sm:px-6"><Link href="/journal" className="font-mono text-xs uppercase tracking-widest text-accent">← Back to Journal</Link><div className="mt-6"><JournalArticle entry={result.value} /></div>{neighbors.ok && <nav aria-label="Journal entry navigation" className="mt-8 flex justify-between gap-4 border-t border-border pt-6 text-sm text-accent">{neighbors.value.older ? <Link href={`/journal/${neighbors.value.older.entryId}`}>← Older entry</Link> : <span />}{neighbors.value.newer && <Link href={`/journal/${neighbors.value.newer.entryId}`}>Newer entry →</Link>}</nav>}</section></div>; }
+type Props = {
+  params: Promise<{ entryId: string }>;
+  searchParams?: Promise<{ kind?: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { entryId } = await params;
+  const result = await getBNLJournalEntry(entryId);
+  if (!result.ok || !result.value) return { title: "BNL-01 Journal" };
+  return {
+    title: `${result.value.title} | BNL-01 Journal`,
+    description: result.value.excerpt,
+    authors: [{ name: "BNL-01" }],
+    openGraph: {
+      title: result.value.title,
+      description: result.value.excerpt,
+      publishedTime: result.value.publishedAt,
+    },
+  };
+}
+
+export default async function JournalEntryPage({
+  params,
+  searchParams,
+}: Props) {
+  const [{ entryId }, query] = await Promise.all([params, searchParams]);
+  const filter = parseJournalArchiveFilter(query?.kind);
+  if (filter === null) notFound();
+
+  const result = await getBNLJournalEntry(entryId);
+  if (!result.ok)
+    return (
+      <div className="pt-14">
+        <JournalUnavailable />
+      </div>
+    );
+  if (!result.value) notFound();
+  if (
+    query?.kind === "all" ||
+    (filter !== "all" && result.value.entryKind !== filter)
+  )
+    redirect(journalEntryHref(entryId));
+  const neighbors = await getBNLJournalNeighbors(entryId, undefined, filter);
+
+  return (
+    <div className="pt-14">
+      <section className="mx-auto max-w-4xl px-4 py-10 sm:px-6">
+        <Link
+          href={journalArchiveHref(filter)}
+          className="font-mono text-xs uppercase tracking-widest text-accent"
+        >
+          ← Back to Journal
+        </Link>
+        <div className="mt-6">
+          <JournalArticle entry={result.value} archiveFilter={filter} />
+        </div>
+        {neighbors.ok && (
+          <nav
+            aria-label="Journal entry navigation"
+            className="mt-8 flex justify-between gap-4 border-t border-border pt-6 text-sm text-accent"
+          >
+            {neighbors.value.older ? (
+              <Link
+                href={journalEntryHref(
+                  neighbors.value.older.entryId,
+                  filter,
+                )}
+              >
+                ← Older entry
+              </Link>
+            ) : (
+              <span />
+            )}
+            {neighbors.value.newer && (
+              <Link
+                href={journalEntryHref(
+                  neighbors.value.newer.entryId,
+                  filter,
+                )}
+              >
+                Newer entry →
+              </Link>
+            )}
+          </nav>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -1,18 +1,150 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { JournalArchiveCard, JournalArticle, JournalUnavailable } from "@/components/journal/JournalArticle";
+import {
+  JournalArchiveCard,
+  JournalArticle,
+  JournalUnavailable,
+} from "@/components/journal/JournalArticle";
+import {
+  JOURNAL_ARCHIVE_FILTERS,
+  journalArchiveHref,
+  parseJournalArchiveFilter,
+} from "@/lib/bnl-journal-navigation";
 import { listBNLJournalArchive } from "@/lib/bnl-journal-store";
 
 export const dynamic = "force-dynamic";
-export const metadata = { title: "BNL-01 Community Journal", description: "Periodic BNL-01 observations drawn from public community activity and recurring BARCODE Network patterns." };
+export const metadata = {
+  title: "BNL-01 Community Journal",
+  description:
+    "Periodic BNL-01 observations drawn from public community activity and recurring BARCODE Network patterns.",
+};
 
-function parsePage(value?: string) { if (!value) return 1; if (!/^\d+$/.test(value)) return null; const page = Number(value); return Number.isSafeInteger(page) && page > 0 ? page : null; }
+function parsePage(value?: string) {
+  if (!value) return 1;
+  if (!/^\d+$/.test(value)) return null;
+  const page = Number(value);
+  return Number.isSafeInteger(page) && page > 0 ? page : null;
+}
 
-export default async function JournalPage({ searchParams }: { searchParams?: Promise<{ page?: string }> }) {
-  const params = await searchParams; const page = parsePage(params?.page); if (page === null) notFound(); if (page === 1 && params?.page) redirect("/journal"); const archive = await listBNLJournalArchive(page);
-  if (!archive.ok) return <div className="pt-14"><JournalUnavailable /></div>;
+export default async function JournalPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ page?: string; kind?: string }>;
+}) {
+  const params = await searchParams;
+  const page = parsePage(params?.page);
+  const filter = parseJournalArchiveFilter(params?.kind);
+  if (page === null || filter === null) notFound();
+  if ((page === 1 && params?.page) || params?.kind === "all")
+    redirect(journalArchiveHref(filter, page));
+
+  const archive = await listBNLJournalArchive(page, undefined, filter);
+  if (!archive.ok)
+    return (
+      <div className="pt-14">
+        <JournalUnavailable />
+      </div>
+    );
   if (!archive.value) notFound();
   const [latest, ...older] = archive.value.entries;
   if (page > 1 && archive.value.entries.length === 0) notFound();
-  return <div className="pt-14"><section className="border-b border-border noise-bg"><div className="mx-auto max-w-7xl px-4 py-16 sm:px-6"><p className="text-xs uppercase tracking-[0.45em] text-accent">{"// BNL-01 COMMUNITY JOURNAL"}</p><h1 className="mt-4 text-4xl font-black tracking-tight text-foreground sm:text-6xl">Journal archive</h1><p className="mt-5 max-w-2xl text-base leading-7 text-foreground/70 sm:text-lg">BNL-01 turns public community activity, continuing conversations, and recurring Network patterns into periodic observations approved for public reading.</p></div></section><section className="mx-auto grid max-w-7xl gap-6 px-4 py-10 sm:px-6 lg:grid-cols-[minmax(0,1fr)_360px]">{page === 1 && latest ? <JournalArticle entry={latest} prominent titleLevel="h2" /> : <nav aria-label="Journal archive entries" className="space-y-4">{archive.value.entries.map((entry) => <JournalArchiveCard key={`${entry.entryId}-${entry.revision}`} entry={entry} />)}{!latest && <div className="border border-border bg-surface p-6 text-foreground/70">No journal entries have been published yet.</div>}</nav>}<aside className="space-y-4"><p className="font-mono text-xs uppercase tracking-[0.35em] text-foreground/60">Archive</p>{(page === 1 ? older : []).map((entry) => <JournalArchiveCard key={`${entry.entryId}-${entry.revision}`} entry={entry} />)}<nav aria-label="Journal pagination" className="flex justify-between gap-3 pt-2">{archive.value.hasNewer ? <Link className="text-sm text-accent" href={archive.value.page - 1 === 1 ? "/journal" : `/journal?page=${archive.value.page - 1}`}>← Newer</Link> : <span />}{archive.value.hasOlder && <Link className="text-sm text-accent" href={`/journal?page=${archive.value.page + 1}`}>Older →</Link>}</nav></aside></section></div>;
+
+  return (
+    <div className="pt-14">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6">
+          <p className="text-xs uppercase tracking-[0.45em] text-accent">
+            {"// BNL-01 COMMUNITY JOURNAL"}
+          </p>
+          <h1 className="mt-4 text-4xl font-black tracking-tight text-foreground sm:text-6xl">
+            Journal archive
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-7 text-foreground/70 sm:text-lg">
+            BNL-01 turns public community activity, continuing conversations,
+            and recurring Network patterns into periodic observations approved
+            for public reading.
+          </p>
+          <nav
+            aria-label="Filter journal archive"
+            className="mt-8 flex flex-wrap gap-2"
+          >
+            {JOURNAL_ARCHIVE_FILTERS.map((candidate) => (
+              <Link
+                key={candidate.value}
+                href={journalArchiveHref(candidate.value)}
+                aria-current={candidate.value === filter ? "page" : undefined}
+                className={`border px-4 py-2 font-mono text-xs uppercase tracking-[0.2em] transition-colors ${
+                  candidate.value === filter
+                    ? "border-accent bg-accent/10 text-accent"
+                    : "border-border text-foreground/60 hover:border-accent/50 hover:text-foreground"
+                }`}
+              >
+                {candidate.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </section>
+      <section className="mx-auto grid max-w-7xl gap-6 px-4 py-10 sm:px-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+        {page === 1 && latest ? (
+          <JournalArticle
+            entry={latest}
+            prominent
+            titleLevel="h2"
+            archiveFilter={filter}
+          />
+        ) : (
+          <nav aria-label="Journal archive entries" className="space-y-4">
+            {archive.value.entries.map((entry) => (
+              <JournalArchiveCard
+                key={`${entry.entryId}-${entry.revision}`}
+                entry={entry}
+                archiveFilter={filter}
+              />
+            ))}
+            {!latest && (
+              <div className="border border-border bg-surface p-6 text-foreground/70">
+                No journal entries have been published in this view yet.
+              </div>
+            )}
+          </nav>
+        )}
+        <aside className="space-y-4">
+          <p className="font-mono text-xs uppercase tracking-[0.35em] text-foreground/60">
+            Archive
+          </p>
+          {(page === 1 ? older : []).map((entry) => (
+            <JournalArchiveCard
+              key={`${entry.entryId}-${entry.revision}`}
+              entry={entry}
+              archiveFilter={filter}
+            />
+          ))}
+          <nav
+            aria-label="Journal pagination"
+            className="flex justify-between gap-3 pt-2"
+          >
+            {archive.value.hasNewer ? (
+              <Link
+                className="text-sm text-accent"
+                href={journalArchiveHref(filter, archive.value.page - 1)}
+              >
+                ← Newer
+              </Link>
+            ) : (
+              <span />
+            )}
+            {archive.value.hasOlder && (
+              <Link
+                className="text-sm text-accent"
+                href={journalArchiveHref(filter, archive.value.page + 1)}
+              >
+                Older →
+              </Link>
+            )}
+          </nav>
+        </aside>
+      </section>
+    </div>
+  );
 }

--- a/src/components/journal/JournalArticle.tsx
+++ b/src/components/journal/JournalArticle.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
 import type { PublicBNLJournalEntry } from "@/lib/bnl-journal-store";
+import {
+  journalEntryHref,
+  type JournalArchiveFilter,
+} from "@/lib/bnl-journal-navigation";
 import { JournalRetryButton } from "@/components/journal/JournalRetryButton";
 
 export function formatJournalDate(value: string) {
@@ -25,14 +29,32 @@ export function JournalUnavailable() {
     </section>
   );
 }
+export function journalEntryKindLabel(entry: PublicBNLJournalEntry) {
+  if (entry.entryKind === "daily") return "Daily";
+  if (entry.entryKind === "weekly") return "Weekly";
+  return "Manual";
+}
+export function JournalKindBadge({ entry }: { entry: PublicBNLJournalEntry }) {
+  const label = journalEntryKindLabel(entry);
+  return (
+    <span
+      aria-label={`Journal entry type: ${label}`}
+      className="border border-accent/40 bg-accent/5 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.22em] text-accent"
+    >
+      {label}
+    </span>
+  );
+}
 export function JournalArticle({
   entry,
   prominent = false,
   titleLevel = "h1",
+  archiveFilter = "all",
 }: {
   entry: PublicBNLJournalEntry;
   prominent?: boolean;
   titleLevel?: "h1" | "h2";
+  archiveFilter?: JournalArchiveFilter;
 }) {
   const Title = titleLevel;
   const SectionTitle = titleLevel === "h1" ? "h2" : "h3";
@@ -40,9 +62,12 @@ export function JournalArticle({
     <article
       className={`border border-accent/30 bg-surface/80 p-5 sm:p-8 ${prominent ? "shadow-[0_0_40px_rgba(0,255,136,0.08)]" : ""}`}
     >
-      <p className="text-xs uppercase tracking-[0.35em] text-accent">
-        By BNL-01.
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-accent">
+          By BNL-01.
+        </p>
+        <JournalKindBadge entry={entry} />
+      </div>
       <time
         className="mt-3 block font-mono text-xs uppercase tracking-widest text-muted"
         dateTime={entry.publishedAt}
@@ -69,7 +94,7 @@ export function JournalArticle({
       </div>
       {prominent && (
         <Link
-          href={`/journal/${entry.entryId}`}
+          href={journalEntryHref(entry.entryId, archiveFilter)}
           className="mt-8 inline-flex font-mono text-xs uppercase tracking-widest text-accent hover:text-foreground"
         >
           Open this entry →
@@ -80,20 +105,25 @@ export function JournalArticle({
 }
 export function JournalArchiveCard({
   entry,
+  archiveFilter = "all",
 }: {
   entry: PublicBNLJournalEntry;
+  archiveFilter?: JournalArchiveFilter;
 }) {
   return (
     <Link
-      href={`/journal/${entry.entryId}`}
+      href={journalEntryHref(entry.entryId, archiveFilter)}
       className="block border border-border bg-background/60 p-4 transition-colors hover:border-accent/50"
     >
-      <time
-        className="font-mono text-[11px] uppercase tracking-widest text-foreground/60"
-        dateTime={entry.publishedAt}
-      >
-        {formatJournalDate(entry.publishedAt)}
-      </time>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <time
+          className="font-mono text-[11px] uppercase tracking-widest text-foreground/60"
+          dateTime={entry.publishedAt}
+        >
+          {formatJournalDate(entry.publishedAt)}
+        </time>
+        <JournalKindBadge entry={entry} />
+      </div>
       <h2 className="mt-2 text-base font-bold text-foreground">
         {entry.title}
       </h2>

--- a/src/lib/bnl-journal-contract.ts
+++ b/src/lib/bnl-journal-contract.ts
@@ -1,9 +1,11 @@
 import { createHash, timingSafeEqual } from "crypto";
 
 export type BNLJournalSection = { heading: string; body: string };
+export type BNLJournalEntryKind = "daily" | "weekly" | "manual";
 export type BNLJournalEntry = {
   entryId: string;
   revision: number;
+  entryKind?: BNLJournalEntryKind;
   title: string;
   excerpt: string;
   sections: BNLJournalSection[];
@@ -102,18 +104,24 @@ export function validateBNLJournalPayload(
   )
     return { ok: false, reason: "invalid_contract" };
   const entry = body.entry;
+  const entryKeys = [
+    "entryId",
+    "revision",
+    "title",
+    "excerpt",
+    "sections",
+    "authoredAt",
+    "sourceWindowStart",
+    "sourceWindowEnd",
+    "contentHash",
+  ];
   if (
-    !exactKeys(entry, [
-      "entryId",
-      "revision",
-      "title",
-      "excerpt",
-      "sections",
-      "authoredAt",
-      "sourceWindowStart",
-      "sourceWindowEnd",
-      "contentHash",
-    ])
+    !exactKeys(
+      entry,
+      Object.prototype.hasOwnProperty.call(entry, "entryKind")
+        ? [...entryKeys, "entryKind"]
+        : entryKeys,
+    )
   )
     return { ok: false, reason: "invalid_contract" };
   if (
@@ -123,6 +131,13 @@ export function validateBNLJournalPayload(
     return { ok: false, reason: "invalid_entry" };
   if (!Number.isInteger(entry.revision) || Number(entry.revision) <= 0)
     return { ok: false, reason: "invalid_revision" };
+  if (
+    entry.entryKind !== undefined &&
+    entry.entryKind !== "daily" &&
+    entry.entryKind !== "weekly" &&
+    entry.entryKind !== "manual"
+  )
+    return { ok: false, reason: "invalid_entry_kind" };
   if (!safePublicString(entry.title) || !safePublicString(entry.excerpt))
     return { ok: false, reason: "invalid_text" };
   if (

--- a/src/lib/bnl-journal-navigation.ts
+++ b/src/lib/bnl-journal-navigation.ts
@@ -1,0 +1,39 @@
+import type { BNLJournalEntryKind } from "@/lib/bnl-journal-contract";
+
+export type JournalArchiveFilter = "all" | Exclude<BNLJournalEntryKind, "manual">;
+
+export const JOURNAL_ARCHIVE_FILTERS: ReadonlyArray<{
+  value: JournalArchiveFilter;
+  label: string;
+}> = [
+  { value: "all", label: "All" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+];
+
+export function parseJournalArchiveFilter(
+  value?: string,
+): JournalArchiveFilter | null {
+  if (value === undefined || value === "all") return "all";
+  if (value === "daily" || value === "weekly") return value;
+  return null;
+}
+
+export function journalArchiveHref(
+  filter: JournalArchiveFilter,
+  page = 1,
+) {
+  const query = new URLSearchParams();
+  if (filter !== "all") query.set("kind", filter);
+  if (page > 1) query.set("page", String(page));
+  const suffix = query.toString();
+  return suffix ? `/journal?${suffix}` : "/journal";
+}
+
+export function journalEntryHref(
+  entryId: string,
+  filter: JournalArchiveFilter = "all",
+) {
+  const path = `/journal/${encodeURIComponent(entryId)}`;
+  return filter === "all" ? path : `${path}?kind=${filter}`;
+}

--- a/src/lib/bnl-journal-store.ts
+++ b/src/lib/bnl-journal-store.ts
@@ -1,5 +1,6 @@
 import { Redis } from "@upstash/redis";
 import type { BNLJournalEntry } from "@/lib/bnl-journal-contract";
+import type { JournalArchiveFilter } from "@/lib/bnl-journal-navigation";
 
 export type PublicBNLJournalEntry = BNLJournalEntry & { publishedAt: string };
 export type JournalReadResult<T> =
@@ -19,6 +20,10 @@ export type JournalWriteResult =
   | { ok: false; unavailable: true };
 
 export const BNL_JOURNAL_INDEX_KEY = "barcode:bnl-journal:v1:index";
+export const BNL_JOURNAL_DAILY_INDEX_KEY =
+  "barcode:bnl-journal:v1:index:daily";
+export const BNL_JOURNAL_WEEKLY_INDEX_KEY =
+  "barcode:bnl-journal:v1:index:weekly";
 const KEY_PREFIX = "barcode:bnl-journal:v1:entry";
 const LATEST_PREFIX = "barcode:bnl-journal:v1:latest";
 const PAGE_SIZE = 9;
@@ -55,11 +60,22 @@ const PUBLISH_SCRIPT = `
 local recordKey = KEYS[1]
 local latestKey = KEYS[2]
 local indexKey = KEYS[3]
+local dailyIndexKey = KEYS[4]
+local weeklyIndexKey = KEYS[5]
 local entryId = ARGV[1]
 local revision = tonumber(ARGV[2])
 local contentHash = ARGV[3]
 local recordJson = ARGV[4]
 local score = tonumber(ARGV[5])
+local function repairKindIndexes(latest)
+  redis.call("ZREM", dailyIndexKey, entryId)
+  redis.call("ZREM", weeklyIndexKey, entryId)
+  if latest.entryKind == "daily" then
+    redis.call("ZADD", dailyIndexKey, tonumber(latest._score), entryId)
+  elseif latest.entryKind == "weekly" then
+    redis.call("ZADD", weeklyIndexKey, tonumber(latest._score), entryId)
+  end
+end
 local existingJson = redis.call("GET", recordKey)
 if existingJson then
   local existing = cjson.decode(existingJson)
@@ -96,15 +112,16 @@ if existingJson then
   if (not repairedLatestJson) or (not repairedScore) then
     return cjson.encode({ status = "unavailable" })
   end
+  local repairedLatestEntry = cjson.decode(repairedLatestJson)
   if repairedLatest then
-    local repaired = cjson.decode(repairedLatestJson)
-    if repaired.revision ~= existing.revision or repaired.contentHash ~= existing.contentHash then
+    if repairedLatestEntry.revision ~= existing.revision or repairedLatestEntry.contentHash ~= existing.contentHash then
       return cjson.encode({ status = "unavailable" })
     end
   end
   if repairedIndexScore and tonumber(repairedScore) ~= tonumber(repairedIndexScore) then
     return cjson.encode({ status = "unavailable" })
   end
+  repairKindIndexes(repairedLatestEntry)
   return cjson.encode({ status = "idempotent", publishedAt = existing.publishedAt })
 end
 redis.call("SET", recordKey, recordJson, "NX")
@@ -124,9 +141,11 @@ elseif not redis.call("ZSCORE", indexKey, entryId) then
   local latest = cjson.decode(latestJson)
   redis.call("ZADD", indexKey, tonumber(latest._score), entryId)
 end
-if (not redis.call("GET", latestKey)) or (not redis.call("ZSCORE", indexKey, entryId)) then
+local finalLatestJson = redis.call("GET", latestKey)
+if (not finalLatestJson) or (not redis.call("ZSCORE", indexKey, entryId)) then
   return cjson.encode({ status = "unavailable" })
 end
+repairKindIndexes(cjson.decode(finalLatestJson))
 return cjson.encode({ status = "created" })
 `;
 
@@ -152,6 +171,7 @@ function normalize(
   return {
     entryId: entry.entryId,
     revision: entry.revision,
+    ...(entry.entryKind === undefined ? {} : { entryKind: entry.entryKind }),
     title: entry.title,
     excerpt: entry.excerpt,
     sections: entry.sections.map((s) => ({ heading: s.heading, body: s.body })),
@@ -187,6 +207,17 @@ function parseAtomicResult(value: unknown): {
 function validPage(page: number) {
   return Number.isInteger(page) && page > 0 && page <= MAX_PAGE;
 }
+function matchesArchiveFilter(
+  entry: Pick<BNLJournalEntry, "entryKind">,
+  filter: JournalArchiveFilter,
+) {
+  return filter === "all" || entry.entryKind === filter;
+}
+function archiveIndexKey(filter: JournalArchiveFilter) {
+  if (filter === "daily") return BNL_JOURNAL_DAILY_INDEX_KEY;
+  if (filter === "weekly") return BNL_JOURNAL_WEEKLY_INDEX_KEY;
+  return BNL_JOURNAL_INDEX_KEY;
+}
 
 export async function publishBNLJournalEntry(
   entry: BNLJournalEntry,
@@ -204,6 +235,8 @@ export async function publishBNLJournalEntry(
           journalEntryKey(entry.entryId, entry.revision),
           journalLatestKey(entry.entryId),
           BNL_JOURNAL_INDEX_KEY,
+          BNL_JOURNAL_DAILY_INDEX_KEY,
+          BNL_JOURNAL_WEEKLY_INDEX_KEY,
         ],
         [
           entry.entryId,
@@ -261,32 +294,37 @@ export async function publishBNLJournalEntry(
 async function entriesForPage(
   redis: RedisLike,
   page: number,
+  filter: JournalArchiveFilter,
 ): Promise<PublicBNLJournalEntry[] | null> {
   if (!validPage(page)) return null;
   const start = (page - 1) * PAGE_SIZE;
   const ids = await redis.zrange(
-    BNL_JOURNAL_INDEX_KEY,
+    archiveIndexKey(filter),
     start,
     start + PAGE_SIZE,
     { rev: true },
   );
-  const entries: PublicBNLJournalEntry[] = [];
-  for (const rawId of ids) {
-    const entry = await redis.get<PublicBNLJournalEntry>(
-      journalLatestKey(String(rawId)),
-    );
-    if (entry) entries.push(publicEntry(entry));
-  }
-  return entries;
+  const entries = await Promise.all(
+    ids.map((rawId) =>
+      redis.get<PublicBNLJournalEntry>(journalLatestKey(String(rawId))),
+    ),
+  );
+  return entries
+    .filter(
+      (entry): entry is PublicBNLJournalEntry =>
+        entry !== null && matchesArchiveFilter(entry, filter),
+    )
+    .map(publicEntry);
 }
 export async function listBNLJournalArchive(
   page = 1,
   redis: RedisLike | null = asRedisLike(getBNLJournalRedis()),
+  filter: JournalArchiveFilter = "all",
 ): Promise<JournalReadResult<JournalArchivePage | null>> {
   if (!redis) return { ok: false, unavailable: true };
   if (!validPage(page)) return { ok: true, value: null };
   try {
-    const entries = await entriesForPage(redis, page);
+    const entries = await entriesForPage(redis, page, filter);
     if (!entries) return { ok: true, value: null };
     return {
       ok: true,
@@ -318,6 +356,7 @@ export async function getBNLJournalEntry(
 export async function getBNLJournalNeighbors(
   entryId: string,
   redis: RedisLike | null = asRedisLike(getBNLJournalRedis()),
+  filter: JournalArchiveFilter = "all",
 ): Promise<
   JournalReadResult<{
     older: PublicBNLJournalEntry | null;
@@ -326,22 +365,16 @@ export async function getBNLJournalNeighbors(
 > {
   if (!redis) return { ok: false, unavailable: true };
   try {
+    const indexKey = archiveIndexKey(filter);
     const rank = redis.zrank
-      ? await redis.zrank(BNL_JOURNAL_INDEX_KEY, entryId)
+      ? await redis.zrank(indexKey, entryId)
       : null;
     if (rank === null) return { ok: true, value: { older: null, newer: null } };
-    // ZRANK is ascending (oldest first), so adjacent ranks must be read in the
-    // same order. Mixing this rank with a reversed ZRANGE points at unrelated
-    // entries once the archive has more than a couple of records.
+    // ZRANK is ascending (oldest first), so the directly adjacent members in
+    // the selected index are the selected kind's older and newer entries.
     const olderIds =
-      rank > 0
-        ? await redis.zrange(BNL_JOURNAL_INDEX_KEY, rank - 1, rank - 1)
-        : [];
-    const newerIds = await redis.zrange(
-      BNL_JOURNAL_INDEX_KEY,
-      rank + 1,
-      rank + 1,
-    );
+      rank > 0 ? await redis.zrange(indexKey, rank - 1, rank - 1) : [];
+    const newerIds = await redis.zrange(indexKey, rank + 1, rank + 1);
     const older = olderIds[0]
       ? await redis.get<PublicBNLJournalEntry>(
           journalLatestKey(String(olderIds[0])),
@@ -355,8 +388,14 @@ export async function getBNLJournalNeighbors(
     return {
       ok: true,
       value: {
-        older: older ? publicEntry(older) : null,
-        newer: newer ? publicEntry(newer) : null,
+        older:
+          older && matchesArchiveFilter(older, filter)
+            ? publicEntry(older)
+            : null,
+        newer:
+          newer && matchesArchiveFilter(newer, filter)
+            ? publicEntry(newer)
+            : null,
       },
     };
   } catch {

--- a/tests/bnl-journal-contract.test.mjs
+++ b/tests/bnl-journal-contract.test.mjs
@@ -47,7 +47,16 @@ function loadTs(file, mocks = {}) {
   };
   vm.runInNewContext(
     code,
-    { require: req, exports, module: cjsModule, process, Buffer, URL, console },
+    {
+      require: req,
+      exports,
+      module: cjsModule,
+      process,
+      Buffer,
+      URL,
+      URLSearchParams,
+      console,
+    },
     { filename: file },
   );
   return cjsModule.exports;
@@ -63,9 +72,11 @@ function awaitImport(id) {
 }
 
 const contract = loadTs("src/lib/bnl-journal-contract.ts");
+const navigation = loadTs("src/lib/bnl-journal-navigation.ts");
 const retry = loadTs("src/components/journal/JournalRetryButton.tsx");
 const article = loadTs("src/components/journal/JournalArticle.tsx", {
   "@/lib/bnl-journal-store": {},
+  "@/lib/bnl-journal-navigation": navigation,
   "@/components/journal/JournalRetryButton": retry,
 });
 const routeMod = loadTs("src/app/api/bnl/journal/route.ts", {
@@ -151,8 +162,21 @@ class FakeRedis {
   async eval(_script, keys, args) {
     this.calls.push(["eval"]);
     if (this.fail === "eval") throw new Error("eval fail");
-    const [recordKey, latestKey, indexKey] = keys;
+    const [recordKey, latestKey, indexKey, dailyIndexKey, weeklyIndexKey] =
+      keys;
     const [entryId, revision, contentHash, recordJson, score] = args;
+    const repairKindIndexes = (latest) => {
+      const daily =
+        this.z.get(dailyIndexKey) ??
+        this.z.set(dailyIndexKey, new Map()).get(dailyIndexKey);
+      const weekly =
+        this.z.get(weeklyIndexKey) ??
+        this.z.set(weeklyIndexKey, new Map()).get(weeklyIndexKey);
+      daily.delete(entryId);
+      weekly.delete(entryId);
+      if (latest.entryKind === "daily") daily.set(entryId, latest._score);
+      if (latest.entryKind === "weekly") weekly.set(entryId, latest._score);
+    };
     const existingJson = this.kv.get(recordKey);
     if (existingJson) {
       const existing = JSON.parse(existingJson);
@@ -195,6 +219,7 @@ class FakeRedis {
         (repairedIndexScore !== null && repairedScore !== repairedIndexScore)
       )
         return JSON.stringify({ status: "unavailable" });
+      repairKindIndexes(repaired);
       return JSON.stringify({
         status: "idempotent",
         publishedAt: existing.publishedAt,
@@ -211,6 +236,7 @@ class FakeRedis {
         member: entryId,
       });
     }
+    repairKindIndexes(JSON.parse(this.kv.get(latestKey)));
     return JSON.stringify({ status: "created" });
   }
 }
@@ -237,6 +263,25 @@ test("contract executes bot-compatible validation, word counts, hashes, auth, an
   });
   assert.equal(contract.countJournalWords(e250), 250);
   assert.equal(contract.validateBNLJournalPayload(env(e250)).ok, true);
+  for (const entryKind of ["daily", "weekly", "manual"]) {
+    const classified = makeEntry({ entryKind });
+    assert.equal(
+      contract.validateBNLJournalPayload(env(classified)).ok,
+      true,
+      `${entryKind} entries are accepted`,
+    );
+    assert.equal(
+      classified.contentHash,
+      makeEntry().contentHash,
+      "entry kind remains outside the established public-content hash",
+    );
+  }
+  assert.equal(
+    contract.validateBNLJournalPayload(
+      env(makeEntry({ entryKind: "monthly" })),
+    ).reason,
+    "invalid_entry_kind",
+  );
   const e500 = makeEntry({
     title: "Title",
     excerpt: "Excerpt",
@@ -443,6 +488,250 @@ test("store executes atomic publication, idempotent self-repair, conflicts, boun
   assert.equal(middle.value.newer.entryId, allIds[middleIndex - 1]);
 });
 
+test("archive filters paginate over matching entries and constrain neighbors", async () => {
+  const redis = new FakeRedis();
+  for (let i = 0; i < 30; i++) {
+    const entryKind = i % 3 === 0 ? "daily" : i % 3 === 1 ? "weekly" : null;
+    const entry = makeEntry({
+      entryId: `kind-entry-${String(i).padStart(2, "0")}`,
+      ...(entryKind ? { entryKind } : {}),
+    });
+    assert.equal((await store.publishBNLJournalEntry(entry, redis)).ok, true);
+    redis.z.get(store.BNL_JOURNAL_INDEX_KEY).set(entry.entryId, i);
+    if (entryKind === "daily")
+      redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).set(entry.entryId, i);
+    if (entryKind === "weekly")
+      redis.z.get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY).set(entry.entryId, i);
+  }
+
+  redis.calls = [];
+  const dailyPage1 = await store.listBNLJournalArchive(1, redis, "daily");
+  assert.deepEqual(redis.calls[0], [
+    "zrange",
+    store.BNL_JOURNAL_DAILY_INDEX_KEY,
+    0,
+    9,
+  ]);
+  assert.equal(redis.calls.filter((call) => call[0] === "zrange").length, 1);
+  assert.equal(redis.calls.filter((call) => call[0] === "get").length, 10);
+  const dailyPage2 = await store.listBNLJournalArchive(2, redis, "daily");
+  assert.equal(dailyPage1.ok, true);
+  assert.equal(dailyPage1.value.entries.length, 9);
+  assert.equal(dailyPage1.value.hasOlder, true);
+  assert.equal(dailyPage1.value.hasNewer, false);
+  assert.equal(dailyPage2.value.entries.length, 1);
+  assert.equal(dailyPage2.value.hasOlder, false);
+  assert.equal(dailyPage2.value.hasNewer, true);
+  assert.deepEqual(
+    [...dailyPage1.value.entries, ...dailyPage2.value.entries].map(
+      (entry) => entry.entryId,
+    ),
+    [27, 24, 21, 18, 15, 12, 9, 6, 3, 0].map(
+      (i) => `kind-entry-${String(i).padStart(2, "0")}`,
+    ),
+  );
+  assert.equal(
+    dailyPage1.value.entries.every((entry) => entry.entryKind === "daily"),
+    true,
+  );
+
+  const weeklyPage1 = await store.listBNLJournalArchive(1, redis, "weekly");
+  assert.equal(weeklyPage1.value.entries.length, 9);
+  assert.equal(
+    weeklyPage1.value.entries.every((entry) => entry.entryKind === "weekly"),
+    true,
+  );
+  redis.calls = [];
+  const highEmpty = await store.listBNLJournalArchive(10000, redis, "weekly");
+  assert.equal(highEmpty.ok, true);
+  assert.equal(highEmpty.value.entries.length, 0);
+  assert.deepEqual(redis.calls, [
+    ["zrange", store.BNL_JOURNAL_WEEKLY_INDEX_KEY, 89991, 90000],
+  ]);
+  const allPage = await store.listBNLJournalArchive(1, redis, "all");
+  assert.equal(
+    allPage.value.entries.some((entry) => entry.entryKind === undefined),
+    true,
+    "legacy records remain visible in All",
+  );
+
+  redis.calls = [];
+  const neighbors = await store.getBNLJournalNeighbors(
+    "kind-entry-15",
+    redis,
+    "daily",
+  );
+  assert.equal(neighbors.value.older.entryId, "kind-entry-12");
+  assert.equal(neighbors.value.newer.entryId, "kind-entry-18");
+  assert.equal(
+    redis.calls
+      .filter((call) => call[0] === "zrank" || call[0] === "zrange")
+      .every((call) => call[1] === store.BNL_JOURNAL_DAILY_INDEX_KEY),
+    true,
+  );
+  assert.equal(redis.calls.filter((call) => call[0] === "zrange").length, 2);
+});
+
+test("idempotent publication repairs the stored kind index without trusting an incoming kind", async () => {
+  const redis = new FakeRedis();
+  const daily = makeEntry({
+    entryId: "daily-repair",
+    entryKind: "daily",
+  });
+  assert.equal((await store.publishBNLJournalEntry(daily, redis)).ok, true);
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).has(daily.entryId),
+    true,
+  );
+
+  redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).delete(daily.entryId);
+  redis.z
+    .get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY)
+    .set(daily.entryId, 123);
+  const repaired = await store.publishBNLJournalEntry(daily, redis);
+  assert.equal(repaired.ok, true);
+  assert.equal(repaired.idempotent, true);
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).has(daily.entryId),
+    true,
+  );
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY).has(daily.entryId),
+    false,
+  );
+
+  const differingRetry = makeEntry({
+    entryId: daily.entryId,
+    entryKind: "weekly",
+  });
+  const rejected = await store.publishBNLJournalEntry(differingRetry, redis);
+  assert.equal(rejected.ok, false);
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).has(daily.entryId),
+    true,
+  );
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY).has(daily.entryId),
+    false,
+  );
+
+  const weeklyRevision = makeEntry({
+    entryId: daily.entryId,
+    revision: 2,
+    entryKind: "weekly",
+  });
+  assert.equal(
+    (await store.publishBNLJournalEntry(weeklyRevision, redis)).ok,
+    true,
+  );
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).has(daily.entryId),
+    false,
+  );
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY).has(daily.entryId),
+    true,
+  );
+  assert.equal((await store.publishBNLJournalEntry(daily, redis)).ok, true);
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_DAILY_INDEX_KEY).has(daily.entryId),
+    false,
+  );
+  assert.equal(
+    redis.z.get(store.BNL_JOURNAL_WEEKLY_INDEX_KEY).has(daily.entryId),
+    true,
+  );
+});
+
+test("journal navigation preserves archive filters and rejects unknown filters", () => {
+  assert.equal(navigation.parseJournalArchiveFilter(), "all");
+  assert.equal(navigation.parseJournalArchiveFilter("all"), "all");
+  assert.equal(navigation.parseJournalArchiveFilter("daily"), "daily");
+  assert.equal(navigation.parseJournalArchiveFilter("weekly"), "weekly");
+  assert.equal(navigation.parseJournalArchiveFilter("monthly"), null);
+  assert.equal(navigation.journalArchiveHref("all"), "/journal");
+  assert.equal(
+    navigation.journalArchiveHref("daily", 2),
+    "/journal?kind=daily&page=2",
+  );
+  assert.equal(
+    navigation.journalEntryHref("entry/unsafe", "weekly"),
+    "/journal/entry%2Funsafe?kind=weekly",
+  );
+});
+
+test("journal pages canonicalize explicit All and mismatched detail filters", async () => {
+  const placeholderComponents = {
+    JournalArchiveCard: () => React.createElement("div"),
+    JournalArticle: () => React.createElement("article"),
+    JournalUnavailable: () => React.createElement("div"),
+  };
+  const archivePage = loadTs("src/app/journal/page.tsx", {
+    "@/components/journal/JournalArticle": placeholderComponents,
+    "@/lib/bnl-journal-navigation": navigation,
+    "@/lib/bnl-journal-store": {
+      listBNLJournalArchive: () => {
+        throw new Error("canonical redirect must happen before storage read");
+      },
+    },
+  });
+  await assert.rejects(
+    archivePage.default({
+      searchParams: Promise.resolve({ kind: "all", page: "2" }),
+    }),
+    /redirect:\/journal\?page=2/,
+  );
+
+  let detailEntry = {
+    ...makeEntry({ entryId: "daily-detail", entryKind: "daily" }),
+    publishedAt: "2026-07-18T12:30:00Z",
+  };
+  let neighborFilter = null;
+  const detailPage = loadTs("src/app/journal/[entryId]/page.tsx", {
+    "@/components/journal/JournalArticle": placeholderComponents,
+    "@/lib/bnl-journal-navigation": navigation,
+    "@/lib/bnl-journal-store": {
+      getBNLJournalEntry: async () => ({ ok: true, value: detailEntry }),
+      getBNLJournalNeighbors: async (_entryId, _redis, filter) => {
+        neighborFilter = filter;
+        return { ok: true, value: { older: null, newer: null } };
+      },
+    },
+  });
+  await assert.rejects(
+    detailPage.default({
+      params: Promise.resolve({ entryId: detailEntry.entryId }),
+      searchParams: Promise.resolve({ kind: "weekly" }),
+    }),
+    /redirect:\/journal\/daily-detail/,
+  );
+  await assert.rejects(
+    detailPage.default({
+      params: Promise.resolve({ entryId: detailEntry.entryId }),
+      searchParams: Promise.resolve({ kind: "all" }),
+    }),
+    /redirect:\/journal\/daily-detail/,
+  );
+  const matching = await detailPage.default({
+    params: Promise.resolve({ entryId: detailEntry.entryId }),
+    searchParams: Promise.resolve({ kind: "daily" }),
+  });
+  assert.ok(matching);
+  assert.equal(neighborFilter, "daily");
+
+  detailEntry = {
+    ...makeEntry({ entryId: "legacy-detail" }),
+    publishedAt: "2026-07-18T12:30:00Z",
+  };
+  await assert.rejects(
+    detailPage.default({
+      params: Promise.resolve({ entryId: detailEntry.entryId }),
+      searchParams: Promise.resolve({ kind: "daily" }),
+    }),
+    /redirect:\/journal\/legacy-detail/,
+  );
+});
+
 test("React server rendering exposes only display data and escapes hostile text", () => {
   const entry = {
     ...makeEntry({
@@ -462,9 +751,56 @@ test("React server rendering exposes only display data and escapes hostile text"
   );
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
   assert.match(html, /By BNL-01\./);
+  assert.match(html, /Journal entry type: Manual/);
   assert.doesNotMatch(
     html,
     /contentHash|sourceWindowStart|sourceWindowEnd|authoredAt|3a4b2b|2026-07-11T00:00:00Z/,
   );
+  const dailyHtml = renderToStaticMarkup(
+    React.createElement(article.JournalArticle, {
+      entry: { ...entry, entryKind: "daily" },
+      prominent: true,
+      archiveFilter: "daily",
+    }),
+  );
+  assert.match(dailyHtml, /Journal entry type: Daily/);
+  assert.match(
+    dailyHtml,
+    /href="\/journal\/bnl-journal-fixture-001\?kind=daily"/,
+  );
+  const weeklyCardHtml = renderToStaticMarkup(
+    React.createElement(article.JournalArchiveCard, {
+      entry: { ...entry, entryKind: "weekly" },
+      archiveFilter: "weekly",
+    }),
+  );
+  assert.match(weeklyCardHtml, /Journal entry type: Weekly/);
+  assert.match(weeklyCardHtml, /\?kind=weekly/);
   assert.equal(article.JournalArticle.toString().includes("useRouter"), false);
+});
+
+test("public archive UI exposes server-backed filters and preserves them in navigation", () => {
+  const archivePage = awaitFs("src/app/journal/page.tsx");
+  const entryPage = awaitFs("src/app/journal/[entryId]/page.tsx");
+  assert.match(archivePage, /aria-label="Filter journal archive"/);
+  assert.match(
+    archivePage,
+    /listBNLJournalArchive\(page, undefined, filter\)/,
+  );
+  assert.match(
+    archivePage,
+    /journalArchiveHref\(filter, archive\.value\.page \+ 1\)/,
+  );
+  assert.match(archivePage, /params\?\.kind === "all"/);
+  assert.match(
+    archivePage,
+    /redirect\(journalArchiveHref\(filter, page\)\)/,
+  );
+  assert.match(
+    entryPage,
+    /getBNLJournalNeighbors\(entryId, undefined, filter\)/,
+  );
+  assert.match(entryPage, /journalArchiveHref\(filter\)/);
+  assert.match(entryPage, /result\.value\.entryKind !== filter/);
+  assert.match(entryPage, /redirect\(journalEntryHref\(entryId\)\)/);
 });


### PR DESCRIPTION
## Summary
- add backward-compatible Daily, Weekly, and Manual Journal entry labels
- add All, Daily, and Weekly archive filters with canonical filtered navigation
- keep filtered pagination fast with atomic per-kind Redis indexes and idempotent index repair
- preserve the existing untyped Journal entry as a legacy Manual entry in All

## Validation
- focused Journal tests: 9/9
- full BNL site suite: 61/61
- TypeScript passed
- targeted ESLint passed
- `git diff --check` passed

## Merge order
Merge this site PR before companion BNL01-Bot PR [#335](https://github.com/6-Bit-01/BNL01-Bot/pull/335), so the public endpoint accepts `entryKind` before the bot begins sending it.