### PR TITLE
Add Journal entry visibility and memory controls

### DIFF
--- a/src/app/admin/journal/page.tsx
+++ b/src/app/admin/journal/page.tsx
@@ -33,8 +33,33 @@ type Telemetry = {
   detail?: string;
   lastRun?: RunRecord;
 };
+type EntryControl = {
+  entryId: string;
+  publicVisible: boolean;
+  memoryEligible: boolean;
+  updatedAt: string;
+  updatedBy: "website-admin";
+};
+type JournalEntry = {
+  entryId: string;
+  revision: number;
+  entryKind?: "daily" | "weekly";
+  title: string;
+  excerpt: string;
+  sections: { heading: string; body: string }[];
+  publishedAt: string;
+  control: EntryControl;
+};
+type EntryControlAudit = EntryControl & {
+  changeId: string;
+  previousPublicVisible: boolean;
+  previousMemoryEligible: boolean;
+};
 type State = {
   config: Config;
+  entryControls: EntryControl[];
+  entries: JournalEntry[];
+  entryControlAudit: EntryControlAudit[];
   runRequests: RunRequest[];
   telemetry: Telemetry | null;
   recentRuns: RunRecord[];
@@ -77,6 +102,9 @@ export default function AdminJournalPage() {
   const [loading, setLoading] = useState<string | null>("load");
   const [error, setError] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
+  const [entryFilter, setEntryFilter] = useState<"all" | "daily" | "weekly">(
+    "all",
+  );
 
   const load = useCallback(async (quiet = false) => {
     if (!quiet) setLoading("load");
@@ -167,7 +195,70 @@ export default function AdminJournalPage() {
     }
   }
 
+  async function updateEntryControl(
+    entry: JournalEntry,
+    publicVisible: boolean,
+    memoryEligible: boolean,
+  ) {
+    if (loading || !state) return;
+    const previous = state;
+    const optimisticControl = {
+      ...entry.control,
+      publicVisible,
+      memoryEligible,
+      updatedAt: new Date().toISOString(),
+    };
+    setState({
+      ...state,
+      entries: state.entries.map((candidate) =>
+        candidate.entryId === entry.entryId
+          ? { ...candidate, control: optimisticControl }
+          : candidate,
+      ),
+    });
+    setLoading(`entry:${entry.entryId}`);
+    setError(null);
+    setNote(null);
+    try {
+      const response = await fetch("/api/admin/journal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "updateEntryControl",
+          entryId: entry.entryId,
+          publicVisible,
+          memoryEligible,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok !== true)
+        throw new Error(
+          typeof payload.error === "string"
+            ? payload.error
+            : `Request failed (${response.status})`,
+        );
+      setNote(
+        !publicVisible
+          ? "Entry hidden. BNL memory access is off unless you deliberately re-enable it."
+          : "Entry controls saved.",
+      );
+      await load(true);
+    } catch (caught) {
+      setState(previous);
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Entry control update failed.",
+      );
+    } finally {
+      setLoading(null);
+    }
+  }
+
   const config = state?.config ?? DEFAULT_CONFIG;
+  const filteredEntries = (state?.entries ?? []).filter(
+    (entry) => entryFilter === "all" || entry.entryKind === entryFilter,
+  );
   return (
     <main className="min-h-screen pt-14">
       <section className="border-b border-border noise-bg">
@@ -325,6 +416,156 @@ export default function AdminJournalPage() {
             )}
           </aside>
         </div>
+
+        <section className="border border-border bg-surface p-5">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.35em] text-muted">
+                Published entry controls
+              </p>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-foreground/70">
+                Hiding an entry removes it from the public archive immediately and
+                turns off future Journal-memory use by default. The two controls
+                remain separate so a hidden entry can be deliberately retained as
+                private continuity.
+              </p>
+            </div>
+            <div className="flex gap-2" aria-label="Filter Journal entries">
+              {(["all", "daily", "weekly"] as const).map((filter) => (
+                <button
+                  key={filter}
+                  onClick={() => setEntryFilter(filter)}
+                  className={`border px-3 py-2 font-mono text-[10px] uppercase tracking-widest ${
+                    entryFilter === filter
+                      ? "border-accent text-accent"
+                      : "border-border text-muted"
+                  }`}
+                >
+                  {filter}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-5 space-y-4">
+            {filteredEntries.length ? (
+              filteredEntries.map((entry) => {
+                const busy = loading === `entry:${entry.entryId}`;
+                return (
+                  <article key={entry.entryId} className="border border-border p-4">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <StatusPill value={entry.entryKind ?? "manual"} />
+                          <StatusPill
+                            value={entry.control.publicVisible ? "public" : "hidden"}
+                          />
+                          <StatusPill
+                            value={
+                              entry.control.memoryEligible
+                                ? "memory eligible"
+                                : "memory excluded"
+                            }
+                          />
+                        </div>
+                        <h2 className="mt-3 text-lg font-bold text-foreground">
+                          {entry.title}
+                        </h2>
+                        <p className="mt-1 font-mono text-[10px] text-muted">
+                          {entry.entryId} · revision {entry.revision} · {localTime(entry.publishedAt)}
+                        </p>
+                        <p className="mt-3 text-sm leading-6 text-foreground/70">
+                          {entry.excerpt}
+                        </p>
+                      </div>
+                      <div className="w-full space-y-3 lg:w-72">
+                        <label className="flex items-center justify-between gap-4 border border-border px-3 py-2 text-sm">
+                          <span>Visible to public</span>
+                          <input
+                            aria-label={`Visible to public: ${entry.title}`}
+                            type="checkbox"
+                            disabled={Boolean(loading)}
+                            checked={entry.control.publicVisible}
+                            onChange={(event) =>
+                              void updateEntryControl(
+                                entry,
+                                event.target.checked,
+                                event.target.checked
+                                  ? entry.control.memoryEligible
+                                  : false,
+                              )
+                            }
+                          />
+                        </label>
+                        <label className="flex items-center justify-between gap-4 border border-border px-3 py-2 text-sm">
+                          <span>Available to BNL memory</span>
+                          <input
+                            aria-label={`Available to BNL memory: ${entry.title}`}
+                            type="checkbox"
+                            disabled={Boolean(loading)}
+                            checked={entry.control.memoryEligible}
+                            onChange={(event) =>
+                              void updateEntryControl(
+                                entry,
+                                entry.control.publicVisible,
+                                event.target.checked,
+                              )
+                            }
+                          />
+                        </label>
+                        {entry.control.publicVisible && (
+                          <Link
+                            href={`/journal/${encodeURIComponent(entry.entryId)}`}
+                            className="inline-block text-xs uppercase tracking-widest text-accent"
+                          >
+                            Open public entry →
+                          </Link>
+                        )}
+                        {busy && <p className="text-xs text-muted">Saving…</p>}
+                      </div>
+                    </div>
+                    <details className="mt-4 border-t border-border pt-4">
+                      <summary className="cursor-pointer font-mono text-xs uppercase tracking-widest text-accent">
+                        Preview full entry
+                      </summary>
+                      <div className="mt-4 space-y-5">
+                        {entry.sections.map((section, index) => (
+                          <section key={`${entry.entryId}-${index}`}>
+                            <h3 className="font-bold text-foreground">
+                              {section.heading}
+                            </h3>
+                            <p className="mt-2 whitespace-pre-wrap text-sm leading-7 text-foreground/75">
+                              {section.body}
+                            </p>
+                          </section>
+                        ))}
+                      </div>
+                    </details>
+                  </article>
+                );
+              })
+            ) : (
+              <p className="text-sm text-muted">
+                No published Journal entries match this filter.
+              </p>
+            )}
+          </div>
+
+          {state?.entryControlAudit.length ? (
+            <details className="mt-6 border-t border-border pt-4">
+              <summary className="cursor-pointer font-mono text-xs uppercase tracking-widest text-muted">
+                Recent entry-control audit
+              </summary>
+              <div className="mt-3 space-y-2">
+                {state.entryControlAudit.slice(0, 10).map((record) => (
+                  <p key={record.changeId} className="text-xs leading-5 text-muted">
+                    {localTime(record.updatedAt)} · {record.entryId} · public {String(record.previousPublicVisible)} → {String(record.publicVisible)} · memory {String(record.previousMemoryEligible)} → {String(record.memoryEligible)}
+                  </p>
+                ))}
+              </div>
+            </details>
+          ) : null}
+        </section>
 
         <section className="border border-border bg-surface p-5">
           <p className="font-mono text-xs uppercase tracking-[0.35em] text-muted">

--- a/src/app/api/admin/journal/route.ts
+++ b/src/app/api/admin/journal/route.ts
@@ -8,6 +8,11 @@ import {
   writeJournalAutomationConfig,
   type JournalCadence,
 } from "@/lib/bnl-journal-control-store";
+import {
+  listBNLJournalAdminEntries,
+  listJournalEntryControlAudit,
+  updateJournalEntryControl,
+} from "@/lib/bnl-journal-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -42,8 +47,22 @@ export async function GET(req: Request) {
       503,
     );
   try {
-    const state = await readJournalControlState(redis);
-    return json({ ...state, persisted: true });
+    const [state, entries, entryControlAudit] = await Promise.all([
+      readJournalControlState(redis),
+      listBNLJournalAdminEntries(redis),
+      listJournalEntryControlAudit(redis),
+    ]);
+    if (!entries.ok)
+      return json(
+        { error: "Journal entries are unavailable.", reason: "read_failed" },
+        503,
+      );
+    return json({
+      ...state,
+      entries: entries.value,
+      entryControlAudit,
+      persisted: true,
+    });
   } catch (error) {
     console.error("[admin/journal] read failed:", error);
     return json(
@@ -99,6 +118,29 @@ export async function POST(req: Request) {
         idempotent: queued.idempotent,
         persisted: true,
       });
+    }
+
+    if (body.action === "updateEntryControl") {
+      if (
+        typeof body.entryId !== "string" ||
+        typeof body.publicVisible !== "boolean" ||
+        typeof body.memoryEligible !== "boolean"
+      )
+        return json({ error: "Invalid Journal entry control." }, 400);
+      const result = await updateJournalEntryControl(
+        body.entryId,
+        body.publicVisible,
+        body.memoryEligible,
+        redis,
+      );
+      if (!result.ok && result.missing)
+        return json({ error: "Journal entry not found." }, 404);
+      if (!result.ok)
+        return json(
+          { error: "Journal entry control is unavailable." },
+          503,
+        );
+      return json({ ok: true, control: result.control, persisted: true });
     }
 
     return json({ error: "Invalid action." }, 400);

--- a/src/app/api/bnl/journal/control/route.ts
+++ b/src/app/api/bnl/journal/control/route.ts
@@ -37,10 +37,17 @@ export async function GET(req: Request) {
   if (!redis) return unavailable();
   try {
     const state = await readJournalControlState(redis);
+    const memoryExcludedEntryIds = state.entryControls
+      .filter((control) => !control.memoryEligible)
+      .map((control) => control.entryId);
     return json({
       contractVersion: 1,
       ...state.config,
-      ...state,
+      config: state.config,
+      runRequests: state.runRequests,
+      telemetry: state.telemetry,
+      recentRuns: state.recentRuns,
+      memoryExcludedEntryIds,
       persisted: true,
     });
   } catch (error) {

--- a/src/lib/bnl-journal-control-store.ts
+++ b/src/lib/bnl-journal-control-store.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "crypto";
-import { getBNLJournalRedis } from "@/lib/bnl-journal-store";
+import {
+  getBNLJournalRedis,
+  listJournalEntryControls,
+  type JournalEntryControl,
+  type RedisLike,
+} from "@/lib/bnl-journal-store";
 
 export type JournalAutomationConfig = {
   journalAutoPublishEnabled: boolean;
@@ -53,6 +58,7 @@ export type JournalAutomationTelemetry = {
 
 export type JournalControlState = {
   config: JournalAutomationConfig;
+  entryControls: JournalEntryControl[];
   runRequests: JournalRunRequest[];
   telemetry: JournalAutomationTelemetry | null;
   recentRuns: JournalRunRecord[];
@@ -79,14 +85,8 @@ export const JOURNAL_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const ID = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{2,119}$/;
 
-export type JournalControlRedis = {
-  get<T = unknown>(key: string): Promise<T | null>;
+export type JournalControlRedis = RedisLike & {
   set(key: string, value: unknown): Promise<unknown>;
-  eval?<T = unknown>(
-    script: string,
-    keys: string[],
-    args: unknown[],
-  ): Promise<T>;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -265,14 +265,16 @@ export function getJournalControlRedis(): JournalControlRedis | null {
 export async function readJournalControlState(
   redis: JournalControlRedis,
 ): Promise<JournalControlState> {
-  const [rawFlags, rawRequests, rawTelemetry, rawRuns] = await Promise.all([
+  const [rawFlags, rawRequests, rawTelemetry, rawRuns, entryControls] = await Promise.all([
     redis.get<unknown>(BNL_FLAGS_KEY),
     redis.get<unknown>(BNL_JOURNAL_RUN_REQUESTS_KEY),
     redis.get<unknown>(BNL_JOURNAL_TELEMETRY_KEY),
     redis.get<unknown>(BNL_JOURNAL_RECENT_RUNS_KEY),
+    listJournalEntryControls(redis),
   ]);
   return {
     config: sanitizeJournalAutomationConfig(rawFlags),
+    entryControls,
     runRequests: sanitizeRequests(rawRequests),
     telemetry: sanitizeJournalTelemetry(rawTelemetry),
     recentRuns: sanitizeRuns(rawRuns),

--- a/src/lib/bnl-journal-store.ts
+++ b/src/lib/bnl-journal-store.ts
@@ -1,8 +1,24 @@
 import { Redis } from "@upstash/redis";
+import { randomUUID } from "crypto";
 import type { BNLJournalEntry } from "@/lib/bnl-journal-contract";
 import type { JournalArchiveFilter } from "@/lib/bnl-journal-navigation";
 
 export type PublicBNLJournalEntry = BNLJournalEntry & { publishedAt: string };
+export type JournalEntryControl = {
+  entryId: string;
+  publicVisible: boolean;
+  memoryEligible: boolean;
+  updatedAt: string;
+  updatedBy: "website-admin";
+};
+export type JournalEntryControlAuditRecord = JournalEntryControl & {
+  changeId: string;
+  previousPublicVisible: boolean;
+  previousMemoryEligible: boolean;
+};
+export type AdminBNLJournalEntry = PublicBNLJournalEntry & {
+  control: JournalEntryControl;
+};
 export type JournalReadResult<T> =
   | { ok: true; value: T }
   | { ok: false; unavailable: true };
@@ -24,6 +40,10 @@ export const BNL_JOURNAL_DAILY_INDEX_KEY =
   "barcode:bnl-journal:v1:index:daily";
 export const BNL_JOURNAL_WEEKLY_INDEX_KEY =
   "barcode:bnl-journal:v1:index:weekly";
+export const BNL_JOURNAL_ENTRY_CONTROLS_KEY =
+  "barcode:bnl-journal:v1:entry-controls";
+export const BNL_JOURNAL_ENTRY_CONTROL_AUDIT_KEY =
+  "barcode:bnl-journal:v1:entry-control-audit";
 const KEY_PREFIX = "barcode:bnl-journal:v1:entry";
 const LATEST_PREFIX = "barcode:bnl-journal:v1:latest";
 const PAGE_SIZE = 9;
@@ -62,14 +82,22 @@ local latestKey = KEYS[2]
 local indexKey = KEYS[3]
 local dailyIndexKey = KEYS[4]
 local weeklyIndexKey = KEYS[5]
+local controlsKey = KEYS[6]
 local entryId = ARGV[1]
 local revision = tonumber(ARGV[2])
 local contentHash = ARGV[3]
 local recordJson = ARGV[4]
 local score = tonumber(ARGV[5])
+local controlsRaw = redis.call("GET", controlsKey)
+local controls = controlsRaw and cjson.decode(controlsRaw) or {}
+local control = controls[entryId]
+local publicVisible = (not control) or control.publicVisible ~= false
 local function repairKindIndexes(latest)
+  redis.call("ZREM", indexKey, entryId)
   redis.call("ZREM", dailyIndexKey, entryId)
   redis.call("ZREM", weeklyIndexKey, entryId)
+  if not publicVisible then return end
+  redis.call("ZADD", indexKey, tonumber(latest._score), entryId)
   if latest.entryKind == "daily" then
     redis.call("ZADD", dailyIndexKey, tonumber(latest._score), entryId)
   elseif latest.entryKind == "weekly" then
@@ -92,7 +120,7 @@ if existingJson then
   local repairedIndexScore = nil
   if (not latestJson) and (not indexScore) then
     redis.call("SET", latestKey, existingJson)
-    redis.call("ZADD", indexKey, existing._score, entryId)
+    if publicVisible then redis.call("ZADD", indexKey, existing._score, entryId) end
     repairedLatest = true
     repairedIndexScore = existing._score
   elseif (not latestJson) and indexScore and tonumber(indexScore) == tonumber(existing._score) then
@@ -100,16 +128,16 @@ if existingJson then
     repairedLatest = true
   elseif latest and existing.revision > latest.revision then
     redis.call("SET", latestKey, existingJson)
-    redis.call("ZADD", indexKey, existing._score, entryId)
+    if publicVisible then redis.call("ZADD", indexKey, existing._score, entryId) end
     repairedLatest = true
     repairedIndexScore = existing._score
-  elseif latest and (not indexScore) then
+  elseif latest and publicVisible and (not indexScore) then
     redis.call("ZADD", indexKey, latest._score, entryId)
     repairedIndexScore = latest._score
   end
   local repairedLatestJson = redis.call("GET", latestKey)
   local repairedScore = redis.call("ZSCORE", indexKey, entryId)
-  if (not repairedLatestJson) or (not repairedScore) then
+  if (not repairedLatestJson) or (publicVisible and (not repairedScore)) then
     return cjson.encode({ status = "unavailable" })
   end
   local repairedLatestEntry = cjson.decode(repairedLatestJson)
@@ -118,7 +146,7 @@ if existingJson then
       return cjson.encode({ status = "unavailable" })
     end
   end
-  if repairedIndexScore and tonumber(repairedScore) ~= tonumber(repairedIndexScore) then
+  if publicVisible and repairedIndexScore and tonumber(repairedScore) ~= tonumber(repairedIndexScore) then
     return cjson.encode({ status = "unavailable" })
   end
   repairKindIndexes(repairedLatestEntry)
@@ -136,16 +164,15 @@ end
 local latestJson = redis.call("GET", latestKey)
 if (not latestJson) or tonumber(cjson.decode(latestJson).revision) <= revision then
   redis.call("SET", latestKey, recordJson)
-  redis.call("ZADD", indexKey, score, entryId)
-elseif not redis.call("ZSCORE", indexKey, entryId) then
-  local latest = cjson.decode(latestJson)
-  redis.call("ZADD", indexKey, tonumber(latest._score), entryId)
 end
 local finalLatestJson = redis.call("GET", latestKey)
-if (not finalLatestJson) or (not redis.call("ZSCORE", indexKey, entryId)) then
+if not finalLatestJson then
   return cjson.encode({ status = "unavailable" })
 end
 repairKindIndexes(cjson.decode(finalLatestJson))
+if publicVisible and (not redis.call("ZSCORE", indexKey, entryId)) then
+  return cjson.encode({ status = "unavailable" })
+end
 return cjson.encode({ status = "created" })
 `;
 
@@ -199,6 +226,7 @@ function scoreOf(publishedAt: string, revision: number) {
 function parseAtomicResult(value: unknown): {
   status?: string;
   publishedAt?: string;
+  control?: unknown;
 } {
   return typeof value === "string"
     ? JSON.parse(value)
@@ -237,6 +265,7 @@ export async function publishBNLJournalEntry(
           BNL_JOURNAL_INDEX_KEY,
           BNL_JOURNAL_DAILY_INDEX_KEY,
           BNL_JOURNAL_WEEKLY_INDEX_KEY,
+          BNL_JOURNAL_ENTRY_CONTROLS_KEY,
         ],
         [
           entry.entryId,
@@ -345,6 +374,13 @@ export async function getBNLJournalEntry(
 ): Promise<JournalReadResult<PublicBNLJournalEntry | null>> {
   if (!redis) return { ok: false, unavailable: true };
   try {
+    const controls = await listJournalEntryControls(redis);
+    if (
+      controls.some(
+        (control) => control.entryId === entryId && !control.publicVisible,
+      )
+    )
+      return { ok: true, value: null };
     const entry = await redis.get<PublicBNLJournalEntry>(
       journalLatestKey(entryId),
     );
@@ -418,6 +454,234 @@ export async function listAllBNLJournalEntries(
       value: entries
         .filter((entry): entry is PublicBNLJournalEntry => Boolean(entry))
         .map(publicEntry),
+    };
+  } catch {
+    return { ok: false, unavailable: true };
+  }
+}
+
+const ENTRY_ID = /^[a-zA-Z0-9][a-zA-Z0-9._-]{2,79}$/;
+const MAX_CONTROL_AUDIT = 250;
+const ENTRY_CONTROL_SCRIPT = `
+-- journal-entry-control-v1
+local controlsKey = KEYS[1]
+local auditKey = KEYS[2]
+local indexKey = KEYS[3]
+local dailyIndexKey = KEYS[4]
+local weeklyIndexKey = KEYS[5]
+local latestKey = KEYS[6]
+local entryId = ARGV[1]
+local control = cjson.decode(ARGV[2])
+local auditRecord = cjson.decode(ARGV[3])
+local maxAudit = tonumber(ARGV[4])
+local latestJson = redis.call("GET", latestKey)
+if not latestJson then return cjson.encode({ status = "missing" }) end
+local latest = cjson.decode(latestJson)
+local controlsRaw = redis.call("GET", controlsKey)
+local controls = controlsRaw and cjson.decode(controlsRaw) or {}
+controls[entryId] = control
+local auditRaw = redis.call("GET", auditKey)
+local audit = auditRaw and cjson.decode(auditRaw) or {}
+table.insert(audit, 1, auditRecord)
+while #audit > maxAudit do table.remove(audit) end
+redis.call("SET", controlsKey, cjson.encode(controls))
+redis.call("SET", auditKey, cjson.encode(audit))
+redis.call("ZREM", indexKey, entryId)
+redis.call("ZREM", dailyIndexKey, entryId)
+redis.call("ZREM", weeklyIndexKey, entryId)
+if control.publicVisible then
+  redis.call("ZADD", indexKey, tonumber(latest._score), entryId)
+  if latest.entryKind == "daily" then
+    redis.call("ZADD", dailyIndexKey, tonumber(latest._score), entryId)
+  elseif latest.entryKind == "weekly" then
+    redis.call("ZADD", weeklyIndexKey, tonumber(latest._score), entryId)
+  end
+end
+return cjson.encode({ status = "updated", control = control })
+`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function validIso(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    Number.isFinite(Date.parse(value)) &&
+    new Date(value).toISOString() === value
+  );
+}
+
+export function defaultJournalEntryControl(
+  entryId: string,
+): JournalEntryControl {
+  return {
+    entryId,
+    publicVisible: true,
+    memoryEligible: true,
+    updatedAt: "1970-01-01T00:00:00.000Z",
+    updatedBy: "website-admin",
+  };
+}
+
+export function sanitizeJournalEntryControl(
+  value: unknown,
+): JournalEntryControl | null {
+  if (
+    !isRecord(value) ||
+    typeof value.entryId !== "string" ||
+    !ENTRY_ID.test(value.entryId) ||
+    typeof value.publicVisible !== "boolean" ||
+    typeof value.memoryEligible !== "boolean" ||
+    !validIso(value.updatedAt) ||
+    value.updatedBy !== "website-admin"
+  )
+    return null;
+  return {
+    entryId: value.entryId,
+    publicVisible: value.publicVisible,
+    memoryEligible: value.memoryEligible,
+    updatedAt: value.updatedAt,
+    updatedBy: "website-admin",
+  };
+}
+
+function sanitizeJournalEntryControlAudit(
+  value: unknown,
+): JournalEntryControlAuditRecord | null {
+  const control = sanitizeJournalEntryControl(value);
+  if (!control || !isRecord(value)) return null;
+  if (
+    typeof value.changeId !== "string" ||
+    !/^[a-zA-Z0-9][a-zA-Z0-9._:-]{2,119}$/.test(value.changeId) ||
+    typeof value.previousPublicVisible !== "boolean" ||
+    typeof value.previousMemoryEligible !== "boolean"
+  )
+    return null;
+  return {
+    ...control,
+    changeId: value.changeId,
+    previousPublicVisible: value.previousPublicVisible,
+    previousMemoryEligible: value.previousMemoryEligible,
+  };
+}
+
+export async function listJournalEntryControls(
+  redis: Pick<RedisLike, "get"> | null = asRedisLike(getBNLJournalRedis()),
+): Promise<JournalEntryControl[]> {
+  if (!redis) return [];
+  const raw = await redis.get<unknown>(BNL_JOURNAL_ENTRY_CONTROLS_KEY);
+  if (!isRecord(raw)) return [];
+  return Object.values(raw)
+    .map(sanitizeJournalEntryControl)
+    .filter((item): item is JournalEntryControl => Boolean(item))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function listJournalEntryControlAudit(
+  redis: Pick<RedisLike, "get"> | null = asRedisLike(getBNLJournalRedis()),
+): Promise<JournalEntryControlAuditRecord[]> {
+  if (!redis) return [];
+  const raw = await redis.get<unknown>(BNL_JOURNAL_ENTRY_CONTROL_AUDIT_KEY);
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(sanitizeJournalEntryControlAudit)
+    .filter((item): item is JournalEntryControlAuditRecord => Boolean(item))
+    .slice(0, MAX_CONTROL_AUDIT);
+}
+
+export async function updateJournalEntryControl(
+  entryId: string,
+  publicVisible: boolean,
+  memoryEligible: boolean,
+  redis: RedisLike | null = asRedisLike(getBNLJournalRedis()),
+): Promise<
+  | { ok: true; control: JournalEntryControl }
+  | { ok: false; missing?: true; unavailable?: true }
+> {
+  if (!redis?.eval || !ENTRY_ID.test(entryId))
+    return { ok: false, unavailable: true };
+  try {
+    const controls = await listJournalEntryControls(redis);
+    const previous =
+      controls.find((item) => item.entryId === entryId) ??
+      defaultJournalEntryControl(entryId);
+    const control: JournalEntryControl = {
+      entryId,
+      publicVisible,
+      memoryEligible,
+      updatedAt: new Date().toISOString(),
+      updatedBy: "website-admin",
+    };
+    const audit: JournalEntryControlAuditRecord = {
+      ...control,
+      changeId: `journal-control-${randomUUID()}`,
+      previousPublicVisible: previous.publicVisible,
+      previousMemoryEligible: previous.memoryEligible,
+    };
+    const result = parseAtomicResult(
+      await redis.eval(
+        ENTRY_CONTROL_SCRIPT,
+        [
+          BNL_JOURNAL_ENTRY_CONTROLS_KEY,
+          BNL_JOURNAL_ENTRY_CONTROL_AUDIT_KEY,
+          BNL_JOURNAL_INDEX_KEY,
+          BNL_JOURNAL_DAILY_INDEX_KEY,
+          BNL_JOURNAL_WEEKLY_INDEX_KEY,
+          journalLatestKey(entryId),
+        ],
+        [
+          entryId,
+          JSON.stringify(control),
+          JSON.stringify(audit),
+          MAX_CONTROL_AUDIT,
+        ],
+      ),
+    );
+    if (result.status === "missing") return { ok: false, missing: true };
+    const stored = sanitizeJournalEntryControl(result.control);
+    return stored
+      ? { ok: true, control: stored }
+      : { ok: false, unavailable: true };
+  } catch {
+    return { ok: false, unavailable: true };
+  }
+}
+
+export async function listBNLJournalAdminEntries(
+  redis: RedisLike | null = asRedisLike(getBNLJournalRedis()),
+): Promise<JournalReadResult<AdminBNLJournalEntry[]>> {
+  if (!redis) return { ok: false, unavailable: true };
+  try {
+    const controls = await listJournalEntryControls(redis);
+    const visibleIds = await redis.zrange(BNL_JOURNAL_INDEX_KEY, 0, -1, {
+      rev: true,
+    });
+    const ids = [
+      ...new Set([
+        ...visibleIds.map(String),
+        ...controls.map((item) => item.entryId),
+      ]),
+    ];
+    const controlMap = new Map(
+      controls.map((item) => [item.entryId, item]),
+    );
+    const entries = await Promise.all(
+      ids.map((id) =>
+        redis.get<PublicBNLJournalEntry>(journalLatestKey(id)),
+      ),
+    );
+    return {
+      ok: true,
+      value: entries
+        .filter((entry): entry is PublicBNLJournalEntry => Boolean(entry))
+        .map((entry) => ({
+          ...publicEntry(entry),
+          control:
+            controlMap.get(entry.entryId) ??
+            defaultJournalEntryControl(entry.entryId),
+        }))
+        .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt)),
     };
   } catch {
     return { ok: false, unavailable: true };

--- a/tests/bnl-journal-admin-control.test.mjs
+++ b/tests/bnl-journal-admin-control.test.mjs
@@ -41,7 +41,10 @@ function loadTs(file, mocks = {}) {
 }
 
 const store = loadTs("src/lib/bnl-journal-control-store.ts", {
-  "@/lib/bnl-journal-store": { getBNLJournalRedis: () => null },
+  "@/lib/bnl-journal-store": {
+    getBNLJournalRedis: () => null,
+    listJournalEntryControls: async () => [],
+  },
 });
 
 class FakeRedis {
@@ -341,6 +344,7 @@ test("Journal control routes return 401 without auth and 503 without Redis", asy
       verifyAdminToken: async () => false,
     },
     "@/lib/bnl-journal-control-store": unavailableStore,
+    "@/lib/bnl-journal-store": {},
   });
   assert.equal(
     (
@@ -362,6 +366,7 @@ test("Journal control routes return 401 without auth and 503 without Redis", asy
       verifyAdminToken: async () => true,
     },
     "@/lib/bnl-journal-control-store": unavailableStore,
+    "@/lib/bnl-journal-store": {},
   });
   assert.equal(
     (
@@ -378,6 +383,49 @@ test("Journal control routes return 401 without auth and 503 without Redis", asy
     ).status,
     503,
   );
+});
+
+test("bot control GET exposes only memory-ineligible entry ids", async () => {
+  const nextServer = {
+    NextResponse: {
+      json: (body, init = {}) =>
+        new Response(JSON.stringify(body), {
+          status: init.status ?? 200,
+          headers: init.headers,
+        }),
+    },
+  };
+  const route = loadTs("src/app/api/bnl/journal/control/route.ts", {
+    "next/server": nextServer,
+    "@/lib/bnl-journal-contract": {
+      authenticateBNLJournalRequest: () => true,
+    },
+    "@/lib/bnl-journal-control-store": {
+      getJournalControlRedis: () => ({}),
+      readJournalControlState: async () => ({
+        config: {
+          journalAutoPublishEnabled: true,
+          journalDailyEnabled: true,
+          journalWeeklyEnabled: true,
+        },
+        runRequests: [],
+        telemetry: null,
+        recentRuns: [],
+        entryControls: [
+          { entryId: "journal-visible", memoryEligible: true },
+          { entryId: "journal-excluded", memoryEligible: false },
+        ],
+      }),
+    },
+  });
+
+  const response = await route.GET(
+    new Request("https://example.test/api/bnl/journal/control"),
+  );
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.memoryExcludedEntryIds, ["journal-excluded"]);
+  assert.equal(body.entryControls, undefined);
 });
 
 test("legacy control mutation cannot write Journal automation fields", () => {

--- a/tests/bnl-journal-contract.test.mjs
+++ b/tests/bnl-journal-contract.test.mjs
@@ -162,18 +162,56 @@ class FakeRedis {
   async eval(_script, keys, args) {
     this.calls.push(["eval"]);
     if (this.fail === "eval") throw new Error("eval fail");
-    const [recordKey, latestKey, indexKey, dailyIndexKey, weeklyIndexKey] =
+    if (_script.includes("journal-entry-control-v1")) {
+      const [controlsKey, auditKey, indexKey, dailyIndexKey, weeklyIndexKey, latestKey] = keys;
+      const [entryId, controlJson, auditJson, maxAudit] = args;
+      const latestJson = this.kv.get(latestKey);
+      if (!latestJson) return JSON.stringify({ status: "missing" });
+      const latest = JSON.parse(latestJson);
+      const controls = this.kv.get(controlsKey)
+        ? JSON.parse(this.kv.get(controlsKey))
+        : {};
+      const control = JSON.parse(controlJson);
+      controls[entryId] = control;
+      const audit = this.kv.get(auditKey)
+        ? JSON.parse(this.kv.get(auditKey))
+        : [];
+      audit.unshift(JSON.parse(auditJson));
+      this.kv.set(controlsKey, JSON.stringify(controls));
+      this.kv.set(auditKey, JSON.stringify(audit.slice(0, Number(maxAudit))));
+      for (const key of [indexKey, dailyIndexKey, weeklyIndexKey])
+        this.z.get(key)?.delete(entryId);
+      if (control.publicVisible) {
+        await this.zadd(indexKey, { score: latest._score, member: entryId });
+        if (latest.entryKind === "daily")
+          await this.zadd(dailyIndexKey, { score: latest._score, member: entryId });
+        if (latest.entryKind === "weekly")
+          await this.zadd(weeklyIndexKey, { score: latest._score, member: entryId });
+      }
+      return JSON.stringify({ status: "updated", control });
+    }
+    const [recordKey, latestKey, indexKey, dailyIndexKey, weeklyIndexKey, controlsKey] =
       keys;
     const [entryId, revision, contentHash, recordJson, score] = args;
+    const controls = this.kv.get(controlsKey)
+      ? JSON.parse(this.kv.get(controlsKey))
+      : {};
+    const publicVisible = controls[entryId]?.publicVisible !== false;
     const repairKindIndexes = (latest) => {
+      const index =
+        this.z.get(indexKey) ??
+        this.z.set(indexKey, new Map()).get(indexKey);
       const daily =
         this.z.get(dailyIndexKey) ??
         this.z.set(dailyIndexKey, new Map()).get(dailyIndexKey);
       const weekly =
         this.z.get(weeklyIndexKey) ??
         this.z.set(weeklyIndexKey, new Map()).get(weeklyIndexKey);
+      index.delete(entryId);
       daily.delete(entryId);
       weekly.delete(entryId);
+      if (!publicVisible) return;
+      index.set(entryId, latest._score);
       if (latest.entryKind === "daily") daily.set(entryId, latest._score);
       if (latest.entryKind === "weekly") weekly.set(entryId, latest._score);
     };
@@ -190,7 +228,8 @@ class FakeRedis {
       let repairedIndexScore = null;
       if (!latestJson && !inIndex) {
         this.kv.set(latestKey, existingJson);
-        await this.zadd(indexKey, { score: existing._score, member: entryId });
+        if (publicVisible)
+          await this.zadd(indexKey, { score: existing._score, member: entryId });
         repairedLatest = true;
         repairedIndexScore = existing._score;
       } else if (!latestJson && zset.get(entryId) === existing._score) {
@@ -201,14 +240,18 @@ class FakeRedis {
         existing.revision > latest.revision
       ) {
         this.kv.set(latestKey, existingJson);
-        await this.zadd(indexKey, { score: existing._score, member: entryId });
+        if (publicVisible)
+          await this.zadd(indexKey, { score: existing._score, member: entryId });
         repairedLatest = true;
         repairedIndexScore = existing._score;
-      } else if (latest && !inIndex) {
+      } else if (latest && publicVisible && !inIndex) {
         await this.zadd(indexKey, { score: latest._score, member: entryId });
         repairedIndexScore = latest._score;
       }
-      if (!this.kv.get(latestKey) || !this.z.get(indexKey)?.has(entryId))
+      if (
+        !this.kv.get(latestKey) ||
+        (publicVisible && !this.z.get(indexKey)?.has(entryId))
+      )
         return JSON.stringify({ status: "unavailable" });
       const repaired = JSON.parse(this.kv.get(latestKey));
       const repairedScore = this.z.get(indexKey).get(entryId);
@@ -216,7 +259,7 @@ class FakeRedis {
         (repairedLatest &&
           (repaired.revision !== existing.revision ||
             repaired.contentHash !== existing.contentHash)) ||
-        (repairedIndexScore !== null && repairedScore !== repairedIndexScore)
+        (publicVisible && repairedIndexScore !== null && repairedScore !== repairedIndexScore)
       )
         return JSON.stringify({ status: "unavailable" });
       repairKindIndexes(repaired);
@@ -229,12 +272,6 @@ class FakeRedis {
     const latestJson = this.kv.get(latestKey);
     if (!latestJson || JSON.parse(latestJson).revision <= Number(revision)) {
       this.kv.set(latestKey, recordJson);
-      await this.zadd(indexKey, { score: Number(score), member: entryId });
-    } else if (!this.z.get(indexKey)?.has(entryId)) {
-      await this.zadd(indexKey, {
-        score: JSON.parse(latestJson)._score,
-        member: entryId,
-      });
     }
     repairKindIndexes(JSON.parse(this.kv.get(latestKey)));
     return JSON.stringify({ status: "created" });
@@ -570,6 +607,77 @@ test("archive filters paginate over matching entries and constrain neighbors", a
     true,
   );
   assert.equal(redis.calls.filter((call) => call[0] === "zrange").length, 2);
+});
+
+test("entry controls hide immediately, remain recoverable, and keep memory eligibility separate", async () => {
+  const redis = new FakeRedis();
+  const entry = makeEntry({
+    entryId: "controlled-daily-entry",
+    entryKind: "daily",
+  });
+  assert.equal((await store.publishBNLJournalEntry(entry, redis)).ok, true);
+
+  const hidden = await store.updateJournalEntryControl(
+    entry.entryId,
+    false,
+    false,
+    redis,
+  );
+  assert.equal(hidden.ok, true);
+  assert.equal(hidden.control.publicVisible, false);
+  assert.equal(hidden.control.memoryEligible, false);
+  assert.equal(
+    (await store.listBNLJournalArchive(1, redis)).value.entries.length,
+    0,
+  );
+  assert.equal((await store.getBNLJournalEntry(entry.entryId, redis)).value, null);
+
+  const adminHidden = await store.listBNLJournalAdminEntries(redis);
+  assert.equal(adminHidden.ok, true);
+  assert.equal(adminHidden.value.length, 1);
+  assert.equal(adminHidden.value[0].entryId, entry.entryId);
+  assert.equal(adminHidden.value[0].control.publicVisible, false);
+  assert.equal((await store.listJournalEntryControlAudit(redis)).length, 1);
+
+  const revisionTwo = makeEntry({
+    entryId: entry.entryId,
+    revision: 2,
+    entryKind: "daily",
+  });
+  assert.equal((await store.publishBNLJournalEntry(revisionTwo, redis)).ok, true);
+  assert.equal(
+    (await store.listBNLJournalArchive(1, redis)).value.entries.length,
+    0,
+    "a later revision cannot silently republish a hidden entry",
+  );
+
+  const restored = await store.updateJournalEntryControl(
+    entry.entryId,
+    true,
+    false,
+    redis,
+  );
+  assert.equal(restored.ok, true);
+  assert.equal(restored.control.publicVisible, true);
+  assert.equal(restored.control.memoryEligible, false);
+  assert.equal(
+    (await store.getBNLJournalEntry(entry.entryId, redis)).value.revision,
+    2,
+  );
+  assert.equal(
+    (await store.listBNLJournalArchive(1, redis, "daily")).value.entries.length,
+    1,
+  );
+  assert.equal((await store.listJournalEntryControlAudit(redis)).length, 2);
+
+  const missing = await store.updateJournalEntryControl(
+    "missing-entry",
+    false,
+    false,
+    redis,
+  );
+  assert.equal(missing.ok, false);
+  assert.equal(missing.missing, true);
 });
 
 test("idempotent publication repairs the stored kind index without trusting an incoming kind", async () => {


### PR DESCRIPTION
## Summary
- add recoverable per-entry public visibility and BNL-memory eligibility controls to the Journal admin dashboard
- remove hidden entries from public archive/detail navigation while retaining them for admin review
- preserve hidden state across later revisions and expose only memory-excluded entry IDs to the authenticated bot control plane
- record an audit trail for every entry-control change

## Behavior
- turning **Visible to public** off also turns **Available to BNL memory** off
- the memory checkbox remains independent, so an admin can deliberately re-enable memory use without making the entry public
- no entry is deleted

## Validation
- `npm run test:bnl` (62 passed)
- focused Journal tests (17 passed)
- `npm run build`