### PR TITLE
Neutralize archived queue public projections

### DIFF
--- a/src/app/api/bnl/read-model/route.ts
+++ b/src/app/api/bnl/read-model/route.ts
@@ -188,17 +188,22 @@ function disabledQueueProjection() {
 
 async function readPublicLiveQueueForBnl() {
   const state = await getRadioQueueState();
-  const realQueueEntries = state.queue.filter(isRealQueueEntry);
+  const sessionEnded =
+    state.session?.status === "archived" ||
+    state.session?.broadcastPhase === "ended";
+  const realQueueEntries = sessionEnded
+    ? []
+    : state.queue.filter(isRealQueueEntry);
   const realCompletedEntries = state.history
     .filter(isRealQueueEntry)
     .slice(0, 10);
   const realRemovedCount = (state.removed ?? []).filter(
     isRealQueueEntry,
   ).length;
-  const realNowPlaying = isRealQueueEntry(state.nowPlaying)
+  const realNowPlaying = !sessionEnded && isRealQueueEntry(state.nowPlaying)
     ? state.nowPlaying
     : null;
-  const realUpNext = isRealQueueEntry(state.nextInLine)
+  const realUpNext = !sessionEnded && isRealQueueEntry(state.nextInLine)
     ? state.nextInLine
     : null;
   const activeIds = new Set<string>();
@@ -225,19 +230,23 @@ async function readPublicLiveQueueForBnl() {
         title: state.session?.title ?? "",
         showDate: state.session?.showDate ?? "",
         status: state.session?.status ?? "prepared",
-        queueOpen: state.session?.queueOpen === true,
+        queueOpen: !sessionEnded && state.session?.queueOpen === true,
         broadcastPhase: state.session?.broadcastPhase ?? null,
         activeCount,
         completedCount: publicCompletedTracks.length,
         removedCount: realRemovedCount,
-        wheelSpinsOwed: state.session?.wheelSpinsOwed ?? 0,
+        wheelSpinsOwed: sessionEnded
+          ? 0
+          : state.session?.wheelSpinsOwed ?? 0,
         priorityUpgradesEnabled:
-          state.session?.priorityUpgradesEnabled === true,
+          !sessionEnded && state.session?.priorityUpgradesEnabled === true,
         priorityUpgradeLabel:
           state.session?.priorityUpgradeLabel ?? "Priority Signal",
       },
       status: {
-        isOpen: state.publicStatus?.isOpen ?? state.session?.queueOpen === true,
+        isOpen:
+          !sessionEnded &&
+          (state.publicStatus?.isOpen ?? state.session?.queueOpen === true),
         activeCount,
         capacity,
         pressure: pressureFor(activeCount, capacity),

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1678,6 +1678,47 @@ export async function getPublicQueueSnapshot(sessionId?: string, identity?: { su
   changed = (await resolvePublicArtworkForSession(session)) || changed;
   if (changed) await writeStore(replaceSession(store, session));
   const normalized = normalizeSession(session);
+  if (normalized.status === "archived") {
+    const publicCompletedEntries = normalized.completed.filter((entry) => !isSimulationTrack(entry));
+    const publicRemovedEntries = normalized.removed.filter((entry) => !isSimulationTrack(entry));
+    const publicSpotlightEntries = normalized.spotlight.filter((entry) => !isSimulationTrack(entry));
+    const publicSession = summarizeSession(normalized);
+    const archivedPublicSession: QueueSessionSummary = {
+      ...publicSession,
+      queueOpen: false,
+      showStarted: false,
+      preShowEndsAt: null,
+      activeCount: 0,
+      nextInLineTrackId: null,
+      nextInLineHoldTrackId: null,
+      loadedTrackId: null,
+      completedCount: publicCompletedEntries.length,
+      removedCount: publicRemovedEntries.length,
+      spotlightCount: publicSpotlightEntries.length,
+      estimatedActiveRuntimeSeconds: 0,
+      completedRuntimeSeconds: publicCompletedEntries.reduce((sum, entry) => sum + getTrackRuntimeSeconds(entry), 0),
+      wheelSpinsOwed: 0,
+      priorityUpgradesEnabled: false,
+      priorityUpgradePaymentsEnabled: false,
+    };
+
+    return {
+      session: archivedPublicSession,
+      status: {
+        isOpen: false,
+        activeCount: 0,
+        estimatedRuntimeSeconds: 0,
+        capacity: normalized.publicStatus.capacity,
+        isFull: false,
+        pressure: "low",
+      },
+      queue: [],
+      completed: publicCompletedEntries.slice(0, 10).map(toPublicQueueTrack),
+      nowPlaying: null,
+      upNext: null,
+      submitterStatus: null,
+    };
+  }
   return { session: summarizeSession(normalized), status: normalized.publicStatus, queue: normalized.queue.map(toPublicQueueTrack), completed: normalized.completed.slice(0, 10).map(toPublicQueueTrack), nowPlaying: normalized.loadedTrack ? toPublicQueueTrack(normalized.loadedTrack) : null, upNext: normalized.nextInLineTrack ? toPublicQueueTrack(normalized.nextInLineTrack) : null, submitterStatus: publicSubmitterStatus(normalized, identity) };
 }
 

--- a/tests/queue-playback.test.mjs
+++ b/tests/queue-playback.test.mjs
@@ -961,6 +961,74 @@ test("ending broadcast is separate from closing submissions", async () => {
   assert.equal(state.streamStatus, "offline");
 });
 
+test("archived public snapshots neutralize active lanes while preserving the real completed log", async () => {
+  const sessionId = await freshOpenSession("archived public projection");
+  const completedRealTrack = await addTrack("Archived Completed Real");
+
+  let state = await queue.updateRadioTrack("", "pullNext");
+  assert.equal(state.nextInLine?.id, completedRealTrack.id);
+  state = await queue.updateRadioTrack(completedRealTrack.id, "load");
+  state = await queue.updateRadioTrack(completedRealTrack.id, "finish");
+  assert.ok(completedTrack(state, completedRealTrack.id));
+
+  state = await queue.updateRadioTrack("", "addSimulationPaidPriority");
+  state = await queue.updateRadioTrack("", "addSimulationFreeTrack");
+  const archivedSimulationIds = [
+    state.nextInLine,
+    ...state.queue,
+  ].filter((entry) => entry?.isTestTrack).map((entry) => entry.id);
+  assert.equal(archivedSimulationIds.length, 2, "archive should retain both simulation tracks internally");
+
+  await queue.archiveCurrentQueueSession();
+
+  for (const publicSnapshot of [
+    await queue.getPublicQueueSnapshot(),
+    await queue.getPublicQueueSnapshot(sessionId),
+  ]) {
+    assert.equal(publicSnapshot.session.status, "archived");
+    assert.equal(publicSnapshot.session.broadcastPhase, "ended");
+    assert.equal(publicSnapshot.session.queueOpen, false);
+    assert.equal(publicSnapshot.session.showStarted, false);
+    assert.equal(publicSnapshot.session.activeCount, 0);
+    assert.equal(publicSnapshot.session.nextInLineTrackId, null);
+    assert.equal(publicSnapshot.session.loadedTrackId, null);
+    assert.equal(publicSnapshot.session.priorityUpgradesEnabled, false);
+    assert.equal(publicSnapshot.session.priorityUpgradePaymentsEnabled, false);
+    assert.equal(publicSnapshot.status.isOpen, false);
+    assert.equal(publicSnapshot.status.activeCount, 0);
+    assert.equal(publicSnapshot.status.estimatedRuntimeSeconds, 0);
+    assert.equal(publicSnapshot.status.pressure, "low");
+    assert.equal(publicSnapshot.status.isFull, false);
+    assert.deepEqual(publicSnapshot.queue, []);
+    assert.equal(publicSnapshot.nowPlaying, null);
+    assert.equal(publicSnapshot.upNext, null);
+    assert.equal(publicSnapshot.submitterStatus, null);
+    assert.ok(publicSnapshot.completed.some((track) => track.id === completedRealTrack.id));
+    assert.equal(archivedSimulationIds.some((id) => JSON.stringify(publicSnapshot).includes(id)), false);
+  }
+
+  const archivedAdminState = await queue.getRadioQueueState(sessionId);
+  const retainedSimulationIds = [
+    archivedAdminState.nextInLine,
+    ...archivedAdminState.queue,
+  ].filter((entry) => entry?.isTestTrack).map((entry) => entry.id);
+  assert.deepEqual(new Set(retainedSimulationIds), new Set(archivedSimulationIds), "admin archive retains its original simulation records");
+
+  const readModelRoute = require("../src/app/api/bnl/read-model/route.ts");
+  const readModel = await (await readModelRoute.GET()).json();
+  assert.equal(readModel.sections.queue.session.status, "archived");
+  assert.equal(readModel.sections.queue.session.queueOpen, false);
+  assert.equal(readModel.sections.queue.session.activeCount, 0);
+  assert.equal(readModel.sections.queue.session.priorityUpgradesEnabled, false);
+  assert.equal(readModel.sections.queue.status.isOpen, false);
+  assert.equal(readModel.sections.queue.status.activeCount, 0);
+  assert.deepEqual(readModel.sections.queue.queue, []);
+  assert.equal(readModel.sections.queue.nowPlaying, null);
+  assert.equal(readModel.sections.queue.upNext, null);
+  assert.ok(readModel.sections.queue.completed.some((track) => track.id === completedRealTrack.id));
+  assert.equal(archivedSimulationIds.some((id) => JSON.stringify(readModel.sections).includes(id)), false);
+});
+
 
 
 test("new sessions default queue capacity to 44", async () => {


### PR DESCRIPTION
## What changed

- return inert public queue snapshots for archived sessions while preserving the real completed-track log
- suppress archived active lanes and operational flags from the BNL read model
- retain the underlying admin archive records unchanged
- add regression coverage for scoped and unscoped public projections, admin archive retention, and BNL filtering

## Why

Ending the July 18 rehearsal correctly archived the session, but the public API still projected preserved simulation tracks as waiting, up next, and runtime. The native cutover would route visitors to that misleading archived state.

## Impact

This is a read-only projection fix. It does not change queue ordering, playback, submissions, Wheel, Priority mechanics, payments, provider handling, or archive storage.

## Validation

- `npm run typecheck`
- targeted ESLint for the changed files
- `npm run test:queue` — 176 passed
- queue playback regression suite — 106 passed
- BNL and capability suites — 48 passed
- `git diff --check`