### PR TITLE
Add BNL-01 Hub with public relay history and Journal

### DIFF
--- a/docs/bnl-presence-relay-contract-v2.md
+++ b/docs/bnl-presence-relay-contract-v2.md
@@ -36,6 +36,8 @@ Source classes are `fresh_public_event`, `recent_public_continuity`, `scoped_bro
 
 Public `GET /api/bnl/status` still returns flat compatibility fields: `status`, `mode`, `message`, `currentDirective`, `source`, `lastSeen`, and `persisted`. It may also include `contractVersion: 2`, `presence`, and `relay`; `relay` is `null` until a validated v2 relay envelope has been accepted. `adminNote`, Redis keys, force-pull status paths, webhook data, secrets, and internal compatibility metadata are not public.
 
+The BNL-01 Hub reads the canonical v2 relay history directly on the server and projects at most the newest 20 accepted records. Each public history item contains only `message` (surface reading), `currentDirective` (network posture), and `publishedAt` (transmission date/time). The global status endpoint and its polling payload remain unchanged.
+
 ## v1 compatibility
 
 The existing flat authenticated payload (`status`, `mode`, `message`, `currentDirective`, `source`, `adminNote`) remains accepted and stored in the existing v1 keys. Existing v1 force-pull, status, history, and admin contracts are not migrated or rewritten. When no v2 relay record exists, the website keeps the latest v1 status in the flat compatibility fields exactly as stored, including its original `source`; the structured `relay` field remains `null` and no legacy record is classified as `grounded_reflection`, `scheduled`, or any accepted v2 relay.

--- a/src/app/bnl/page.tsx
+++ b/src/app/bnl/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { BNLRelayModule } from "@/components/BNLRelay";
+import {
+  JournalArchiveCard,
+  JournalArticle,
+} from "@/components/journal/JournalArticle";
+import { listBNLJournalArchive } from "@/lib/bnl-journal-store";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "BNL-01 Public Liaison",
+  description:
+    "The current public BNL-01 relay signal and BNL-01 Community Journal field log.",
+};
+
+export default async function BNLPage() {
+  const archive = await listBNLJournalArchive(1);
+  const entries = archive.ok ? (archive.value?.entries ?? []) : [];
+  const [latest, ...recent] = entries;
+
+  return (
+    <div className="pt-14">
+      <section className="border-b border-border noise-bg">
+        <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6">
+          <p className="text-xs uppercase tracking-[0.45em] text-accent">
+            {"// NETWORK LIAISON // PUBLIC SIGNAL"}
+          </p>
+          <h1 className="mt-4 text-4xl font-black tracking-tight text-foreground sm:text-6xl">
+            BNL-01
+          </h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-foreground/70 sm:text-lg">
+            One public surface for BNL-01&apos;s current Network relay and
+            Community Journal field log.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link
+              href="/journal"
+              className="inline-flex items-center border border-accent px-5 py-3 font-mono text-xs uppercase tracking-widest text-accent transition-colors hover:bg-accent hover:text-background"
+            >
+              Open the full Journal →
+            </Link>
+            <Link
+              href="/database/bnl-01"
+              className="inline-flex items-center border border-border-light px-5 py-3 font-mono text-xs uppercase tracking-widest text-foreground/70 transition-colors hover:border-foreground hover:text-foreground"
+            >
+              Read the BNL-01 dossier →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border">
+        <div className="mx-auto grid max-w-7xl gap-6 px-4 py-12 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+          <div className="border border-border bg-background/60 p-6 sm:p-8">
+            <p className="text-xs uppercase tracking-[0.4em] text-muted">
+              What BNL-01 does
+            </p>
+            <h2 className="mt-4 text-2xl font-black tracking-tight text-foreground sm:text-4xl">
+              Discord liaison and website relay
+            </h2>
+            <p className="mt-5 text-base leading-8 text-foreground/70">
+              BNL-01 connects approved public Discord-side activity and
+              grounded Network status to website relay surfaces. It helps keep
+              public BARCODE Network information consistent across community
+              discussions, live broadcasts, and public transmissions.
+            </p>
+            <p className="mt-4 text-base leading-8 text-foreground/70">
+              This is not an embedded chatbot, an autonomous site operator, or
+              a replacement for BARCODE Radio submissions. Private Discord
+              activity and restricted Network records do not belong on this
+              public surface.
+            </p>
+          </div>
+          <BNLRelayModule title="Current BNL-01 Signal" />
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-12 sm:px-6 sm:py-16">
+        <div className="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-accent">
+              {"// COMMUNITY JOURNAL"}
+            </p>
+            <h2 className="mt-3 text-3xl font-black tracking-tight text-foreground sm:text-5xl">
+              BNL-01&apos;s public field log
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-foreground/70">
+              Periodic observations drawn from public community activity,
+              continuing conversations, and recurring Network patterns.
+            </p>
+          </div>
+          <Link
+            href="/journal"
+            className="shrink-0 font-mono text-xs uppercase tracking-widest text-accent hover:text-foreground"
+          >
+            Browse every public entry →
+          </Link>
+        </div>
+
+        {!archive.ok ? (
+          <div
+            role="status"
+            className="border border-danger/40 bg-surface p-6 sm:p-8"
+          >
+            <p className="text-xs uppercase tracking-[0.4em] text-danger">
+              Journal signal unavailable
+            </p>
+            <p className="mt-3 max-w-2xl text-foreground/70">
+              The public Journal archive cannot be read right now. The current
+              BNL-01 relay above remains available while the Journal retries on
+              the next page load.
+            </p>
+          </div>
+        ) : !latest ? (
+          <div className="border border-border bg-surface p-6 text-foreground/70 sm:p-8">
+            No public Journal entries have been published yet.
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <JournalArticle entry={latest} prominent titleLevel="h2" />
+            <aside className="space-y-4">
+              <p className="font-mono text-xs uppercase tracking-[0.35em] text-foreground/60">
+                Recent entries
+              </p>
+              {recent.slice(0, 4).map((entry) => (
+                <JournalArchiveCard
+                  key={`${entry.entryId}-${entry.revision}`}
+                  entry={entry}
+                />
+              ))}
+              {recent.length === 0 ? (
+                <p className="border border-border bg-background/60 p-4 text-sm leading-6 text-foreground/60">
+                  This is the only public Journal entry so far.
+                </p>
+              ) : null}
+            </aside>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/bnl/page.tsx
+++ b/src/app/bnl/page.tsx
@@ -1,21 +1,25 @@
 import Link from "next/link";
-import { BNLRelayModule } from "@/components/BNLRelay";
+import { BNLRelayHistoryModule } from "@/components/BNLRelayHistory";
 import {
   JournalArchiveCard,
   JournalArticle,
 } from "@/components/journal/JournalArticle";
 import { listBNLJournalArchive } from "@/lib/bnl-journal-store";
+import { listBNLPublicRelayHistory } from "@/lib/bnl-status-store";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "BNL-01 Public Liaison",
+  title: "BNL-01 Hub",
   description:
-    "The current public BNL-01 relay signal and BNL-01 Community Journal field log.",
+    "BNL-01's public home for recent Network relays and the Community Journal field log.",
 };
 
 export default async function BNLPage() {
-  const archive = await listBNLJournalArchive(1);
+  const [archive, relayHistory] = await Promise.all([
+    listBNLJournalArchive(1),
+    listBNLPublicRelayHistory(),
+  ]);
   const entries = archive.ok ? (archive.value?.entries ?? []) : [];
   const [latest, ...recent] = entries;
 
@@ -24,13 +28,13 @@ export default async function BNLPage() {
       <section className="border-b border-border noise-bg">
         <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6">
           <p className="text-xs uppercase tracking-[0.45em] text-accent">
-            {"// NETWORK LIAISON // PUBLIC SIGNAL"}
+            {"// BNL-01 HUB // PUBLIC SIGNAL"}
           </p>
           <h1 className="mt-4 text-4xl font-black tracking-tight text-foreground sm:text-6xl">
-            BNL-01
+            BNL-01 Hub
           </h1>
           <p className="mt-5 max-w-3xl text-base leading-7 text-foreground/70 sm:text-lg">
-            One public surface for BNL-01&apos;s current Network relay and
+            BNL-01&apos;s public home for recent Network relays and the
             Community Journal field log.
           </p>
           <div className="mt-8 flex flex-wrap gap-3">
@@ -51,7 +55,7 @@ export default async function BNLPage() {
       </section>
 
       <section className="border-b border-border">
-        <div className="mx-auto grid max-w-7xl gap-6 px-4 py-12 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+        <div className="mx-auto grid max-w-7xl gap-6 px-4 py-12 sm:px-6 lg:grid-cols-[0.75fr_1.25fr] lg:items-start">
           <div className="border border-border bg-background/60 p-6 sm:p-8">
             <p className="text-xs uppercase tracking-[0.4em] text-muted">
               What BNL-01 does
@@ -72,7 +76,10 @@ export default async function BNLPage() {
               public surface.
             </p>
           </div>
-          <BNLRelayModule title="Current BNL-01 Signal" />
+          <BNLRelayHistoryModule
+            entries={relayHistory.value}
+            unavailable={!relayHistory.ok}
+          />
         </div>
       </section>
 
@@ -107,9 +114,9 @@ export default async function BNLPage() {
               Journal signal unavailable
             </p>
             <p className="mt-3 max-w-2xl text-foreground/70">
-              The public Journal archive cannot be read right now. The current
-              BNL-01 relay above remains available while the Journal retries on
-              the next page load.
+              {relayHistory.ok
+                ? "The public Journal archive cannot be read right now. The recent BNL-01 relay history above remains available while the Journal retries on the next page load."
+                : "The public Journal archive and relay history cannot be read right now. Both will retry on the next page load."}
             </p>
           </div>
         ) : !latest ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -184,7 +184,7 @@ export default function Home() {
               BNL-01 is the Network’s Discord liaison and website relay system. It connects public Discord-side activity and approved Network status to website relay surfaces; it is not an embedded chatbot, autonomous site operator, or replacement for BARCODE Radio submissions.
             </p>
             <Link href="/bnl" className="mt-5 inline-flex text-sm font-mono uppercase tracking-widest text-accent hover:text-foreground">
-              Open the BNL-01 hub →
+              Open the BNL-01 Hub →
             </Link>
           </div>
           <BNLRelayModule title="Latest Network Relay" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -183,8 +183,8 @@ export default function Home() {
             <p className="text-base leading-relaxed text-muted">
               BNL-01 is the Network’s Discord liaison and website relay system. It connects public Discord-side activity and approved Network status to website relay surfaces; it is not an embedded chatbot, autonomous site operator, or replacement for BARCODE Radio submissions.
             </p>
-            <Link href="/journal" className="mt-5 inline-flex text-sm font-mono uppercase tracking-widest text-accent hover:text-foreground">
-              Read BNL-01’s Journal →
+            <Link href="/bnl" className="mt-5 inline-flex text-sm font-mono uppercase tracking-widest text-accent hover:text-foreground">
+              Open the BNL-01 hub →
             </Link>
           </div>
           <BNLRelayModule title="Latest Network Relay" />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: base, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
     { url: `${base}/radio`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${base}/database`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/bnl`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: `${base}/journal`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: `${base}/releases`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
     { url: `${base}/merch`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },

--- a/src/components/BNLRelayHistory.tsx
+++ b/src/components/BNLRelayHistory.tsx
@@ -1,0 +1,105 @@
+import type { BNLPublicRelayHistoryEntry } from "@/lib/bnl-presence-relay-contract";
+
+function formatTransmissionTime(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Time unavailable";
+
+  return `${new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(parsed)} UTC`;
+}
+
+export function BNLRelayHistoryModule({
+  entries,
+  unavailable = false,
+}: {
+  entries: BNLPublicRelayHistoryEntry[];
+  unavailable?: boolean;
+}) {
+  const headingId = "recent-bnl-relays-heading";
+
+  return (
+    <section className="border border-border bg-surface p-6 sm:p-8">
+      <div className="mb-5 flex flex-col justify-between gap-2 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs uppercase tracking-[0.4em] text-accent">
+            {"// PUBLIC SIGNAL HISTORY"}
+          </p>
+          <h2
+            id={headingId}
+            className="mt-3 text-2xl font-black tracking-tight text-foreground sm:text-3xl"
+          >
+            Recent BNL-01 relays
+          </h2>
+        </div>
+        <p className="font-mono text-[11px] uppercase tracking-[0.25em] text-muted">
+          Newest first · up to 20
+        </p>
+      </div>
+
+      {unavailable ? (
+        <div role="status" className="border border-danger/40 bg-background/60 p-5">
+          <p className="text-xs uppercase tracking-[0.35em] text-danger">
+            Relay history unavailable
+          </p>
+          <p className="mt-3 text-sm leading-6 text-foreground/70">
+            The public relay archive cannot be read right now. It will retry on
+            the next page load.
+          </p>
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="border border-border bg-background/60 p-5 text-sm leading-6 text-foreground/70">
+          No public BNL-01 relays have been published yet.
+        </p>
+      ) : (
+        <ol
+          aria-labelledby={headingId}
+          tabIndex={0}
+          className="max-h-[34rem] space-y-4 overflow-y-auto overscroll-contain pr-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent"
+        >
+          {entries.slice(0, 20).map((entry, index) => (
+            <li
+              key={`${entry.publishedAt}-${index}`}
+              className="border border-border bg-background/60 p-5"
+            >
+              <dl className="space-y-4">
+                <div>
+                  <dt className="font-mono text-[11px] uppercase tracking-[0.3em] text-muted">
+                    Surface reading
+                  </dt>
+                  <dd className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-foreground/80">
+                    {entry.message}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-mono text-[11px] uppercase tracking-[0.3em] text-muted">
+                    Network posture
+                  </dt>
+                  <dd className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-foreground/80">
+                    {entry.currentDirective}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-mono text-[11px] uppercase tracking-[0.3em] text-muted">
+                    Transmission date / time
+                  </dt>
+                  <dd className="mt-2 font-mono text-xs uppercase tracking-[0.18em] text-foreground/70">
+                    <time dateTime={entry.publishedAt}>
+                      {formatTransmissionTime(entry.publishedAt)}
+                    </time>
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,8 +58,8 @@ export function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="/journal" className="text-sm text-foreground/70 hover:text-accent transition-colors">
-                  BNL Journal
+                <Link href="/bnl" className="text-sm text-foreground/70 hover:text-accent transition-colors">
+                  BNL-01 Hub
                 </Link>
               </li>
             </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ const navItems = [
   { href: "/terminal", label: "Terminal" },
   { href: "/radio", label: "Radio" },
   { href: "/database", label: "Database" },
-  { href: "/journal", label: "Journal" },
+  { href: "/bnl", label: "BNL-01 Hub" },
   { href: "/releases", label: "Releases" },
   { href: "/transmissions", label: "Transmissions" },
   { href: "/merch", label: "Merch" },
@@ -22,6 +22,17 @@ const navItems = [
 const mobileNavItems = navItems.map((item) =>
   item.href === "/terminal" ? { ...item, label: "Terminal Archive" } : item,
 );
+
+function isNavItemActive(pathname: string, href: string) {
+  if (href === "/bnl") {
+    return (
+      pathname === "/bnl" ||
+      pathname === "/journal" ||
+      pathname.startsWith("/journal/")
+    );
+  }
+  return pathname === href;
+}
 
 export function Header() {
   const pathname = usePathname();
@@ -58,7 +69,7 @@ export function Header() {
 
           <nav className="hidden xl:flex items-center gap-1">
             {navItems.map((item) => {
-              const isActive = pathname === item.href;
+              const isActive = isNavItemActive(pathname, item.href);
               return (
                 <Link
                   key={item.href}
@@ -127,7 +138,7 @@ function MobileMenu({ pathname }: { pathname: string }) {
         <div id={menuId} className="absolute top-14 left-0 right-0 bg-background border-b border-border p-4">
           <nav className="flex flex-col gap-2">
             {mobileNavItems.map((item) => {
-              const isActive = pathname === item.href;
+              const isActive = isNavItemActive(pathname, item.href);
               return (
                 <Link
                   key={item.href}

--- a/src/lib/bnl-presence-relay-contract.ts
+++ b/src/lib/bnl-presence-relay-contract.ts
@@ -9,6 +9,10 @@ export type BNLV1Status = { status: BNLStatusValue; mode: BNLModeValue; message:
 export type BNLV1HistoryEntry = { timestamp: string; status: BNLStatusValue; mode: BNLModeValue; currentDirective?: string; message: string; source: BNLSourceValue; adminNote?: string; persisted?: boolean };
 export type BNLV2PresenceRecord = { contractVersion: 2; status: BNLStatusValue; mode: BNLModeValue; source: BNLV2PresenceSource; receivedAt: string };
 export type BNLV2RelayRecord = { contractVersion: 2; relayId: string; message: string; currentDirective: string; sourceClass: BNLV2RelaySourceClass; trigger: BNLV2RelayTrigger; publishedAt: string };
+export type BNLPublicRelayHistoryEntry = Pick<
+  BNLV2RelayRecord,
+  "message" | "currentDirective" | "publishedAt"
+>;
 export type BNLCurrentView = Omit<BNLV1Status, "adminNote"> & { persisted: boolean; contractVersion: 2; presence: BNLV2PresenceRecord; relay: BNLV2RelayRecord | null };
 export type BNLRelayStorageDecision =
   | { action: "insert"; relay: BNLV2RelayRecord; history: BNLV2RelayRecord[] }
@@ -20,6 +24,7 @@ export const BNL_V1_HISTORY_KEY = "bnl:history";
 export const BNL_V2_PRESENCE_KEY = "bnl:presence:v2";
 export const BNL_V2_RELAY_CURRENT_KEY = "bnl:relay:current:v2";
 export const BNL_V2_RELAY_HISTORY_KEY = "bnl:relay:history:v2";
+export const PUBLIC_BNL_RELAY_HISTORY_LIMIT = 20;
 export const MAX_MESSAGE_LENGTH = 600;
 export const MAX_DIRECTIVE_LENGTH = 800;
 export const MAX_ADMIN_NOTE_LENGTH = 400;
@@ -56,6 +61,17 @@ export function parseV2RelayWrite(body: unknown, now: string): BNLV2RelayRecord 
 export function sanitizeStoredV2Presence(value: unknown): BNLV2PresenceRecord | null { if (!isRecord(value)) return null; try { exactKeys(value, ["contractVersion", "status", "mode", "source", "receivedAt"]); if (value.contractVersion !== 2 || typeof value.receivedAt !== "string") return null; return { contractVersion: 2, status: enumValue(value.status, statuses), mode: enumValue(value.mode, modes), source: enumValue(value.source, presenceSources), receivedAt: value.receivedAt }; } catch { return null; } }
 export function sanitizeStoredV2Relay(value: unknown): BNLV2RelayRecord | null { if (!isRecord(value)) return null; try { exactKeys(value, ["contractVersion", "relayId", "message", "currentDirective", "sourceClass", "trigger", "publishedAt"]); if (value.contractVersion !== 2 || typeof value.publishedAt !== "string") return null; return { contractVersion: 2, relayId: relayId(value.relayId), message: text(value.message, MAX_MESSAGE_LENGTH)!, currentDirective: text(value.currentDirective, MAX_DIRECTIVE_LENGTH)!, sourceClass: enumValue(value.sourceClass, sourceClasses), trigger: enumValue(value.trigger, triggers), publishedAt: value.publishedAt }; } catch { return null; } }
 export function sanitizeRelayHistory(value: unknown): BNLV2RelayRecord[] { return Array.isArray(value) ? value.map(sanitizeStoredV2Relay).filter((x): x is BNLV2RelayRecord => Boolean(x)).slice(0, 25) : []; }
+export function serializePublicRelayHistory(
+  value: unknown,
+): BNLPublicRelayHistoryEntry[] {
+  return sanitizeRelayHistory(value)
+    .slice(0, PUBLIC_BNL_RELAY_HISTORY_LIMIT)
+    .map(({ message, currentDirective, publishedAt }) => ({
+      message,
+      currentDirective,
+      publishedAt,
+    }));
+}
 function sameRelayContent(a: BNLV2RelayRecord, b: BNLV2RelayRecord): boolean { return a.relayId === b.relayId && a.message === b.message && a.currentDirective === b.currentDirective && a.sourceClass === b.sourceClass && a.trigger === b.trigger; }
 export function decideRelayStorage(input: { current: BNLV2RelayRecord | null; history: BNLV2RelayRecord[]; relay: BNLV2RelayRecord }): BNLRelayStorageDecision { const existing = [input.current, ...input.history].filter((item): item is BNLV2RelayRecord => Boolean(item)).find((item) => item.relayId === input.relay.relayId); if (existing) { if (!sameRelayContent(existing, input.relay)) return { action: "conflict", relay: existing, history: input.history }; return { action: "idempotent", relay: existing, history: input.history }; } return { action: "insert", relay: input.relay, history: [input.relay, ...input.history].slice(0, 25) }; }
 export function upsertRelayHistory(history: BNLV2RelayRecord[], relay: BNLV2RelayRecord): { history: BNLV2RelayRecord[]; changed: boolean } { const decision = decideRelayStorage({ current: null, history, relay }); if (decision.action === "conflict") throw new BNLContractConflictError(); return { history: decision.history, changed: decision.action === "insert" }; }

--- a/src/lib/bnl-status-store.ts
+++ b/src/lib/bnl-status-store.ts
@@ -15,12 +15,14 @@ import {
   sanitizeStoredV2Presence,
   sanitizeV1History,
   serializePublicCurrentView,
+  serializePublicRelayHistory,
   v1HistoryEntryFromStatus,
   type BNLCurrentView,
   type BNLV1HistoryEntry,
   type BNLV1Status,
   type BNLV2PresenceRecord,
   type BNLV2RelayRecord,
+  type BNLPublicRelayHistoryEntry,
 } from "@/lib/bnl-presence-relay-contract";
 
 export const BNL_NO_STORE_HEADERS = { "Cache-Control": "no-store, no-cache, must-revalidate" };
@@ -66,6 +68,45 @@ export async function readBNLAdminState(redis = getBNLRedis()) {
     legacyHistory: memoryHistory,
     persisted: Boolean(redis),
   };
+}
+
+export type BNLPublicRelayHistoryResult =
+  | {
+      ok: true;
+      value: BNLPublicRelayHistoryEntry[];
+      persisted: boolean;
+    }
+  | {
+      ok: false;
+      value: [];
+      persisted: boolean;
+      unavailable: true;
+    };
+
+export async function listBNLPublicRelayHistory(
+  redis?: Redis | null,
+): Promise<BNLPublicRelayHistoryResult> {
+  let persisted = false;
+  try {
+    const relayRedis = redis === undefined ? getBNLRedis() : redis;
+    persisted = Boolean(relayRedis);
+    const stored = relayRedis
+      ? await relayRedis.get<unknown>(BNL_V2_RELAY_HISTORY_KEY)
+      : memoryRelayHistory;
+    memoryRelayHistory = sanitizeRelayHistory(stored);
+    return {
+      ok: true,
+      value: serializePublicRelayHistory(memoryRelayHistory),
+      persisted,
+    };
+  } catch {
+    return {
+      ok: false,
+      value: [],
+      persisted,
+      unavailable: true,
+    };
+  }
 }
 
 export async function appendLegacyBNLHistory(entry: BNLV1HistoryEntry, redis = getBNLRedis()) {

--- a/tests/bnl-presence-relay-contract.test.mjs
+++ b/tests/bnl-presence-relay-contract.test.mjs
@@ -2,11 +2,39 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import vm from 'node:vm';
 import ts from 'typescript';
 
 let source = readFileSync(resolve('src/lib/bnl-presence-relay-contract.ts'), 'utf8');
 const js = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 } }).outputText;
 const mod = await import(`data:text/javascript,${encodeURIComponent(js)}`);
+
+function loadStatusStore() {
+  const file = resolve('src/lib/bnl-status-store.ts');
+  const code = ts.transpileModule(readFileSync(file, 'utf8'), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+    },
+  }).outputText;
+  const cjsModule = { exports: {} };
+  vm.runInNewContext(
+    code,
+    {
+      require: (id) => {
+        if (id === '@upstash/redis') return { Redis: class Redis {} };
+        if (id === '@/lib/bnl-presence-relay-contract') return mod;
+        throw new Error(`unmocked import ${id} in ${file}`);
+      },
+      exports: cjsModule.exports,
+      module: cjsModule,
+      process,
+    },
+    { filename: file },
+  );
+  return cjsModule.exports;
+}
 
 const now = '2026-07-15T00:00:00.000Z';
 const v1Body = { status: 'ONLINE', mode: 'OBSERVATION', message: 'relay speech', currentDirective: 'listen', source: 'forcePull', adminNote: 'private' };
@@ -101,6 +129,80 @@ test('public serialization excludes injected admin notes, force-pull internals, 
   assert.equal(json.includes('statusPath'), false);
   assert.equal(json.includes('bnl:'), false);
   assert.equal(json.includes('secret'), false);
+});
+
+test('public relay history filters first, caps at 20, and exposes exactly the three approved fields', () => {
+  const valid = Array.from({ length: 22 }, (_, index) => ({
+    contractVersion: 2,
+    relayId: `relay-${String(index).padStart(3, '0')}`,
+    message: `message-${index}`,
+    currentDirective: `directive-${index}`,
+    sourceClass: 'approved_canon',
+    trigger: 'scheduled',
+    publishedAt: `2026-07-19T${String(index % 24).padStart(2, '0')}:00:00.000Z`,
+  }));
+  const legacy = {
+    timestamp: now,
+    status: 'ONLINE',
+    mode: 'OBSERVATION',
+    message: 'legacy speech',
+    source: 'relay',
+  };
+  const serialized = mod.serializePublicRelayHistory([
+    { malformed: true },
+    legacy,
+    ...valid,
+    { ...valid[0], extra: 'private' },
+  ]);
+
+  assert.equal(serialized.length, 20);
+  assert.deepEqual(serialized[0], {
+    message: 'message-0',
+    currentDirective: 'directive-0',
+    publishedAt: '2026-07-19T00:00:00.000Z',
+  });
+  assert.equal(serialized.at(-1).message, 'message-19');
+  assert.deepEqual(Object.keys(serialized[0]), [
+    'message',
+    'currentDirective',
+    'publishedAt',
+  ]);
+  const json = JSON.stringify(serialized);
+  assert.equal(json.includes('relayId'), false);
+  assert.equal(json.includes('sourceClass'), false);
+  assert.equal(json.includes('trigger'), false);
+  assert.equal(json.includes('legacy speech'), false);
+  assert.equal(json.includes('private'), false);
+});
+
+test('public relay history reader uses only canonical v2 storage and fails closed', async () => {
+  const relay = mod.parseV2RelayWrite(relayBody, now);
+  const requestedKeys = [];
+  const store = loadStatusStore();
+  const success = await store.listBNLPublicRelayHistory({
+    get: async (key) => {
+      requestedKeys.push(key);
+      return [relay];
+    },
+  });
+
+  assert.equal(success.ok, true);
+  assert.deepEqual(requestedKeys, [mod.BNL_V2_RELAY_HISTORY_KEY]);
+  assert.equal(success.value.length, 1);
+  assert.deepEqual(Object.keys(success.value[0]), [
+    'message',
+    'currentDirective',
+    'publishedAt',
+  ]);
+
+  const failure = await loadStatusStore().listBNLPublicRelayHistory({
+    get: async () => {
+      throw new Error('redis unavailable');
+    },
+  });
+  assert.equal(failure.ok, false);
+  assert.equal(failure.unavailable, true);
+  assert.equal(failure.value.length, 0);
 });
 
 test('every legacy v1 source retains exact flat source and never becomes structured relay provenance', () => {

--- a/tests/bnl-public-hub.test.mjs
+++ b/tests/bnl-public-hub.test.mjs
@@ -11,7 +11,10 @@ const require = createRequire(import.meta.url);
 const read = (path) =>
   fs.readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
 
-function loadHub(readArchive) {
+function loadHub(
+  readArchive,
+  readRelayHistory = async () => ({ ok: true, value: [] }),
+) {
   const file = "src/app/bnl/page.tsx";
   const code = ts.transpileModule(read(file), {
     compilerOptions: {
@@ -33,10 +36,14 @@ function loadHub(readArchive) {
           children,
         );
       };
-    if (id === "@/components/BNLRelay")
+    if (id === "@/components/BNLRelayHistory")
       return {
-        BNLRelayModule: ({ title }) =>
-          React.createElement("div", { "data-relay": true }, title),
+        BNLRelayHistoryModule: ({ entries, unavailable }) =>
+          React.createElement("div", {
+            "data-relay-history": true,
+            "data-relay-count": entries.length,
+            "data-relay-unavailable": unavailable,
+          }),
       };
     if (id === "@/components/journal/JournalArticle")
       return {
@@ -55,6 +62,8 @@ function loadHub(readArchive) {
       };
     if (id === "@/lib/bnl-journal-store")
       return { listBNLJournalArchive: readArchive };
+    if (id === "@/lib/bnl-status-store")
+      return { listBNLPublicRelayHistory: readRelayHistory };
     throw new Error(`unmocked import ${id} in ${file}`);
   };
   vm.runInNewContext(
@@ -71,22 +80,59 @@ function loadHub(readArchive) {
   return cjsModule.exports;
 }
 
+function loadRelayHistoryComponent() {
+  const file = "src/components/BNLRelayHistory.tsx";
+  const code = ts.transpileModule(read(file), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const cjsModule = { exports: {} };
+  vm.runInNewContext(
+    code,
+    {
+      require: (id) => {
+        if (id === "react/jsx-runtime") return require("react/jsx-runtime");
+        if (id === "react") return React;
+        throw new Error(`unmocked import ${id} in ${file}`);
+      },
+      exports: cjsModule.exports,
+      module: cjsModule,
+      Intl,
+      Date,
+    },
+    { filename: file },
+  );
+  return cjsModule.exports;
+}
+
 function entry(entryId, title) {
   return { entryId, title, revision: 1 };
 }
 
-test("public BNL hub reuses only the public relay and Journal read paths", () => {
+test("public BNL hub uses only the bounded public relay and Journal read paths", () => {
   const hub = read("src/app/bnl/page.tsx");
+  const relayStore = read("src/lib/bnl-status-store.ts");
+  const publicReader = relayStore.slice(
+    relayStore.indexOf("export async function listBNLPublicRelayHistory"),
+    relayStore.indexOf("export async function appendLegacyBNLHistory"),
+  );
 
   assert.match(hub, /export const dynamic = "force-dynamic"/);
-  assert.match(hub, /BNLRelayModule/);
+  assert.match(hub, /BNLRelayHistoryModule/);
+  assert.match(hub, /listBNLPublicRelayHistory\(\)/);
   assert.match(hub, /listBNLJournalArchive\(1\)/);
   assert.match(hub, /href="\/journal"/);
   assert.match(hub, /href="\/database\/bnl-01"/);
   assert.doesNotMatch(
     hub,
-    /listBNLJournalAdminEntries|listAllBNLJournalEntries|journal-control|read-model|queue|api\/admin|relay-history/i,
+    /listBNLJournalAdminEntries|listAllBNLJournalEntries|journal-control|read-model|queue|api\/admin/i,
   );
+  assert.match(publicReader, /BNL_V2_RELAY_HISTORY_KEY/);
+  assert.doesNotMatch(publicReader, /BNL_V1_HISTORY_KEY|readBNLAdminState/);
 });
 
 test("public BNL hub renders the newest entry and a bounded recent list", async () => {
@@ -98,20 +144,38 @@ test("public BNL hub renders the newest entry and a bounded recent list", async 
     entry("journal-recent-4", "Fourth recent observation"),
     entry("journal-recent-5", "Fifth recent observation"),
   ];
-  let calls = 0;
-  const hub = loadHub(async (page) => {
-    calls += 1;
-    assert.equal(page, 1);
-    return {
-      ok: true,
-      value: { entries, page: 1, hasOlder: false, hasNewer: false },
-    };
-  });
+  let journalCalls = 0;
+  let relayCalls = 0;
+  const hub = loadHub(
+    async (page) => {
+      journalCalls += 1;
+      assert.equal(page, 1);
+      return {
+        ok: true,
+        value: { entries, page: 1, hasOlder: false, hasNewer: false },
+      };
+    },
+    async () => {
+      relayCalls += 1;
+      return {
+        ok: true,
+        value: [
+          {
+            message: "Latest relay",
+            currentDirective: "Observe",
+            publishedAt: "2026-07-19T00:00:00.000Z",
+          },
+        ],
+      };
+    },
+  );
 
   const html = renderToStaticMarkup(await hub.default());
 
-  assert.equal(calls, 1);
-  assert.match(html, /data-relay="true"/);
+  assert.equal(journalCalls, 1);
+  assert.equal(relayCalls, 1);
+  assert.match(html, /data-relay-history="true"/);
+  assert.match(html, /data-relay-count="1"/);
   assert.match(html, /data-latest-entry="journal-latest"/);
   assert.match(html, /data-recent-entry="journal-recent-1"/);
   assert.match(html, /data-recent-entry="journal-recent-2"/);
@@ -127,7 +191,28 @@ test("public BNL hub distinguishes an unavailable Journal from an empty one", as
   }));
   const unavailable = renderToStaticMarkup(await unavailableHub.default());
   assert.match(unavailable, /Journal signal unavailable/);
-  assert.match(unavailable, /current BNL-01 relay above remains available/);
+  assert.match(unavailable, /recent BNL-01 relay history above remains available/);
+
+  const combinedFailureHub = loadHub(
+    async () => ({ ok: false, unavailable: true }),
+    async () => ({
+      ok: false,
+      value: [],
+      persisted: true,
+      unavailable: true,
+    }),
+  );
+  const combinedFailure = renderToStaticMarkup(
+    await combinedFailureHub.default(),
+  );
+  assert.match(
+    combinedFailure,
+    /public Journal archive and relay history cannot be read right now/,
+  );
+  assert.doesNotMatch(
+    combinedFailure,
+    /relay history above remains available/,
+  );
 
   const emptyHub = loadHub(async () => ({
     ok: true,
@@ -143,6 +228,54 @@ test("the homepage and sitemap expose the public BNL hub", () => {
   const sitemap = read("src/app/sitemap.ts");
 
   assert.match(home, /href="\/bnl"/);
-  assert.match(home, /Open the BNL-01 hub/);
+  assert.match(home, /Open the BNL-01 Hub/);
   assert.match(sitemap, /`\$\{base\}\/bnl`/);
+});
+
+test("the Hub relay box renders at most 20 newest-first public projections", () => {
+  const relayHistory = loadRelayHistoryComponent();
+  const relayEntries = Array.from({ length: 21 }, (_, index) => ({
+    message: `surface-reading-${String(index).padStart(2, "0")}`,
+    currentDirective: `network-posture-${String(index).padStart(2, "0")}`,
+    publishedAt: `2026-07-${String(19 - Math.floor(index / 2)).padStart(2, "0")}T${String(index % 24).padStart(2, "0")}:00:00.000Z`,
+  }));
+  const html = renderToStaticMarkup(
+    React.createElement(relayHistory.BNLRelayHistoryModule, {
+      entries: relayEntries,
+    }),
+  );
+
+  assert.equal((html.match(/Surface reading/g) ?? []).length, 20);
+  assert.equal((html.match(/Network posture/g) ?? []).length, 20);
+  assert.equal((html.match(/<time/g) ?? []).length, 20);
+  assert.match(html, /surface-reading-00/);
+  assert.match(html, /surface-reading-19/);
+  assert.doesNotMatch(html, /surface-reading-20/);
+  assert.match(html, /dateTime="2026-07-19T00:00:00.000Z"/);
+  assert.match(html, /max-h-\[34rem\]/);
+  assert.match(html, /overflow-y-auto/);
+  assert.match(html, /tabindex="0"/);
+  assert.match(html, /aria-labelledby="recent-bnl-relays-heading"/);
+  assert.doesNotMatch(html, /Signal condition|Signal origin/i);
+});
+
+test("the Hub relay box distinguishes empty history from an unavailable read", () => {
+  const relayHistory = loadRelayHistoryComponent();
+  const empty = renderToStaticMarkup(
+    React.createElement(relayHistory.BNLRelayHistoryModule, { entries: [] }),
+  );
+  const unavailable = renderToStaticMarkup(
+    React.createElement(relayHistory.BNLRelayHistoryModule, {
+      entries: [],
+      unavailable: true,
+    }),
+  );
+
+  assert.match(empty, /No public BNL-01 relays have been published yet/);
+  assert.doesNotMatch(empty, /Relay history unavailable/);
+  assert.match(unavailable, /Relay history unavailable/);
+  assert.doesNotMatch(
+    unavailable,
+    /No public BNL-01 relays have been published yet/,
+  );
 });

--- a/tests/bnl-public-hub.test.mjs
+++ b/tests/bnl-public-hub.test.mjs
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import vm from "node:vm";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+const read = (path) =>
+  fs.readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+function loadHub(readArchive) {
+  const file = "src/app/bnl/page.tsx";
+  const code = ts.transpileModule(read(file), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const cjsModule = { exports: {} };
+  const req = (id) => {
+    if (id === "react/jsx-runtime") return require("react/jsx-runtime");
+    if (id === "react") return React;
+    if (id === "next/link")
+      return function LinkMock({ href, children, ...props }) {
+        return React.createElement(
+          "a",
+          { href: String(href), ...props },
+          children,
+        );
+      };
+    if (id === "@/components/BNLRelay")
+      return {
+        BNLRelayModule: ({ title }) =>
+          React.createElement("div", { "data-relay": true }, title),
+      };
+    if (id === "@/components/journal/JournalArticle")
+      return {
+        JournalArticle: ({ entry }) =>
+          React.createElement(
+            "article",
+            { "data-latest-entry": entry.entryId },
+            entry.title,
+          ),
+        JournalArchiveCard: ({ entry }) =>
+          React.createElement(
+            "article",
+            { "data-recent-entry": entry.entryId },
+            entry.title,
+          ),
+      };
+    if (id === "@/lib/bnl-journal-store")
+      return { listBNLJournalArchive: readArchive };
+    throw new Error(`unmocked import ${id} in ${file}`);
+  };
+  vm.runInNewContext(
+    code,
+    {
+      require: req,
+      exports: cjsModule.exports,
+      module: cjsModule,
+      process,
+      console,
+    },
+    { filename: file },
+  );
+  return cjsModule.exports;
+}
+
+function entry(entryId, title) {
+  return { entryId, title, revision: 1 };
+}
+
+test("public BNL hub reuses only the public relay and Journal read paths", () => {
+  const hub = read("src/app/bnl/page.tsx");
+
+  assert.match(hub, /export const dynamic = "force-dynamic"/);
+  assert.match(hub, /BNLRelayModule/);
+  assert.match(hub, /listBNLJournalArchive\(1\)/);
+  assert.match(hub, /href="\/journal"/);
+  assert.match(hub, /href="\/database\/bnl-01"/);
+  assert.doesNotMatch(
+    hub,
+    /listBNLJournalAdminEntries|listAllBNLJournalEntries|journal-control|read-model|queue|api\/admin|relay-history/i,
+  );
+});
+
+test("public BNL hub renders the newest entry and a bounded recent list", async () => {
+  const entries = [
+    entry("journal-latest", "Latest public observation"),
+    entry("journal-recent-1", "First recent observation"),
+    entry("journal-recent-2", "Second recent observation"),
+    entry("journal-recent-3", "Third recent observation"),
+    entry("journal-recent-4", "Fourth recent observation"),
+    entry("journal-recent-5", "Fifth recent observation"),
+  ];
+  let calls = 0;
+  const hub = loadHub(async (page) => {
+    calls += 1;
+    assert.equal(page, 1);
+    return {
+      ok: true,
+      value: { entries, page: 1, hasOlder: false, hasNewer: false },
+    };
+  });
+
+  const html = renderToStaticMarkup(await hub.default());
+
+  assert.equal(calls, 1);
+  assert.match(html, /data-relay="true"/);
+  assert.match(html, /data-latest-entry="journal-latest"/);
+  assert.match(html, /data-recent-entry="journal-recent-1"/);
+  assert.match(html, /data-recent-entry="journal-recent-2"/);
+  assert.match(html, /data-recent-entry="journal-recent-3"/);
+  assert.match(html, /data-recent-entry="journal-recent-4"/);
+  assert.doesNotMatch(html, /data-recent-entry="journal-recent-5"/);
+});
+
+test("public BNL hub distinguishes an unavailable Journal from an empty one", async () => {
+  const unavailableHub = loadHub(async () => ({
+    ok: false,
+    unavailable: true,
+  }));
+  const unavailable = renderToStaticMarkup(await unavailableHub.default());
+  assert.match(unavailable, /Journal signal unavailable/);
+  assert.match(unavailable, /current BNL-01 relay above remains available/);
+
+  const emptyHub = loadHub(async () => ({
+    ok: true,
+    value: { entries: [], page: 1, hasOlder: false, hasNewer: false },
+  }));
+  const empty = renderToStaticMarkup(await emptyHub.default());
+  assert.match(empty, /No public Journal entries have been published yet/);
+  assert.doesNotMatch(empty, /Journal signal unavailable/);
+});
+
+test("the homepage and sitemap expose the public BNL hub", () => {
+  const home = read("src/app/page.tsx");
+  const sitemap = read("src/app/sitemap.ts");
+
+  assert.match(home, /href="\/bnl"/);
+  assert.match(home, /Open the BNL-01 hub/);
+  assert.match(sitemap, /`\$\{base\}\/bnl`/);
+});

--- a/tests/global-identity-shell.test.mjs
+++ b/tests/global-identity-shell.test.mjs
@@ -43,6 +43,19 @@ test("Header navigation remains compact until xl and switches consistently", () 
   assert.match(header, /label: "Terminal Archive"/);
 });
 
+test("BNL-01 Hub replaces Journal in global navigation while Journal routes remain active aliases", () => {
+  const header = read("src/components/Header.tsx");
+  const footer = read("src/components/Footer.tsx");
+
+  assert.match(header, /\{ href: "\/bnl", label: "BNL-01 Hub" \}/);
+  assert.doesNotMatch(header, /\{ href: "\/journal", label: "Journal" \}/);
+  assert.match(header, /pathname === "\/journal"/);
+  assert.match(header, /pathname\.startsWith\("\/journal\/"\)/);
+  assert.match(footer, /href="\/bnl"/);
+  assert.match(footer, />\s*BNL-01 Hub\s*</);
+  assert.doesNotMatch(footer, /BNL Journal/);
+});
+
 test("Header live CTA has compact mobile labels and full accessible labels", () => {
   const header = read("src/components/Header.tsx");
 


### PR DESCRIPTION
## What changed

- Added the dynamic public `/bnl` destination and named it **BNL-01 Hub** in page metadata, the global Header, Footer, and homepage CTA.
- Kept the Community Journal as BNL-01's public field log inside the Hub, with `/journal` remaining the full Journal archive.
- Replaced the Hub's single current-signal card with a keyboard-scrollable, newest-first list of up to 20 accepted public BNL-01 relays.
- Each history item displays only:
  - surface reading
  - network posture
  - transmission date/time
- Added distinct empty, relay-unavailable, Journal-unavailable, and combined-unavailable states.
- Kept both `/bnl` and `/journal` discoverable in the sitemap.

## Data and safety boundaries

- Reads only canonical authenticated/validated v2 history from `bnl:relay:history:v2`.
- Sanitizes records before applying the 20-item cap.
- Projects exactly `message`, `currentDirective`, and `publishedAt`.
- Does not expose relay IDs, provenance/source class, trigger, presence/status/mode, Admin notes, Redis metadata, secrets, or legacy v1 history.
- Leaves `GET /api/bnl/status` and its existing polling payload unchanged.
- Does not change BNL relay production, approval, cadence, storage mechanics, the shared live ticker/homepage/Radio relay components, the bot, Discord behavior, queue, payments, production gates, or VPS configuration.

## Validation

- Focused Hub/relay/shell/controller regressions: **45 passed**.
- `npm run check`: TypeScript passed; ESLint reported **0 errors** and the existing **33 warnings**; all **608 tests passed**.
- `npm run build`: production build passed and emitted `/bnl` as a dynamic route.
- Independent final review: no security, privacy, approval-boundary, or blocking correctness findings.
