### PR TITLE
Show BNL relay times in each visitor's timezone

### DIFF
--- a/src/components/BNLRelayHistory.tsx
+++ b/src/components/BNLRelayHistory.tsx
@@ -1,19 +1,5 @@
 import type { BNLPublicRelayHistoryEntry } from "@/lib/bnl-presence-relay-contract";
-
-function formatTransmissionTime(value: string): string {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return "Time unavailable";
-
-  return `${new Intl.DateTimeFormat("en-US", {
-    timeZone: "UTC",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  }).format(parsed)} UTC`;
-}
+import { BNLRelayTimestamp } from "@/components/BNLRelayTimestamp";
 
 export function BNLRelayHistoryModule({
   entries,
@@ -90,9 +76,7 @@ export function BNLRelayHistoryModule({
                     Transmission date / time
                   </dt>
                   <dd className="mt-2 font-mono text-xs uppercase tracking-[0.18em] text-foreground/70">
-                    <time dateTime={entry.publishedAt}>
-                      {formatTransmissionTime(entry.publishedAt)}
-                    </time>
+                    <BNLRelayTimestamp value={entry.publishedAt} />
                   </dd>
                 </div>
               </dl>

--- a/src/components/BNLRelayTimestamp.tsx
+++ b/src/components/BNLRelayTimestamp.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribeToHydration = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+function tryFormatTransmissionTime(
+  value: string,
+  timeZone?: string,
+): string | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      ...(timeZone ? { timeZone } : {}),
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+      timeZoneName: "short",
+    }).format(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function formatTransmissionTime(
+  value: string,
+  timeZone?: string,
+): string {
+  return tryFormatTransmissionTime(value, timeZone) ?? "Time unavailable";
+}
+
+export function BNLRelayTimestamp({ value }: { value: string }) {
+  const hydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+  const utcFallback = formatTransmissionTime(value, "UTC");
+  const localTime = hydrated ? tryFormatTransmissionTime(value) : null;
+
+  return <time dateTime={value}>{localTime ?? utcFallback}</time>;
+}

--- a/tests/bnl-public-hub.test.mjs
+++ b/tests/bnl-public-hub.test.mjs
@@ -97,11 +97,60 @@ function loadRelayHistoryComponent() {
       require: (id) => {
         if (id === "react/jsx-runtime") return require("react/jsx-runtime");
         if (id === "react") return React;
+        if (id === "@/components/BNLRelayTimestamp")
+          return {
+            BNLRelayTimestamp: ({ value }) =>
+              React.createElement("time", { dateTime: value }, value),
+          };
         throw new Error(`unmocked import ${id} in ${file}`);
       },
       exports: cjsModule.exports,
       module: cjsModule,
       Intl,
+      Date,
+    },
+    { filename: file },
+  );
+  return cjsModule.exports;
+}
+
+function intlWithDefaultTimeZone(defaultTimeZone) {
+  function DateTimeFormat(locales, options = {}) {
+    return new Intl.DateTimeFormat(locales, {
+      ...options,
+      timeZone: options.timeZone ?? defaultTimeZone,
+    });
+  }
+
+  return { DateTimeFormat };
+}
+
+function loadRelayTimestampComponent({
+  hydrated = false,
+  defaultTimeZone = "UTC",
+} = {}) {
+  const file = "src/components/BNLRelayTimestamp.tsx";
+  const code = ts.transpileModule(read(file), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const cjsModule = { exports: {} };
+  vm.runInNewContext(
+    code,
+    {
+      require: (id) => {
+        if (id === "react/jsx-runtime") return require("react/jsx-runtime");
+        if (id === "react")
+          return { ...React, useSyncExternalStore: () => hydrated };
+        throw new Error(`unmocked import ${id} in ${file}`);
+      },
+      exports: cjsModule.exports,
+      module: cjsModule,
+      Intl: intlWithDefaultTimeZone(defaultTimeZone),
       Date,
     },
     { filename: file },
@@ -257,6 +306,59 @@ test("the Hub relay box renders at most 20 newest-first public projections", () 
   assert.match(html, /tabindex="0"/);
   assert.match(html, /aria-labelledby="recent-bnl-relays-heading"/);
   assert.doesNotMatch(html, /Signal condition|Signal origin/i);
+});
+
+test("relay timestamps hydrate from UTC into the visitor's browser timezone", () => {
+  const value = "2026-07-19T19:40:00.000Z";
+  const serverTimestamp = loadRelayTimestampComponent({
+    hydrated: false,
+    defaultTimeZone: "America/Los_Angeles",
+  });
+  const pacificTimestamp = loadRelayTimestampComponent({
+    hydrated: true,
+    defaultTimeZone: "America/Los_Angeles",
+  });
+
+  const serverHtml = renderToStaticMarkup(
+    React.createElement(serverTimestamp.BNLRelayTimestamp, { value }),
+  );
+  const pacificHtml = renderToStaticMarkup(
+    React.createElement(pacificTimestamp.BNLRelayTimestamp, { value }),
+  );
+
+  assert.match(serverHtml, /Jul 19, 2026, 7:40 PM UTC/);
+  assert.match(pacificHtml, /Jul 19, 2026, 12:40 PM PDT/);
+  assert.match(pacificHtml, /datetime="2026-07-19T19:40:00.000Z"/i);
+});
+
+test("relay timestamp formatting handles DST, date rollover, and invalid input", () => {
+  const timestamp = loadRelayTimestampComponent();
+
+  assert.equal(
+    timestamp.formatTransmissionTime(
+      "2026-01-19T19:40:00.000Z",
+      "America/Los_Angeles",
+    ),
+    "Jan 19, 2026, 11:40 AM PST",
+  );
+  assert.equal(
+    timestamp.formatTransmissionTime(
+      "2026-07-19T19:40:00.000Z",
+      "America/New_York",
+    ),
+    "Jul 19, 2026, 3:40 PM EDT",
+  );
+  assert.equal(
+    timestamp.formatTransmissionTime(
+      "2026-07-19T19:40:00.000Z",
+      "Asia/Tokyo",
+    ),
+    "Jul 20, 2026, 4:40 AM GMT+9",
+  );
+  assert.equal(
+    timestamp.formatTransmissionTime("not-a-timestamp"),
+    "Time unavailable",
+  );
 });
 
 test("the Hub relay box distinguishes empty history from an unavailable read", () => {


### PR DESCRIPTION
## What changed

- Replaced the BNL-01 Hub relay history's forced UTC display with a small, timestamp-only client component.
- Keeps a deterministic UTC label for server rendering and the first hydration pass, then automatically renders the same instant in the visitor's browser/device timezone.
- Includes the local timezone abbreviation and preserves the canonical ISO value in the semantic `<time dateTime>` element.
- Falls back to the labeled UTC value if browser-local formatting is unavailable.

For a Pacific-time visitor, the screenshot's `Jul 19, 2026, 7:40 PM UTC` now displays as `Jul 19, 2026, 12:40 PM PDT`.

## Scope boundaries

- No API or stored relay data changes.
- No relay generation, approval, cadence, Redis, Journal, bot, Discord, queue, Radio, VPS, or production-gate changes.
- The existing newest-first 20-relay history behavior is unchanged.

## Validation

- Focused BNL Hub tests: **8 passed**.
- Full `npm run check`: TypeScript passed; ESLint reported **0 errors** and the existing **33 warnings**; all **610 tests passed**.
- `npm run build`: production build passed.
- `git diff --check`: passed.
- Independent final review: no blockers, hydration mismatch, accessibility regression, or scope creep found.
