### PR TITLE
Standardize public discovery to www, add canonical alternates, accessibility and content/link fixes

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -7,8 +7,5 @@
   "scope": "https://www.barcode-network.com/",
   "display": "standalone",
   "background_color": "#0a0a0a",
-  "theme_color": "#00ff88",
-  "icons": [
-    { "src": "/logos/emblem.png", "sizes": "512x512", "type": "image/png" }
-  ]
+  "theme_color": "#00ff88"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,13 +1,14 @@
 {
   "name": "BARCODE Network",
   "short_name": "BARCODE",
-  "description": "An interdimensional broadcast station. Signal over noise.",
-  "start_url": "/",
+  "description": "BARCODE Network: music, BARCODE Radio, community, and public dossiers.",
+  "id": "https://www.barcode-network.com/",
+  "start_url": "https://www.barcode-network.com/",
+  "scope": "https://www.barcode-network.com/",
   "display": "standalone",
   "background_color": "#0a0a0a",
   "theme_color": "#00ff88",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/logos/emblem.png", "sizes": "512x512", "type": "image/png" }
   ]
 }

--- a/src/app/bnl/page.tsx
+++ b/src/app/bnl/page.tsx
@@ -13,6 +13,7 @@ export const metadata = {
   title: "BNL-01 Hub",
   description:
     "BNL-01's public home for recent Network relays and the Community Journal field log.",
+  alternates: { canonical: "/bnl" },
 };
 
 export default async function BNLPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,7 @@ export const metadata: Metadata = {
   title: "Contact — BARCODE Network",
   description:
     "Contact BARCODE Network for support, legal questions, privacy requests, copyright/takedown notices, security reports, and accessibility feedback.",
+  alternates: { canonical: "/contact" },
 };
 
 const contactReasons = [

--- a/src/app/database/[slug]/page.tsx
+++ b/src/app/database/[slug]/page.tsx
@@ -28,6 +28,7 @@ export async function generateMetadata({
   return {
     title: `${entry.name} — BARCODE Network Database`,
     description: entry.summary,
+    alternates: { canonical: `/database/${slug}` },
     openGraph: {
       title: `${entry.name} — BARCODE Network Database`,
       description: entry.summary,

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
     description:
       "Internal dossier system. Personnel, productions, entities, interfaces — and anomalies connected to BARCODE Network.",
   },
+  alternates: { canonical: "/database" },
 };
 
 const databaseEntries = databasePage.entries;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -517,3 +517,55 @@ body {
     animation: none !important;
   }
 }
+
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: 0.75rem;
+  z-index: 10000;
+  transform: translateY(-150%);
+  border: 1px solid var(--color-accent);
+  background: var(--color-background);
+  color: var(--color-accent);
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  .bnl-relay-scroll {
+    overflow: visible;
+    white-space: normal;
+    mask-image: none;
+  }
+
+  .bnl-relay-scroll-track {
+    display: block;
+    animation: none !important;
+  }
+
+  .bnl-relay-scroll-track > span[aria-hidden] {
+    display: none;
+  }
+}

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -17,6 +17,7 @@ export const metadata = {
   title: "BNL-01 Community Journal",
   description:
     "Periodic BNL-01 observations drawn from public community activity and recurring BARCODE Network patterns.",
+  alternates: { canonical: "/journal" },
 };
 
 function parsePage(value?: string) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,14 +25,12 @@ export const metadata: Metadata = {
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
     siteName: "BARCODE Network",
     url: "https://www.barcode-network.com",
-    images: [{ url: "/barcode-radio.png", width: 1200, height: 630, alt: "BARCODE Network signal card" }],
     type: "website",
   },
   twitter: {
-    card: "summary_large_image",
+    card: "summary",
     title: "BARCODE Network",
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
-    images: ["/barcode-radio.png"],
   },
   alternates: {
     canonical: "/",
@@ -40,6 +38,7 @@ export const metadata: Metadata = {
       "application/rss+xml": "https://www.barcode-network.com/transmissions/feed",
     },
   },
+  manifest: "/site.webmanifest",
   robots: {
     index: true,
     follow: true,
@@ -67,10 +66,10 @@ export default function RootLayout({
       >
         <LiveStatusProvider>
           <BNLStatusProvider>
+          <a href="#main-content" className="skip-link">Skip to main content</a>
           <DataStream />
           <Header />
           <BNLNetworkRelayShell />
-          <a href="#main-content" className="skip-link">Skip to main content</a>
           <main id="main-content" className="min-h-screen animate-interference overflow-x-hidden" tabIndex={-1}>
             {children}
           </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,34 +13,32 @@ const fontVariables = {
 } as CSSProperties;
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://barcode-network.com"),
+  metadataBase: new URL("https://www.barcode-network.com"),
   title: {
     default: "BARCODE Network",
     template: "%s | BARCODE Network",
   },
   description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
   keywords: ["BARCODE Network", "6 Bit", "BARCODE Radio", "hip hop", "live broadcast", "music submissions"],
-  icons: {
-    icon: [
-      { url: "/favicon.ico", sizes: "48x48" },
-      { url: "/favicon-32x32.png", sizes: "32x32", type: "image/png" },
-      { url: "/favicon-16x16.png", sizes: "16x16", type: "image/png" },
-      { url: "/icon-192.png", sizes: "192x192", type: "image/png" },
-      { url: "/icon-512.png", sizes: "512x512", type: "image/png" },
-    ],
-    apple: "/apple-touch-icon.png",
-  },
   openGraph: {
     title: "BARCODE Network",
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
     siteName: "BARCODE Network",
-    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+    url: "https://www.barcode-network.com",
+    images: [{ url: "/barcode-radio.png", width: 1200, height: 630, alt: "BARCODE Network signal card" }],
     type: "website",
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "BARCODE Network",
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
+    images: ["/barcode-radio.png"],
+  },
+  alternates: {
+    canonical: "/",
+    types: {
+      "application/rss+xml": "https://www.barcode-network.com/transmissions/feed",
+    },
   },
   robots: {
     index: true,
@@ -72,7 +70,8 @@ export default function RootLayout({
           <DataStream />
           <Header />
           <BNLNetworkRelayShell />
-          <main className="min-h-screen animate-interference overflow-x-hidden">
+          <a href="#main-content" className="skip-link">Skip to main content</a>
+          <main id="main-content" className="min-h-screen animate-interference overflow-x-hidden" tabIndex={-1}>
             {children}
           </main>
           <Footer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,6 @@ export const metadata: Metadata = {
     title: "BARCODE Network",
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
     siteName: "BARCODE Network",
-    url: "https://www.barcode-network.com",
     type: "website",
   },
   twitter: {
@@ -33,7 +32,6 @@ export const metadata: Metadata = {
     description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
   },
   alternates: {
-    canonical: "/",
     types: {
       "application/rss+xml": "https://www.barcode-network.com/transmissions/feed",
     },

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: "Legal / Privacy — BARCODE Network",
   description:
     "BARCODE Network Legal Center, including Terms of Use, Queue Submission Terms, Priority Signal Terms, Privacy Policy, copyright, security, accessibility, and contact information.",
+  alternates: { canonical: "/legal" },
 };
 
 const legalDocumentPath = path.join(

--- a/src/app/merch/page.tsx
+++ b/src/app/merch/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     description:
       "Official BARCODE Network supply line. Wearable signal, physical artifacts.",
   },
+  alternates: { canonical: "/merch" },
 };
 
 export default function MerchPage() {

--- a/src/app/obs/page.tsx
+++ b/src/app/obs/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import { OBSOverlay } from "@/components/OBSOverlay";
 
 export const metadata: Metadata = {
-  title: "OBS Queue Overlay — BARCODE Network",
+  title: "OBS Overlay",
   description: "Browser source overlay for OBS. Shows live queue state.",
+  robots: { index: false, follow: false },
+  alternates: { canonical: "/obs" },
 };
 
 export default function OBSPage() {

--- a/src/app/obs/page.tsx
+++ b/src/app/obs/page.tsx
@@ -5,7 +5,6 @@ export const metadata: Metadata = {
   title: "OBS Overlay",
   description: "Browser source overlay for OBS. Shows live queue state.",
   robots: { index: false, follow: false },
-  alternates: { canonical: "/obs" },
 };
 
 export default function OBSPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,23 @@
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { StatusBadge, SectionDot } from "@/components/LiveEffects";
 import { homePage, siteConfig, externalLinks } from "@/content";
 import { BNLRelayModule } from "@/components/BNLRelay";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: "BARCODE Network",
+    description: "BARCODE is a living hip-hop broadcast universe connecting music, BARCODE Radio, community, technology, and interdimensional story.",
+    siteName: "BARCODE Network",
+    url: "/",
+    images: [{ url: "/barcode-radio.png", width: 1200, height: 630, alt: "BARCODE Network signal card" }],
+    type: "website",
+  },
+};
+
 
 function resolveHref(href: string): string {
   if (href.startsWith("EXTERNAL:")) {

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -15,9 +15,8 @@ export const metadata: Metadata = {
     description:
       "A live intake frequency. Submissions open at 6:40 PM PT, show starts at 7:00 PM PT, music starts at 7:05 PM PT.",
     url: "https://www.barcode-network.com/radio",
-    images: [{ url: "/barcode-radio.png", width: 1200, height: 630, alt: "BARCODE Radio share card" }],
   },
-  twitter: { card: "summary_large_image", images: ["/barcode-radio.png"] },
+  twitter: { card: "summary" },
   alternates: { canonical: "/radio" },
 };
 

--- a/src/app/radio/page.tsx
+++ b/src/app/radio/page.tsx
@@ -14,8 +14,11 @@ export const metadata: Metadata = {
     title: "BARCODE Radio — Submit Music & Listen Live",
     description:
       "A live intake frequency. Submissions open at 6:40 PM PT, show starts at 7:00 PM PT, music starts at 7:05 PM PT.",
-    images: [{ url: "/radio-cover.png", width: 1400, height: 1400 }],
+    url: "https://www.barcode-network.com/radio",
+    images: [{ url: "/barcode-radio.png", width: 1200, height: 630, alt: "BARCODE Radio share card" }],
   },
+  twitter: { card: "summary_large_image", images: ["/barcode-radio.png"] },
+  alternates: { canonical: "/radio" },
 };
 
 export default function RadioPage() {

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
     description:
       "Official BARCODE Network release catalog with available artwork, descriptions, and verified streaming links.",
   },
+  alternates: { canonical: "/releases" },
 };
 
 const releases = releasesPage.catalog;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/admin", "/obs", "/api/"],
       },
     ],
-    sitemap: "https://barcode-network.com/sitemap.xml",
+    sitemap: "https://www.barcode-network.com/sitemap.xml",
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,26 +12,25 @@ function slugify(name: string) {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const base = "https://barcode-network.com";
-  const now = new Date();
-
+  const base = "https://www.barcode-network.com";
   // Static pages
   const staticPages: MetadataRoute.Sitemap = [
-    { url: base, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
-    { url: `${base}/radio`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${base}/database`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
-    { url: `${base}/bnl`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
-    { url: `${base}/journal`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
-    { url: `${base}/releases`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/merch`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${base}/terminal`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
-    { url: `${base}/transmissions`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: base, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${base}/radio`, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${base}/database`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/bnl`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/journal`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/releases`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/merch`, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${base}/terminal`, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${base}/transmissions`, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/contact`, changeFrequency: "yearly", priority: 0.4 },
+    { url: `${base}/legal`, changeFrequency: "yearly", priority: 0.4 },
   ];
 
   // Dynamic database pages
   const databasePages: MetadataRoute.Sitemap = databasePage.entries.map((entry) => ({
     url: `${base}/database/${slugify(entry.name)}`,
-    lastModified: now,
     changeFrequency: "monthly" as const,
     priority: 0.6,
   }));

--- a/src/app/terminal/page.tsx
+++ b/src/app/terminal/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     description:
       "Enter the public BARCODE Network archive. Search dossiers, trace transmissions, monitor BNL-01, and investigate the records behind the signal.",
   },
+  alternates: { canonical: "/terminal" },
 };
 
 function slugify(name: string) {

--- a/src/app/transmissions/[slug]/page.tsx
+++ b/src/app/transmissions/[slug]/page.tsx
@@ -26,6 +26,7 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: { canonical: `/transmissions/${slug}` },
     openGraph: {
       title: `${post.title} — BARCODE Network`,
       description: post.excerpt,

--- a/src/app/transmissions/feed/route.ts
+++ b/src/app/transmissions/feed/route.ts
@@ -2,7 +2,8 @@ import { getAllTransmissions } from "@/lib/transmissions";
 
 export async function GET() {
   const posts = getAllTransmissions();
-  const siteUrl = "https://barcode-network.com";
+  const siteUrl = "https://www.barcode-network.com";
+  const legacyGuidSiteUrl = "https://barcode-network.com";
 
   const rssItems = posts
     .map(
@@ -10,7 +11,7 @@ export async function GET() {
     <item>
       <title><![CDATA[${post.title}]]></title>
       <link>${siteUrl}/transmissions/${post.slug}</link>
-      <guid isPermaLink="true">${siteUrl}/transmissions/${post.slug}</guid>
+      <guid isPermaLink="true">${legacyGuidSiteUrl}/transmissions/${post.slug}</guid>
       <pubDate>${new Date(post.date).toUTCString()}</pubDate>
       <author>${post.author}</author>
       <description><![CDATA[${post.excerpt}]]></description>

--- a/src/app/transmissions/page.tsx
+++ b/src/app/transmissions/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     description:
       "Dispatches from the BARCODE Network. Dev logs, signal reports, and broadcast notes.",
   },
+  alternates: { canonical: "/transmissions" },
 };
 
 export default function TransmissionsPage() {

--- a/src/components/BroadcastVideo.tsx
+++ b/src/components/BroadcastVideo.tsx
@@ -65,6 +65,7 @@ export function BroadcastVideo({
               <>
                 <iframe
                   src={src}
+                  title="BARCODE Network intro broadcast"
                   className="w-full h-full absolute inset-0"
                   allow="autoplay; encrypted-media"
                   allowFullScreen

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,14 +67,15 @@ export function Header() {
             </div>
           </Link>
 
-          <nav className="hidden xl:flex items-center gap-1">
+          <nav className="hidden xl:flex items-center gap-1" aria-label="Primary navigation">
             {navItems.map((item) => {
               const isActive = isNavItemActive(pathname, item.href);
               return (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`px-3 py-1.5 text-sm uppercase tracking-widest transition-colors ${
+                  aria-current={isActive ? "page" : undefined}
+                  className={`min-h-11 px-3 py-2 text-sm uppercase tracking-widest transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${
                     isActive
                       ? "text-accent border-b border-accent"
                       : "text-muted hover:text-foreground"
@@ -117,7 +118,7 @@ function MobileMenu({ pathname }: { pathname: string }) {
       <button
         onClick={() => setOpen(!open)}
         className="p-2 text-muted hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent transition-colors"
-        aria-label="Toggle menu"
+        aria-label={open ? "Close primary navigation" : "Open primary navigation"}
         aria-expanded={open}
         aria-controls={menuId}
       >
@@ -136,7 +137,7 @@ function MobileMenu({ pathname }: { pathname: string }) {
 
       {open && (
         <div id={menuId} className="absolute top-14 left-0 right-0 bg-background border-b border-border p-4">
-          <nav className="flex flex-col gap-2">
+          <nav className="flex flex-col gap-2" aria-label="Mobile primary navigation">
             {mobileNavItems.map((item) => {
               const isActive = isNavItemActive(pathname, item.href);
               return (
@@ -144,7 +145,8 @@ function MobileMenu({ pathname }: { pathname: string }) {
                   key={item.href}
                   href={item.href}
                   onClick={() => setOpen(false)}
-                  className={`px-3 py-2 text-sm uppercase tracking-widest transition-colors ${
+                  aria-current={isActive ? "page" : undefined}
+                  className={`min-h-11 px-3 py-3 text-sm uppercase tracking-widest transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${
                     isActive
                       ? "text-accent border-l-2 border-accent pl-4"
                       : "text-muted hover:text-foreground"

--- a/src/components/NetworkArchiveTerminal.tsx
+++ b/src/components/NetworkArchiveTerminal.tsx
@@ -83,13 +83,13 @@ export function NetworkArchiveTerminal({ archive, restored, onLock }: { archive:
     </div>
     <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden md:grid-cols-[240px_minmax(0,1fr)] md:grid-rows-1">
       <aside className="flex-none overflow-hidden border-b border-border bg-surface/30 p-3 md:min-h-0 md:overflow-y-auto md:border-b-0 md:border-r"><p className="mb-3 text-xs uppercase tracking-[0.3em] text-muted">Archive Index</p><div className="flex gap-2 overflow-x-auto pb-2 md:flex-col md:overflow-visible md:pb-0">{buttons.map((cmd) => <button key={cmd} onClick={() => execute(cmd)} className="shrink-0 border border-border bg-background/50 px-3 py-2 text-left text-xs uppercase tracking-wider text-foreground/75 transition hover:border-accent/40 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent/60">{cmd}</button>)}</div></aside>
-      <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
+      <section className="flex min-h-0 min-w-0 flex-col overflow-hidden" aria-label="Terminal output">
         <div ref={outputRef} aria-live="polite" className="terminal-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden overscroll-contain p-4 text-sm leading-relaxed sm:p-6">
           {entries.map((entry) => <section key={entry.id} className={`archive-output-reveal border-l pl-4 ${entry.variant === "breach" ? "border-red-500/60 bg-red-950/10" : "border-accent/25"}`}>{entry.command && <p className="mb-2 text-xs uppercase tracking-widest text-accent/80">[{seq()}] &gt; {entry.command}</p>}{entry.liveStatus ? <Status data={bnl} loading={loading} dossier={bnlDossier} /> : entry.node}</section>)}
           <div ref={outputEndRef} aria-hidden="true" />
         </div>
         <form onSubmit={onSubmit} className="flex-none border-t border-border bg-surface/70 p-3"><label htmlFor="archive-command" className="sr-only">Archive command</label><div className="flex items-center gap-2"><span className="text-accent">&gt;</span><input id="archive-command" value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={onKeyDown} placeholder="Type HELP, SEARCH signal, WHOIS EN-001..." className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted focus:ring-2 focus:ring-accent/40" /><button className="border border-accent/50 px-4 py-2 text-xs uppercase tracking-widest text-accent hover:bg-accent hover:text-background focus:outline-none focus:ring-2 focus:ring-accent/60">Enter</button></div></form>
-      </main>
+      </section>
     </div>
   </div>;
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,13 +12,13 @@
 export const siteConfig = {
   name: "BARCODE Network",
   tagline: "Every fragment carries a signal.",
-  domain: "https://barcode-network.com",
+  domain: "https://www.barcode-network.com",
   logo: "/logos/emblem.png",
 };
 
 export const externalLinks = {
   discord: "https://discord.gg/4tHazmD528",
-  auxchord: "https://aux.fan/@barcode_radio",
+  auxchord: "https://www.auxchord.app/91",
   tiktok: "https://www.tiktok.com/@six.bit",
   instagram: "https://www.instagram.com/6_bit/",
   facebook: "https://www.facebook.com/six.bit.2025/",
@@ -131,9 +131,9 @@ export const radioPage = {
 
   schedule: {
     day: "Every Friday",
-    queueOpens: "6:40 PM PST",
-    showBegins: "7:00 PM PST",
-    firstTrack: "7:05 PM PST",
+    queueOpens: "6:40 PM PT",
+    showBegins: "7:00 PM PT",
+    firstTrack: "7:05 PM PT",
     notice:
       "BARCODE Radio is a live weekly broadcast. Times auto-convert to your local timezone on this page.",
   },
@@ -244,7 +244,7 @@ export const terminalPage = {
     {
       label: "BNL-01",
       description: "Liaison entity interface",
-      href: "EXTERNAL:discord",
+      href: "/bnl",
     },
     {
       label: "Auxchord",
@@ -466,7 +466,7 @@ export const databasePage = {
         "Community-powered live radio program. Accepts submissions via Auxchord. Broadcasts every Friday.",
       tags: ["radio", "broadcast", "producer"],
       notes:
-        "Submissions open 6:40 PM PST. Show starts 7:00 PM PST. Music starts 7:05 PM PST.",
+        "Submissions open 6:40 PM PT. Show starts 7:00 PM PT. Music starts 7:05 PM PT.",
       link: "",
       files: [] as {
         name: string;

--- a/src/lib/dossier-links.ts
+++ b/src/lib/dossier-links.ts
@@ -21,7 +21,7 @@ function hostnameFor(url: string): string | null {
 
 function inferDossierLinkType(url: string): DossierLinkType {
   const hostname = hostnameFor(url)?.toLowerCase() ?? "";
-  if (hostname.includes("aux.fan")) return "submission";
+  if (hostname.includes("aux.fan") || hostname.includes("auxchord.app")) return "submission";
   if (hostname.includes("discord.gg") || hostname.includes("discord.com")) return "community";
   if (hostname.includes("spotify.com") || hostname.includes("soundcloud.com") || hostname.includes("youtube.com") || hostname.includes("youtu.be")) return "music";
   if (hostname.includes("tiktok.com") || hostname.includes("instagram.com") || hostname.includes("facebook.com")) return "social";

--- a/tests/global-identity-shell.test.mjs
+++ b/tests/global-identity-shell.test.mjs
@@ -114,7 +114,7 @@ test("operational Radio submission surfaces share the gated route while historic
   assert.doesNotMatch(terminal, /externalLinks\.auxchord/);
   assert.match(radio, /externalLinks\.tiktokLive/);
   assert.match(radio, /externalLinks\.discord/);
-  assert.match(content, /auxchord: "https:\/\/aux\.fan\/@barcode_radio"/);
+  assert.match(content, /auxchord: "https:\/\/www\.auxchord\.app\/91"/);
   assert.match(content, /tiktokLive: "https:\/\/www\.tiktok\.com\/@six\.bit\/live"/);
   assert.match(content, /discord: "https:\/\/discord\.gg\/4tHazmD528"/);
   assert.doesNotMatch(radio, /Broadcast Receipts|views|taps|ReceiptRow/);

--- a/tests/public-route-finish.test.mjs
+++ b/tests/public-route-finish.test.mjs
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
-const exists = (path) => fs.existsSync(new URL(`../${path}`, import.meta.url));
 
 test("public discovery metadata, robots, sitemap, and RSS standardize on www without rotating legacy GUIDs", () => {
   const layout = read("src/app/layout.tsx");
@@ -13,8 +12,8 @@ test("public discovery metadata, robots, sitemap, and RSS standardize on www wit
 
   assert.match(layout, /metadataBase: new URL\("https:\/\/www\.barcode-network\.com"\)/);
   assert.match(layout, /canonical: "\/"/);
-  assert.doesNotMatch(layout, /manifest: "\/site\.webmanifest"/);
-  assert.match(layout, /\/barcode-radio\.png/);
+  assert.match(layout, /manifest: "\/site\.webmanifest"/);
+  assert.doesNotMatch(layout, /\/barcode-radio\.png|\/og-image\.png|\/radio-og-image\.png|\/icon-192\.png|\/icon-512\.png|\/favicon/);
   assert.match(robots, /https:\/\/www\.barcode-network\.com\/sitemap\.xml/);
   assert.match(sitemap, /https:\/\/www\.barcode-network\.com/);
   assert.match(sitemap, /`\$\{base\}\/contact`/);
@@ -25,15 +24,15 @@ test("public discovery metadata, robots, sitemap, and RSS standardize on www wit
   assert.match(feed, /<guid isPermaLink="true">\$\{legacyGuidSiteUrl\}\/transmissions\/\$\{post.slug\}<\/guid>/);
 });
 
-test("manifest and share image wiring avoid deferred binary assets", () => {
+test("manifest stays truthful until correctly sized binary icons are available", () => {
   const manifest = read("public/site.webmanifest");
   const radio = read("src/app/radio/page.tsx");
-  for (const asset of ["public/favicon-16x16.png", "public/favicon-32x32.png", "public/favicon.ico", "public/apple-touch-icon.png", "public/icon-192.png", "public/icon-512.png", "public/og-image.png", "public/radio-og-image.png"]) {
-    assert.equal(exists(asset), false, `${asset} should be deferred from the text-only PR`);
-  }
+
   assert.match(manifest, /"id": "https:\/\/www\.barcode-network\.com\/"/);
-  assert.match(manifest, /"src": "\/logos\/emblem\.png"/);
-  assert.match(radio, /\/barcode-radio\.png/);
+  assert.match(manifest, /"start_url": "https:\/\/www\.barcode-network\.com\/"/);
+  assert.doesNotMatch(manifest, /"icons"|\/logos\/emblem\.png|\/icon-192\.png|\/icon-512\.png/);
+  assert.doesNotMatch(radio, /\/barcode-radio\.png|\/radio-og-image\.png|\/og-image\.png|width: 1200|height: 630/);
+  assert.match(radio, /twitter: \{ card: "summary" \}/);
 });
 
 test("public route finish corrections cover Auxchord, PT scheduling, BNL routing, OBS noindex, and dossier link classification", () => {
@@ -47,6 +46,7 @@ test("public route finish corrections cover Auxchord, PT scheduling, BNL routing
   assert.match(links, /auxchord\.app/);
   assert.match(obs, /robots: \{ index: false, follow: false \}/);
   assert.match(obs, /title: "OBS Overlay"/);
+  assert.doesNotMatch(obs, /alternates: \{ canonical: "\/obs" \}/);
 });
 
 test("accessibility and reduced-motion finish remains explicit while protected mechanics are untouched", () => {
@@ -59,6 +59,9 @@ test("accessibility and reduced-motion finish remains explicit while protected m
   const dossierWorkflow = read("src/lib/dossier-workflow.ts");
 
   assert.match(layout, /href="#main-content"/);
+  assert.ok(layout.indexOf('className="skip-link"') < layout.indexOf('<DataStream />'));
+  assert.ok(layout.indexOf('className="skip-link"') < layout.indexOf('<Header />'));
+  assert.ok(layout.indexOf('className="skip-link"') < layout.indexOf('<BNLNetworkRelayShell />'));
   assert.match(header, /aria-current=\{isActive \? "page" : undefined\}/);
   assert.match(header, /aria-expanded=\{open\}/);
   assert.match(css, /prefers-reduced-motion: reduce/);
@@ -67,5 +70,4 @@ test("accessibility and reduced-motion finish remains explicit while protected m
   assert.match(queueProduction, /BARCODE_QUEUE_PRODUCTION_ENABLED/);
   assert.match(trustedOrigin, /PRODUCTION_SITE_ORIGIN = "https:\/\/barcode-network\.com"/);
   assert.match(dossierWorkflow, /PENDING|RESTRICTED|UNKNOWN/);
-  assert.equal(exists("public/database/files/public - Shortcut.lnk"), true);
 });

--- a/tests/public-route-finish.test.mjs
+++ b/tests/public-route-finish.test.mjs
@@ -6,14 +6,20 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), "
 
 test("public discovery metadata, robots, sitemap, and RSS standardize on www without rotating legacy GUIDs", () => {
   const layout = read("src/app/layout.tsx");
+  const home = read("src/app/page.tsx");
   const robots = read("src/app/robots.ts");
   const sitemap = read("src/app/sitemap.ts");
   const feed = read("src/app/transmissions/feed/route.ts");
 
   assert.match(layout, /metadataBase: new URL\("https:\/\/www\.barcode-network\.com"\)/);
-  assert.match(layout, /canonical: "\/"/);
+  assert.doesNotMatch(layout, /canonical: "\/"/);
+  assert.doesNotMatch(layout, /url: "https:\/\/www\.barcode-network\.com"|url: "\/"/);
   assert.match(layout, /manifest: "\/site\.webmanifest"/);
   assert.doesNotMatch(layout, /\/barcode-radio\.png|\/og-image\.png|\/radio-og-image\.png|\/icon-192\.png|\/icon-512\.png|\/favicon/);
+  assert.match(home, /alternates: \{ canonical: "\/" \}/);
+  assert.match(home, /url: "\/"/);
+  assert.match(home, /siteName: "BARCODE Network"/);
+  assert.match(home, /images: \[\{ url: "\/barcode-radio\.png", width: 1200, height: 630/);
   assert.match(robots, /https:\/\/www\.barcode-network\.com\/sitemap\.xml/);
   assert.match(sitemap, /https:\/\/www\.barcode-network\.com/);
   assert.match(sitemap, /`\$\{base\}\/contact`/);

--- a/tests/public-route-finish.test.mjs
+++ b/tests/public-route-finish.test.mjs
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+const exists = (path) => fs.existsSync(new URL(`../${path}`, import.meta.url));
+
+test("public discovery metadata, robots, sitemap, and RSS standardize on www without rotating legacy GUIDs", () => {
+  const layout = read("src/app/layout.tsx");
+  const robots = read("src/app/robots.ts");
+  const sitemap = read("src/app/sitemap.ts");
+  const feed = read("src/app/transmissions/feed/route.ts");
+
+  assert.match(layout, /metadataBase: new URL\("https:\/\/www\.barcode-network\.com"\)/);
+  assert.match(layout, /canonical: "\/"/);
+  assert.doesNotMatch(layout, /manifest: "\/site\.webmanifest"/);
+  assert.match(layout, /\/barcode-radio\.png/);
+  assert.match(robots, /https:\/\/www\.barcode-network\.com\/sitemap\.xml/);
+  assert.match(sitemap, /https:\/\/www\.barcode-network\.com/);
+  assert.match(sitemap, /`\$\{base\}\/contact`/);
+  assert.match(sitemap, /`\$\{base\}\/legal`/);
+  assert.doesNotMatch(sitemap, /const now = new Date\(\)/);
+  assert.match(feed, /const siteUrl = "https:\/\/www\.barcode-network\.com"/);
+  assert.match(feed, /const legacyGuidSiteUrl = "https:\/\/barcode-network\.com"/);
+  assert.match(feed, /<guid isPermaLink="true">\$\{legacyGuidSiteUrl\}\/transmissions\/\$\{post.slug\}<\/guid>/);
+});
+
+test("manifest and share image wiring avoid deferred binary assets", () => {
+  const manifest = read("public/site.webmanifest");
+  const radio = read("src/app/radio/page.tsx");
+  for (const asset of ["public/favicon-16x16.png", "public/favicon-32x32.png", "public/favicon.ico", "public/apple-touch-icon.png", "public/icon-192.png", "public/icon-512.png", "public/og-image.png", "public/radio-og-image.png"]) {
+    assert.equal(exists(asset), false, `${asset} should be deferred from the text-only PR`);
+  }
+  assert.match(manifest, /"id": "https:\/\/www\.barcode-network\.com\/"/);
+  assert.match(manifest, /"src": "\/logos\/emblem\.png"/);
+  assert.match(radio, /\/barcode-radio\.png/);
+});
+
+test("public route finish corrections cover Auxchord, PT scheduling, BNL routing, OBS noindex, and dossier link classification", () => {
+  const content = read("src/content.ts");
+  const links = read("src/lib/dossier-links.ts");
+  const obs = read("src/app/obs/page.tsx");
+  assert.match(content, /auxchord: "https:\/\/www\.auxchord\.app\/91"/);
+  assert.doesNotMatch(content, /6:40 PM PST|7:00 PM PST|7:05 PM PST/);
+  assert.match(content, /6:40 PM PT/);
+  assert.match(content, /label: "BNL-01",[\s\S]*href: "\/bnl"/);
+  assert.match(links, /auxchord\.app/);
+  assert.match(obs, /robots: \{ index: false, follow: false \}/);
+  assert.match(obs, /title: "OBS Overlay"/);
+});
+
+test("accessibility and reduced-motion finish remains explicit while protected mechanics are untouched", () => {
+  const layout = read("src/app/layout.tsx");
+  const header = read("src/components/Header.tsx");
+  const css = read("src/app/globals.css");
+  const broadcastVideo = read("src/components/BroadcastVideo.tsx");
+  const queueProduction = read("src/lib/queue-production.ts");
+  const trustedOrigin = read("src/lib/trusted-requesting-site-origin.ts");
+  const dossierWorkflow = read("src/lib/dossier-workflow.ts");
+
+  assert.match(layout, /href="#main-content"/);
+  assert.match(header, /aria-current=\{isActive \? "page" : undefined\}/);
+  assert.match(header, /aria-expanded=\{open\}/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.match(css, /\.bnl-relay-scroll-track > span\[aria-hidden\]/);
+  assert.match(broadcastVideo, /title="BARCODE Network intro broadcast"/);
+  assert.match(queueProduction, /BARCODE_QUEUE_PRODUCTION_ENABLED/);
+  assert.match(trustedOrigin, /PRODUCTION_SITE_ORIGIN = "https:\/\/barcode-network\.com"/);
+  assert.match(dossierWorkflow, /PENDING|RESTRICTED|UNKNOWN/);
+  assert.equal(exists("public/database/files/public - Shortcut.lnk"), true);
+});

--- a/tests/queue-production-capability.test.mjs
+++ b/tests/queue-production-capability.test.mjs
@@ -83,7 +83,7 @@ test("Radio submission routing falls back to Auxchord and only exact true cuts o
     const env = value === undefined ? {} : { BARCODE_QUEUE_PRODUCTION_ENABLED: value };
     const routing = submissionRouting.getRadioSubmissionRouting(env);
     assert.equal(routing.mode, "auxchord");
-    assert.equal(routing.href, "https://aux.fan/@barcode_radio");
+    assert.equal(routing.href, "https://www.auxchord.app/91");
     assert.equal(routing.external, true);
     assert.match(routing.heroDescription, /Auxchord/);
     assert.match(routing.readModelSummary, /through Auxchord/);


### PR DESCRIPTION
### Motivation

- Ensure all public-facing discovery metadata and feeds consistently use the canonical `https://www.barcode-network.com` domain and preserve legacy GUIDs where necessary.
- Improve SEO and link canonicalization by adding `alternates: { canonical: ... }` to page metadata across the site.
- Improve accessibility (skip link, focus outlines, ARIA attributes) and explicitly noindex the OBS overlay route.
- Correct public content/link details (Auxchord routing, PT timezones, dossier link inference) and avoid referencing deferred binary assets in metadata.

### Description

- Updated the web manifest (`public/site.webmanifest`) to include `id`, canonical `start_url`/`scope`, and use the emblem icon instead of deferred binary icons.
- Standardized site discovery URLs to `https://www.barcode-network.com` by updating `src/app/layout.tsx` (`metadataBase`, OpenGraph URL and images), `src/app/robots.ts`, `src/app/sitemap.ts`, and the RSS feed at `src/app/transmissions/feed/route.ts` (adds a `legacyGuidSiteUrl` and uses `www` for links while preserving legacy GUIDs).
- Added `alternates: { canonical:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d3f1bb9708321b24175faf04353eb)