### PR TITLE
Site: localize Journal dates for each visitor

### DIFF
--- a/src/components/journal/JournalArticle.tsx
+++ b/src/components/journal/JournalArticle.tsx
@@ -11,7 +11,7 @@ export function formatJournalDate(value: string) {
     month: "long",
     day: "numeric",
     year: "numeric",
-    timeZone: "UTC",
+    timeZone: "America/Los_Angeles",
   }).format(new Date(value));
 }
 export function JournalUnavailable() {

--- a/src/components/journal/JournalArticle.tsx
+++ b/src/components/journal/JournalArticle.tsx
@@ -5,15 +5,7 @@ import {
   type JournalArchiveFilter,
 } from "@/lib/bnl-journal-navigation";
 import { JournalRetryButton } from "@/components/journal/JournalRetryButton";
-
-export function formatJournalDate(value: string) {
-  return new Intl.DateTimeFormat("en", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "America/Los_Angeles",
-  }).format(new Date(value));
-}
+import { JournalDate } from "@/components/journal/JournalDate";
 export function JournalUnavailable() {
   return (
     <section className="mx-auto max-w-3xl px-4 py-24 sm:px-6">
@@ -68,12 +60,10 @@ export function JournalArticle({
         </p>
         <JournalKindBadge entry={entry} />
       </div>
-      <time
+      <JournalDate
         className="mt-3 block font-mono text-xs uppercase tracking-widest text-muted"
-        dateTime={entry.publishedAt}
-      >
-        {formatJournalDate(entry.publishedAt)}
-      </time>
+        value={entry.publishedAt}
+      />
       <Title className="mt-5 text-3xl font-black leading-tight tracking-tight text-foreground sm:text-5xl">
         {entry.title}
       </Title>
@@ -116,12 +106,10 @@ export function JournalArchiveCard({
       className="block border border-border bg-background/60 p-4 transition-colors hover:border-accent/50"
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <time
+        <JournalDate
           className="font-mono text-[11px] uppercase tracking-widest text-foreground/60"
-          dateTime={entry.publishedAt}
-        >
-          {formatJournalDate(entry.publishedAt)}
-        </time>
+          value={entry.publishedAt}
+        />
         <JournalKindBadge entry={entry} />
       </div>
       <h2 className="mt-2 text-base font-bold text-foreground">

--- a/src/components/journal/JournalDate.tsx
+++ b/src/components/journal/JournalDate.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribeToHydration = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+function tryFormatJournalDate(
+  value: string,
+  timeZone?: string,
+): string | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      ...(timeZone ? { timeZone } : {}),
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).format(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function formatJournalDate(value: string, timeZone?: string): string {
+  return tryFormatJournalDate(value, timeZone) ?? "Date unavailable";
+}
+
+export function JournalDate({
+  value,
+  className,
+}: {
+  value: string;
+  className?: string;
+}) {
+  const hydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+  const utcFallback = formatJournalDate(value, "UTC");
+  const localDate = hydrated ? tryFormatJournalDate(value) : null;
+
+  return (
+    <time className={className} dateTime={value}>
+      {localDate ?? utcFallback}
+    </time>
+  );
+}

--- a/tests/bnl-journal-contract.test.mjs
+++ b/tests/bnl-journal-contract.test.mjs
@@ -8,7 +8,7 @@ import { createRequire } from "node:module";
 import { renderToStaticMarkup } from "react-dom/server";
 
 const require = createRequire(import.meta.url);
-function loadTs(file, mocks = {}) {
+function loadTs(file, mocks = {}, globals = {}) {
   let code = ts.transpileModule(awaitFs(file), {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
@@ -56,10 +56,33 @@ function loadTs(file, mocks = {}) {
       URL,
       URLSearchParams,
       console,
+      ...globals,
     },
     { filename: file },
   );
   return cjsModule.exports;
+}
+function intlWithDefaultTimeZone(defaultTimeZone) {
+  function DateTimeFormat(locales, options = {}) {
+    return new Intl.DateTimeFormat(locales, {
+      ...options,
+      timeZone: options.timeZone ?? defaultTimeZone,
+    });
+  }
+
+  return { DateTimeFormat };
+}
+function loadJournalDateComponent({
+  hydrated = false,
+  defaultTimeZone = "UTC",
+} = {}) {
+  return loadTs(
+    "src/components/journal/JournalDate.tsx",
+    {
+      react: { ...React, useSyncExternalStore: () => hydrated },
+    },
+    { Intl: intlWithDefaultTimeZone(defaultTimeZone) },
+  );
 }
 function awaitFs(file) {
   return requireFs().readFileSync(file, "utf8");
@@ -74,10 +97,12 @@ function awaitImport(id) {
 const contract = loadTs("src/lib/bnl-journal-contract.ts");
 const navigation = loadTs("src/lib/bnl-journal-navigation.ts");
 const retry = loadTs("src/components/journal/JournalRetryButton.tsx");
+const journalDate = loadTs("src/components/journal/JournalDate.tsx");
 const article = loadTs("src/components/journal/JournalArticle.tsx", {
   "@/lib/bnl-journal-store": {},
   "@/lib/bnl-journal-navigation": navigation,
   "@/components/journal/JournalRetryButton": retry,
+  "@/components/journal/JournalDate": journalDate,
 });
 const routeMod = loadTs("src/app/api/bnl/journal/route.ts", {
   "@/lib/bnl-journal-contract": contract,
@@ -842,11 +867,41 @@ test("journal pages canonicalize explicit All and mismatched detail filters", as
   );
 });
 
-test("public Journal dates use the Pacific publication day across a UTC rollover", () => {
-  assert.equal(
-    article.formatJournalDate("2026-07-20T04:52:03Z"),
-    "July 19, 2026",
+test("public Journal dates resolve in the viewer's browser timezone after hydration", () => {
+  const value = "2026-07-20T04:52:03Z";
+  const serverHtml = renderToStaticMarkup(
+    React.createElement(
+      loadJournalDateComponent({
+        hydrated: false,
+        defaultTimeZone: "America/Los_Angeles",
+      }).JournalDate,
+      { value },
+    ),
   );
+  const pacificHtml = renderToStaticMarkup(
+    React.createElement(
+      loadJournalDateComponent({
+        hydrated: true,
+        defaultTimeZone: "America/Los_Angeles",
+      }).JournalDate,
+      { value },
+    ),
+  );
+  const tokyoHtml = renderToStaticMarkup(
+    React.createElement(
+      loadJournalDateComponent({
+        hydrated: true,
+        defaultTimeZone: "Asia/Tokyo",
+      }).JournalDate,
+      { value },
+    ),
+  );
+
+  assert.match(serverHtml, /July 20, 2026/);
+  assert.match(pacificHtml, /July 19, 2026/);
+  assert.match(tokyoHtml, /July 20, 2026/);
+  assert.match(pacificHtml, /datetime="2026-07-20T04:52:03Z"/i);
+  assert.equal(journalDate.formatJournalDate("not-a-date"), "Date unavailable");
 });
 
 test("React server rendering exposes only display data and escapes hostile text", () => {

--- a/tests/bnl-journal-contract.test.mjs
+++ b/tests/bnl-journal-contract.test.mjs
@@ -842,6 +842,13 @@ test("journal pages canonicalize explicit All and mismatched detail filters", as
   );
 });
 
+test("public Journal dates use the Pacific publication day across a UTC rollover", () => {
+  assert.equal(
+    article.formatJournalDate("2026-07-20T04:52:03Z"),
+    "July 19, 2026",
+  );
+});
+
 test("React server rendering exposes only display data and escapes hostile text", () => {
   const entry = {
     ...makeEntry({


### PR DESCRIPTION
## Summary
- render public Journal dates in each visitor's browser timezone
- keep a deterministic UTC server/initial-hydration fallback
- add regression coverage for one publication appearing as July 19 in Los Angeles and July 20 in Tokyo

## Root cause
The public Journal rendered a server-fixed calendar date, while the admin dashboard formatted the same stored timestamp in the browser. That made the public date disagree with the viewer's local publication date around timezone boundaries.

## Behavior
The stored ISO publication timestamp remains authoritative and unchanged. After hydration, the date-only Journal display uses the visitor's browser timezone. For the reported timestamp, a Pacific visitor sees July 19; visitors whose local date was already July 20 see July 20.

## Impact
Existing entries gain viewer-local display after the site change is deployed. No Journal data migration, republishing, bot change, or bot restart is required.

## Validation
- `npm test` — 619 passed
- `npm run test:bnl` — 67 passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors (33 existing warnings)
- `git diff --check` — passed
