### PR TITLE
Add private BARCODE World Loose Signal greybox

### DIFF
--- a/docs/barcode-world-loose-signal-greybox.md
+++ b/docs/barcode-world-loose-signal-greybox.md
@@ -1,0 +1,229 @@
+# BARCODE World: Outskirts → Loose Signal greybox
+
+Status: **IMPLEMENTED — PRIVATE DEVELOPMENT ROUTE**
+
+Source revision: `BARCODE_WORLD_PLAYTEST_READY_VERTICAL_SLICE_SOURCE_PACK_2026-07-26`
+
+This document describes the bounded first-playable browser greybox at
+`/world/playtest`. The route is not linked from the public shell or sitemap,
+sets no-index metadata, and returns `notFound()` in production. It has no API,
+database, BNL, queue, Relay, Journal, account, economy, or persistence
+dependency.
+
+## Status language
+
+- **OWNER-APPROVED** — printed as approved or locked in the controlling source.
+- **PAPER SIMULATION FINDING** — a source expectation, not an observed result.
+- **IMPLEMENTED** — represented by the deterministic engine or UI.
+- **VERIFIED** — covered by an automated assertion or browser observation.
+- **TEMPORARY IMPLEMENTATION ASSUMPTION** — needed to make the bounded browser
+  test executable where the source does not close the rule.
+- **UNRESOLVED / EXCLUDED** — deliberately not promoted into a permanent rule.
+
+## Architecture and ownership
+
+The website repository owns this surface. The BNL repository was inspected as
+an integration boundary and is not modified or imported.
+
+| Layer | Responsibility |
+| --- | --- |
+| `constants.mjs` | Six ordered builds, exact costs, fixed 12-card decks, opening order, four exact test loadouts, physical LS-01 relationships, profiles, and paper expectations |
+| `engine.mjs` | Pure deterministic in-memory state transitions, planning, ownership, claims, consent, packet resolution, Settle, evidence, and reset |
+| `BarcodeWorldGreybox.tsx` | Preparation, Outskirts commitment, physical map, contextual action browser, projection, personal plans, lock/resolve, causal log, Settle choices, and evidence download |
+| `page.tsx` | Development-only route and production 404 boundary |
+| Node tests | Mechanical, profile, concurrency, ownership, failure, and isolation evidence |
+
+No game result crosses the engine boundary. Evidence export is a user-triggered
+download of the current isolated state only.
+
+## Implemented rules
+
+### Preparation and profile state
+
+- **IMPLEMENTED / VERIFIED:** six ordered Major/Minor builds in source order.
+- **IMPLEMENTED / VERIFIED:** Command 16 start, +16 at nonterminal Settle, cap
+  32, four personal paid-action slots, one ordinary Reposition outside that
+  limit, Condition 12, and armor Guard caps.
+- **IMPLEMENTED / VERIFIED:** fixed 12-card solo-safe decks, fixed opening five,
+  draw two, retain seven, explicit discard, and no party-only card in a default
+  solo deck.
+- **IMPLEMENTED:** exact test loadouts A–D and active/reserve swap. The
+  class-isolation profiles default to Loadout A as printed.
+- **IMPLEMENTED / VERIFIED:** solo, mixed duo, mixed trio, duplicate-build,
+  duplicate-Major, and rescue fixtures.
+
+### Spatial expedition
+
+- **IMPLEMENTED / VERIFIED:** Outskirts and LS-01 are one connected physical
+  expedition, not a detached combat board.
+- **IMPLEMENTED:** Frontier Marker, Upper Trace Rail, Entry Shelf, Shutter
+  Console, Broken-Lane Lip, Natural Opening / Maintenance Plate, Far Platform,
+  release socket, Relay cache, Threshold, enemies, Packages, capacities, and
+  approach-specific state.
+- **IMPLEMENTED:** ordinary paths, object relationships, and the special
+  Opening are visually distinct. Release and cache are objects on Far Platform,
+  not walkable positions.
+- **IMPLEMENTED / VERIFIED:** blocked Threshold connection, capacity-one
+  contention, source-bound plate crossing, shutter access, release access, and
+  deterministic reinforcement entry.
+- **UNRESOLVED / EXCLUDED:** the optional Hanging Panel variant is not required
+  by the base class-comparison seed and is not added to this first-playable
+  state. The view deliberately does not decide top-down 2D versus isometric
+  2.5D.
+
+### Planning, projection, and ownership
+
+- **IMPLEMENTED / VERIFIED:** focus-bound Context Cards, discipline actions,
+  core actions, prepared cards, and equipment are grouped under at most four
+  immediate roots. Legal variants remain visible inside those roots.
+- **IMPLEMENTED:** actor, target, timing, Tempo, Command, slot use,
+  requirements, access, claims, invalidators, Guard, Condition, Force,
+  movement, Work, Control, Route, Package, Integrity, objective, extraction,
+  uncertainty, and alternatives are projected before queueing.
+- **IMPLEMENTED / VERIFIED:** actions, cards, equipment, Command, Major state,
+  Routes, Control, Packages, locks, and plans remain character-owned.
+- **IMPLEMENTED / VERIFIED:** ally effects require recipient consent.
+  Equal-time Primary claims block resolution; `If Available` and `Yielded`
+  remain explicit.
+- **IMPLEMENTED / VERIFIED:** Command reservations, modifier costs, separate
+  Contingency reserve, invalidation-before-begin refunds, triggered reserve
+  spend, overflow, and retain-limit lock blocking.
+
+### Discipline engines and LS-01
+
+- **IMPLEMENTED / VERIFIED:** Battle Answer creates owner-tied Battle
+  Advantage and Convert spends it for Drive, Pin, or controlled disarm.
+- **IMPLEMENTED / VERIFIED:** Exploration Prepare creates an owner Route with
+  one Exploit and one authorized Follow passage; Exploit and Follow consume
+  only their printed ownership.
+- **IMPLEMENTED / VERIFIED:** Hacking Establish creates character-owned
+  Temporary Control; Hold Open, Expose Cache, and Blind Repeater are bounded,
+  mutually exclusive Outputs that spend it.
+- **IMPLEMENTED / VERIFIED:** Battle responses inherit the Commitment packet;
+  Fast, Standard, and Slow packets resolve in Tempo order with explicit
+  start-legality, response, protection, damage, movement, completion, and
+  state-change layers.
+- **IMPLEMENTED / VERIFIED:** Skimmer A crossing pressure, Skimmer B
+  marker/access selector, Skimmer C reinforcement/Razor selector, shutter
+  Reseal, jam sacrifice, release Work, cache recovery, and full-entered-threat
+  clear.
+- **IMPLEMENTED / VERIFIED:** Maintenance Plate universal crossing, same-cycle
+  Expose Cache → Recover causal dependency, source-owned Package pickup, two
+  exposed Package slots, drop on Compromised, two-Settle rescue window,
+  Stabilize, Standard Extract, and deterministic reset.
+
+### Prepared cards and equipment
+
+- **IMPLEMENTED:** exact deck order, printed form, compatibility, Command cost,
+  reservation model, single-card attachment limit, commit, and discard.
+- **IMPLEMENTED / VERIFIED in LS-01:** Fallback Guard, Controlled Withdrawal,
+  Field Patch, Brace Through, Hold the Edge state, Safe Landing, Route
+  Capacity, Backtrack Marker, Clean Buffer, Delay Stack, Emergency Disconnect,
+  Trace Echo, Covering Step, Objective Brace eligibility, Last Exit,
+  Recovery Mesh, Insulated Shell, Brace Frame Force resistance, Anchor Lock,
+  Protected Access state, reserve swap, Needle attack, and Traversal Line
+  ordinary path/clearance.
+- **SOURCE-BOUND / NOT TRIGGERED IN LS-01:** Destination Claim, Broken Map,
+  Chained Output, Pass the Opening, Hand Signal, and Linked Effort have no
+  authored base-seed trigger, alternate destination, chainable Output, or
+  party-deck substitution in this profile. They are not used as balance
+  evidence.
+- **UNRESOLVED / EXCLUDED FROM BALANCE EVIDENCE:** optional weapon-technique
+  vector/cone choices that the base class-isolation profiles do not exercise
+  are represented for inspection but are not treated as validated balance
+  outcomes.
+
+## Source conflicts and temporary assumptions
+
+| ID | Status | Treatment |
+| --- | --- | --- |
+| `LS-FULL-CLEAR-VS-DUO-EXPECTED` | **SOURCE CONFLICT** | LS-01 §12 says every entered Skimmer must be neutralized before release validation. The mixed-duo paper result says all three remain active. The detailed deterministic encounter rule controls; active entered threats block validation. |
+| `DISCIPLINE-TIMING-OMISSION` | **TEMPORARY IMPLEMENTATION ASSUMPTION** | The controlling pack omits standalone lane/Tempo for discipline actions while REV7 labels its table provisional. Printed REV7 values are used where present; Battle responses inherit their Commitment; LS Opening transit uses Standard / 5. |
+| `LS-PROFILE-SCRIPT-OMISSION` | **SOURCE LIMIT** | The paper matrix prints final totals and state timing but not a complete lock-ready action/card/target script for every result. The UI compares observed runs to those totals; automated six-build evidence uses a declared conservative core baseline and does not masquerade as the missing canonical plan. |
+| `OUTSKIRTS-COORDINATES` | **TEMPORARY PRESENTATION ASSUMPTION** | Exact Outskirts coordinates are absent. A neutral relationship diagram is used without choosing the final camera. |
+| `OPTIONAL-PANEL-BASE-SEED` | **UNRESOLVED / EXCLUDED** | Hanging Panel is explicitly optional and not required in the base class-comparison seed. No Force vector or cover placement choice is invented. |
+
+The paper mixed-duo two-cycle result and other fast LS paper results cannot
+simultaneously satisfy the detailed full-entered-threat-clear rule. Those
+paper totals remain visible as **PAPER SIMULATION FINDINGS**, not silently
+rewritten acceptance criteria.
+
+## Local playtest
+
+Requirements: Node 20.9 or newer and npm.
+
+```bash
+npm ci
+npm run dev
+```
+
+Open `http://localhost:3000/world/playtest` in a development environment.
+
+Focused evidence path:
+
+1. In Preparation, select a deterministic profile. Confirm build order,
+   Loadout A, opening five, priorities, and the paper expectation.
+2. Enter Outskirts. Inspect each approach. Verify Major-specific information,
+   select one result, and confirm every continuing seat.
+3. Commit the approach. Select map nodes and compare ordinary paths, the
+   special Opening, object links, occupancy, enemies, objectives, Packages,
+   and the closed Threshold.
+4. Select a focus. Open each of the four action roots and inspect variants.
+   Select a variant and verify the complete projection before adding it.
+5. Build each personal plan separately. Test card attachment, a consent
+   request, a Primary/If Available claim, four paid slots, and ordinary
+   Reposition.
+6. Lock every seat and resolve. Expand the causal log and verify packet order,
+   start legality, responses, protection, damage, movement, completion, and
+   state changes.
+7. Settle. Verify refunds, card discard/draw, retain-seven gate, Command
+   income/cap, Reseal, reinforcement, rescue clock, and release validation.
+8. Complete LS-01 only after the shutter is open and every entered Skimmer is
+   neutralized. Inspect Packages, infrastructure, characters, and the paper
+   comparison.
+9. Confirm Protect Packages is unavailable before a later physical Safe Node.
+   Record Continue, Retreat, or extraction evidence.
+10. Download isolated evidence JSON if desired, then Reset. Verify the selected
+    profile returns to its exact starting state.
+
+## Automated validation
+
+```bash
+node --test tests/barcode-world-engine.test.mjs \
+  tests/barcode-world-boundary.test.mjs
+npm run check
+npm run build
+```
+
+The focused suite covers:
+
+- all six ordered solo builds completing a deterministic conservative baseline;
+- Battle, Exploration, and Hacking Major state creation and spend;
+- all supported local duo/trio/duplicate/rescue fixtures entering and resolving
+  deterministic concurrency;
+- four-root action presentation;
+- Command banking/cap, retain limit, and paid slots;
+- consent and exclusive-claim conflicts;
+- same-packet movement capacity;
+- Fallback Guard refund/reserve accounting;
+- full-clear release validation;
+- same-cycle Expose Cache → Recover;
+- rescue, extraction, personal Package ownership, and reset;
+- production 404, no public link/sitemap entry, no persistence, and no
+  BNL/queue/live-system import.
+
+## Post-merge deployment and focused verification
+
+This draft must not be deployed as part of the bounded implementation. If a
+future owner-approved merge is followed by deployment, keep
+`/world/playtest` production-inaccessible unless a separate explicit decision
+changes that gate.
+
+Post-deploy evidence:
+
+1. Request `/world/playtest` on production and capture the 404 response.
+2. Confirm the public header and sitemap contain no `/world/playtest` entry.
+3. Confirm existing homepage, queue, BNL, Journal, and admin health checks are
+   unchanged.
+4. Run the greybox only in an approved nonproduction development environment
+   and repeat the focused evidence path above.

--- a/src/app/world/playtest/page.tsx
+++ b/src/app/world/playtest/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { BarcodeWorldGreybox } from "@/components/BarcodeWorldGreybox";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "BARCODE World Deterministic Greybox",
+  description:
+    "Private development-only evidence equipment for the Outskirts to Loose Signal BARCODE World slice.",
+  robots: {
+    index: false,
+    follow: false,
+    noarchive: true,
+    nocache: true,
+  },
+};
+
+export default function BarcodeWorldPlaytestPage() {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  return <BarcodeWorldGreybox />;
+}

--- a/src/components/BarcodeWorldGreybox.module.css
+++ b/src/components/BarcodeWorldGreybox.module.css
@@ -1,0 +1,1294 @@
+.shell {
+  --bw-bg: #070a0d;
+  --bw-panel: #0d1217;
+  --bw-panel-2: #121a20;
+  --bw-line: #26333c;
+  --bw-line-strong: #3d515e;
+  --bw-text: #e8f0f2;
+  --bw-muted: #91a3aa;
+  --bw-green: #52ff9b;
+  --bw-cyan: #4edfff;
+  --bw-amber: #ffc857;
+  --bw-red: #ff6474;
+  --bw-violet: #bd8cff;
+  min-height: 100vh;
+  padding: 5.5rem 1rem 4rem;
+  background:
+    linear-gradient(rgba(78, 223, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(78, 223, 255, 0.025) 1px, transparent 1px),
+    radial-gradient(circle at 70% 0%, rgba(78, 223, 255, 0.07), transparent 34rem),
+    var(--bw-bg);
+  background-size: 28px 28px, 28px 28px, auto, auto;
+  color: var(--bw-text);
+}
+
+.shell button,
+.shell select {
+  font: inherit;
+}
+
+.prototypeHeader,
+.workspace,
+.stageRail,
+.sourceBoundary,
+.prototypeFooter,
+.warningStack {
+  width: min(100%, 1540px);
+  margin-inline: auto;
+}
+
+.prototypeHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem;
+  border: 1px solid var(--bw-line);
+  border-bottom-color: rgba(82, 255, 155, 0.7);
+  background: rgba(7, 10, 13, 0.93);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.3);
+}
+
+.prototypeHeader h1 {
+  margin: 0.2rem 0 0.45rem;
+  font-size: clamp(2rem, 5vw, 4.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+}
+
+.prototypeHeader p {
+  max-width: 62rem;
+  margin: 0;
+  color: var(--bw-muted);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--bw-cyan);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.headerBadges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 1.65rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--bw-line-strong);
+  border-radius: 999px;
+  color: var(--bw-muted);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pill.good {
+  border-color: rgba(82, 255, 155, 0.45);
+  color: var(--bw-green);
+}
+
+.pill.warn {
+  border-color: rgba(255, 200, 87, 0.5);
+  color: var(--bw-amber);
+}
+
+.pill.bad {
+  border-color: rgba(255, 100, 116, 0.5);
+  color: var(--bw-red);
+}
+
+.pill.info {
+  border-color: rgba(78, 223, 255, 0.5);
+  color: var(--bw-cyan);
+}
+
+.pill.neutral {
+  color: var(--bw-muted);
+}
+
+.stageRail {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border-inline: 1px solid var(--bw-line);
+  border-bottom: 1px solid var(--bw-line);
+  background: rgba(13, 18, 23, 0.9);
+}
+
+.stageRail > div {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 3.2rem;
+  padding: 0.65rem 1rem;
+  border-right: 1px solid var(--bw-line);
+  color: var(--bw-muted);
+}
+
+.stageRail > div:last-child {
+  border-right: 0;
+}
+
+.stageRail span {
+  display: grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.65rem;
+}
+
+.stageRail strong {
+  font-size: 0.7rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.currentStage {
+  color: var(--bw-green) !important;
+  background: rgba(82, 255, 155, 0.055);
+}
+
+.pastStage {
+  color: var(--bw-cyan) !important;
+}
+
+.futureStage {
+  opacity: 0.5;
+}
+
+.workspace {
+  padding: clamp(1rem, 3vw, 2.25rem);
+  border-inline: 1px solid var(--bw-line);
+  background: rgba(7, 10, 13, 0.88);
+}
+
+.sectionHeading,
+.cardTopline,
+.planHeader,
+.resolveBar,
+.prototypeFooter {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.sectionHeading {
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.sectionHeading h2 {
+  margin: 0.2rem 0 0;
+  font-size: clamp(1.35rem, 3vw, 2.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.prepToolbar,
+.commitPanel,
+.paperExpectation,
+.resolveBar,
+.sourceBoundary,
+.warningStack {
+  border: 1px solid var(--bw-line);
+  background: var(--bw-panel);
+}
+
+.prepToolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.shell label {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.shell label > span,
+.shell legend {
+  color: var(--bw-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.shell select {
+  max-width: 100%;
+  min-height: 2.6rem;
+  padding: 0.55rem 2.2rem 0.55rem 0.65rem;
+  border: 1px solid var(--bw-line-strong);
+  border-radius: 0;
+  color: var(--bw-text);
+  background: #090d11;
+}
+
+.contractStrip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.contractStrip span {
+  padding: 0.32rem 0.5rem;
+  border: 1px solid var(--bw-line);
+  color: var(--bw-muted);
+  font-size: 0.68rem;
+}
+
+.seatGrid,
+.resourceGrid,
+.resultGrid,
+.mismatchGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr));
+  gap: 1rem;
+}
+
+.seatCard,
+.resourceCard,
+.resultCard,
+.mapPanel,
+.intentPanel,
+.actionBrowser,
+.planPanel,
+.approachInspector {
+  border: 1px solid var(--bw-line);
+  background: linear-gradient(145deg, rgba(18, 26, 32, 0.95), rgba(10, 15, 19, 0.96));
+}
+
+.seatCard {
+  display: grid;
+  align-content: start;
+  gap: 0.9rem;
+  padding: 1rem;
+}
+
+.cardTopline {
+  align-items: center;
+}
+
+.cardTopline h3,
+.cardTopline h4,
+.planHeader h3,
+.intentPanel h3,
+.mapPanel h3,
+.approachInspector h3,
+.resultCard h3 {
+  margin: 0.15rem 0 0;
+}
+
+.identityLine {
+  min-height: 3.2rem;
+  margin: 0;
+  color: var(--bw-cyan);
+  font-size: 0.82rem;
+}
+
+.loadoutList,
+.resultCard dl,
+.intentCard dl,
+.projection dl {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+
+.loadoutList > div,
+.resultCard dl > div,
+.intentCard dl > div,
+.projection dl > div {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, 0.34fr) 1fr;
+  gap: 0.8rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid rgba(38, 51, 60, 0.65);
+}
+
+.loadoutList dt,
+.resultCard dt,
+.intentCard dt,
+.projection dt {
+  color: var(--bw-muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.loadoutList dd,
+.resultCard dd,
+.intentCard dd,
+.projection dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.78rem;
+}
+
+.priorityPair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.deckDetails,
+.causalLog,
+.sourceBoundary {
+  color: var(--bw-muted);
+}
+
+.deckDetails summary,
+.causalLog summary,
+.sourceBoundary summary {
+  cursor: pointer;
+  color: var(--bw-text);
+  font-weight: 700;
+}
+
+.deckDetails ol {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.7rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.deckDetails li {
+  color: var(--bw-muted);
+  font-size: 0.72rem;
+}
+
+.deckDetails li span {
+  color: var(--bw-cyan);
+}
+
+.deckDetails em {
+  color: var(--bw-green);
+  font-size: 0.62rem;
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.paperExpectation {
+  display: grid;
+  gap: 0.2rem;
+  margin: 1rem 0;
+  padding: 0.9rem 1rem;
+  border-left: 3px solid var(--bw-amber);
+}
+
+.paperExpectation span {
+  color: var(--bw-muted);
+  font-size: 0.78rem;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton,
+.activeChoice,
+.removeButton,
+.variantButton,
+.variantSelected,
+.seatTab,
+.activeSeatTab,
+.decisionGrid button,
+.prototypeFooter button,
+.consentRequest button,
+.discardStrip button {
+  min-height: 2.65rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--bw-line-strong);
+  color: var(--bw-text);
+  background: #0a0f13;
+  cursor: pointer;
+  transition: 120ms ease;
+}
+
+.primaryButton {
+  border-color: rgba(82, 255, 155, 0.7);
+  color: #06120b;
+  background: var(--bw-green);
+  font-weight: 900;
+}
+
+.secondaryButton:hover,
+.variantButton:hover,
+.seatTab:hover,
+.prototypeFooter button:hover {
+  border-color: var(--bw-cyan);
+  color: var(--bw-cyan);
+}
+
+.dangerButton {
+  border-color: rgba(255, 100, 116, 0.7);
+  color: var(--bw-red);
+}
+
+.dangerButton:not(:disabled):hover {
+  color: #180507;
+  background: var(--bw-red);
+}
+
+.activeChoice,
+.variantSelected,
+.activeSeatTab {
+  border-color: var(--bw-green);
+  color: var(--bw-green);
+  background: rgba(82, 255, 155, 0.08);
+}
+
+.shell button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.approachMap {
+  position: relative;
+  min-height: 24rem;
+  margin-bottom: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--bw-line);
+  background:
+    radial-gradient(circle at center, rgba(78, 223, 255, 0.09), transparent 35%),
+    var(--bw-panel);
+}
+
+.approachMap::before {
+  content: "";
+  position: absolute;
+  inset: 50% 15% auto;
+  height: 1px;
+  background: var(--bw-line-strong);
+}
+
+.approachCenter,
+.approachNode {
+  position: absolute;
+  translate: -50% -50%;
+}
+
+.approachCenter {
+  left: 50%;
+  top: 50%;
+  display: grid;
+  place-items: center;
+  width: 9rem;
+  height: 9rem;
+  border: 1px solid var(--bw-cyan);
+  border-radius: 50%;
+  color: var(--bw-cyan);
+  background: #071015;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.approachNode {
+  display: grid;
+  gap: 0.3rem;
+  width: min(12rem, 28%);
+  min-height: 5.5rem;
+  padding: 0.75rem;
+  border: 1px solid var(--bw-line-strong);
+  color: var(--bw-text);
+  background: #0a1014;
+  cursor: pointer;
+}
+
+.approachNode[data-index="0"] {
+  left: 16%;
+  top: 50%;
+}
+
+.approachNode[data-index="1"] {
+  left: 84%;
+  top: 28%;
+}
+
+.approachNode[data-index="2"] {
+  left: 84%;
+  top: 72%;
+}
+
+.approachNode span {
+  font-weight: 800;
+}
+
+.approachNode small {
+  color: var(--bw-muted);
+  text-transform: uppercase;
+}
+
+.approachNode.selected {
+  border-color: var(--bw-green);
+  box-shadow: 0 0 25px rgba(82, 255, 155, 0.09);
+}
+
+.approachInspector {
+  padding: 1rem;
+}
+
+.approachInspector > p {
+  color: var(--bw-muted);
+}
+
+.compactSelect {
+  width: min(100%, 28rem);
+}
+
+.readout {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.9rem;
+  border-left: 3px solid var(--bw-cyan);
+  background: rgba(78, 223, 255, 0.045);
+}
+
+.readout span {
+  color: var(--bw-muted);
+}
+
+.resultButtons,
+.evidenceActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.commitPanel {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) minmax(12rem, 1fr) minmax(14rem, 1fr) auto;
+  align-items: end;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  border-color: rgba(82, 255, 155, 0.45);
+}
+
+.commitPanel h3 {
+  margin: 0.2rem 0 0;
+}
+
+.commitPanel fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.confirmCheck {
+  display: flex !important;
+  align-items: center;
+}
+
+.resourceGrid {
+  margin-bottom: 1rem;
+}
+
+.resourceCard {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.85rem;
+}
+
+.resourceCard.activeSeat {
+  border-color: rgba(78, 223, 255, 0.65);
+}
+
+.resourceCard > span {
+  color: var(--bw-muted);
+  font-size: 0.7rem;
+}
+
+.resourceNumbers {
+  display: grid;
+  grid-template-columns: repeat(4, auto minmax(0, 1fr));
+  align-items: baseline;
+  gap: 0.2rem 0.35rem;
+}
+
+.resourceNumbers b {
+  color: var(--bw-green);
+  font-size: 1.2rem;
+}
+
+.resourceNumbers small {
+  color: var(--bw-muted);
+  font-size: 0.58rem;
+  line-height: 1.1;
+}
+
+.positionLabel {
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--bw-line);
+}
+
+.encounterGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.7fr);
+  gap: 1rem;
+}
+
+.mapPanel,
+.intentPanel,
+.actionBrowser,
+.planPanel {
+  padding: 1rem;
+}
+
+.mapNote,
+.actionHint,
+.tieOrder,
+.muted {
+  color: var(--bw-muted);
+  font-size: 0.72rem;
+}
+
+.mapCanvas {
+  position: relative;
+  min-height: 42rem;
+  overflow: hidden;
+  border: 1px solid var(--bw-line);
+  background:
+    linear-gradient(rgba(78, 223, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(78, 223, 255, 0.025) 1px, transparent 1px),
+    #080d11;
+  background-size: 24px 24px;
+}
+
+.mapCanvas svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.edge,
+.specialEdge,
+.objectRelation {
+  stroke: var(--bw-line-strong);
+  stroke-width: 0.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.specialEdge {
+  stroke: var(--bw-violet);
+  stroke-width: 1;
+  stroke-dasharray: 2 1.2;
+}
+
+.objectRelation {
+  stroke: var(--bw-cyan);
+  stroke-dasharray: 0.8 1.4;
+  opacity: 0.55;
+}
+
+.mapNode {
+  position: absolute;
+  left: var(--map-x);
+  top: var(--map-y);
+  z-index: 2;
+  display: grid;
+  gap: 0.05rem;
+  min-width: 6.2rem;
+  max-width: 8.5rem;
+  min-height: 2.7rem;
+  padding: 0.35rem 0.5rem;
+  translate: -50% -50%;
+  border: 1px solid var(--bw-line-strong);
+  color: var(--bw-text);
+  background: #0b1116;
+  font-size: 0.61rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mapNode strong {
+  font-size: 0.66rem;
+}
+
+.mapNode small,
+.mapNode span {
+  color: var(--bw-muted);
+  font-size: 0.55rem;
+}
+
+.worldNode {
+  border-color: rgba(78, 223, 255, 0.5);
+}
+
+.characterNode {
+  z-index: 4;
+  border-color: rgba(82, 255, 155, 0.75);
+  box-shadow: 0 0 20px rgba(82, 255, 155, 0.08);
+}
+
+.enemyNode {
+  z-index: 3;
+  border-color: rgba(255, 100, 116, 0.75);
+}
+
+.mapSelected {
+  outline: 2px solid var(--bw-amber);
+  outline-offset: 3px;
+}
+
+.mapLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin-top: 0.7rem;
+  color: var(--bw-muted);
+  font-size: 0.62rem;
+}
+
+.mapLegend span {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.mapLegend i {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 1px solid;
+}
+
+.legendWorld {
+  border-color: var(--bw-cyan) !important;
+}
+
+.legendCharacter {
+  border-color: var(--bw-green) !important;
+}
+
+.legendEnemy {
+  border-color: var(--bw-red) !important;
+}
+
+.legendSpecial {
+  border-color: var(--bw-violet) !important;
+  border-style: dashed !important;
+}
+
+.intentPanel {
+  align-self: start;
+}
+
+.intentCard {
+  margin-top: 0.65rem;
+  border: 1px solid var(--bw-line);
+  background: rgba(255, 100, 116, 0.025);
+}
+
+.intentCard summary {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.65rem;
+  color: var(--bw-muted);
+  cursor: pointer;
+}
+
+.intentCard summary b {
+  color: var(--bw-red);
+}
+
+.intentCard dl {
+  padding: 0 0.65rem 0.65rem;
+}
+
+.planningGrid {
+  display: grid;
+  grid-template-columns: minmax(20rem, 0.8fr) minmax(28rem, 1.2fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.actionFamilies {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.actionFamilies button {
+  display: grid;
+  gap: 0.1rem;
+  text-align: left;
+}
+
+.actionFamilies small {
+  color: var(--bw-muted);
+  font-size: 0.58rem;
+}
+
+.variantList {
+  display: grid;
+  gap: 0.4rem;
+  max-height: 22rem;
+  margin: 0.75rem 0;
+  overflow: auto;
+}
+
+.variantButton,
+.variantSelected {
+  display: grid;
+  gap: 0.15rem;
+  text-align: left;
+}
+
+.variantButton small,
+.variantSelected small {
+  color: var(--bw-muted);
+  font-size: 0.61rem;
+}
+
+.projection,
+.emptyProjection {
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  border: 1px solid var(--bw-line);
+  background: #080c0f;
+}
+
+.emptyProjection {
+  min-height: 6rem;
+  color: var(--bw-muted);
+  font-size: 0.72rem;
+}
+
+.projection dl {
+  max-height: 22rem;
+  margin-top: 0.65rem;
+  overflow: auto;
+}
+
+.seatTabs {
+  display: flex;
+  gap: 0.4rem;
+  margin: -1rem -1rem 1rem;
+  padding: 0.6rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--bw-line);
+  background: #080d11;
+}
+
+.seatTab,
+.activeSeatTab {
+  display: grid;
+  gap: 0.05rem;
+  min-width: 6rem;
+}
+
+.seatTab small,
+.activeSeatTab small {
+  color: var(--bw-muted);
+  font-size: 0.55rem;
+}
+
+.slotReadout {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.slotReadout span {
+  padding: 0.28rem 0.45rem;
+  border: 1px solid var(--bw-line);
+  color: var(--bw-muted);
+  font-size: 0.6rem;
+}
+
+.planList {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0.8rem 0;
+}
+
+.planAction {
+  position: relative;
+  padding: 0.75rem;
+  border: 1px solid var(--bw-line);
+  background: #090e12;
+}
+
+.planAction > p {
+  margin: 0.35rem 0;
+  color: var(--bw-muted);
+  font-size: 0.7rem;
+}
+
+.planAction details {
+  margin: 0.45rem 0;
+}
+
+.planAction details > summary {
+  color: var(--bw-cyan);
+  font-size: 0.68rem;
+  cursor: pointer;
+}
+
+.actionIndex,
+.commandCost {
+  color: var(--bw-cyan);
+  font-size: 0.61rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.commandCost {
+  color: var(--bw-green);
+}
+
+.inlineControl,
+.consentLine,
+.cardAttach,
+.consentRequest,
+.discardStrip {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-top: 0.45rem;
+}
+
+.inlineControl select,
+.cardAttach select {
+  min-height: 2rem;
+  padding-block: 0.25rem;
+}
+
+.consentLine,
+.cardAttach {
+  padding: 0.45rem;
+  border: 1px solid var(--bw-line);
+  color: var(--bw-muted);
+  font-size: 0.66rem;
+}
+
+.cardAttach button,
+.removeButton {
+  min-height: 2rem;
+  padding: 0.3rem 0.55rem;
+}
+
+.removeButton {
+  margin-top: 0.5rem;
+  color: var(--bw-red);
+}
+
+.consentRequest,
+.discardStrip {
+  padding: 0.65rem;
+  border: 1px solid rgba(255, 200, 87, 0.5);
+  color: var(--bw-amber);
+  background: rgba(255, 200, 87, 0.035);
+  font-size: 0.7rem;
+}
+
+.discardStrip {
+  flex-wrap: wrap;
+}
+
+.errorText {
+  color: var(--bw-red);
+  font-size: 0.72rem;
+}
+
+.causalLog {
+  margin-top: 1rem;
+  border: 1px solid var(--bw-line);
+  background: var(--bw-panel);
+}
+
+.causalLog > summary,
+.sourceBoundary > summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.causalLog ol {
+  display: grid;
+  gap: 0;
+  max-height: 32rem;
+  margin: 0;
+  padding: 0 1rem 1rem;
+  overflow: auto;
+  list-style: none;
+}
+
+.causalLog li {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 0.75rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--bw-line);
+}
+
+.causalLog p {
+  margin: 0.15rem 0;
+  color: var(--bw-text);
+  font-size: 0.72rem;
+}
+
+.causalLog small {
+  color: var(--bw-muted);
+  font-size: 0.61rem;
+}
+
+.packetLabel {
+  color: var(--bw-cyan);
+  font-size: 0.65rem;
+}
+
+.resolveBar {
+  align-items: center;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.resolveBar > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.resolveBar span {
+  color: var(--bw-muted);
+  font-size: 0.7rem;
+}
+
+.resultCard {
+  padding: 1rem;
+}
+
+.resultCard table {
+  width: 100%;
+  margin-top: 0.7rem;
+  border-collapse: collapse;
+  font-size: 0.68rem;
+}
+
+.resultCard th,
+.resultCard td {
+  padding: 0.4rem;
+  border: 1px solid var(--bw-line);
+  text-align: left;
+}
+
+.resultCard th {
+  color: var(--bw-muted);
+}
+
+.decisionGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.decisionGrid button,
+.disabledDecision {
+  display: grid;
+  gap: 0.35rem;
+  min-height: 8rem;
+  padding: 1rem;
+  text-align: left;
+}
+
+.decisionGrid button:hover {
+  border-color: var(--bw-green);
+}
+
+.decisionGrid span,
+.disabledDecision span {
+  color: var(--bw-muted);
+  font-size: 0.72rem;
+}
+
+.disabledDecision {
+  border: 1px dashed var(--bw-line-strong);
+  color: var(--bw-muted);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.warningStack {
+  padding: 0.65rem 1rem;
+  border-top: 0;
+  border-left: 3px solid var(--bw-amber);
+}
+
+.warningStack p {
+  margin: 0.15rem 0;
+  color: var(--bw-amber);
+  font-size: 0.72rem;
+}
+
+.sourceBoundary {
+  border-top: 1px solid rgba(255, 200, 87, 0.45);
+}
+
+.mismatchGrid {
+  padding: 0 1rem 1rem;
+}
+
+.mismatchGrid article {
+  padding: 0.8rem;
+  border: 1px solid var(--bw-line);
+  background: #090e12;
+}
+
+.mismatchGrid p,
+.boundaryCopy {
+  color: var(--bw-muted);
+  font-size: 0.7rem;
+}
+
+.boundaryCopy {
+  margin: 0;
+  padding: 0 1rem 1rem;
+}
+
+.prototypeFooter {
+  align-items: center;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--bw-line);
+  color: var(--bw-muted);
+  background: #070a0d;
+  font-size: 0.65rem;
+}
+
+@media (max-width: 1100px) {
+  .encounterGrid,
+  .planningGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .mapCanvas {
+    min-height: 36rem;
+  }
+
+  .commitPanel {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    padding: 4.5rem 0 2rem;
+  }
+
+  .prototypeHeader,
+  .sectionHeading,
+  .prepToolbar,
+  .resolveBar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .headerBadges,
+  .contractStrip {
+    justify-content: flex-start;
+  }
+
+  .stageRail {
+    grid-template-columns: 1fr;
+  }
+
+  .stageRail > div {
+    min-height: 2.3rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--bw-line);
+  }
+
+  .futureStage {
+    display: none !important;
+  }
+
+  .priorityPair,
+  .commitPanel,
+  .decisionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .approachMap {
+    min-height: auto;
+    padding: 1rem;
+  }
+
+  .approachMap::before {
+    display: none;
+  }
+
+  .approachCenter,
+  .approachNode {
+    position: static;
+    width: 100%;
+    min-height: auto;
+    margin-bottom: 0.6rem;
+    translate: none;
+  }
+
+  .approachCenter {
+    height: auto;
+    padding: 1rem;
+    border-radius: 0;
+  }
+
+  .mapCanvas {
+    min-height: 34rem;
+    overflow: auto;
+  }
+
+  .mapNode {
+    min-width: 5rem;
+    max-width: 6rem;
+    font-size: 0.55rem;
+  }
+
+  .resourceNumbers {
+    grid-template-columns: repeat(2, auto minmax(0, 1fr));
+  }
+
+  .actionFamilies {
+    grid-template-columns: 1fr;
+  }
+
+  .planHeader,
+  .cardTopline {
+    align-items: flex-start;
+  }
+
+  .slotReadout {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell button {
+    transition: none;
+  }
+}

--- a/src/components/BarcodeWorldGreybox.tsx
+++ b/src/components/BarcodeWorldGreybox.tsx
@@ -1,0 +1,1363 @@
+"use client";
+
+import { useMemo, useState, type CSSProperties } from "react";
+import {
+  APPROACHES,
+  ARMOR,
+  BUILDS,
+  CARDS,
+  CORE_RULES,
+  LOADOUTS,
+  POSITIONS,
+  PROFILES,
+  RIGS,
+  WEAPONS,
+  attachCard,
+  beginOutskirts,
+  canResolvePlans,
+  chooseSegmentDecision,
+  commitApproach,
+  compareToPaperExpectation,
+  compatibleCardsForAction,
+  createGreyboxState,
+  detachCard,
+  discardCard,
+  getFocuses,
+  getImmediateActionGroups,
+  getLayeredIntents,
+  inspectApproach,
+  loadProfile,
+  lockSeatPlan,
+  queueAction,
+  removeAction,
+  resetGreybox,
+  resolvePlans,
+  resultSummary,
+  seatCommandAvailable,
+  selectApproachResult,
+  selectFocus,
+  selectSeat,
+  setApproachConfirmation,
+  setClaimMode,
+  setConsent,
+  settleCycle,
+  unlockSeatPlan,
+  updatePreparation,
+  type GreyboxAction,
+  type GreyboxRecord,
+} from "@/lib/barcode-world/engine.mjs";
+import styles from "./BarcodeWorldGreybox.module.css";
+
+const PRIORITIES = ["Complete", "Recover", "Survey", "Speed", "Integrity"];
+const STAGES = [
+  ["preparation", "Prepare"],
+  ["outskirts", "Outskirts"],
+  ["loose-signal", "Plan / Resolve"],
+  ["segment-settle", "Settle"],
+  ["complete", "Evidence"],
+];
+
+function stageReached(current: string, target: string) {
+  const order = STAGES.map(([id]) => id);
+  const currentIndex =
+    current === "segment-settle"
+      ? order.indexOf("segment-settle")
+      : current === "complete"
+        ? order.indexOf("complete")
+        : order.indexOf(current);
+  return currentIndex >= order.indexOf(target);
+}
+
+function buildFor(id: string) {
+  return BUILDS.find((build: { id: string }) => build.id === id) ?? BUILDS[0];
+}
+
+function formatCard(cardId: string) {
+  return CARDS[cardId]?.name ?? cardId;
+}
+
+function StatusPill({
+  tone = "neutral",
+  children,
+}: {
+  tone?: "good" | "warn" | "bad" | "neutral" | "info";
+  children: React.ReactNode;
+}) {
+  return <span className={`${styles.pill} ${styles[tone]}`}>{children}</span>;
+}
+
+function Preparation({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  return (
+    <section className={styles.workspace}>
+      <div className={styles.sectionHeading}>
+        <div>
+          <p className={styles.eyebrow}>Home preparation</p>
+          <h2>Load only the deterministic test equipment.</h2>
+        </div>
+        <StatusPill tone="info">No persistence</StatusPill>
+      </div>
+
+      <div className={styles.prepToolbar}>
+        <label>
+          <span>Deterministic profile</span>
+          <select
+            value={game.profileId}
+            onChange={(event) => apply(loadProfile(game, event.target.value))}
+          >
+            {PROFILES.map((profile: { id: string; name: string }) => (
+              <option key={profile.id} value={profile.id}>
+                {profile.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className={styles.contractStrip}>
+          <span>Seed LS-01</span>
+          <span>16 → 32 Command</span>
+          <span>4 paid slots</span>
+          <span>1 ordinary Reposition</span>
+          <span>12-card fixed deck</span>
+        </div>
+      </div>
+
+      <div className={styles.seatGrid}>
+        {game.seats.map((seat: GreyboxRecord) => {
+          const build = buildFor(seat.buildId);
+          const loadout = LOADOUTS[seat.loadoutId];
+          return (
+            <article className={styles.seatCard} key={seat.id}>
+              <div className={styles.cardTopline}>
+                <h3>{seat.label}</h3>
+                <StatusPill>{game.profileMode}</StatusPill>
+              </div>
+              <label>
+                <span>Ordered Major / Minor</span>
+                <select
+                  value={seat.buildId}
+                  onChange={(event) =>
+                    apply(
+                      updatePreparation(game, seat.id, {
+                        buildId: event.target.value,
+                      }),
+                    )
+                  }
+                >
+                  {BUILDS.map((candidate: { id: string; name: string }) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <p className={styles.identityLine}>{build.identity}</p>
+              <label>
+                <span>Fixed sidegrade loadout</span>
+                <select
+                  value={seat.loadoutId}
+                  onChange={(event) =>
+                    apply(
+                      updatePreparation(game, seat.id, {
+                        loadoutId: event.target.value,
+                      }),
+                    )
+                  }
+                >
+                  {Object.values(LOADOUTS).map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.id} · {candidate.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <dl className={styles.loadoutList}>
+                <div>
+                  <dt>Active</dt>
+                  <dd>{WEAPONS[loadout.activeWeapon].name}</dd>
+                </div>
+                <div>
+                  <dt>Reserve</dt>
+                  <dd>{WEAPONS[loadout.reserveWeapon].name}</dd>
+                </div>
+                <div>
+                  <dt>Armor</dt>
+                  <dd>
+                    {ARMOR[loadout.armor].name} · Guard{" "}
+                    {ARMOR[loadout.armor].guardCap}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Rig</dt>
+                  <dd>{RIGS[loadout.rig].name}</dd>
+                </div>
+              </dl>
+              <div className={styles.priorityPair}>
+                <label>
+                  <span>Primary</span>
+                  <select
+                    value={seat.primaryPriority}
+                    onChange={(event) =>
+                      apply(
+                        updatePreparation(game, seat.id, {
+                          primaryPriority: event.target.value,
+                        }),
+                      )
+                    }
+                  >
+                    {PRIORITIES.map((priority) => (
+                      <option key={priority}>{priority}</option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  <span>Secondary</span>
+                  <select
+                    value={seat.secondaryPriority}
+                    onChange={(event) =>
+                      apply(
+                        updatePreparation(game, seat.id, {
+                          secondaryPriority: event.target.value,
+                        }),
+                      )
+                    }
+                  >
+                    {PRIORITIES.map((priority) => (
+                      <option key={priority}>{priority}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <details className={styles.deckDetails}>
+                <summary>Fixed deck and opening order</summary>
+                <ol>
+                  {seat.deck.map((cardId: string, index: number) => (
+                    <li key={`${cardId}-${index}`}>
+                      <span>{index + 1}.</span> {formatCard(cardId)}
+                      {index < CORE_RULES.openingHand && (
+                        <em> opening</em>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </details>
+            </article>
+          );
+        })}
+      </div>
+
+      {game.expectedPaperResult && (
+        <aside className={styles.paperExpectation}>
+          <strong>Paper expectation loaded for comparison only.</strong>
+          <span>
+            It does not auto-resolve a hidden plan. The source gives final
+            totals but omits the full solo action scripts.
+          </span>
+        </aside>
+      )}
+
+      <button className={styles.primaryButton} onClick={() => apply(beginOutskirts(game))}>
+        Enter the Outskirts
+      </button>
+    </section>
+  );
+}
+
+function Outskirts({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  const [openApproach, setOpenApproach] = useState(
+    game.approach.selectedId ?? "impact-scar",
+  );
+  const activeSeat = game.seats.find(
+    (seat: GreyboxRecord) => seat.id === game.activeSeatId,
+  );
+  const activeMajor = buildFor(activeSeat.buildId).major;
+  const selected = game.approach.selectedId
+    ? APPROACHES[game.approach.selectedId]
+    : null;
+
+  const selectResult = (approachId: string, resultId: string) => {
+    apply(
+      selectApproachResult(
+        game,
+        approachId,
+        resultId,
+        game.approach.resolverSeatId,
+      ),
+    );
+  };
+
+  return (
+    <section className={styles.workspace}>
+      <div className={styles.sectionHeading}>
+        <div>
+          <p className={styles.eyebrow}>Freely explored physical block</p>
+          <h2>Inspect all three boundaries. Commit to one.</h2>
+        </div>
+        <StatusPill tone="warn">Other approaches close on commit</StatusPill>
+      </div>
+
+      <div className={styles.approachMap} aria-label="Outskirts approach relationship map">
+        <div className={styles.approachCenter}>OUTSKIRTS BLOCK</div>
+        {Object.values(APPROACHES).map((approach, index: number) => {
+          const inspected = game.approach.inspected.includes(approach.id);
+          const selectedApproach = game.approach.selectedId === approach.id;
+          return (
+            <button
+              key={approach.id}
+              className={`${styles.approachNode} ${selectedApproach ? styles.selected : ""}`}
+              data-index={index}
+              onClick={() => {
+                setOpenApproach(approach.id);
+                apply(inspectApproach(game, approach.id, game.activeSeatId));
+              }}
+            >
+              <span>{approach.name}</span>
+              <small>{inspected ? "Inspected" : "Unknown"}</small>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.approachInspector}>
+        <div className={styles.cardTopline}>
+          <div>
+            <p className={styles.eyebrow}>Selected world focus</p>
+            <h3>{APPROACHES[openApproach].name}</h3>
+          </div>
+          <label className={styles.compactSelect}>
+            <span>Reading seat</span>
+            <select
+              value={game.activeSeatId}
+              onChange={(event) => apply(selectSeat(game, event.target.value))}
+            >
+              {game.seats.map((seat: GreyboxRecord) => (
+                <option key={seat.id} value={seat.id}>
+                  {seat.label} · {buildFor(seat.buildId).name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <p>{APPROACHES[openApproach].broad}</p>
+        <div className={styles.readout}>
+          <strong>{buildFor(activeSeat.buildId).name} read</strong>
+          <span>{APPROACHES[openApproach].major[activeMajor]}</span>
+        </div>
+        <div className={styles.resultButtons}>
+          {APPROACHES[openApproach].results.map((resultId: string) => {
+            const disabled =
+              (openApproach === "impact-scar" &&
+                resultId === "exact" &&
+                activeMajor !== "battle") ||
+              (openApproach === "mute-repeater" &&
+                resultId === "preserved" &&
+                activeMajor !== "hacking");
+            const label =
+              resultId === "exact"
+                ? "Exact confrontation"
+                : resultId === "ordinary"
+                  ? "Ordinary defeat"
+                  : resultId === "preserved"
+                    ? "Preserve repeater"
+                    : resultId === "destroyed"
+                      ? "Destroy repeater"
+                      : "Take folded entry";
+            return (
+              <button
+                key={resultId}
+                disabled={disabled}
+                className={
+                  game.approach.selectedId === openApproach &&
+                  game.approach.resultId === resultId
+                    ? styles.activeChoice
+                    : styles.secondaryButton
+                }
+                onClick={() => selectResult(openApproach, resultId)}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {selected && (
+        <div className={styles.commitPanel}>
+          <div>
+            <p className={styles.eyebrow}>Physical commitment</p>
+            <h3>
+              {selected.name} · {game.approach.resultId}
+            </h3>
+          </div>
+          <label className={styles.compactSelect}>
+            <span>Resolving seat</span>
+            <select
+              value={game.approach.resolverSeatId}
+              onChange={(event) =>
+                apply(
+                  selectApproachResult(
+                    game,
+                    selected.id,
+                    game.approach.resultId,
+                    event.target.value,
+                  ),
+                )
+              }
+            >
+              {game.seats.map((seat: GreyboxRecord) => (
+                <option key={seat.id} value={seat.id}>
+                  {seat.label} · {buildFor(seat.buildId).name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <fieldset>
+            <legend>Every continuing seat confirms</legend>
+            {game.seats.map((seat: GreyboxRecord) => (
+              <label key={seat.id} className={styles.confirmCheck}>
+                <input
+                  type="checkbox"
+                  checked={game.approach.confirmations[seat.id]}
+                  onChange={(event) =>
+                    apply(
+                      setApproachConfirmation(
+                        game,
+                        seat.id,
+                        event.target.checked,
+                      ),
+                    )
+                  }
+                />
+                <span>{seat.label} confirms</span>
+              </label>
+            ))}
+          </fieldset>
+          <button
+            className={styles.primaryButton}
+            onClick={() => apply(commitApproach(game))}
+          >
+            Commit and enter Loose Signal
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ResourceBar({ game }: { game: ReturnType<typeof createGreyboxState> }) {
+  return (
+    <div className={styles.resourceGrid}>
+      {game.seats.map((seat: GreyboxRecord) => {
+        const active = seat.id === game.activeSeatId;
+        return (
+          <article className={`${styles.resourceCard} ${active ? styles.activeSeat : ""}`} key={seat.id}>
+            <div className={styles.cardTopline}>
+              <strong>{seat.label}</strong>
+              <StatusPill tone={seat.compromised ? "bad" : seat.locked ? "good" : "neutral"}>
+                {seat.compromised ? "Compromised" : seat.locked ? "Locked" : "Planning"}
+              </StatusPill>
+            </div>
+            <span>{buildFor(seat.buildId).name}</span>
+            <div className={styles.resourceNumbers}>
+              <b>{seatCommandAvailable(seat)}</b>
+              <small>Command free / {seat.command}</small>
+              <b>{seat.guard + seat.temporaryGuard}</b>
+              <small>Guard</small>
+              <b>{seat.condition}</b>
+              <small>Condition</small>
+              <b>{seat.disruption}</b>
+              <small>Disruption</small>
+            </div>
+            <span className={styles.positionLabel}>
+              {POSITIONS[seat.position]?.name ?? seat.position}
+            </span>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+const MAP_LINES: Array<
+  [number, number, number, number, "ordinary" | "opening" | "object"]
+> = [
+  [7, 36, 28, 36, "ordinary"],
+  [30, 8, 28, 36, "ordinary"],
+  [28, 36, 51, 36, "ordinary"],
+  [28, 36, 35, 61, "ordinary"],
+  [35, 61, 65, 61, "opening"],
+  [65, 61, 80, 47, "object"],
+  [65, 61, 85, 67, "object"],
+  [65, 61, 70, 88, "ordinary"],
+];
+
+function TacticalMap({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  const focuses = getFocuses(game);
+  const activeSeat = game.seats.find(
+    (seat: GreyboxRecord) => seat.id === game.activeSeatId,
+  );
+  return (
+    <div className={styles.mapPanel}>
+      <div className={styles.cardTopline}>
+        <div>
+          <p className={styles.eyebrow}>Physical expedition view</p>
+          <h3>Loose Signal Crossing</h3>
+        </div>
+        <StatusPill>Relationship greybox</StatusPill>
+      </div>
+      <p className={styles.mapNote}>
+        Positions and connections are mechanical. This does not decide
+        top-down 2D versus isometric 2.5D.
+      </p>
+      <div className={styles.mapCanvas}>
+        <svg viewBox="0 0 100 100" aria-hidden="true">
+          {MAP_LINES.map(([x1, y1, x2, y2, relationship], index) => (
+            <line
+              key={index}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              className={
+                relationship === "opening"
+                  ? styles.specialEdge
+                  : relationship === "object"
+                    ? styles.objectRelation
+                    : styles.edge
+              }
+            />
+          ))}
+        </svg>
+        {focuses.map((focus) => {
+          const style = {
+            "--map-x": `${focus.x}%`,
+            "--map-y": `${focus.y}%`,
+          } as CSSProperties;
+          const selected = activeSeat.focusId === focus.id;
+          const kind =
+            focus.kind === "Enemy"
+              ? styles.enemyNode
+              : focus.kind === "Character"
+                ? styles.characterNode
+                : styles.worldNode;
+          return (
+            <button
+              key={focus.id}
+              style={style}
+              className={`${styles.mapNode} ${kind} ${selected ? styles.mapSelected : ""}`}
+              onClick={() =>
+                apply(selectFocus(game, game.activeSeatId, focus.id))
+              }
+              aria-pressed={selected}
+            >
+              <strong>{focus.name}</strong>
+              <small>{focus.status}</small>
+              {typeof focus.condition === "number" && (
+                <span>
+                  G{focus.guard} · C{focus.condition}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className={styles.mapLegend}>
+        <span><i className={styles.legendWorld} /> World focus</span>
+        <span><i className={styles.legendCharacter} /> Character</span>
+        <span><i className={styles.legendEnemy} /> Enemy</span>
+        <span><i className={styles.legendSpecial} /> Special Opening</span>
+      </div>
+    </div>
+  );
+}
+
+function IntentPanel({ game }: { game: ReturnType<typeof createGreyboxState> }) {
+  const intents = getLayeredIntents(game);
+  return (
+    <aside className={styles.intentPanel}>
+      <div className={styles.cardTopline}>
+        <div>
+          <p className={styles.eyebrow}>Layered enemy intent</p>
+          <h3>Visible pressure</h3>
+        </div>
+        <StatusPill tone="warn">Tie order visible</StatusPill>
+      </div>
+      <p className={styles.tieOrder}>
+        Tie Order: {game.encounter.tieOrder.join(" → ")}
+      </p>
+      {intents.length === 0 ? (
+        <p className={styles.muted}>No active hostile intent.</p>
+      ) : (
+        intents.map((intent) => (
+          <details key={intent.enemyId} className={styles.intentCard} open>
+            <summary>
+              <span>{intent.enemy}</span>
+              <b>{intent.intent}</b>
+            </summary>
+            <dl>
+              <div><dt>Layer</dt><dd>{intent.layer}</dd></div>
+              <div><dt>Trigger</dt><dd>{intent.trigger}</dd></div>
+              <div><dt>Target</dt><dd>{intent.target}</dd></div>
+              <div><dt>Timing</dt><dd>{intent.timing}</dd></div>
+              <div><dt>Consequence</dt><dd>{intent.consequence}</dd></div>
+              <div><dt>Certainty</dt><dd>{intent.certainty}</dd></div>
+            </dl>
+          </details>
+        ))
+      )}
+    </aside>
+  );
+}
+
+function Projection({ action }: { action: GreyboxAction | null }) {
+  if (!action) {
+    return (
+      <div className={styles.emptyProjection}>
+        Select one action variant to review its projected consequence before
+        adding it.
+      </div>
+    );
+  }
+  return (
+    <div className={styles.projection}>
+      <div className={styles.cardTopline}>
+        <div>
+          <p className={styles.eyebrow}>Pre-lock projection</p>
+          <h4>{action.name}</h4>
+        </div>
+        <StatusPill tone={action.projection.certainty.startsWith("Confirmed") ? "good" : "warn"}>
+          {action.tag}
+        </StatusPill>
+      </div>
+      <dl>
+        {Object.entries(action.projection).map(([key, value]) => (
+          <div key={key}>
+            <dt>{key.replace(/([A-Z])/g, " $1")}</dt>
+            <dd>{String(value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function ActionBrowser({
+  game,
+  apply,
+  selectedCandidate,
+  setSelectedCandidate,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+  selectedCandidate: GreyboxAction | null;
+  setSelectedCandidate: (action: GreyboxAction | null) => void;
+}) {
+  const activeSeat = game.seats.find(
+    (seat: GreyboxRecord) => seat.id === game.activeSeatId,
+  );
+  const groups = getImmediateActionGroups(
+    game,
+    activeSeat.id,
+    activeSeat.focusId,
+  );
+  const [openGroup, setOpenGroup] = useState(groups[0]?.name ?? "");
+  const visibleGroup =
+    groups.find((group) => group.name === openGroup) ?? groups[0];
+
+  return (
+    <div className={styles.actionBrowser}>
+      <div className={styles.cardTopline}>
+        <div>
+          <p className={styles.eyebrow}>World focus</p>
+          <h3>
+            {getFocuses(game).find((focus) => focus.id === activeSeat.focusId)?.name ??
+              activeSeat.focusId}
+          </h3>
+        </div>
+        <StatusPill tone={groups.length <= 4 ? "good" : "bad"}>
+          {groups.length} immediate choice{groups.length === 1 ? "" : "s"}
+        </StatusPill>
+      </div>
+      <p className={styles.actionHint}>
+        Root choices are true action families. Their variants replace this
+        layer; no legal action is dropped to satisfy the four-choice target.
+      </p>
+      <div className={styles.actionFamilies}>
+        {groups.map((group) => (
+          <button
+            key={group.name}
+            className={visibleGroup?.name === group.name ? styles.activeChoice : styles.secondaryButton}
+            onClick={() => {
+              setOpenGroup(group.name);
+              setSelectedCandidate(null);
+            }}
+          >
+            {group.name}
+            <small>{group.variants.length} variant{group.variants.length === 1 ? "" : "s"}</small>
+          </button>
+        ))}
+      </div>
+      <div className={styles.variantList}>
+        {visibleGroup?.variants.map((action: GreyboxAction) => (
+          <button
+            key={`${action.id}-${action.targetId}-${action.destinationId ?? ""}`}
+            className={
+              selectedCandidate?.id === action.id &&
+              selectedCandidate?.targetId === action.targetId
+                ? styles.variantSelected
+                : styles.variantButton
+            }
+            onClick={() => setSelectedCandidate(action)}
+          >
+            <span>{action.name}</span>
+            <small>
+              {action.cost} Command · {action.lane}/{action.tempo}
+              {!action.paid && " · free slot"}
+            </small>
+          </button>
+        ))}
+      </div>
+      <Projection action={selectedCandidate} />
+      <button
+        className={styles.primaryButton}
+        disabled={!selectedCandidate || activeSeat.locked}
+        onClick={() => {
+          if (!selectedCandidate) return;
+          apply(queueAction(game, activeSeat.id, selectedCandidate));
+          setSelectedCandidate(null);
+        }}
+      >
+        Add projected action
+      </button>
+    </div>
+  );
+}
+
+function PlanPanel({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  const activeSeat = game.seats.find(
+    (seat: GreyboxRecord) => seat.id === game.activeSeatId,
+  );
+  const paid = activeSeat.plan.filter(
+    (action: GreyboxAction) => action.paid,
+  ).length;
+  const reposition = activeSeat.plan.some(
+    (action: GreyboxAction) => action.baseId === "reposition",
+  );
+
+  return (
+    <div className={styles.planPanel}>
+      <div className={styles.seatTabs} role="tablist" aria-label="Local player seats">
+        {game.seats.map((seat: GreyboxRecord) => (
+          <button
+            key={seat.id}
+            role="tab"
+            aria-selected={seat.id === game.activeSeatId}
+            className={seat.id === game.activeSeatId ? styles.activeSeatTab : styles.seatTab}
+            onClick={() => apply(selectSeat(game, seat.id))}
+          >
+            {seat.label}
+            <small>{seat.locked ? "locked" : `${seat.plan.length} planned`}</small>
+          </button>
+        ))}
+      </div>
+      <div className={styles.planHeader}>
+        <div>
+          <p className={styles.eyebrow}>Personal plan ownership</p>
+          <h3>{activeSeat.label}</h3>
+        </div>
+        <div className={styles.slotReadout}>
+          <span>{paid} / 4 paid</span>
+          <span>{reposition ? "1 / 1" : "0 / 1"} Reposition</span>
+          <span>{seatCommandAvailable(activeSeat)} Command free</span>
+        </div>
+      </div>
+
+      {activeSeat.hand.length > CORE_RULES.retainLimit && (
+        <div className={styles.discardStrip}>
+          <strong>Discard to seven before the next lock.</strong>
+          {activeSeat.hand.map((cardId: string) => (
+            <button
+              key={cardId}
+              onClick={() => apply(discardCard(game, activeSeat.id, cardId))}
+            >
+              {formatCard(cardId)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className={styles.planList}>
+        {activeSeat.plan.length === 0 && (
+          <p className={styles.muted}>No paid actions or Reposition declared.</p>
+        )}
+        {activeSeat.plan.map((action: GreyboxAction, index: number) => {
+          const compatible = compatibleCardsForAction(activeSeat, action);
+          return (
+            <article className={styles.planAction} key={action.instanceId}>
+              <div className={styles.cardTopline}>
+                <div>
+                  <span className={styles.actionIndex}>
+                    {action.paid ? `SLOT ${index + 1}` : "REPOSITION"}
+                  </span>
+                  <h4>{action.name}</h4>
+                </div>
+                <span className={styles.commandCost}>
+                  {action.totalReservedCommand} CMD
+                </span>
+              </div>
+              <p>
+                {action.lane}/{action.tempo} · {action.tag} · target{" "}
+                {action.projection.target}
+              </p>
+              {action.exclusiveClaim && (
+                <label className={styles.inlineControl}>
+                  <span>Claim</span>
+                  <select
+                    value={action.claimMode}
+                    disabled={activeSeat.locked}
+                    onChange={(event) =>
+                      apply(
+                        setClaimMode(
+                          game,
+                          activeSeat.id,
+                          action.instanceId,
+                          event.target.value,
+                        ),
+                      )
+                    }
+                  >
+                    <option>Primary</option>
+                    <option>If Available</option>
+                    <option>Yielded</option>
+                  </select>
+                </label>
+              )}
+              {action.requiresConsentFromSeatId && (
+                <div className={styles.consentLine}>
+                  <span>
+                    Consent:{" "}
+                    {
+                      game.seats.find(
+                        (seat: GreyboxRecord) =>
+                          seat.id === action.requiresConsentFromSeatId,
+                      )?.label
+                    }
+                  </span>
+                  <StatusPill tone={action.consentGranted ? "good" : "warn"}>
+                    {action.consentGranted ? "Granted" : "Required"}
+                  </StatusPill>
+                </div>
+              )}
+              <details>
+                <summary>Projection and invalidators</summary>
+                <Projection action={action} />
+              </details>
+              <div className={styles.cardAttach}>
+                {action.attachedCardId ? (
+                  <>
+                    <span>
+                      {formatCard(action.attachedCardId)} ·{" "}
+                      {CARDS[action.attachedCardId].kind}
+                    </span>
+                    <button
+                      disabled={activeSeat.locked}
+                      onClick={() =>
+                        apply(
+                          detachCard(
+                            game,
+                            activeSeat.id,
+                            action.instanceId,
+                          ),
+                        )
+                      }
+                    >
+                      Detach
+                    </button>
+                  </>
+                ) : compatible.length ? (
+                  <>
+                    <span>Attach one compatible Prepared Card</span>
+                    <select
+                      defaultValue=""
+                      disabled={activeSeat.locked}
+                      onChange={(event) => {
+                        if (!event.target.value) return;
+                        apply(
+                          attachCard(
+                            game,
+                            activeSeat.id,
+                            action.instanceId,
+                            event.target.value,
+                          ),
+                        );
+                        event.target.value = "";
+                      }}
+                    >
+                      <option value="">Choose card…</option>
+                      {compatible.map((card) => (
+                        <option key={card.id} value={card.id}>
+                          {card.name} · +{card.cost}
+                        </option>
+                      ))}
+                    </select>
+                  </>
+                ) : (
+                  <span>No compatible card in hand.</span>
+                )}
+              </div>
+              <button
+                className={styles.removeButton}
+                disabled={activeSeat.locked}
+                onClick={() =>
+                  apply(
+                    removeAction(game, activeSeat.id, action.instanceId),
+                  )
+                }
+              >
+                Remove
+              </button>
+            </article>
+          );
+        })}
+      </div>
+
+      {game.seats
+        .flatMap((seat: GreyboxRecord) =>
+          seat.plan.map((action: GreyboxAction) => ({ actor: seat, action })),
+        )
+        .filter(
+          ({ action }: { action: GreyboxAction }) =>
+            action.requiresConsentFromSeatId === activeSeat.id,
+        )
+        .map(
+          ({
+            actor,
+            action,
+          }: {
+            actor: GreyboxRecord;
+            action: GreyboxAction;
+          }) => (
+          <div className={styles.consentRequest} key={action.instanceId}>
+            <span>
+              {actor.label} requests consent for <b>{action.name}</b>.
+            </span>
+            <button
+              disabled={activeSeat.locked}
+              onClick={() =>
+                apply(setConsent(game, activeSeat.id, action.instanceId, true))
+              }
+            >
+              Grant
+            </button>
+            <button
+              disabled={activeSeat.locked}
+              onClick={() =>
+                apply(setConsent(game, activeSeat.id, action.instanceId, false))
+              }
+            >
+              Withhold
+            </button>
+          </div>
+          ),
+        )}
+
+      {activeSeat.lockError && (
+        <p className={styles.errorText}>{activeSeat.lockError}</p>
+      )}
+      <button
+        className={activeSeat.locked ? styles.secondaryButton : styles.primaryButton}
+        onClick={() =>
+          apply(
+            activeSeat.locked
+              ? unlockSeatPlan(game, activeSeat.id)
+              : lockSeatPlan(game, activeSeat.id),
+          )
+        }
+      >
+        {activeSeat.locked ? `Unlock ${activeSeat.label}` : `Lock ${activeSeat.label}`}
+      </button>
+    </div>
+  );
+}
+
+function CausalLog({ game }: { game: ReturnType<typeof createGreyboxState> }) {
+  const events = game.encounter?.causalLog ?? [];
+  return (
+    <details className={styles.causalLog} open={game.encounter?.resolutionComplete}>
+      <summary>
+        Causal resolution log <span>{events.length} events</span>
+      </summary>
+      <ol>
+        {events.map((event: GreyboxRecord) => (
+          <li key={`${event.index}-${event.cycle}`}>
+            <span className={styles.packetLabel}>
+              {event.packet}
+            </span>
+            <div>
+              <strong>{event.actionId}</strong>
+              <p>{event.detail}</p>
+              <small>{event.outcome} · {event.tags.join(" · ")}</small>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function Encounter({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  const [selectedCandidate, setSelectedCandidate] =
+    useState<GreyboxAction | null>(null);
+  const resolved = game.encounter.resolutionComplete;
+  return (
+    <section className={styles.workspace}>
+      <div className={styles.sectionHeading}>
+        <div>
+          <p className={styles.eyebrow}>LS-01 · cycle {game.encounter.cycle}</p>
+          <h2>{resolved ? "Resolution complete. Settle the causal state." : "Inspect → focus → plan → project → lock."}</h2>
+        </div>
+        <StatusPill tone={resolved ? "good" : "info"}>
+          {resolved ? "Awaiting Settle" : "Planning Phase"}
+        </StatusPill>
+      </div>
+      <ResourceBar game={game} />
+      <div className={styles.encounterGrid}>
+        <TacticalMap game={game} apply={apply} />
+        <IntentPanel game={game} />
+      </div>
+      {!resolved && (
+        <div className={styles.planningGrid}>
+          <ActionBrowser
+            game={game}
+            apply={apply}
+            selectedCandidate={selectedCandidate}
+            setSelectedCandidate={setSelectedCandidate}
+          />
+          <PlanPanel game={game} apply={apply} />
+        </div>
+      )}
+
+      <CausalLog game={game} />
+
+      <div className={styles.resolveBar}>
+        {!resolved ? (
+          <>
+            <div>
+              <strong>
+                {
+                  game.seats.filter((seat: GreyboxRecord) => seat.locked)
+                    .length
+                }{" "}
+                /{" "}
+                {game.seats.length} personal plans locked
+              </strong>
+              <span>
+                No seat can edit another seat&apos;s plan. Equal-time exclusive
+                conflicts block resolution.
+              </span>
+            </div>
+            <button
+              className={styles.dangerButton}
+              disabled={!canResolvePlans(game)}
+              onClick={() => apply(resolvePlans(game))}
+            >
+              Resolve Fast → Standard → Slow
+            </button>
+          </>
+        ) : (
+          <>
+            <div>
+              <strong>Resolution packets complete.</strong>
+              <span>
+                Refunds, Reseal, release validation, reinforcement, income,
+                draw, and rescue clocks occur at Settle.
+              </span>
+            </div>
+            <button
+              className={styles.primaryButton}
+              onClick={() => apply(settleCycle(game))}
+            >
+              Settle cycle {game.encounter.cycle}
+            </button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ResultTable({ game }: { game: ReturnType<typeof createGreyboxState> }) {
+  const summary = resultSummary(game);
+  const comparison = compareToPaperExpectation(game);
+  return (
+    <div className={styles.resultGrid}>
+      <article className={styles.resultCard}>
+        <p className={styles.eyebrow}>World state</p>
+        <h3>Loose Signal result</h3>
+        <dl>
+          <div><dt>Cycle</dt><dd>{summary.cycle}</dd></div>
+          <div><dt>Survey</dt><dd>{summary.survey}</dd></div>
+          <div><dt>Marker</dt><dd>{summary.markerIntegrity} Integrity</dd></div>
+          <div><dt>Shutter</dt><dd>{summary.shutter} · {summary.shutterState}</dd></div>
+          <div><dt>Threat clear</dt><dd>{summary.fullEnteredThreatClear ? "Yes" : "No"}</dd></div>
+          <div><dt>Protection</dt><dd>{summary.protectedPackages}</dd></div>
+        </dl>
+      </article>
+      {summary.seats.map((seat: GreyboxRecord) => (
+        <article className={styles.resultCard} key={seat.id}>
+          <p className={styles.eyebrow}>{seat.id}</p>
+          <h3>{seat.build}</h3>
+          <dl>
+            <div><dt>Condition</dt><dd>{seat.condition}</dd></div>
+            <div><dt>Guard</dt><dd>{seat.guard}</dd></div>
+            <div><dt>Command</dt><dd>{seat.command}</dd></div>
+            <div><dt>Disruption</dt><dd>{seat.disruption}</dd></div>
+            <div><dt>Position</dt><dd>{seat.position}</dd></div>
+            <div><dt>Major state</dt><dd>{seat.majorState}</dd></div>
+            <div><dt>Packages</dt><dd>{seat.packages.join(", ") || "None"}</dd></div>
+          </dl>
+        </article>
+      ))}
+      {comparison.length > 0 && (
+        <article className={styles.resultCard}>
+          <p className={styles.eyebrow}>Paper versus playable</p>
+          <h3>Mismatch ledger</h3>
+          <table>
+            <thead><tr><th>Field</th><th>Paper</th><th>Observed</th><th /></tr></thead>
+            <tbody>
+              {comparison.map((row) => (
+                <tr key={row.field}>
+                  <td>{row.field}</td>
+                  <td>{String(row.expected)}</td>
+                  <td>{String(row.observed)}</td>
+                  <td>{row.match ? "MATCH" : "MISMATCH"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </article>
+      )}
+    </div>
+  );
+}
+
+function SegmentSettle({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  return (
+    <section className={styles.workspace}>
+      <div className={styles.sectionHeading}>
+        <div>
+          <p className={styles.eyebrow}>Segment Settle</p>
+          <h2>The Threshold is open. The bounded evidence target is complete.</h2>
+        </div>
+        <StatusPill tone="good">Outskirts → Loose Signal</StatusPill>
+      </div>
+      <ResultTable game={game} />
+      <div className={styles.decisionGrid}>
+        <button onClick={() => apply(chooseSegmentDecision(game, "continue"))}>
+          <strong>Continue to Quiet Shift</strong>
+          <span>Record the carried tactical state, then stop at this PR&apos;s boundary.</span>
+        </button>
+        <button onClick={() => apply(chooseSegmentDecision(game, "retreat"))}>
+          <strong>Retreat and record</strong>
+          <span>Record a private noncanonical retreat. No canonical reward or persistent economy write.</span>
+        </button>
+        <button onClick={() => apply(chooseSegmentDecision(game, "extract-record"))}>
+          <strong>Record extraction evidence</strong>
+          <span>Use the opened Threshold state as deterministic extraction evidence; no account persistence.</span>
+        </button>
+        <div className={styles.disabledDecision}>
+          <strong>Protect Packages</strong>
+          <span>Unavailable here. Protected claims belong to the later physical Safe Node; the greybox will not invent an earlier protection system.</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Evidence({
+  game,
+  apply,
+}: {
+  game: ReturnType<typeof createGreyboxState>;
+  apply: (next: ReturnType<typeof createGreyboxState>) => void;
+}) {
+  const downloadEvidence = () => {
+    const payload = {
+      sourceRevision: game.sourceRevision,
+      profileId: game.profileId,
+      expectedPaperResult: game.expectedPaperResult,
+      sourceMismatches: game.sourceMismatches,
+      result: resultSummary(game),
+      evidence: game.evidence,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const href = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = `${game.profileId.toLowerCase()}-evidence.json`;
+    anchor.click();
+    URL.revokeObjectURL(href);
+  };
+  return (
+    <section className={styles.workspace}>
+      <div className={styles.sectionHeading}>
+        <div>
+          <p className={styles.eyebrow}>Private evidence boundary</p>
+          <h2>{game.stageLabel}</h2>
+        </div>
+        <StatusPill tone="good">No canonical write</StatusPill>
+      </div>
+      <ResultTable game={game} />
+      <div className={styles.evidenceActions}>
+        <button className={styles.secondaryButton} onClick={downloadEvidence}>
+          Download isolated evidence JSON
+        </button>
+        <button className={styles.primaryButton} onClick={() => apply(resetGreybox(game))}>
+          Reset to known profile start
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function SourceBoundary({ game }: { game: ReturnType<typeof createGreyboxState> }) {
+  return (
+    <details className={styles.sourceBoundary}>
+      <summary>
+        Source conflicts, assumptions, and intentionally excluded behavior
+        <span>{game.sourceMismatches.length}</span>
+      </summary>
+      <div className={styles.mismatchGrid}>
+        {game.sourceMismatches.map((item: GreyboxRecord) => (
+          <article key={item.id}>
+            <div className={styles.cardTopline}>
+              <strong>{item.id}</strong>
+              <StatusPill tone={item.status === "SOURCE CONFLICT" ? "bad" : "warn"}>
+                {item.status}
+              </StatusPill>
+            </div>
+            <p>{item.rule}</p>
+            {item.conflictingExpectation && (
+              <p><b>Conflict:</b> {item.conflictingExpectation}</p>
+            )}
+            <p><b>Greybox treatment:</b> {item.implementation}</p>
+          </article>
+        ))}
+      </div>
+      <p className={styles.boundaryCopy}>
+        Intentionally absent: creatures, permanent progression, artist
+        takeover, account persistence, online sync, canonical rewards, stores,
+        crafting, trading, rarity, queue events, Discord, TikTok, Relay,
+        Journal, BNL calls, dossiers, and Source Files.
+      </p>
+    </details>
+  );
+}
+
+export function BarcodeWorldGreybox() {
+  const [game, setGame] = useState(() => createGreyboxState());
+
+  const apply = (next: ReturnType<typeof createGreyboxState>) => {
+    setGame(next);
+  };
+
+  const progressStage = useMemo(
+    () => (game.stage === "loose-signal" && game.encounter?.resolutionComplete ? "loose-signal" : game.stage),
+    [game.stage, game.encounter?.resolutionComplete],
+  );
+
+  return (
+    <div className={styles.shell}>
+      <header className={styles.prototypeHeader}>
+        <div>
+          <p className={styles.eyebrow}>BARCODE World // evidence equipment</p>
+          <h1>Outskirts → Loose Signal</h1>
+          <p>
+            Private, resettable, deterministic browser greybox. Working
+            noncanonical names. No model call. No live data.
+          </p>
+        </div>
+        <div className={styles.headerBadges}>
+          <StatusPill tone="warn">Development only</StatusPill>
+          <StatusPill>LS-01</StatusPill>
+          <StatusPill>{game.profileId}</StatusPill>
+        </div>
+      </header>
+
+      <nav className={styles.stageRail} aria-label="Greybox phase">
+        {STAGES.map(([id, label], index) => (
+          <div
+            key={id}
+            className={
+              id === progressStage
+                ? styles.currentStage
+                : stageReached(progressStage, id)
+                  ? styles.pastStage
+                  : styles.futureStage
+            }
+          >
+            <span>{index + 1}</span>
+            <strong>{label}</strong>
+          </div>
+        ))}
+      </nav>
+
+      {game.warnings.length > 0 && (
+        <div className={styles.warningStack} role="status">
+          {game.warnings.slice(-3).map((warning: string, index: number) => (
+            <p key={`${warning}-${index}`}>{warning}</p>
+          ))}
+        </div>
+      )}
+
+      {game.stage === "preparation" && <Preparation game={game} apply={apply} />}
+      {game.stage === "outskirts" && <Outskirts game={game} apply={apply} />}
+      {game.stage === "loose-signal" && <Encounter game={game} apply={apply} />}
+      {game.stage === "segment-settle" && <SegmentSettle game={game} apply={apply} />}
+      {game.stage === "complete" && <Evidence game={game} apply={apply} />}
+
+      <SourceBoundary game={game} />
+
+      <footer className={styles.prototypeFooter}>
+        <span>{game.sourceRevision}</span>
+        <button onClick={() => apply(resetGreybox(game))}>Reset profile</button>
+      </footer>
+    </div>
+  );
+}

--- a/src/lib/barcode-world/constants.mjs
+++ b/src/lib/barcode-world/constants.mjs
@@ -1,0 +1,999 @@
+export const SOURCE_REVISION =
+  "BARCODE_WORLD_PLAYTEST_READY_VERTICAL_SLICE_SOURCE_PACK_2026-07-26";
+
+export const CORE_RULES = Object.freeze({
+  commandStart: 16,
+  commandIncome: 16,
+  commandCap: 32,
+  paidActionCap: 4,
+  ordinaryRepositionPerPhase: 1,
+  condition: 12,
+  majorSetupCost: 7,
+  minorFoundationCost: 6,
+  majorPayoffCost: 8,
+  deckSize: 12,
+  openingHand: 5,
+  drawPerSettle: 2,
+  retainLimit: 7,
+  exposedPackageSlots: 2,
+  normalImmediateChoices: 4,
+  exceptionalImmediateChoices: 5,
+});
+
+export const DISCIPLINES = Object.freeze({
+  battle: {
+    id: "battle",
+    name: "Battle",
+    state: "Battle Advantage",
+    awareness:
+      "Reads hostile Commitments, collision paths, threatened destinations, and direct consequences.",
+    minor: {
+      id: "contest",
+      name: "Contest",
+      cost: 6,
+      lane: "Inherited",
+      tempo: null,
+      tag: "Instant",
+    },
+    setup: {
+      id: "answer-commitment",
+      name: "Answer Commitment",
+      cost: 7,
+      lane: "Inherited",
+      tempo: null,
+      tag: "Instant",
+    },
+    payoff: {
+      id: "convert-advantage",
+      name: "Convert Advantage",
+      cost: 8,
+      lane: "Standard",
+      tempo: 5,
+      tag: "Instant",
+    },
+  },
+  exploration: {
+    id: "exploration",
+    name: "Exploration",
+    state: "Prepared Route",
+    awareness:
+      "Reads Openings, destinations, recurrence, landing pressure, pursuit, rescue, and extraction geometry.",
+    minor: {
+      id: "cross-opening",
+      name: "Cross Opening",
+      cost: 6,
+      lane: "Standard",
+      tempo: 5,
+      tag: "Transit",
+    },
+    setup: {
+      id: "prepare-route",
+      name: "Prepare Route",
+      cost: 7,
+      lane: "Standard",
+      tempo: 4,
+      tag: "Instant",
+    },
+    payoff: {
+      id: "exploit-route",
+      name: "Exploit Route",
+      cost: 8,
+      lane: "Standard",
+      tempo: 5,
+      tag: "Transit",
+    },
+  },
+  hacking: {
+    id: "hacking",
+    name: "Hacking",
+    state: "Temporary Control",
+    awareness:
+      "Reads Dependencies, access points, automatic responses, connected components, reserves, and bounded Outputs.",
+    minor: {
+      id: "suppress-response",
+      name: "Suppress Response",
+      cost: 6,
+      lane: "Fast",
+      tempo: 6,
+      tag: "Instant",
+    },
+    setup: {
+      id: "establish-control",
+      name: "Establish Control",
+      cost: 7,
+      lane: "Standard",
+      tempo: 3,
+      tag: "Sustained",
+    },
+    payoff: {
+      id: "execute-output",
+      name: "Execute Output",
+      cost: 8,
+      lane: "Standard",
+      tempo: 6,
+      tag: "Sustained",
+    },
+  },
+});
+
+const UNIVERSAL_CARDS = {
+  "fallback-guard": {
+    id: "fallback-guard",
+    name: "Fallback Guard",
+    kind: "Contingency",
+    cost: 4,
+    compatibility: ["paid"],
+    text: "If the primary invalidates before beginning, gain 3 temporary Guard and Brace against one visible direct Commitment.",
+  },
+  "covering-step": {
+    id: "covering-step",
+    name: "Covering Step",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["reposition", "additional-movement"],
+    text: "After successful movement, gain 2 temporary Guard against the first ranged or line attack before Settle.",
+  },
+  "field-patch": {
+    id: "field-patch",
+    name: "Field Patch",
+    kind: "Action",
+    cost: 8,
+    lane: "Slow",
+    tempo: 3,
+    tag: "Sustained",
+    compatibility: ["standalone"],
+    text: "Self or adjacent non-Compromised ally restores 3 Condition. Once per character per encounter. Cannot Stabilize.",
+  },
+  "emergency-drag": {
+    id: "emergency-drag",
+    name: "Emergency Drag",
+    kind: "Action",
+    cost: 8,
+    lane: "Standard",
+    tempo: 4,
+    tag: "Transit",
+    compatibility: ["standalone"],
+    text: "Move the user and an adjacent willing ally, Compromised ally, or one-slot Package one ordinary adjacent position.",
+  },
+  "hand-signal": {
+    id: "hand-signal",
+    name: "Hand Signal",
+    kind: "Team Modifier",
+    cost: 0,
+    compatibility: ["assist"],
+    partyOnly: true,
+    text: "Assist may target a visible ally within two connected positions and resolves Fast / 6.",
+  },
+  "objective-brace": {
+    id: "objective-brace",
+    name: "Objective Brace",
+    kind: "Preparation",
+    cost: 2,
+    compatibility: [
+      "work-objective",
+      "stabilize-plate",
+      "complete-release",
+    ],
+    text: "Ignore the first visible direct interruption that would cancel Work or remove its completed Work before Settle.",
+  },
+  "last-exit": {
+    id: "last-exit",
+    name: "Last Exit",
+    kind: "Modifier",
+    cost: 4,
+    compatibility: ["standard-extract"],
+    text: "Secure one exposed one-slot Package if Extract succeeds.",
+  },
+  "linked-effort": {
+    id: "linked-effort",
+    name: "Linked Effort",
+    kind: "Team Modifier",
+    cost: 2,
+    compatibility: ["assist"],
+    partyOnly: true,
+    text: "If both actions resolve, the supported ally gains 2 temporary Guard until Settle.",
+  },
+};
+
+const BATTLE_CARDS = {
+  "brace-through": {
+    id: "brace-through",
+    name: "Brace Through",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["contest", "answer-commitment"],
+    text: "+1 Force resistance against that Commitment; gain 2 temporary Guard if still at the contact point.",
+  },
+  "extended-intercept": {
+    id: "extended-intercept",
+    name: "Extended Intercept",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["contest", "answer-commitment"],
+    text: "Meet the Commitment from one additional ordinary position away and move to contact. Cannot cross a special Opening.",
+  },
+  "controlled-withdrawal": {
+    id: "controlled-withdrawal",
+    name: "Controlled Withdrawal",
+    kind: "Contingency",
+    cost: 4,
+    compatibility: ["attack", "contest", "answer-commitment"],
+    text: "If the target leaves and the primary invalidates, move to a declared adjacent fallback and gain 1 temporary Guard.",
+  },
+  "press-the-break": {
+    id: "press-the-break",
+    name: "Press the Break",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["convert-advantage"],
+    text: "Choose Crush (+2 Guard Break), Drive (+1 Force), or Finish (+2 Impact when the target is projected at zero Guard).",
+  },
+  "hold-the-edge": {
+    id: "hold-the-edge",
+    name: "Hold the Edge",
+    kind: "Preparation",
+    cost: 2,
+    compatibility: ["answer-commitment"],
+    text: "The resulting Advantage survives the first ordinary move or one-position forced shift while the confrontation remains valid.",
+  },
+  "pass-the-opening": {
+    id: "pass-the-opening",
+    name: "Pass the Opening",
+    kind: "Team Modifier",
+    cost: 2,
+    compatibility: ["convert-advantage"],
+    partyOnly: true,
+    text: "A visible ally within two positions may Reposition into newly legal adjacent space after displacement or breach.",
+  },
+};
+
+const EXPLORATION_CARDS = {
+  "safe-landing": {
+    id: "safe-landing",
+    name: "Safe Landing",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["cross-opening", "cross-plate", "follow-route", "exploit-route"],
+    text: "Ignore up to 2 crossing or landing Impact and 1 landing Force.",
+  },
+  "carry-line": {
+    id: "carry-line",
+    name: "Carry Line",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: [
+      "reposition",
+      "cross-opening",
+      "cross-plate",
+      "follow-route",
+      "exploit-route",
+    ],
+    text: "A legal carried Package or Assist relationship does not reduce or cancel movement.",
+  },
+  "backtrack-marker": {
+    id: "backtrack-marker",
+    name: "Backtrack Marker",
+    kind: "Preparation",
+    cost: 2,
+    compatibility: ["cross-opening", "follow-route", "exploit-route"],
+    text: "Mark the origin and expose Backtrack — 4, Standard / 5 before Settle while the same Opening remains legal.",
+  },
+  "route-capacity": {
+    id: "route-capacity",
+    name: "Route Capacity",
+    kind: "Modifier",
+    cost: 4,
+    compatibility: ["prepare-route"],
+    text: "Add one allied Follow passage or one recurrence when the Opening is authored as recurring.",
+  },
+  "destination-claim": {
+    id: "destination-claim",
+    name: "Destination Claim",
+    kind: "Preparation",
+    cost: 2,
+    compatibility: ["prepare-route"],
+    text: "One observed destination feature survives one ordinary environmental shift or closure before Exploit.",
+  },
+  "broken-map": {
+    id: "broken-map",
+    name: "Broken Map",
+    kind: "Contingency",
+    cost: 4,
+    compatibility: ["prepare-route", "exploit-route"],
+    text: "Redirect to one declared observed alternate destination if the primary becomes illegal and the Opening remains legal.",
+  },
+};
+
+const HACKING_CARDS = {
+  "clean-buffer": {
+    id: "clean-buffer",
+    name: "Clean Buffer",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: [
+      "basic-interface",
+      "suppress-response",
+      "establish-control",
+      "execute-output",
+    ],
+    text: "Ignore the first applicable 1 Disruption or 2 system-origin Impact caused directly by the action.",
+  },
+  "delay-stack": {
+    id: "delay-stack",
+    name: "Delay Stack",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["suppress-response", "basic-interface"],
+    text: "Move a Basic Interface response one lane later, or delay a Suppressed response until after the next Settle.",
+  },
+  "emergency-disconnect": {
+    id: "emergency-disconnect",
+    name: "Emergency Disconnect",
+    kind: "Contingency",
+    cost: 4,
+    compatibility: [
+      "basic-interface",
+      "suppress-response",
+      "establish-control",
+      "execute-output",
+    ],
+    text: "Abort before the parent begins, sever access, and ignore one named system response. Access is unavailable until next planning phase.",
+  },
+  "chained-output": {
+    id: "chained-output",
+    name: "Chained Output",
+    kind: "Modifier",
+    cost: 4,
+    compatibility: ["execute-output"],
+    text: "Execute one secondary Chainable Output from the same Dependency after the primary.",
+  },
+  "quiet-rewrite": {
+    id: "quiet-rewrite",
+    name: "Quiet Rewrite",
+    kind: "Modifier",
+    cost: 2,
+    compatibility: ["establish-control"],
+    text: "Delay the first alert, lockout, or hostile response caused by establishing Control until after Settle.",
+  },
+  "trace-echo": {
+    id: "trace-echo",
+    name: "Trace Echo",
+    kind: "Preparation",
+    cost: 2,
+    compatibility: ["execute-output"],
+    text: "Confirm the next response from one affected component and reduce the next eligible Scan or Basic Interface by 2, minimum 4.",
+  },
+};
+
+export const CARDS = Object.freeze({
+  ...UNIVERSAL_CARDS,
+  ...BATTLE_CARDS,
+  ...EXPLORATION_CARDS,
+  ...HACKING_CARDS,
+});
+
+const DECKS = {
+  "battle-exploration": [
+    "fallback-guard",
+    "objective-brace",
+    "brace-through",
+    "hold-the-edge",
+    "safe-landing",
+    "covering-step",
+    "extended-intercept",
+    "field-patch",
+    "controlled-withdrawal",
+    "press-the-break",
+    "carry-line",
+    "last-exit",
+  ],
+  "exploration-battle": [
+    "fallback-guard",
+    "objective-brace",
+    "safe-landing",
+    "destination-claim",
+    "brace-through",
+    "covering-step",
+    "route-capacity",
+    "field-patch",
+    "backtrack-marker",
+    "controlled-withdrawal",
+    "broken-map",
+    "last-exit",
+  ],
+  "battle-hacking": [
+    "fallback-guard",
+    "objective-brace",
+    "brace-through",
+    "hold-the-edge",
+    "clean-buffer",
+    "covering-step",
+    "extended-intercept",
+    "field-patch",
+    "controlled-withdrawal",
+    "press-the-break",
+    "delay-stack",
+    "last-exit",
+  ],
+  "hacking-battle": [
+    "fallback-guard",
+    "objective-brace",
+    "clean-buffer",
+    "quiet-rewrite",
+    "brace-through",
+    "covering-step",
+    "emergency-disconnect",
+    "field-patch",
+    "chained-output",
+    "controlled-withdrawal",
+    "trace-echo",
+    "last-exit",
+  ],
+  "exploration-hacking": [
+    "fallback-guard",
+    "objective-brace",
+    "safe-landing",
+    "destination-claim",
+    "clean-buffer",
+    "covering-step",
+    "route-capacity",
+    "field-patch",
+    "backtrack-marker",
+    "delay-stack",
+    "broken-map",
+    "last-exit",
+  ],
+  "hacking-exploration": [
+    "fallback-guard",
+    "objective-brace",
+    "clean-buffer",
+    "quiet-rewrite",
+    "safe-landing",
+    "covering-step",
+    "emergency-disconnect",
+    "field-patch",
+    "chained-output",
+    "carry-line",
+    "trace-echo",
+    "last-exit",
+  ],
+};
+
+export const BUILDS = Object.freeze(
+  [
+    ["battle", "exploration", "Confrontation creates space."],
+    ["exploration", "battle", "Space is established first; confrontation preserves it."],
+    ["battle", "hacking", "Confrontation exposes a system."],
+    ["hacking", "battle", "Control is established first; confrontation preserves access."],
+    ["exploration", "hacking", "A natural Route exists first; Hacking delays its closure."],
+    ["hacking", "exploration", "A Hacking Output creates temporary geometry to cross."],
+  ].map(([major, minor, identity]) => {
+    const id = `${major}-${minor}`;
+    return {
+      id,
+      name: `${DISCIPLINES[major].name} / ${DISCIPLINES[minor].name}`,
+      major,
+      minor,
+      identity,
+      deck: DECKS[id],
+    };
+  }),
+);
+
+export const WEAPONS = Object.freeze({
+  "needle-carbine": {
+    id: "needle-carbine",
+    name: "Needle Carbine",
+    range: 4,
+    lane: "Standard",
+    tempo: 6,
+    impact: 4,
+    guardBreak: 0,
+    force: 0,
+    technique: {
+      id: "hold-line",
+      name: "Hold Line",
+      cost: 6,
+      lane: "Fast",
+      tempo: 5,
+      tag: "Instant",
+      text: "Select a line up to four positions. The first hostile crossing before Settle receives a 3-Impact Needle attack.",
+    },
+  },
+  breaker: {
+    id: "breaker",
+    name: "Breaker",
+    range: 1,
+    lane: "Slow",
+    tempo: 5,
+    impact: 5,
+    guardBreak: 2,
+    force: 2,
+    technique: {
+      id: "drive-through",
+      name: "Drive Through",
+      cost: 8,
+      lane: "Slow",
+      tempo: 4,
+      tag: "Instant",
+      text: "Requires Braced or a stable adjacent Anchor. 5 Impact, 2 Guard Break, Force 3; may breach fragile cover.",
+    },
+  },
+  "tether-lance": {
+    id: "tether-lance",
+    name: "Tether Lance",
+    range: 2,
+    lane: "Standard",
+    tempo: 5,
+    impact: 3,
+    guardBreak: 0,
+    force: 1,
+    technique: {
+      id: "anchor-tether",
+      name: "Anchor Tether",
+      cost: 6,
+      lane: "Standard",
+      tempo: 4,
+      tag: "Instant",
+      text: "Link a character, movable objective, or Package to a stable Anchor and reduce the first movement away by 2.",
+    },
+  },
+  "pulse-blade": {
+    id: "pulse-blade",
+    name: "Pulse Blade",
+    range: 1,
+    lane: "Fast",
+    tempo: 6,
+    impact: 3,
+    guardBreak: 0,
+    force: 0,
+    technique: {
+      id: "phase-cut",
+      name: "Phase Cut",
+      cost: 8,
+      lane: "Fast",
+      tempo: 5,
+      tag: "Instant",
+      text: "Step, make a 3-Impact attack, then step. Cannot cross a special Opening.",
+    },
+  },
+  "static-driver": {
+    id: "static-driver",
+    name: "Static Driver",
+    range: 3,
+    lane: "Standard",
+    tempo: 5,
+    impact: 2,
+    guardBreak: 4,
+    guardBreakBody: 0,
+    force: 0,
+    technique: {
+      id: "ground-lock",
+      name: "Ground Lock",
+      cost: 8,
+      lane: "Standard",
+      tempo: 4,
+      tag: "Instant",
+      text: "If the machine target reaches zero Guard, it cannot restore Guard or conceal a component before next Settle.",
+    },
+  },
+  "scatter-array": {
+    id: "scatter-array",
+    name: "Scatter Array",
+    range: 2,
+    lane: "Standard",
+    tempo: 4,
+    impact: 3,
+    guardBreak: 0,
+    force: 0,
+    technique: {
+      id: "clear-lane",
+      name: "Clear Lane",
+      cost: 8,
+      lane: "Slow",
+      tempo: 4,
+      tag: "Instant",
+      text: "3 Impact and Force 1 through a short cone; destroys light cover without ally or Package discrimination.",
+    },
+  },
+});
+
+export const ARMOR = Object.freeze({
+  "mobile-weave": {
+    id: "mobile-weave",
+    name: "Mobile Weave",
+    guardCap: 4,
+    forceResistance: 0,
+    text: "Ignore the first difficult-terrain surcharge each planning phase.",
+  },
+  "brace-frame": {
+    id: "brace-frame",
+    name: "Brace Frame",
+    guardCap: 7,
+    forceResistance: 1,
+    text: "+1 Force resistance. Lock Frame — 4 Braces against every visible direct Commitment.",
+  },
+  "insulated-shell": {
+    id: "insulated-shell",
+    name: "Insulated Shell",
+    guardCap: 5,
+    forceResistance: 0,
+    text: "Ignore the first point of system backlash or encounter-action Disruption each encounter.",
+  },
+  "recovery-mesh": {
+    id: "recovery-mesh",
+    name: "Recovery Mesh",
+    guardCap: 4,
+    forceResistance: 0,
+    text: "The first Field Patch or Stabilization affecting the wearer restores +1 Condition.",
+  },
+});
+
+export const RIGS = Object.freeze({
+  "traversal-line": {
+    id: "traversal-line",
+    name: "Traversal Line",
+    action: {
+      id: "line-move",
+      name: "Line Move",
+      cost: 4,
+      lane: "Standard",
+      tempo: 6,
+      tag: "Transit",
+    },
+    text: "Move through up to two connected ordinary positions; cannot cross a special Opening or carry a Major Package.",
+  },
+  "anchor-rig": {
+    id: "anchor-rig",
+    name: "Anchor Rig",
+    action: {
+      id: "anchor-lock",
+      name: "Anchor Lock",
+      cost: 4,
+      lane: "Fast",
+      tempo: 5,
+      tag: "Instant",
+    },
+    text: "Prevent the first 2 Force before Settle. Ends on voluntary movement.",
+  },
+  "interface-shield": {
+    id: "interface-shield",
+    name: "Interface Shield",
+    action: {
+      id: "protected-access",
+      name: "Protected Access",
+      cost: 4,
+      lane: "Fast",
+      tempo: 5,
+      tag: "Instant",
+    },
+    text: "The first direct hit does not invalidate one declared Interface or Hacking action solely because damage occurred.",
+  },
+  "signal-lens": {
+    id: "signal-lens",
+    name: "Signal Lens",
+    action: null,
+    text: "The first Scan may reveal two related authored facts or improve one uncertain fact by two bands.",
+  },
+});
+
+export const LOADOUTS = Object.freeze({
+  A: {
+    id: "A",
+    name: "Baseline Mobility",
+    activeWeapon: "needle-carbine",
+    reserveWeapon: "pulse-blade",
+    armor: "mobile-weave",
+    rig: "traversal-line",
+  },
+  B: {
+    id: "B",
+    name: "Hold and Collision",
+    activeWeapon: "tether-lance",
+    reserveWeapon: "breaker",
+    armor: "brace-frame",
+    rig: "anchor-rig",
+  },
+  C: {
+    id: "C",
+    name: "System Pressure",
+    activeWeapon: "static-driver",
+    reserveWeapon: "needle-carbine",
+    armor: "insulated-shell",
+    rig: "interface-shield",
+  },
+  D: {
+    id: "D",
+    name: "Survey and Recovery",
+    activeWeapon: "needle-carbine",
+    reserveWeapon: "tether-lance",
+    armor: "recovery-mesh",
+    rig: "signal-lens",
+  },
+});
+
+export const POSITIONS = Object.freeze({
+  "frontier-marker": {
+    id: "frontier-marker",
+    name: "Frontier Marker",
+    x: 7,
+    y: 36,
+    kind: "Anchor",
+    capacity: 1,
+  },
+  "entry-shelf": {
+    id: "entry-shelf",
+    name: "Entry Shelf",
+    x: 28,
+    y: 36,
+    kind: "Position",
+    capacity: 3,
+  },
+  "shutter-console": {
+    id: "shutter-console",
+    name: "Shutter Console",
+    x: 51,
+    y: 36,
+    kind: "Infrastructure",
+    capacity: 1,
+  },
+  "upper-trace-rail": {
+    id: "upper-trace-rail",
+    name: "Upper Trace Rail",
+    x: 30,
+    y: 8,
+    kind: "Enemy line",
+    capacity: 3,
+  },
+  "broken-lane-lip": {
+    id: "broken-lane-lip",
+    name: "Broken-Lane Lip",
+    x: 35,
+    y: 61,
+    kind: "Opening",
+    capacity: 2,
+  },
+  "far-platform": {
+    id: "far-platform",
+    name: "Far Platform",
+    x: 65,
+    y: 61,
+    kind: "Position",
+    capacity: 2,
+  },
+  "release-socket": {
+    id: "release-socket",
+    name: "Release Socket",
+    x: 80,
+    y: 47,
+    kind: "Objective",
+    capacity: 1,
+  },
+  "relay-cache": {
+    id: "relay-cache",
+    name: "Relay Cache",
+    x: 85,
+    y: 67,
+    kind: "Package source",
+    capacity: 1,
+  },
+  threshold: {
+    id: "threshold",
+    name: "Threshold",
+    x: 70,
+    y: 88,
+    kind: "Exit",
+    capacity: 3,
+  },
+});
+
+export const ORDINARY_EDGES = Object.freeze([
+  ["frontier-marker", "entry-shelf"],
+  ["upper-trace-rail", "entry-shelf"],
+  ["entry-shelf", "shutter-console"],
+  ["entry-shelf", "broken-lane-lip"],
+  ["far-platform", "threshold"],
+]);
+
+export const SPECIAL_EDGE = Object.freeze({
+  id: "natural-opening",
+  name: "Natural Opening / Maintenance Plate",
+  origin: "broken-lane-lip",
+  destination: "far-platform",
+  clearance: ["Character", "One-slot"],
+  capacity: 1,
+});
+
+const PAPER_EXPECTED_SOLO = {
+  "battle-exploration": {
+    cycles: 3,
+    condition: 10,
+    command: 9,
+    survey: "Lost",
+    shutter: "Damaged",
+    namedResult: "Skimmer A removed",
+  },
+  "exploration-battle": {
+    cycles: 2,
+    condition: 12,
+    command: 3,
+    survey: "Preserved",
+    shutter: "Damaged",
+    namedResult: "fastest baseline",
+  },
+  "battle-hacking": {
+    cycles: 3,
+    condition: 6,
+    command: 3,
+    survey: "Preserved",
+    shutter: "Intact",
+    namedResult: "Skimmer B removed",
+  },
+  "hacking-battle": {
+    cycles: 3,
+    condition: 3,
+    command: 1,
+    survey: "Preserved",
+    shutter: "Intact",
+    namedResult: "Relay Needle",
+  },
+  "exploration-hacking": {
+    cycles: 3,
+    condition: 7,
+    command: 7,
+    survey: "Preserved",
+    shutter: "Intact",
+    namedResult: "clean Route result",
+  },
+  "hacking-exploration": {
+    cycles: 3,
+    condition: 10,
+    command: 7,
+    survey: "Preserved",
+    shutter: "Intact",
+    namedResult: "reinforcement prevented",
+  },
+};
+
+function seat(id, build, loadout = "A") {
+  return { id, build, loadout, primaryPriority: "Complete", secondaryPriority: "Survey" };
+}
+
+export const PROFILES = Object.freeze([
+  ...BUILDS.map((build, index) => ({
+    id: `LS-SOLO-${index + 1}`,
+    name: `Solo · ${build.name}`,
+    mode: "solo",
+    seats: [seat("seat-1", build.id)],
+    expected: PAPER_EXPECTED_SOLO[build.id],
+  })),
+  {
+    id: "LS-DUO-MIXED",
+    name: "Local duo · Exploration/Battle + Hacking/Battle",
+    mode: "local-duo",
+    seats: [
+      seat("seat-1", "exploration-battle"),
+      seat("seat-2", "hacking-battle"),
+    ],
+    expected: {
+      cycles: 2,
+      survey: "Preserved",
+      shutter: "Intact",
+      namedResult: "Relay Needle",
+      sourceConflict:
+        "The expected profile says all three Skimmers remain active at validation, but LS-01 §12 requires every entered Skimmer neutralized first.",
+    },
+  },
+  {
+    id: "LS-TRIO-MIXED",
+    name: "Local trio · mixed disciplines",
+    mode: "local-trio",
+    seats: [
+      seat("seat-1", "battle-exploration"),
+      seat("seat-2", "exploration-hacking"),
+      seat("seat-3", "hacking-battle"),
+    ],
+    expected: {
+      cycles: 3,
+      survey: "Preserved",
+      shutter: "Intact",
+      namedResult: "Relay Needle + Razor Actuator",
+    },
+  },
+  {
+    id: "LS-TRIO-DUP-EB",
+    name: "Local trio · duplicate Exploration/Battle",
+    mode: "local-trio",
+    seats: [
+      seat("seat-1", "exploration-battle"),
+      seat("seat-2", "exploration-battle"),
+      seat("seat-3", "exploration-battle"),
+    ],
+    expected: {
+      cycles: 2,
+      namedResult: "one Route owner; two Major weak phases",
+    },
+  },
+  {
+    id: "LS-DUO-DUP-HB",
+    name: "Local duo · duplicate Hacking/Battle",
+    mode: "local-duo",
+    seats: [
+      seat("seat-1", "hacking-battle"),
+      seat("seat-2", "hacking-battle"),
+    ],
+    expected: {
+      namedResult: "one Control owner; second Hacking Major contributes elsewhere",
+    },
+  },
+  {
+    id: "LS-RESCUE-GREEDY",
+    name: "Local trio · greedy controller rescue",
+    mode: "local-trio",
+    seats: [
+      seat("seat-1", "exploration-battle"),
+      seat("seat-2", "hacking-battle"),
+      seat("seat-3", "battle-exploration"),
+    ],
+    expected: {
+      cycles: 4,
+      namedResult: "Control lost; Stabilize + Assist sacrifice the cache line",
+    },
+  },
+]);
+
+export const APPROACHES = Object.freeze({
+  "impact-scar": {
+    id: "impact-scar",
+    name: "Impact Scar",
+    broad:
+      "A roaming hostile is preparing to strike the Frontier Marker. A counterweight assembly sits behind the line.",
+    major: {
+      battle:
+        "Confirmed: exact Commitment, collision path, Marker target, and intact confrontation opportunity.",
+      exploration:
+        "Confirmed: the collision closes this boundary after commitment; no alternate Route survives.",
+      hacking:
+        "Confirmed: no accessible Dependency controls the collision before commitment.",
+    },
+    results: ["exact", "ordinary"],
+  },
+  "folded-service-walk": {
+    id: "folded-service-walk",
+    name: "Folded Service Walk",
+    broad:
+      "An unstable side street overlaps the main path. Its true landing and collapse pressure are uncertain.",
+    major: {
+      battle:
+        "Confirmed: no direct hostile Commitment owns this approach boundary.",
+      exploration:
+        "Confirmed: true landing, recurrence, safer entry, later anomaly access, and collapse pressure.",
+      hacking:
+        "Confirmed: the overlap is physical geometry, not a Dependency or command surface.",
+    },
+    results: ["folded"],
+  },
+  "mute-repeater": {
+    id: "mute-repeater",
+    name: "Mute Repeater",
+    broad:
+      "A damaged repeater is transmitting the party's arrival and preserving one route fact.",
+    major: {
+      battle:
+        "Confirmed: destroying the hardware stops the signal but loses its preserved fact.",
+      exploration:
+        "Confirmed: the route fact is useful later, but the signal still calls reinforcement.",
+      hacking:
+        "Confirmed: reinforcement Dependency, preserved route fact, destructive alternative, and response relationship.",
+    },
+    results: ["preserved", "destroyed"],
+  },
+});
+
+export function getBuild(buildId) {
+  return BUILDS.find((build) => build.id === buildId);
+}
+
+export function getProfile(profileId) {
+  return PROFILES.find((profile) => profile.id === profileId) ?? PROFILES[0];
+}

--- a/src/lib/barcode-world/engine.d.mts
+++ b/src/lib/barcode-world/engine.d.mts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- MJS engine boundary shared with Node's test runner. */
+
+export type GreyboxRecord = Record<string, any>;
+export type GreyboxState = GreyboxRecord;
+export type GreyboxAction = GreyboxRecord;
+
+export const APPROACHES: Record<string, any>;
+export const ARMOR: Record<string, any>;
+export const BUILDS: any[];
+export const CARDS: Record<string, any>;
+export const CORE_RULES: Record<string, any>;
+export const LOADOUTS: Record<string, any>;
+export const POSITIONS: Record<string, any>;
+export const PROFILES: any[];
+export const RIGS: Record<string, any>;
+export const WEAPONS: Record<string, any>;
+
+export function createGreyboxState(profileId?: string): GreyboxState;
+export function resetGreybox(state: GreyboxState): GreyboxState;
+export function loadProfile(
+  state: GreyboxState,
+  profileId: string,
+): GreyboxState;
+export function updatePreparation(
+  state: GreyboxState,
+  seatId: string,
+  changes: Record<string, unknown>,
+): GreyboxState;
+export function beginOutskirts(state: GreyboxState): GreyboxState;
+export function inspectApproach(
+  state: GreyboxState,
+  approachId: string,
+  seatId?: string,
+): GreyboxState;
+export function selectApproachResult(
+  state: GreyboxState,
+  approachId: string,
+  resultId: string,
+  resolverSeatId: string,
+): GreyboxState;
+export function setApproachConfirmation(
+  state: GreyboxState,
+  seatId: string,
+  confirmed: boolean,
+): GreyboxState;
+export function commitApproach(state: GreyboxState): GreyboxState;
+export function selectSeat(
+  state: GreyboxState,
+  seatId: string,
+): GreyboxState;
+export function selectFocus(
+  state: GreyboxState,
+  seatId: string,
+  focusId: string,
+): GreyboxState;
+export function seatCommandAvailable(seat: any): number;
+export function getImmediateActionGroups(
+  state: GreyboxState,
+  seatId: string,
+  focusId: string,
+): any[];
+export function queueAction(
+  state: GreyboxState,
+  seatId: string,
+  candidate: GreyboxAction,
+): GreyboxState;
+export function removeAction(
+  state: GreyboxState,
+  seatId: string,
+  actionInstanceId: string,
+): GreyboxState;
+export function attachCard(
+  state: GreyboxState,
+  seatId: string,
+  actionInstanceId: string,
+  cardId: string,
+): GreyboxState;
+export function detachCard(
+  state: GreyboxState,
+  seatId: string,
+  actionInstanceId: string,
+): GreyboxState;
+export function setClaimMode(
+  state: GreyboxState,
+  seatId: string,
+  actionInstanceId: string,
+  claimMode: string,
+): GreyboxState;
+export function setConsent(
+  state: GreyboxState,
+  ownerSeatId: string,
+  actionInstanceId: string,
+  granted: boolean,
+): GreyboxState;
+export function compatibleCardsForAction(seat: any, action: any): any[];
+export function lockSeatPlan(
+  state: GreyboxState,
+  seatId: string,
+): GreyboxState;
+export function unlockSeatPlan(
+  state: GreyboxState,
+  seatId: string,
+): GreyboxState;
+export function canResolvePlans(state: GreyboxState): boolean;
+export function resolvePlans(state: GreyboxState): GreyboxState;
+export function settleCycle(state: GreyboxState): GreyboxState;
+export function discardCard(
+  state: GreyboxState,
+  seatId: string,
+  cardId: string,
+): GreyboxState;
+export function chooseSegmentDecision(
+  state: GreyboxState,
+  decision: string,
+): GreyboxState;
+export function getFocuses(state: GreyboxState): any[];
+export function getLayeredIntents(state: GreyboxState): any[];
+export function resultSummary(state: GreyboxState): any;
+export function compareToPaperExpectation(state: GreyboxState): any[];

--- a/src/lib/barcode-world/engine.mjs
+++ b/src/lib/barcode-world/engine.mjs
@@ -1,0 +1,4031 @@
+import {
+  APPROACHES,
+  ARMOR,
+  BUILDS,
+  CARDS,
+  CORE_RULES,
+  DISCIPLINES,
+  LOADOUTS,
+  ORDINARY_EDGES,
+  POSITIONS,
+  PROFILES,
+  RIGS,
+  SOURCE_REVISION,
+  SPECIAL_EDGE,
+  WEAPONS,
+  getBuild,
+  getProfile,
+} from "./constants.mjs";
+
+const LANE_RANK = { Fast: 0, Standard: 1, Slow: 2 };
+const ENTERED_CLEAR_STATUSES = new Set(["defeated", "disabled", "driven", "bound"]);
+const SYSTEM_ACTION_IDS = new Set([
+  "manual-shutter-release",
+  "jam-shutter-track",
+  "complete-release",
+  "recover-relay-cache",
+  "basic-interface",
+  "establish-control",
+  "execute-hold-open",
+  "execute-expose-cache",
+  "execute-blind-repeater",
+]);
+const CROSSING_ACTION_IDS = new Set([
+  "cross-opening",
+  "cross-plate",
+  "follow-route",
+  "exploit-route",
+  "backtrack",
+]);
+const PAID_REPEAT_LIMIT_IDS = new Set([
+  "attack",
+  "guard",
+  "additional-movement",
+  "scan",
+  "basic-interface",
+  "work-objective",
+  "assist",
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function pushEvidence(state, type, detail = {}) {
+  state.evidence.push({
+    sequence: state.evidence.length + 1,
+    type,
+    stage: state.stage,
+    cycle: state.encounter?.cycle ?? 0,
+    ...detail,
+  });
+}
+
+function buildSeat(profileSeat, index) {
+  const build = getBuild(profileSeat.build) ?? BUILDS[0];
+  const loadout = LOADOUTS[profileSeat.loadout] ?? LOADOUTS.A;
+  const armor = ARMOR[loadout.armor];
+  return {
+    id: profileSeat.id || `seat-${index + 1}`,
+    label: `Seat ${index + 1}`,
+    buildId: build.id,
+    loadoutId: loadout.id,
+    primaryPriority: profileSeat.primaryPriority ?? "Complete",
+    secondaryPriority: profileSeat.secondaryPriority ?? "Survey",
+    activeWeaponId: loadout.activeWeapon,
+    reserveWeaponId: loadout.reserveWeapon,
+    armorId: loadout.armor,
+    rigId: loadout.rig,
+    command: CORE_RULES.commandStart,
+    condition: CORE_RULES.condition,
+    guard: armor.guardCap,
+    temporaryGuard: 0,
+    disruption: 0,
+    position: "entry-shelf",
+    majorState: null,
+    packages: [],
+    hand: build.deck.slice(0, CORE_RULES.openingHand),
+    deck: [...build.deck],
+    drawIndex: CORE_RULES.openingHand,
+    discard: [],
+    committedCards: [],
+    plan: [],
+    locked: false,
+    lockError: "",
+    focusId: "entry-shelf",
+    compromised: false,
+    rescueSettlesRemaining: null,
+    fieldPatchUsed: false,
+    scanUsed: false,
+    insulatedShellUsed: false,
+    recoveryMeshUsed: false,
+    difficultTerrainIgnored: false,
+    forceResistance: armor.forceResistance ?? 0,
+    flags: {},
+  };
+}
+
+export function createGreyboxState(profileId = PROFILES[0].id) {
+  const profile = getProfile(profileId);
+  const seats = profile.seats.map(buildSeat);
+  const state = {
+    sourceRevision: SOURCE_REVISION,
+    profileId: profile.id,
+    profileName: profile.name,
+    profileMode: profile.mode,
+    expectedPaperResult: clone(profile.expected ?? null),
+    stage: "preparation",
+    stageLabel: "Home preparation",
+    seats,
+    activeSeatId: seats[0].id,
+    approach: {
+      inspected: [],
+      selectedId: null,
+      resultId: null,
+      resolverSeatId: seats[0].id,
+      confirmations: Object.fromEntries(seats.map((seat) => [seat.id, false])),
+      committed: false,
+    },
+    encounter: null,
+    resolution: null,
+    segmentDecision: null,
+    nextActionSequence: 1,
+    evidence: [],
+    warnings: [],
+    sourceMismatches: [
+      {
+        id: "LS-FULL-CLEAR-VS-DUO-EXPECTED",
+        status: "SOURCE CONFLICT",
+        rule:
+          "LS-01 §12 requires every entered Skimmer to be neutralized before release validation.",
+        conflictingExpectation:
+          "The mixed-duo profile says all three Skimmers remain active when release validates.",
+        implementation:
+          "The complete LS-01 deterministic specification controls; active entered threats block validation.",
+      },
+      {
+        id: "DISCIPLINE-TIMING-OMISSION",
+        status: "TEMPORARY IMPLEMENTATION ASSUMPTION",
+        rule:
+          "The controlling pack fixes discipline costs and causal layers but omits standalone lane/Tempo values; REV7 labels its timing table provisional.",
+        implementation:
+          "The greybox uses the REV7 provisional table where printed, lets Battle responses inherit the threatened packet, uses Standard / 5 for LS Opening transit, and preserves exact LS Context Card timing.",
+      },
+      {
+        id: "LS-PROFILE-SCRIPT-OMISSION",
+        status: "SOURCE LIMIT",
+        rule:
+          "The source provides final paper totals for solo LS profiles but no complete per-cycle action scripts for those totals.",
+        implementation:
+          "The greybox compares observed runs to the paper totals without fabricating a hidden canonical plan.",
+      },
+      {
+        id: "OUTSKIRTS-COORDINATES",
+        status: "TEMPORARY PRESENTATION ASSUMPTION",
+        rule:
+          "The three approaches share one freely explored physical block, but exact coordinates are not specified.",
+        implementation:
+          "The greybox uses a neutral three-branch node diagram and does not choose top-down versus isometric presentation.",
+      },
+      {
+        id: "OPTIONAL-PANEL-BASE-SEED",
+        status: "UNRESOLVED / EXCLUDED",
+        rule:
+          "The Hanging Panel is explicitly optional and not required in the base class-comparison seed.",
+        implementation:
+          "The first playable excludes it rather than inventing a Force vector or cover-placement choice.",
+      },
+      {
+        id: "EQUIPMENT-VECTOR-CHOICES",
+        status: "EXCLUDED FROM BALANCE EVIDENCE",
+        rule:
+          "Several exact optional weapon techniques require a player-selected line, cone, pull, breach, or step vector.",
+        implementation:
+          "The base Loadout A profile and exact basic equipment values remain available; optional technique projections are not treated as verified balance outcomes until the spatial choice UI is complete.",
+      },
+    ],
+  };
+  pushEvidence(state, "profile_loaded", {
+    profileId: profile.id,
+    seatCount: seats.length,
+    buildIds: seats.map((seat) => seat.buildId),
+  });
+  return state;
+}
+
+export function resetGreybox(state) {
+  const next = createGreyboxState(state.profileId);
+  pushEvidence(next, "reset", { fromStage: state.stage });
+  return next;
+}
+
+export function loadProfile(state, profileId) {
+  const next = createGreyboxState(profileId);
+  pushEvidence(next, "profile_changed", { priorProfileId: state.profileId, profileId });
+  return next;
+}
+
+export function updatePreparation(state, seatId, changes) {
+  if (state.stage !== "preparation") return state;
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat) return state;
+
+  if (changes.buildId && getBuild(changes.buildId)) {
+    const build = getBuild(changes.buildId);
+    seat.buildId = build.id;
+    seat.deck = [...build.deck];
+    seat.hand = build.deck.slice(0, CORE_RULES.openingHand);
+    seat.drawIndex = CORE_RULES.openingHand;
+    seat.discard = [];
+  }
+  if (changes.loadoutId && LOADOUTS[changes.loadoutId]) {
+    const loadout = LOADOUTS[changes.loadoutId];
+    const armor = ARMOR[loadout.armor];
+    seat.loadoutId = loadout.id;
+    seat.activeWeaponId = loadout.activeWeapon;
+    seat.reserveWeaponId = loadout.reserveWeapon;
+    seat.armorId = loadout.armor;
+    seat.rigId = loadout.rig;
+    seat.guard = armor.guardCap;
+    seat.forceResistance = armor.forceResistance ?? 0;
+  }
+  if (typeof changes.primaryPriority === "string") {
+    seat.primaryPriority = changes.primaryPriority;
+  }
+  if (typeof changes.secondaryPriority === "string") {
+    seat.secondaryPriority = changes.secondaryPriority;
+  }
+  pushEvidence(next, "preparation_changed", { seatId, changes });
+  return next;
+}
+
+export function beginOutskirts(state) {
+  if (state.stage !== "preparation") return state;
+  const next = clone(state);
+  next.stage = "outskirts";
+  next.stageLabel = "Outskirts approach block";
+  pushEvidence(next, "outskirts_entered");
+  return next;
+}
+
+export function inspectApproach(state, approachId, seatId = state.activeSeatId) {
+  if (state.stage !== "outskirts" || !APPROACHES[approachId]) return state;
+  const next = clone(state);
+  if (!next.approach.inspected.includes(approachId)) {
+    next.approach.inspected.push(approachId);
+  }
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  pushEvidence(next, "approach_inspected", {
+    approachId,
+    seatId,
+    major: getBuild(seat?.buildId)?.major,
+  });
+  return next;
+}
+
+export function selectApproachResult(state, approachId, resultId, resolverSeatId) {
+  if (state.stage !== "outskirts") return state;
+  const approach = APPROACHES[approachId];
+  const resolver = state.seats.find((seat) => seat.id === resolverSeatId);
+  if (!approach || !resolver || !approach.results.includes(resultId)) return state;
+
+  const major = getBuild(resolver.buildId)?.major;
+  if (approachId === "impact-scar" && resultId === "exact" && major !== "battle") {
+    return withWarning(state, "Exact Impact Scar confrontation requires a Battle Major.");
+  }
+  if (approachId === "mute-repeater" && resultId === "preserved" && major !== "hacking") {
+    return withWarning(state, "Preserving the Mute Repeater result requires a Hacking Major.");
+  }
+
+  const next = clone(state);
+  next.approach.selectedId = approachId;
+  next.approach.resultId = resultId;
+  next.approach.resolverSeatId = resolverSeatId;
+  next.approach.confirmations = Object.fromEntries(
+    next.seats.map((seat) => [seat.id, false]),
+  );
+  pushEvidence(next, "approach_result_selected", {
+    approachId,
+    resultId,
+    resolverSeatId,
+  });
+  return next;
+}
+
+export function setApproachConfirmation(state, seatId, confirmed) {
+  if (state.stage !== "outskirts" || !(seatId in state.approach.confirmations)) {
+    return state;
+  }
+  const next = clone(state);
+  next.approach.confirmations[seatId] = Boolean(confirmed);
+  pushEvidence(next, "approach_confirmation", { seatId, confirmed: Boolean(confirmed) });
+  return next;
+}
+
+function approachPackage(approachId, resultId) {
+  if (approachId === "impact-scar" && resultId === "exact") {
+    return { id: "counterweight-breaker", name: "Counterweight Breaker", slots: 1 };
+  }
+  if (approachId === "impact-scar") {
+    return { id: "weapon-parts", name: "Weapon Parts", slots: 1 };
+  }
+  if (approachId === "mute-repeater" && resultId === "destroyed") {
+    return { id: "rig-parts", name: "Rig Parts", slots: 1 };
+  }
+  return null;
+}
+
+export function commitApproach(state) {
+  if (state.stage !== "outskirts") return state;
+  if (!state.approach.selectedId || !state.approach.resultId) {
+    return withWarning(state, "Select an approach result before committing.");
+  }
+  const missing = state.seats.filter(
+    (seat) => !state.approach.confirmations[seat.id],
+  );
+  if (missing.length) {
+    return withWarning(
+      state,
+      `Every continuing seat must confirm. Missing: ${missing
+        .map((seat) => seat.label)
+        .join(", ")}.`,
+    );
+  }
+
+  const next = clone(state);
+  const resolver =
+    next.seats.find((seat) => seat.id === next.approach.resolverSeatId) ??
+    next.seats[0];
+  const packageResult = approachPackage(
+    next.approach.selectedId,
+    next.approach.resultId,
+  );
+  if (packageResult) {
+    resolver.packages.push({ ...packageResult, ownerSeatId: resolver.id, exposed: true });
+  }
+
+  const folded = next.approach.selectedId === "folded-service-walk";
+  const muted = next.approach.selectedId === "mute-repeater";
+  const impact = next.approach.selectedId === "impact-scar";
+  const trio = next.seats.length === 3;
+  next.seats.forEach((seat) => {
+    seat.position = folded ? "broken-lane-lip" : "entry-shelf";
+    seat.focusId = seat.position;
+    seat.command = CORE_RULES.commandStart;
+    seat.condition = CORE_RULES.condition;
+    seat.guard = ARMOR[seat.armorId].guardCap;
+    seat.temporaryGuard = 0;
+    seat.disruption = 0;
+    seat.plan = [];
+    seat.locked = false;
+  });
+  next.approach.committed = true;
+  next.stage = "loose-signal";
+  next.stageLabel = "Loose Signal Crossing · Planning";
+  next.encounter = {
+    id: "LS-01",
+    cycle: 1,
+    tieOrder: next.seats.map((seat) => seat.id),
+    marker: {
+      integrity: 4,
+      locked: false,
+      dislodged: false,
+      surveyAvailable: true,
+    },
+    plate: {
+      stabilized: false,
+      naturalOpeningConfirmed: folded,
+      crossingCollisionReduction: folded ? 1 : 0,
+    },
+    shutter: {
+      state: "closed",
+      intact: true,
+      resealSuppressedUntilCycle: null,
+      outputWindowEndsAfterCycle: null,
+      controlledBySeatId: null,
+      hackingOutputsAvailable: true,
+    },
+    release: {
+      work: 0,
+      pendingValidation: false,
+      validated: false,
+      thresholdOpen: false,
+      blockedReason: "",
+    },
+    cache: {
+      exposed: false,
+      recovered: false,
+      destroyed: false,
+    },
+    reinforcementPrevented: muted,
+    majorDestinationFact:
+      muted && next.approach.resultId === "preserved"
+        ? "One major-destination system fact secured."
+        : null,
+    approachDiscoveries:
+      folded
+        ? ["Folded Entry Record"]
+        : muted && next.approach.resultId === "preserved"
+          ? ["Repeater Pattern", "Major-destination route fact"]
+          : [],
+    enemies: {
+      "skimmer-a": makeSkimmer("skimmer-a", "Trace Skimmer A", "far-platform", "active"),
+      "skimmer-b": makeSkimmer(
+        "skimmer-b",
+        "Trace Skimmer B",
+        "upper-trace-rail",
+        impact ? "absent" : "active",
+      ),
+      "skimmer-c": makeSkimmer(
+        "skimmer-c",
+        "Trace Skimmer C",
+        "upper-trace-rail",
+        muted ? "prevented" : trio ? "active" : "pending",
+      ),
+    },
+    enteredEnemyIds: [
+      "skimmer-a",
+      ...(impact ? [] : ["skimmer-b"]),
+      ...(trio && !muted ? ["skimmer-c"] : []),
+    ],
+    packagesOnMap: [],
+    causalLog: [],
+    refundsPending: Object.fromEntries(next.seats.map((seat) => [seat.id, 0])),
+    resolutionComplete: false,
+    selectedOutcome: null,
+  };
+  next.resolution = null;
+  next.warnings = [];
+  pushEvidence(next, "approach_committed", {
+    approachId: next.approach.selectedId,
+    resultId: next.approach.resultId,
+    resolverSeatId: resolver.id,
+  });
+  pushEvidence(next, "encounter_started", {
+    encounterId: "LS-01",
+    activeEnemies: Object.values(next.encounter.enemies)
+      .filter((enemy) => enemy.status === "active")
+      .map((enemy) => enemy.id),
+  });
+  return next;
+}
+
+function makeSkimmer(id, name, position, status) {
+  return {
+    id,
+    name,
+    position,
+    guard: 1,
+    condition: 4,
+    force: 1,
+    status,
+    pinnedUntilSettle: null,
+    intactActuator: true,
+    entered: status === "active",
+  };
+}
+
+function withWarning(state, message) {
+  const next = clone(state);
+  next.warnings = [...next.warnings.slice(-3), message];
+  return next;
+}
+
+export function selectSeat(state, seatId) {
+  if (!state.seats.some((seat) => seat.id === seatId)) return state;
+  const next = clone(state);
+  next.activeSeatId = seatId;
+  return next;
+}
+
+export function selectFocus(state, seatId, focusId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || seat.locked) return state;
+  seat.focusId = focusId;
+  pushEvidence(next, "focus_selected", { seatId, focusId });
+  return next;
+}
+
+function activePlanCost(seat) {
+  return seat.plan.reduce((sum, action) => sum + action.totalReservedCommand, 0);
+}
+
+export function seatCommandAvailable(seat) {
+  return seat.command - activePlanCost(seat);
+}
+
+function canReachOrdinary(from, to) {
+  return ORDINARY_EDGES.some(
+    ([left, right]) =>
+      (left === from && right === to) || (left === to && right === from),
+  );
+}
+
+function ordinaryNeighbors(position) {
+  return ORDINARY_EDGES.flatMap(([left, right]) => {
+    if (left === position) return [right];
+    if (right === position) return [left];
+    return [];
+  });
+}
+
+function physicalDistance(from, to) {
+  if (from === to) return 0;
+  const edges = [
+    ...ORDINARY_EDGES,
+    [SPECIAL_EDGE.origin, SPECIAL_EDGE.destination],
+  ];
+  const visited = new Set([from]);
+  let frontier = [from];
+  let distance = 0;
+  while (frontier.length > 0) {
+    distance += 1;
+    const next = [];
+    for (const current of frontier) {
+      for (const [left, right] of edges) {
+        const neighbor =
+          left === current ? right : right === current ? left : null;
+        if (!neighbor || visited.has(neighbor)) continue;
+        if (neighbor === to) return distance;
+        visited.add(neighbor);
+        next.push(neighbor);
+      }
+    }
+    frontier = next;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+function sameOrOrdinarilyAdjacent(left, right) {
+  return left === right || canReachOrdinary(left, right);
+}
+
+function positionOccupants(state, positionId) {
+  return state.seats.filter(
+    (seat) => !seat.compromised && seat.position === positionId,
+  );
+}
+
+function enemyIsActive(enemy) {
+  return enemy && (enemy.status === "active" || enemy.status === "pinned");
+}
+
+function focusLabel(state, focusId) {
+  if (POSITIONS[focusId]) return POSITIONS[focusId].name;
+  if (state.encounter?.enemies[focusId]) return state.encounter.enemies[focusId].name;
+  const seat = state.seats.find((candidate) => candidate.id === focusId);
+  return seat?.label ?? focusId;
+}
+
+function baseProjection(action, state, seat) {
+  return {
+    actor: seat.label,
+    target: focusLabel(state, action.targetId),
+    action: action.name,
+    timing: `${action.lane} / ${action.tempo}`,
+    command: action.cost,
+    paidSlot: action.paid ? "Paid" : "Outside paid-action limit",
+    requirements: action.requirements?.join("; ") || "Visible legal source",
+    rangeAccess: action.rangeAccess ?? "Confirmed by current position and source",
+    claims: action.exclusiveClaim
+      ? `${action.claimMode ?? "Primary"} · ${action.exclusiveClaim}`
+      : "None",
+    invalidators: action.invalidators?.join("; ") || "Actor, target, or source becomes illegal before beginning",
+    guard: action.guardEffect ?? "No projected Guard change",
+    condition: action.conditionEffect ?? "No projected Condition change",
+    force: action.forceEffect ?? "No projected Force",
+    movement: action.movementEffect ?? "No projected movement",
+    work: action.workEffect ?? "No projected Work",
+    control: action.controlEffect ?? "No projected Control change",
+    route: action.routeEffect ?? "No projected Route change",
+    packages: action.packageEffect ?? "No projected Package change",
+    integrity: action.integrityEffect ?? "No projected Integrity change",
+    objective: action.objectiveEffect ?? "No projected objective change",
+    extraction: action.extractionEffect ?? "No projected extraction",
+    certainty: action.certainty ?? "Confirmed",
+    alternatives: action.alternatives ?? "None",
+    executionTag: action.tag,
+  };
+}
+
+function actionTemplate(state, seat, spec) {
+  const action = {
+    instanceId: `candidate:${seat.id}:${spec.id}`,
+    id: spec.id,
+    baseId: spec.baseId ?? spec.id,
+    name: spec.name,
+    actorSeatId: seat.id,
+    targetId: spec.targetId ?? seat.focusId,
+    sourceId: spec.sourceId ?? seat.focusId,
+    cost: spec.cost ?? 0,
+    modifierCost: 0,
+    contingencyReserve: 0,
+    totalReservedCommand: spec.cost ?? 0,
+    lane: spec.lane ?? "Standard",
+    tempo: spec.tempo ?? 4,
+    paid: spec.paid !== false,
+    tag: spec.tag ?? "Instant",
+    family: spec.family ?? "Core",
+    group: spec.group ?? "Act",
+    requirements: spec.requirements ?? [],
+    invalidators: spec.invalidators ?? [],
+    rangeAccess: spec.rangeAccess,
+    exclusiveClaim: spec.exclusiveClaim ?? null,
+    claimMode: spec.claimMode ?? (spec.exclusiveClaim ? "Primary" : null),
+    requiresConsentFromSeatId: spec.requiresConsentFromSeatId ?? null,
+    consentGranted: spec.requiresConsentFromSeatId ? false : true,
+    attachedCardId: null,
+    refocusCardIds: spec.refocusCardIds ?? [],
+    destinationId: spec.destinationId ?? null,
+    includedActionId: spec.includedActionId ?? null,
+    outputId: spec.outputId ?? null,
+    payoffId: spec.payoffId ?? null,
+    supportedActionInstanceId: spec.supportedActionInstanceId ?? null,
+    dependsOnActionInstanceId: spec.dependsOnActionInstanceId ?? null,
+    guardEffect: spec.guardEffect,
+    conditionEffect: spec.conditionEffect,
+    forceEffect: spec.forceEffect,
+    movementEffect: spec.movementEffect,
+    workEffect: spec.workEffect,
+    controlEffect: spec.controlEffect,
+    routeEffect: spec.routeEffect,
+    packageEffect: spec.packageEffect,
+    integrityEffect: spec.integrityEffect,
+    objectiveEffect: spec.objectiveEffect,
+    extractionEffect: spec.extractionEffect,
+    certainty: spec.certainty,
+    alternatives: spec.alternatives,
+    effect: spec.effect ?? {},
+  };
+  action.projection = baseProjection(action, state, seat);
+  return action;
+}
+
+function currentEnemyIntentPreview(state, enemyId) {
+  const enemy = state.encounter?.enemies[enemyId];
+  if (!enemyIsActive(enemy)) return null;
+  if (enemyId === "skimmer-a") {
+    const crossing = state.seats
+      .flatMap((seat) => seat.plan)
+      .find((action) => CROSSING_ACTION_IDS.has(action.baseId));
+    return crossing
+      ? {
+          id: "crossing-intercept",
+          name: "Crossing Intercept",
+          targetSeatId: crossing.actorSeatId,
+          lane: crossing.lane,
+          tempo: crossing.tempo,
+        }
+      : null;
+  }
+  if (enemyId === "skimmer-b") {
+    const access = earliestAccessAction(state);
+    return access
+      ? {
+          id: "access-clamp",
+          name: "Access Clamp",
+          targetSeatId: access.actorSeatId,
+          lane: "Standard",
+          tempo: 5,
+        }
+      : {
+          id: "marker-clamp",
+          name: "Marker Clamp",
+          targetSeatId: null,
+          lane: "Standard",
+          tempo: 5,
+        };
+  }
+  return {
+    id: "razor-pass",
+    name: "Razor Pass",
+    targetSeatId: chooseRazorTarget(state),
+    lane: "Fast",
+    tempo: 7,
+  };
+}
+
+function earliestAccessAction(state) {
+  const actions = state.seats.flatMap((seat) => seat.plan);
+  return actions
+    .filter((action) => SYSTEM_ACTION_IDS.has(action.baseId))
+    .sort(compareTiming)[0];
+}
+
+function compareTiming(left, right) {
+  const laneDifference = LANE_RANK[left.lane] - LANE_RANK[right.lane];
+  if (laneDifference !== 0) return laneDifference;
+  if (right.tempo !== left.tempo) return right.tempo - left.tempo;
+  return String(left.instanceId).localeCompare(String(right.instanceId));
+}
+
+function chooseRazorTarget(state) {
+  const active = state.seats.filter((seat) => !seat.compromised);
+  const majorCarrier = active.find((seat) =>
+    seat.packages.some((item) => item.slots === 2),
+  );
+  if (majorCarrier) return majorCarrier.id;
+  const far = active.find((seat) => seat.position === "far-platform");
+  if (far) return far.id;
+  return state.encounter.tieOrder.find((seatId) =>
+    active.some((seat) => seat.id === seatId),
+  );
+}
+
+function makeCoreActions(state, seat, focusId) {
+  const actions = [];
+  const focusEnemy = state.encounter.enemies[focusId];
+  const focusPosition = POSITIONS[focusId];
+  const focusSeat = state.seats.find((candidate) => candidate.id === focusId);
+  const weapon = WEAPONS[seat.activeWeaponId];
+  const rig = RIGS[seat.rigId];
+
+  if (focusEnemy && enemyIsActive(focusEnemy)) {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "attack",
+        name: `Attack · ${weapon.name}`,
+        targetId: focusId,
+        cost: 6,
+        lane: weapon.lane,
+        tempo: weapon.tempo,
+        tag: "Instant",
+        group: "Direct",
+        requirements: [`${weapon.name} line and range ${weapon.range}`],
+        rangeAccess: `Authored LS line; weapon range ${weapon.range}`,
+        conditionEffect: `${weapon.impact} Impact after ${weapon.guardBreak} Guard Break`,
+        forceEffect: weapon.force ? `Force ${weapon.force}` : "No Force",
+        effect: {
+          impact: weapon.impact,
+          guardBreak:
+            weapon.id === "static-driver" ? weapon.guardBreak : weapon.guardBreak,
+          force: weapon.force,
+        },
+      }),
+    );
+    if (weapon.technique) {
+      actions.push(
+        actionTemplate(state, seat, {
+          ...weapon.technique,
+          baseId: weapon.technique.id,
+          targetId: focusId,
+          group: "Gear technique",
+          requirements: [weapon.technique.text],
+          conditionEffect:
+            weapon.technique.id === "drive-through"
+              ? "5 Impact after 2 Guard Break"
+              : weapon.technique.id === "phase-cut"
+                ? "3 Impact"
+                : "Technique-specific effect",
+          forceEffect:
+            weapon.technique.id === "drive-through" ? "Force 3" : undefined,
+          effect: {
+            impact:
+              weapon.technique.id === "drive-through"
+                ? 5
+                : weapon.technique.id === "phase-cut"
+                  ? 3
+                  : weapon.impact,
+            guardBreak:
+              weapon.technique.id === "drive-through" ? 2 : weapon.guardBreak,
+            force: weapon.technique.id === "drive-through" ? 3 : weapon.force,
+          },
+        }),
+      );
+    }
+  }
+
+  actions.push(
+    actionTemplate(state, seat, {
+      id: "guard",
+      name: focusSeat && focusSeat.id !== seat.id ? `Guard ${focusSeat.label}` : "Guard",
+      targetId: focusSeat?.id ?? seat.id,
+      cost: 6,
+      lane: "Fast",
+      tempo: 7,
+      tag: "Instant",
+      group: "Protect",
+      guardEffect:
+        focusSeat && focusSeat.id !== seat.id
+          ? "+3 temporary Guard to adjacent ally"
+          : "Restore 4 Guard to armor cap and Brace against one visible Commitment",
+      requiresConsentFromSeatId:
+        focusSeat && focusSeat.id !== seat.id ? focusSeat.id : null,
+    }),
+  );
+
+  if (focusPosition || focusEnemy) {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "scan",
+        name: "Scan",
+        targetId: focusId,
+        cost: 4,
+        lane: "Fast",
+        tempo: 4,
+        tag: "Instant",
+        group: "Observe",
+        certainty: "Improves one authored uncertain fact by one information band",
+        objectiveEffect: "No discipline authority or exact conversion",
+      }),
+    );
+  }
+
+  ordinaryNeighbors(seat.position).forEach((destinationId) => {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: `reposition:${destinationId}`,
+        baseId: "reposition",
+        name: `Reposition → ${POSITIONS[destinationId].name}`,
+        targetId: destinationId,
+        destinationId,
+        cost: 0,
+        lane: "Standard",
+        tempo: 5,
+        paid: false,
+        tag: "Transit",
+        group: "Move",
+        requirements: ["Adjacent ordinary legal position", "Available destination capacity"],
+        movementEffect: `Move one ordinary position to ${POSITIONS[destinationId].name}`,
+      }),
+    );
+    actions.push(
+      actionTemplate(state, seat, {
+        id: `additional-movement:${destinationId}`,
+        baseId: "additional-movement",
+        name: `Additional Movement → ${POSITIONS[destinationId].name}`,
+        targetId: destinationId,
+        destinationId,
+        cost: 4,
+        lane: "Standard",
+        tempo: 5,
+        tag: "Transit",
+        group: "Move",
+        requirements: ["Adjacent ordinary legal position", "Available destination capacity"],
+        movementEffect: `Move one additional ordinary position to ${POSITIONS[destinationId].name}`,
+      }),
+    );
+  });
+
+  if (
+    rig?.id === "traversal-line" &&
+    !seat.packages.some((item) => item.slots >= 2)
+  ) {
+    const paths = new Map();
+    ordinaryNeighbors(seat.position).forEach((first) => {
+      paths.set(first, [seat.position, first]);
+      ordinaryNeighbors(first)
+        .filter((second) => second !== seat.position)
+        .forEach((second) => {
+          if (!paths.has(second)) {
+            paths.set(second, [seat.position, first, second]);
+          }
+        });
+    });
+    paths.forEach((path, destinationId) => {
+      if (
+        destinationId === "threshold" &&
+        !state.encounter.release.thresholdOpen
+      ) {
+        return;
+      }
+      actions.push(
+        actionTemplate(state, seat, {
+          ...rig.action,
+          id: `line-move:${destinationId}`,
+          baseId: "line-move",
+          targetId: destinationId,
+          destinationId,
+          group: "Gear technique",
+          requirements: [
+            rig.text,
+            "Selected path uses one or two ordinary connections",
+            "No carried Major Package",
+          ],
+          movementEffect: `Move through ${path
+            .slice(1)
+            .map((positionId) => focusLabel(state, positionId))
+            .join(" → ")}`,
+          effect: { path },
+        }),
+      );
+    });
+  } else if (rig?.action) {
+    actions.push(
+      actionTemplate(state, seat, {
+        ...rig.action,
+        targetId: seat.id,
+        group: "Gear technique",
+        requirements: [rig.text],
+        guardEffect:
+          rig.action.id === "anchor-lock"
+            ? "Prevent first 2 Force before Settle"
+            : rig.action.id === "protected-access"
+              ? "Protect one declared access action from direct-hit invalidation"
+              : undefined,
+        movementEffect:
+          rig.action.id === "line-move"
+            ? "Choose up to two connected ordinary positions; no special Opening"
+            : undefined,
+      }),
+    );
+  }
+
+  actions.push(
+    actionTemplate(state, seat, {
+      id: "swap-weapon",
+      name: `Swap to ${WEAPONS[seat.reserveWeaponId].name}`,
+      targetId: seat.id,
+      cost: 4,
+      lane: "Fast",
+      tempo: 3,
+      tag: "Instant",
+      group: "Gear technique",
+      requirements: ["Once per planning phase", "Includes no Attack"],
+      objectiveEffect: "Active and reserve weapons exchange",
+    }),
+  );
+
+  seat.hand.forEach((cardId) => {
+    if (cardId === "field-patch" && !seat.fieldPatchUsed) {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "field-patch",
+          name: "Field Patch",
+          targetId: focusSeat?.id ?? seat.id,
+          cost: CARDS["field-patch"].cost,
+          lane: "Slow",
+          tempo: 3,
+          tag: "Sustained",
+          group: "Prepared card",
+          requirements: ["Self or adjacent non-Compromised ally", "Once per character per encounter"],
+          conditionEffect: "Restore 3 Condition; cannot Stabilize",
+          requiresConsentFromSeatId:
+            focusSeat && focusSeat.id !== seat.id ? focusSeat.id : null,
+          effect: { cardActionId: "field-patch" },
+        }),
+      );
+    }
+    actions.push(
+      actionTemplate(state, seat, {
+        id: `refocus:${cardId}`,
+        baseId: "refocus",
+        name: `Refocus · ${CARDS[cardId].name}`,
+        targetId: seat.id,
+        cost: 4,
+        lane: "Fast",
+        tempo: 2,
+        tag: "Instant",
+        group: "Prepared card",
+        requirements: ["Once per planning phase", "Cycle one selected card"],
+        objectiveEffect: `Discard ${CARDS[cardId].name} and immediately draw one`,
+        refocusCardIds: [cardId],
+      }),
+    );
+  });
+
+  return actions;
+}
+
+function makeDisciplineActions(state, seat, focusId) {
+  const actions = [];
+  const build = getBuild(seat.buildId);
+  const focusEnemy = state.encounter.enemies[focusId];
+  const intent = focusEnemy ? currentEnemyIntentPreview(state, focusId) : null;
+  const plannedAnswer = seat.plan.find(
+    (action) =>
+      action.baseId === "answer-commitment" &&
+      action.targetId === focusId,
+  );
+
+  if (build.major === "battle" || build.minor === "battle") {
+    if (focusEnemy && intent) {
+      const definition =
+        build.major === "battle"
+          ? DISCIPLINES.battle.setup
+          : DISCIPLINES.battle.minor;
+      actions.push(
+        actionTemplate(state, seat, {
+          id: definition.id,
+          name: `${definition.name} · ${intent.name}`,
+          targetId: focusId,
+          cost: definition.cost,
+          lane: intent.lane,
+          tempo: intent.tempo,
+          tag: "Instant",
+          family: build.major === "battle" ? "Major engine" : "Minor foundation",
+          group: "Commitment",
+          requirements: [`Visible ${intent.name}`, "One primary responder per Commitment"],
+          exclusiveClaim: `commitment:${focusId}:${intent.id}`,
+          certainty:
+            "Confirmed response layer; inherits the threatened Commitment packet",
+          forceEffect:
+            build.major === "battle"
+              ? "Changes the Commitment and creates Battle Advantage on success"
+              : "Reduces Force by 2; creates no Battle Advantage",
+          controlEffect:
+            build.major === "battle"
+              ? "Create Battle Advantage tied to this enemy and confrontation"
+              : "No stored state",
+          effect: { intentId: intent.id },
+        }),
+      );
+    }
+    const hasBattleAdvantage =
+      seat.majorState?.type === "battle-advantage" &&
+      seat.majorState.targetId === focusId;
+    if (build.major === "battle" && (hasBattleAdvantage || plannedAnswer)) {
+      [
+        ["drive", "Drive to Trace Rail", "Remove target; intact component may become inaccessible"],
+        ["pin", "Pin", "Cancel movement Commitment through next Settle"],
+        ["disarm", "Controlled Disarm", "Disable pressure and preserve an intact actuator if requirements hold"],
+      ].forEach(([payoffId, name, result]) => {
+        actions.push(
+          actionTemplate(state, seat, {
+            id: `convert-${payoffId}`,
+            baseId: "convert-advantage",
+            name,
+            targetId: focusId,
+            cost: 8,
+            lane: "Standard",
+            tempo: 5,
+            tag: "Instant",
+            family: "Major engine",
+            group: "Advantage",
+            requirements:
+              payoffId === "disarm"
+                ? [
+                    hasBattleAdvantage
+                      ? "Owned Battle Advantage"
+                      : "Planned Answer Commitment must complete first",
+                    "Zero Guard or confrontation-created exposure",
+                  ]
+                : payoffId === "pin"
+                  ? [
+                      hasBattleAdvantage
+                        ? "Owned Battle Advantage"
+                        : "Planned Answer Commitment must complete first",
+                      "Stable physical relationship",
+                    ]
+                  : [
+                      hasBattleAdvantage
+                        ? "Owned Battle Advantage"
+                        : "Planned Answer Commitment must complete first",
+                    ],
+            controlEffect: `Spend Battle Advantage · ${result}`,
+            payoffId,
+            dependsOnActionInstanceId: hasBattleAdvantage
+              ? null
+              : plannedAnswer.instanceId,
+            certainty: hasBattleAdvantage
+              ? "Confirmed"
+              : "Conditional: begins only after the planned Answer creates Battle Advantage",
+          }),
+        );
+      });
+    }
+  }
+
+  const atOpening =
+    focusId === "broken-lane-lip" ||
+    focusId === "far-platform" ||
+    focusId === SPECIAL_EDGE.id;
+  if (atOpening && (build.major === "exploration" || build.minor === "exploration")) {
+    if (build.major === "exploration") {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "prepare-route",
+          name: "Prepare Route",
+          targetId: SPECIAL_EDGE.id,
+          sourceId: SPECIAL_EDGE.id,
+          cost: 7,
+          lane: "Standard",
+          tempo: 4,
+          tag: "Instant",
+          family: "Major engine",
+          group: "Opening",
+          requirements: ["Natural Opening accessible", "One owner for this origin/destination relationship"],
+          exclusiveClaim: `route:${SPECIAL_EDGE.origin}:${SPECIAL_EDGE.destination}`,
+          routeEffect: "Create owner Exploit passage and one authorized allied Follow passage",
+          certainty:
+            "Confirmed geometry; standalone timing is a declared prototype assumption because the source omits it",
+        }),
+      );
+    } else {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "cross-opening",
+          name: "Cross Opening",
+          targetId: "far-platform",
+          sourceId: SPECIAL_EDGE.id,
+          destinationId:
+            seat.position === "far-platform" ? "broken-lane-lip" : "far-platform",
+          cost: 6,
+          lane: "Standard",
+          tempo: 5,
+          tag: "Transit",
+          family: "Minor foundation",
+          group: "Opening",
+          requirements: ["Natural Opening accessible", "Legal destination capacity"],
+          movementEffect: "Personal immediate crossing; no stored Route or destination action",
+          certainty:
+            "Crossing Intercept resolves as an explicit response in this packet",
+        }),
+      );
+    }
+  }
+
+  if (build.major === "exploration" && seat.majorState?.type === "prepared-route") {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "exploit-route",
+        name: "Exploit Route · cross",
+        targetId: seat.majorState.destinationId,
+        sourceId: seat.majorState.openingId,
+        destinationId: seat.majorState.destinationId,
+        cost: 8,
+        lane: "Standard",
+        tempo: 5,
+        tag: "Transit",
+        family: "Major engine",
+        group: "Route",
+        requirements: ["Owned active prepared Route", "Legal landing position"],
+        routeEffect: "Spend owner passage and traverse; no arbitrary extra objective is compressed",
+        movementEffect: `Cross to ${focusLabel(state, seat.majorState.destinationId)}`,
+      }),
+    );
+    if (
+      seat.majorState.destinationId === "far-platform" &&
+      state.encounter.shutter.state !== "closed"
+    ) {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "exploit-release",
+          baseId: "exploit-route",
+          name: "Exploit Route · Complete Release",
+          targetId: "release-socket",
+          sourceId: seat.majorState.openingId,
+          destinationId: seat.majorState.destinationId,
+          includedActionId: "complete-release",
+          cost: 8,
+          lane: "Standard",
+          tempo: 5,
+          tag: "Transit",
+          family: "Major engine",
+          group: "Route",
+          requirements: ["Owned prepared Route", "Open or bypassed shutter", "Legal release access at destination"],
+          routeEffect: "Spend owner passage",
+          movementEffect: "Cross to Far Platform",
+          workEffect: "Included legal destination action adds 1 Release Work",
+          objectiveEffect: "Release validates only at Settle if the shutter remains open and entered threats are clear",
+        }),
+      );
+    }
+  }
+
+  const alliedRouteOwner = state.seats.find(
+    (candidate) =>
+      candidate.id !== seat.id &&
+      candidate.majorState?.type === "prepared-route" &&
+      candidate.majorState.followPassages > 0,
+  );
+  if (alliedRouteOwner && atOpening) {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "follow-route",
+        name: `Follow ${alliedRouteOwner.label}'s Route`,
+        targetId: alliedRouteOwner.majorState.destinationId,
+        sourceId: alliedRouteOwner.majorState.openingId,
+        destinationId: alliedRouteOwner.majorState.destinationId,
+        cost: 4,
+        lane: "Standard",
+        tempo: 5,
+        tag: "Transit",
+        family: "Allied discipline passage",
+        group: "Route",
+        requirements: ["Authorized allied passage", "Distinct legal landing position"],
+        requiresConsentFromSeatId: alliedRouteOwner.id,
+        exclusiveClaim: `route-passage:${alliedRouteOwner.id}:follow`,
+        movementEffect: "Traversal only; no destination action",
+      }),
+    );
+  }
+
+  if (
+    seat.flags.backtrack &&
+    seat.position === seat.flags.backtrack.destinationId &&
+    atOpening
+  ) {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "backtrack",
+        name: `Backtrack → ${focusLabel(
+          state,
+          seat.flags.backtrack.originId,
+        )}`,
+        targetId: seat.flags.backtrack.originId,
+        sourceId: seat.flags.backtrack.openingId,
+        destinationId: seat.flags.backtrack.originId,
+        cost: 4,
+        lane: "Standard",
+        tempo: 5,
+        tag: "Transit",
+        family: "Prepared card",
+        group: "Route",
+        requirements: [
+          "Backtrack Marker created this cycle",
+          "Same Opening or Route remains legal",
+          "Legal destination capacity",
+        ],
+        movementEffect: "Return to the marked origin before Settle",
+        certainty: "Confirmed temporary action from Backtrack Marker",
+      }),
+    );
+  }
+
+  const shutterFocus = new Set([
+    "shutter-console",
+    "far-platform",
+    "release-socket",
+    "relay-cache",
+  ]).has(focusId);
+  if (shutterFocus && (build.major === "hacking" || build.minor === "hacking")) {
+    if (build.major === "hacking") {
+      if (!seat.majorState) {
+        actions.push(
+          actionTemplate(state, seat, {
+            id: "establish-control",
+            name: "Establish Control · Shutter Dependency",
+            targetId: "shutter-console",
+            sourceId: "shutter-console",
+            cost: 7,
+            lane: "Standard",
+            tempo: 3,
+            tag: "Sustained",
+            family: "Major engine",
+            group: "Control",
+            requirements: ["Console or Far Platform access", "Continuous legal access"],
+            exclusiveClaim: "control:shutter-dependency",
+            controlEffect: "Create character-owned Temporary Control; already-committed actions remain",
+          }),
+        );
+      }
+      const hasTemporaryControl =
+        seat.majorState?.type === "temporary-control";
+      if (hasTemporaryControl) {
+        [
+          {
+            id: "execute-hold-open",
+            outputId: "hold-open",
+            name: "Execute Output · Hold Open",
+            text: "Keep shutter open for the encounter; no cache; reinforcement remains.",
+          },
+          {
+            id: "execute-expose-cache",
+            outputId: "expose-cache",
+            name: "Execute Output · Expose Cache",
+            text: "Keep shutter open and expose Relay Needle; +1 Disruption at Settle unless prevented.",
+          },
+          {
+            id: "execute-blind-repeater",
+            outputId: "blind-repeater",
+            name: "Execute Output · Blind Repeater",
+            text: "Prevent reinforcement; shutter stays open through the next planning cycle only.",
+          },
+        ].forEach((output) => {
+          if (
+            output.outputId === "blind-repeater" &&
+            state.encounter.reinforcementPrevented
+          ) {
+            return;
+          }
+          actions.push(
+            actionTemplate(state, seat, {
+              id: output.id,
+              baseId: "execute-output",
+              name: output.name,
+              targetId: "shutter-console",
+              sourceId: "shutter-console",
+              outputId: output.outputId,
+              cost: 8,
+              lane: "Standard",
+              tempo: 6,
+              tag: "Sustained",
+              family: "Major engine",
+              group: "Control",
+              requirements: ["Owned active Control", "Continuous legal access"],
+              controlEffect: `Spend Control · ${output.text}`,
+              alternatives: "Outputs are mutually exclusive because Control is spent",
+              certainty: "Confirmed",
+            }),
+          );
+        });
+      }
+    } else {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "suppress-response",
+          name: "Suppress Reseal Response",
+          targetId: "shutter-console",
+          sourceId: "shutter-console",
+          cost: 6,
+          lane: "Fast",
+          tempo: 6,
+          tag: "Instant",
+          family: "Minor foundation",
+          group: "Control",
+          requirements: ["Visible immediate Reseal or lockout response"],
+          controlEffect: "Delay the authored Reseal response; creates no Control",
+        }),
+      );
+    }
+  }
+  return actions;
+}
+
+function makeContextActions(state, seat, focusId) {
+  const actions = [];
+  if (focusId === "frontier-marker") {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "lock-frontier-marker",
+        name: "Lock Frontier Marker",
+        targetId: "frontier-marker",
+        cost: 6,
+        lane: "Fast",
+        tempo: 6,
+        tag: "Sustained",
+        family: "Context Card",
+        group: "Secure",
+        requirements: ["Accessible Frontier Marker", "1 Work embodied in this action"],
+        exclusiveClaim: "work:frontier-marker-lock",
+        guardEffect: "Marker gains +1 Force resistance; remains damageable",
+        integrityEffect: "Preserves Survey against Force, not direct damage",
+      }),
+    );
+  }
+
+  if (focusId === "broken-lane-lip" || focusId === SPECIAL_EDGE.id) {
+    if (!state.encounter.plate.stabilized) {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "stabilize-plate",
+          name: "Stabilize Maintenance Plate",
+          targetId: SPECIAL_EDGE.id,
+          sourceId: "broken-lane-lip",
+          cost: 6,
+          lane: "Standard",
+          tempo: 4,
+          tag: "Sustained",
+          family: "Context Card",
+          group: "Repair",
+          requirements: ["Broken-Lane Lip access", "1 Work"],
+          exclusiveClaim: "work:maintenance-plate",
+          workEffect: "Add 1 Work of 1; creates Cross Plate for the encounter",
+        }),
+      );
+    } else {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "cross-plate",
+          name: "Cross Plate",
+          targetId: "far-platform",
+          sourceId: SPECIAL_EDGE.id,
+          destinationId:
+            seat.position === "far-platform" ? "broken-lane-lip" : "far-platform",
+          cost: 6,
+          lane: "Standard",
+          tempo: 5,
+          tag: "Transit",
+          family: "Context Card",
+          group: "Opening",
+          requirements: ["Stabilized plate", "One character at a time", "Legal landing"],
+          exclusiveClaim: `passage:plate:${state.encounter.cycle}`,
+          movementEffect: "Universal crossing; not an Exploration action or Route",
+          certainty:
+            "Crossing Intercept remains visible and resolves in this crossing packet",
+        }),
+      );
+    }
+  }
+
+  const shutterAccessible =
+    seat.position === "shutter-console" || seat.position === "far-platform";
+  if (
+    ["shutter-console", "far-platform"].includes(focusId) &&
+    shutterAccessible
+  ) {
+    const traceEchoDiscount =
+      seat.flags.traceEcho?.componentId === "shutter-console" ? 2 : 0;
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "manual-shutter-release",
+        name: "Manual Shutter Release",
+        targetId: "shutter-console",
+        cost: 6,
+        lane: "Standard",
+        tempo: 6,
+        tag: "Sustained",
+        family: "Context Card",
+        group: "Operate",
+        requirements: ["Console or Far Platform access"],
+        objectiveEffect: "Open shutter for this resolution; visible Reseal Response occurs at Settle",
+        certainty:
+          "Release Work cannot validate unless the shutter remains open through Settle",
+      }),
+      actionTemplate(state, seat, {
+        id: "jam-shutter-track",
+        name: "Jam Shutter Track",
+        targetId: "shutter-console",
+        cost: 6,
+        lane: "Standard",
+        tempo: 5,
+        tag: "Sustained",
+        family: "Context Card",
+        group: "Operate",
+        requirements: ["Shutter access", "1 Work"],
+        objectiveEffect: "Shutter stays open for encounter",
+        packageEffect: "Relay cache destroyed",
+        integrityEffect: "Shutter damaged; Hacking Outputs become unavailable",
+      }),
+      actionTemplate(state, seat, {
+        id: "basic-interface",
+        name: "Basic Interface · cycle shutter",
+        targetId: "shutter-console",
+        cost: Math.max(4, 6 - traceEchoDiscount),
+        lane: "Standard",
+        tempo: 4,
+        tag: "Sustained",
+        family: "Core",
+        group: "Operate",
+        requirements: ["Visible accessible interface point"],
+        objectiveEffect: "Perform exposed standard operation; Reseal Response remains projected",
+        controlEffect: "No Dependency reveal, Control, or Output selection",
+        certainty: traceEchoDiscount
+          ? "Confirmed by Trace Echo; first eligible interface receives its 2-Command reduction"
+          : "Confirmed",
+      }),
+    );
+  }
+
+  if (focusId === "release-socket" && seat.position === "far-platform") {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "complete-release",
+        name: "Complete Far-Side Release",
+        targetId: "release-socket",
+        cost: 6,
+        lane: "Standard",
+        tempo: 4,
+        tag: "Sustained",
+        family: "Context Card",
+        group: "Objective",
+        requirements: ["Far-side access", "Open or bypassed shutter", "1 Work"],
+        exclusiveClaim: "work:far-side-release",
+        workEffect: "Add 1 Release Work of 1",
+        objectiveEffect:
+          "Validate at Settle only if shutter remains open and every entered Skimmer is neutralized",
+      }),
+    );
+  }
+
+  if (
+    focusId === "relay-cache" &&
+    (state.encounter.cache.exposed ||
+      state.seats.some((candidate) =>
+        candidate.plan.some(
+          (planned) => planned.id === "execute-expose-cache",
+        ),
+      )) &&
+    !state.encounter.cache.recovered &&
+    seat.position === "far-platform"
+  ) {
+    const plannedExpose = state.seats
+      .flatMap((candidate) => candidate.plan)
+      .find((planned) => planned.id === "execute-expose-cache");
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "recover-relay-cache",
+        name: "Recover Relay Cache",
+        targetId: "relay-cache",
+        cost: 6,
+        lane: "Standard",
+        tempo: 4,
+        tag: "Sustained",
+        family: "Context Card",
+        group: "Package",
+        requirements: ["Exposed cache", "Far Platform access", "One exposed Package slot"],
+        exclusiveClaim: "package:relay-needle",
+        packageEffect: "Recover Relay Needle · one slot",
+        dependsOnActionInstanceId:
+          state.encounter.cache.exposed ? null : plannedExpose?.instanceId ?? null,
+        certainty:
+          state.encounter.cache.exposed
+            ? "Confirmed"
+            : "Conditional: delayed until the planned Expose Cache Output completes",
+      }),
+    );
+  }
+
+  if (focusId === "threshold") {
+    actions.push(
+      actionTemplate(state, seat, {
+        id: "standard-extract",
+        name: "Standard Extract",
+        targetId: "threshold",
+        cost: 8,
+        lane: "Slow",
+        tempo: 3,
+        tag: "Sustained",
+        family: "Core",
+        group: "Exit",
+        requirements: ["Prepared legal exit", "Occupy the exit through completion"],
+        extractionEffect:
+          state.encounter.release.thresholdOpen
+            ? "Extract this character and carried Packages"
+            : "Unavailable: Threshold is not yet open or prepared",
+      }),
+    );
+  }
+
+  const ally = state.seats.find(
+    (candidate) => candidate.id === focusId && candidate.id !== seat.id,
+  );
+  if (ally) {
+    const supported = ally.plan[0];
+    if (supported) {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "assist",
+          name: `Assist ${ally.label} · ${supported.name}`,
+          targetId: ally.id,
+          cost: 4,
+          lane: supported.lane,
+          tempo: supported.tempo + 1,
+          tag: "Instant",
+          family: "Core",
+          group: "Support",
+          requirements: ["Printed contextual Assist use", "Maximum one standard Assist per supported action"],
+          requiresConsentFromSeatId: ally.id,
+          supportedActionInstanceId: supported.instanceId,
+          guardEffect: "Contextual protection or +1 Work if both actions complete",
+        }),
+      );
+    }
+    if (ally.compromised) {
+      actions.push(
+        actionTemplate(state, seat, {
+          id: "stabilize",
+          name: `Stabilize ${ally.label}`,
+          targetId: ally.id,
+          cost: 12,
+          lane: "Slow",
+          tempo: 2,
+          tag: "Sustained",
+          family: "Core",
+          group: "Rescue",
+          requirements: ["Compromised teammate", "Complete before two-Settle window expires"],
+          requiresConsentFromSeatId: ally.id,
+          conditionEffect: "Return next planning phase at 4 Condition, 0 Guard, +1 Disruption",
+        }),
+      );
+    }
+  }
+  return actions;
+}
+
+function dedupeActions(actions) {
+  const seen = new Set();
+  return actions.filter((action) => {
+    const key = `${action.id}|${action.targetId}|${action.destinationId ?? ""}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function getImmediateActionGroups(state, seatId, focusId) {
+  if (state.stage !== "loose-signal" || state.encounter?.resolutionComplete) {
+    return [];
+  }
+  const seat = state.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || seat.compromised || seat.locked) return [];
+  const actions = dedupeActions([
+    ...makeContextActions(state, seat, focusId),
+    ...makeDisciplineActions(state, seat, focusId),
+    ...makeCoreActions(state, seat, focusId),
+  ]).filter((action) => isActionCurrentlyVisible(state, seat, action));
+
+  const familyFor = (action) => {
+    if (action.family === "Context Card") return "World action";
+    if (
+      ["Major engine", "Minor foundation", "Allied discipline passage"].includes(
+        action.family,
+      )
+    ) {
+      return "Discipline";
+    }
+    if (
+      action.group === "Gear technique" ||
+      action.group === "Prepared card"
+    ) {
+      return "Cards & equipment";
+    }
+    return "Core action";
+  };
+  const grouped = new Map();
+  actions.forEach((action) => {
+    const family = familyFor(action);
+    if (!grouped.has(family)) grouped.set(family, []);
+    grouped.get(family).push(action);
+  });
+  const preferredOrder = [
+    "World action",
+    "Discipline",
+    "Core action",
+    "Cards & equipment",
+  ];
+  const result = [...grouped.entries()]
+    .sort(
+      ([left], [right]) =>
+        preferredOrder.indexOf(left) - preferredOrder.indexOf(right),
+    )
+    .map(([name, variants]) => ({ name, variants }));
+
+  pushEvidencePreview(state, seatId, focusId, actions, result);
+  return result;
+}
+
+function pushEvidencePreview(state, seatId, focusId, actions, groups) {
+  // Read-only option queries must not mutate the state. The UI records the
+  // actual focus event; this helper only keeps the choice-cap logic explicit.
+  void state;
+  void seatId;
+  void focusId;
+  void actions;
+  void groups;
+}
+
+function isActionCurrentlyVisible(state, seat, action) {
+  if (
+    [
+      "attack",
+      "drive-through",
+      "phase-cut",
+      "ground-lock",
+      "clear-lane",
+    ].includes(action.baseId) &&
+    action.targetId?.startsWith("skimmer-")
+  ) {
+    const enemy = state.encounter.enemies[action.targetId];
+    if (
+      !enemy ||
+      physicalDistance(seat.position, enemy.position) >
+        WEAPONS[seat.activeWeaponId].range
+    ) {
+      return false;
+    }
+  }
+  if (
+    action.baseId === "guard" &&
+    action.targetId !== seat.id &&
+    !sameOrOrdinarilyAdjacent(
+      seat.position,
+      state.seats.find((candidate) => candidate.id === action.targetId)
+        ?.position,
+    )
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "lock-frontier-marker" &&
+    !sameOrOrdinarilyAdjacent(seat.position, "frontier-marker")
+  ) {
+    return false;
+  }
+  if (
+    action.destinationId === "threshold" &&
+    !state.encounter.release.thresholdOpen
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "standard-extract" &&
+    (!state.encounter.release.thresholdOpen || seat.position !== "threshold")
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "establish-control" &&
+    !["shutter-console", "far-platform"].includes(seat.position)
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "suppress-response" &&
+    state.encounter.shutter.state !== "open-until-settle" &&
+    !seat.plan.some((planned) => planned.baseId === "manual-shutter-release") &&
+    !state.seats.some((candidate) =>
+      candidate.plan.some((planned) => planned.baseId === "manual-shutter-release"),
+    )
+  ) {
+    return false;
+  }
+  if (
+    CROSSING_ACTION_IDS.has(action.baseId) &&
+    !["broken-lane-lip", "far-platform"].includes(seat.position)
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "cross-plate" &&
+    !state.encounter.plate.stabilized
+  ) {
+    return false;
+  }
+  if (
+    action.baseId === "complete-release" &&
+    state.encounter.shutter.state === "closed" &&
+    !state.seats.some((candidate) =>
+      candidate.plan.some((planned) =>
+        [
+          "manual-shutter-release",
+          "jam-shutter-track",
+          "execute-hold-open",
+          "execute-expose-cache",
+          "execute-blind-repeater",
+        ].includes(planned.id),
+      ),
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function queueAction(state, seatId, candidate) {
+  if (state.stage !== "loose-signal" || state.encounter?.resolutionComplete) {
+    return state;
+  }
+  const next = clone(state);
+  const seat = next.seats.find((item) => item.id === seatId);
+  if (!seat || seat.locked) return state;
+  const action = clone(candidate);
+  action.instanceId = `${seat.id}:c${next.encounter.cycle}:a${next.nextActionSequence}`;
+  next.nextActionSequence += 1;
+  action.actorSeatId = seatId;
+  action.consentGranted = !action.requiresConsentFromSeatId;
+
+  const validation = validateQueuedAction(next, seat, action);
+  if (!validation.ok) return withWarning(state, validation.reason);
+  seat.plan.push(action);
+  seat.lockError = "";
+  pushEvidence(next, "action_queued", {
+    seatId,
+    actionId: action.baseId,
+    targetId: action.targetId,
+    cost: action.cost,
+    paid: action.paid,
+    lane: action.lane,
+    tempo: action.tempo,
+    claim: action.exclusiveClaim,
+  });
+  return next;
+}
+
+function validateQueuedAction(state, seat, action) {
+  const paidCount = seat.plan.filter((planned) => planned.paid).length;
+  if (action.paid && paidCount >= CORE_RULES.paidActionCap) {
+    return { ok: false, reason: "This personal plan already uses four paid action slots." };
+  }
+  if (
+    !action.paid &&
+    action.baseId === "reposition" &&
+    seat.plan.some((planned) => planned.baseId === "reposition")
+  ) {
+    return { ok: false, reason: "Ordinary Reposition is limited to once per planning phase." };
+  }
+  if (
+    ["answer-commitment", "prepare-route", "establish-control"].includes(
+      action.baseId,
+    ) &&
+    seat.plan.some((planned) => planned.baseId === action.baseId)
+  ) {
+    return { ok: false, reason: "That guaranteed Major setup is limited to once this phase." };
+  }
+  if (
+    ["contest", "cross-opening", "suppress-response"].includes(action.baseId) &&
+    seat.plan.some((planned) => planned.baseId === action.baseId)
+  ) {
+    return { ok: false, reason: "That guaranteed Minor foundation is limited to once this phase." };
+  }
+  if (
+    action.baseId === "refocus" &&
+    seat.plan.some((planned) => planned.baseId === "refocus")
+  ) {
+    return { ok: false, reason: "Refocus is limited to once per planning phase." };
+  }
+  if (
+    action.baseId === "swap-weapon" &&
+    seat.plan.some((planned) => planned.baseId === "swap-weapon")
+  ) {
+    return { ok: false, reason: "Reserve swap is limited to once per planning phase." };
+  }
+  if (
+    PAID_REPEAT_LIMIT_IDS.has(action.baseId) &&
+    seat.plan.filter((planned) => planned.baseId === action.baseId).length >= 2
+  ) {
+    return { ok: false, reason: "Identical core or equipment actions are limited to twice." };
+  }
+  if (seatCommandAvailable(seat) < action.totalReservedCommand) {
+    return {
+      ok: false,
+      reason: `Insufficient Command. Available ${seatCommandAvailable(seat)}, required ${action.totalReservedCommand}.`,
+    };
+  }
+  return { ok: true };
+}
+
+export function removeAction(state, seatId, actionInstanceId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || seat.locked) return state;
+  const index = seat.plan.findIndex((action) => action.instanceId === actionInstanceId);
+  if (index < 0) return state;
+  const [removed] = seat.plan.splice(index, 1);
+  pushEvidence(next, "action_removed", {
+    seatId,
+    actionId: removed.baseId,
+    actionInstanceId,
+  });
+  return next;
+}
+
+export function attachCard(state, seatId, actionInstanceId, cardId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  const action = seat?.plan.find((candidate) => candidate.instanceId === actionInstanceId);
+  const card = CARDS[cardId];
+  if (!seat || !action || seat.locked || !card || !seat.hand.includes(cardId)) {
+    return state;
+  }
+  if (
+    seat.plan.some(
+      (planned) =>
+        planned.instanceId !== action.instanceId &&
+        planned.attachedCardId === cardId,
+    )
+  ) {
+    return withWarning(
+      state,
+      `${card.name} is a single-copy controlled test card and is already committed.`,
+    );
+  }
+  if (card.kind === "Action" || !card.compatibility.includes(action.baseId) && !card.compatibility.includes("paid")) {
+    return withWarning(state, `${card.name} is not compatible with ${action.name}.`);
+  }
+
+  const priorCard = action.attachedCardId ? CARDS[action.attachedCardId] : null;
+  const nextModifierCost =
+    card.kind === "Contingency" ? 0 : card.cost;
+  const nextReserve = card.kind === "Contingency" ? card.cost : 0;
+  const priorReserved = priorCard?.cost ?? 0;
+  const newReserved = card.cost;
+  const availableWithPrior = seatCommandAvailable(seat) + priorReserved;
+  if (availableWithPrior < newReserved) {
+    return withWarning(state, `Insufficient Command to attach ${card.name}.`);
+  }
+
+  action.attachedCardId = cardId;
+  action.modifierCost = nextModifierCost;
+  action.contingencyReserve = nextReserve;
+  action.totalReservedCommand = action.cost + nextModifierCost + nextReserve;
+  action.projection.command = `${action.cost} primary + ${card.cost} ${card.kind === "Contingency" ? "reserve" : "modifier"}`;
+  action.projection.invalidators =
+    card.kind === "Contingency"
+      ? `${action.projection.invalidators}; ${card.name} tests if the primary invalidates before beginning`
+      : action.projection.invalidators;
+  pushEvidence(next, "card_attached", {
+    seatId,
+    actionInstanceId,
+    cardId,
+    kind: card.kind,
+  });
+  return next;
+}
+
+export function detachCard(state, seatId, actionInstanceId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  const action = seat?.plan.find((candidate) => candidate.instanceId === actionInstanceId);
+  if (!seat || !action || seat.locked || !action.attachedCardId) return state;
+  const cardId = action.attachedCardId;
+  action.attachedCardId = null;
+  action.modifierCost = 0;
+  action.contingencyReserve = 0;
+  action.totalReservedCommand = action.cost;
+  action.projection.command = action.cost;
+  pushEvidence(next, "card_detached", { seatId, actionInstanceId, cardId });
+  return next;
+}
+
+export function setClaimMode(state, seatId, actionInstanceId, claimMode) {
+  if (!["Primary", "If Available", "Yielded"].includes(claimMode)) return state;
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  const action = seat?.plan.find((candidate) => candidate.instanceId === actionInstanceId);
+  if (!seat || !action || seat.locked || !action.exclusiveClaim) return state;
+  action.claimMode = claimMode;
+  action.projection.claims = `${claimMode} · ${action.exclusiveClaim}`;
+  pushEvidence(next, "claim_mode_changed", {
+    seatId,
+    actionInstanceId,
+    claimMode,
+  });
+  return next;
+}
+
+export function setConsent(state, ownerSeatId, actionInstanceId, granted) {
+  const next = clone(state);
+  let targetAction = null;
+  for (const seat of next.seats) {
+    const action = seat.plan.find(
+      (candidate) => candidate.instanceId === actionInstanceId,
+    );
+    if (action) {
+      targetAction = action;
+      break;
+    }
+  }
+  if (
+    !targetAction ||
+    targetAction.requiresConsentFromSeatId !== ownerSeatId ||
+    next.seats.find((seat) => seat.id === ownerSeatId)?.locked
+  ) {
+    return state;
+  }
+  targetAction.consentGranted = Boolean(granted);
+  pushEvidence(next, "consent_changed", {
+    ownerSeatId,
+    actionInstanceId,
+    granted: Boolean(granted),
+  });
+  return next;
+}
+
+export function compatibleCardsForAction(seat, action) {
+  return seat.hand
+    .map((cardId) => CARDS[cardId])
+    .filter(
+      (card) =>
+        card &&
+        card.kind !== "Action" &&
+        (card.compatibility.includes(action.baseId) ||
+          (card.compatibility.includes("paid") && action.paid)),
+    );
+}
+
+function validatePartyPlans(state) {
+  const errors = [];
+  for (const seat of state.seats) {
+    if (seat.hand.length > CORE_RULES.retainLimit) {
+      errors.push(
+        `${seat.label} must discard to ${CORE_RULES.retainLimit} before locking.`,
+      );
+    }
+    if (activePlanCost(seat) > seat.command) {
+      errors.push(`${seat.label} reserves more Command than it owns.`);
+    }
+    const missingConsent = seat.plan.find(
+      (action) => action.requiresConsentFromSeatId && !action.consentGranted,
+    );
+    if (missingConsent) {
+      errors.push(`${seat.label}: ${missingConsent.name} still needs consent.`);
+    }
+  }
+
+  const claims = new Map();
+  state.seats
+    .flatMap((seat) => seat.plan)
+    .filter(
+      (action) => action.exclusiveClaim && action.claimMode === "Primary",
+    )
+    .forEach((action) => {
+      const key = `${action.exclusiveClaim}|${action.lane}|${action.tempo}`;
+      if (!claims.has(key)) claims.set(key, []);
+      claims.get(key).push(action);
+    });
+  for (const [key, actions] of claims.entries()) {
+    if (actions.length > 1) {
+      errors.push(
+        `Conflict: ${actions.length} equal-time Primary claims on ${key.split("|")[0]}. Revise, yield, or mark one If Available.`,
+      );
+    }
+  }
+  return errors;
+}
+
+export function lockSeatPlan(state, seatId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || seat.locked || state.stage !== "loose-signal") return state;
+  const localError = validatePartyPlans(next).find((error) =>
+    error.startsWith(seat.label),
+  );
+  if (localError) {
+    seat.lockError = localError;
+    return withWarning(next, localError);
+  }
+  seat.locked = true;
+  seat.lockError = "";
+  pushEvidence(next, "plan_locked", {
+    seatId,
+    actions: seat.plan.map((action) => action.baseId),
+    commandReserved: activePlanCost(seat),
+  });
+  return next;
+}
+
+export function unlockSeatPlan(state, seatId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || !seat.locked || state.encounter?.resolutionComplete) return state;
+  seat.locked = false;
+  pushEvidence(next, "plan_unlocked", { seatId });
+  return next;
+}
+
+export function canResolvePlans(state) {
+  return (
+    state.stage === "loose-signal" &&
+    state.seats.length > 0 &&
+    state.seats.every((seat) => seat.locked) &&
+    validatePartyPlans(state).length === 0
+  );
+}
+
+function enemyActionsForPlan(state) {
+  const actions = [];
+  const encounter = state.encounter;
+  const a = encounter.enemies["skimmer-a"];
+  if (a.status === "active") {
+    const crossing = state.seats
+      .flatMap((seat) => seat.plan)
+      .filter((action) => CROSSING_ACTION_IDS.has(action.baseId))
+      .sort(compareTiming)[0];
+    if (crossing) {
+      actions.push({
+        instanceId: "enemy-a-intercept",
+        id: "crossing-intercept",
+        baseId: "crossing-intercept",
+        name: "Crossing Intercept",
+        actorEnemyId: a.id,
+        targetId: crossing.actorSeatId,
+        targetActionInstanceId: crossing.instanceId,
+        lane: crossing.lane,
+        tempo: crossing.tempo,
+        paid: false,
+        tag: "Instant",
+        effect: { impact: 3, force: 1, edgeCollision: 1 },
+      });
+    } else {
+      const farTarget = state.seats.find((seat) => seat.position === "far-platform");
+      if (farTarget) {
+        actions.push(enemyRazorAction(a.id, farTarget.id, "enemy-a-razor"));
+      }
+    }
+  }
+  const b = encounter.enemies["skimmer-b"];
+  if (b.status === "active") {
+    const access = earliestAccessAction(state);
+    actions.push(
+      access
+        ? {
+            instanceId: "enemy-b-access",
+            id: "access-clamp",
+            baseId: "access-clamp",
+            name: "Access Clamp",
+            actorEnemyId: b.id,
+            targetId: access.actorSeatId,
+            targetActionInstanceId: access.instanceId,
+            lane: "Standard",
+            tempo: 5,
+            paid: false,
+            tag: "Instant",
+            effect: { impact: 2, force: 1, compactCollision: 1 },
+          }
+        : {
+            instanceId: "enemy-b-marker",
+            id: "marker-clamp",
+            baseId: "marker-clamp",
+            name: "Marker Clamp",
+            actorEnemyId: b.id,
+            targetId: "frontier-marker",
+            lane: "Standard",
+            tempo: 5,
+            paid: false,
+            tag: "Instant",
+            effect: { impact: 2, force: 1 },
+          },
+    );
+  }
+  const c = encounter.enemies["skimmer-c"];
+  if (c.status === "active") {
+    actions.push(
+      enemyRazorAction(c.id, chooseRazorTarget(state), "enemy-c-razor"),
+    );
+  }
+  return actions;
+}
+
+function enemyRazorAction(enemyId, targetSeatId, instanceId) {
+  return {
+    instanceId,
+    id: "razor-pass",
+    baseId: "razor-pass",
+    name: "Razor Pass",
+    actorEnemyId: enemyId,
+    targetId: targetSeatId,
+    lane: "Fast",
+    tempo: 7,
+    paid: false,
+    tag: "Instant",
+    effect: { impact: 3, force: 0 },
+  };
+}
+
+function logEvent(state, packet, action, outcome, detail, tags = []) {
+  const event = {
+    index: state.encounter.causalLog.length + 1,
+    cycle: state.encounter.cycle,
+    lane: packet.lane,
+    tempo: packet.tempo,
+    packet: `${packet.lane}/${packet.tempo}`,
+    actionId: action.baseId,
+    actor: action.actorEnemyId ?? action.actorSeatId,
+    target: action.targetId,
+    outcome,
+    detail,
+    tags,
+  };
+  state.encounter.causalLog.push(event);
+  pushEvidence(state, "resolution_event", event);
+}
+
+function findSeat(state, seatId) {
+  return state.seats.find((seat) => seat.id === seatId);
+}
+
+function findEnemy(state, enemyId) {
+  return state.encounter.enemies[enemyId];
+}
+
+function actionStartLegal(state, action) {
+  if (action.claimMode === "Yielded") {
+    return { ok: false, reason: "Claim yielded before beginning" };
+  }
+  if (action.requiresConsentFromSeatId && !action.consentGranted) {
+    return { ok: false, reason: "Required consent missing" };
+  }
+  if (action.actorEnemyId) {
+    const enemy = findEnemy(state, action.actorEnemyId);
+    return enemyIsActive(enemy)
+      ? { ok: true }
+      : { ok: false, reason: "Enemy no longer active" };
+  }
+  if (
+    ["contest", "answer-commitment"].includes(action.baseId) &&
+    !state.resolution.actions.some(
+      (candidate) =>
+        candidate.actorEnemyId === action.targetId &&
+        candidate.id === action.effect.intentId,
+    )
+  ) {
+    return { ok: false, reason: "The named visible Commitment changed before lock" };
+  }
+  if (action.dependsOnActionInstanceId) {
+    const dependency = state.resolution.results[action.dependsOnActionInstanceId];
+    if (!dependency || dependency.status !== "completed") {
+      return {
+        ok: false,
+        reason: "Projected causal prerequisite did not complete",
+      };
+    }
+  }
+  const seat = findSeat(state, action.actorSeatId);
+  if (!seat || seat.compromised) {
+    return { ok: false, reason: "Actor is Compromised or absent" };
+  }
+  if (seat.flags.emergencyDisconnectTriggeredFor === action.instanceId) {
+    return {
+      ok: false,
+      reason: "Emergency Disconnect aborted the parent before beginning",
+    };
+  }
+  if (state.resolution.claimWinners[action.exclusiveClaim] && action.claimMode === "If Available") {
+    return { ok: false, reason: "Exclusive source already claimed" };
+  }
+  if (action.targetId?.startsWith("skimmer-")) {
+    const enemy = findEnemy(state, action.targetId);
+    if (!enemyIsActive(enemy)) {
+      return { ok: false, reason: "Target no longer active" };
+    }
+    if (
+      [
+        "attack",
+        "drive-through",
+        "phase-cut",
+        "ground-lock",
+        "clear-lane",
+      ].includes(action.baseId)
+    ) {
+      const weapon = WEAPONS[seat.activeWeaponId];
+      if (physicalDistance(seat.position, enemy.position) > weapon.range) {
+        return {
+          ok: false,
+          reason: `${weapon.name} no longer has a legal range-${weapon.range} line`,
+        };
+      }
+    }
+  }
+  if (
+    action.baseId === "guard" &&
+    action.targetId !== seat.id &&
+    !sameOrOrdinarilyAdjacent(
+      seat.position,
+      findSeat(state, action.targetId)?.position,
+    )
+  ) {
+    return { ok: false, reason: "Guard target is no longer adjacent" };
+  }
+  if (
+    action.baseId === "hold-line" &&
+    physicalDistance(
+      seat.position,
+      findEnemy(state, action.targetId)?.position,
+    ) > 4
+  ) {
+    return { ok: false, reason: "Selected Hold Line exceeds four positions" };
+  }
+  if (
+    CROSSING_ACTION_IDS.has(action.baseId) &&
+    !["broken-lane-lip", "far-platform"].includes(seat.position)
+  ) {
+    return { ok: false, reason: "Actor no longer has Opening access" };
+  }
+  if (
+    ["complete-release", "recover-relay-cache"].includes(action.baseId) &&
+    seat.position !== "far-platform"
+  ) {
+    return { ok: false, reason: "Far-side access lost" };
+  }
+  if (
+    action.baseId === "stabilize-plate" &&
+    seat.position !== "broken-lane-lip"
+  ) {
+    return { ok: false, reason: "Broken-Lane Lip access lost" };
+  }
+  if (
+    action.baseId === "lock-frontier-marker" &&
+    !sameOrOrdinarilyAdjacent(seat.position, "frontier-marker")
+  ) {
+    return { ok: false, reason: "Frontier Marker access lost" };
+  }
+  if (
+    [
+      "manual-shutter-release",
+      "jam-shutter-track",
+      "basic-interface",
+      "establish-control",
+      "execute-output",
+    ].includes(action.baseId) &&
+    !["shutter-console", "far-platform"].includes(seat.position)
+  ) {
+    return { ok: false, reason: "Shutter Dependency access lost" };
+  }
+  if (
+    action.baseId === "standard-extract" &&
+    (seat.position !== "threshold" ||
+      !state.encounter.release.thresholdOpen)
+  ) {
+    return { ok: false, reason: "Prepared Threshold exit is unavailable" };
+  }
+  if (
+    action.destinationId === "threshold" &&
+    !state.encounter.release.thresholdOpen
+  ) {
+    return { ok: false, reason: "Threshold connection remains closed" };
+  }
+  if (
+    action.baseId === "line-move" &&
+    (action.effect.path?.[0] !== seat.position ||
+      action.effect.path
+        .slice(1)
+        .some(
+          (positionId, index) =>
+            !canReachOrdinary(action.effect.path[index], positionId),
+        ) ||
+      seat.packages.some((item) => item.slots >= 2))
+  ) {
+    return {
+      ok: false,
+      reason: "Traversal Line path or carried-Package clearance became illegal",
+    };
+  }
+  if (
+    action.baseId === "complete-release" &&
+    state.encounter.shutter.state === "closed"
+  ) {
+    return { ok: false, reason: "Shutter is closed" };
+  }
+  if (
+    action.baseId === "recover-relay-cache" &&
+    (!state.encounter.cache.exposed || state.encounter.cache.recovered)
+  ) {
+    return { ok: false, reason: "Relay cache is not recoverable" };
+  }
+  if (
+    action.baseId === "execute-output" &&
+    seat.majorState?.type !== "temporary-control"
+  ) {
+    return { ok: false, reason: "Temporary Control unavailable" };
+  }
+  if (
+    action.baseId === "convert-advantage" &&
+    seat.majorState?.type !== "battle-advantage"
+  ) {
+    return { ok: false, reason: "Battle Advantage unavailable" };
+  }
+  if (
+    action.baseId === "exploit-route" &&
+    seat.majorState?.type !== "prepared-route"
+  ) {
+    return { ok: false, reason: "Prepared Route unavailable" };
+  }
+  return { ok: true };
+}
+
+function markPrimaryClaim(state, action) {
+  if (!action.exclusiveClaim || action.claimMode !== "Primary") return;
+  state.resolution.claimWinners[action.exclusiveClaim] = action.instanceId;
+}
+
+function invalidateBeforeBegin(state, packet, action, reason) {
+  if (!action.actorEnemyId) {
+    const seat = findSeat(state, action.actorSeatId);
+    const primaryTotal = action.cost + action.modifierCost;
+    const refund = Math.floor(primaryTotal / 2);
+    state.encounter.refundsPending[seat.id] += refund;
+    if (action.attachedCardId) {
+      const card = CARDS[action.attachedCardId];
+      if (card.kind === "Contingency") {
+        if (card.id === "fallback-guard") {
+          seat.temporaryGuard += 3;
+          seat.flags.braced = true;
+          seat.flags.contingencyReserveSpent = action.contingencyReserve;
+        } else if (card.id === "controlled-withdrawal") {
+          seat.temporaryGuard += 1;
+          const destination = ordinaryNeighbors(seat.position).find(
+            (candidate) =>
+              positionOccupants(state, candidate).length <
+              (POSITIONS[candidate]?.capacity ?? 1),
+          );
+          if (destination) seat.position = destination;
+          seat.flags.contingencyReserveSpent = action.contingencyReserve;
+        } else if (card.id === "emergency-disconnect") {
+          seat.flags.accessSevered = true;
+          seat.flags.contingencyReserveSpent = action.contingencyReserve;
+        }
+      } else {
+        seat.flags.returnContingencyReserve =
+          (seat.flags.returnContingencyReserve ?? 0) + action.contingencyReserve;
+      }
+    }
+    logEvent(
+      state,
+      packet,
+      action,
+      "invalidated_before_begin",
+      `${reason}; refund ${refund} at Settle`,
+      ["refund", "start-legality"],
+    );
+  } else {
+    logEvent(
+      state,
+      packet,
+      action,
+      "invalidated_before_begin",
+      reason,
+      ["start-legality"],
+    );
+  }
+  state.resolution.results[action.instanceId] = {
+    status: "invalidated_before_begin",
+    reason,
+  };
+}
+
+function spendPlannedCommand(state) {
+  state.seats.forEach((seat) => {
+    const reserved = activePlanCost(seat);
+    seat.command -= reserved;
+    seat.committedCards = seat.plan
+      .flatMap((action) => [
+        ...(action.attachedCardId ? [action.attachedCardId] : []),
+        ...(action.baseId === "field-patch" ? ["field-patch"] : []),
+      ])
+      .filter((cardId, index, list) => list.indexOf(cardId) === index);
+  });
+}
+
+function applyGuardBreakAndImpact(target, guardBreak, impact) {
+  const broken = Math.min(target.guard, Math.max(0, guardBreak));
+  target.guard -= broken;
+  let remainingImpact = Math.max(0, impact);
+  const tempTaken = Math.min(target.temporaryGuard ?? 0, remainingImpact);
+  target.temporaryGuard = Math.max(0, (target.temporaryGuard ?? 0) - tempTaken);
+  remainingImpact -= tempTaken;
+  const guardTaken = Math.min(target.guard, remainingImpact);
+  target.guard -= guardTaken;
+  remainingImpact -= guardTaken;
+  target.condition = Math.max(0, target.condition - remainingImpact);
+  return {
+    guardBreak: broken,
+    temporaryGuardDamage: tempTaken,
+    guardDamage: guardTaken,
+    conditionDamage: remainingImpact,
+  };
+}
+
+function compromiseIfNeeded(state, seat, packet, causeAction) {
+  if (seat.condition > 0 || seat.compromised) return;
+  seat.compromised = true;
+  seat.guard = 0;
+  seat.temporaryGuard = 0;
+  seat.majorState = null;
+  seat.rescueSettlesRemaining = 2;
+  seat.packages.forEach((item) => {
+    state.encounter.packagesOnMap.push({
+      ...item,
+      position: seat.position,
+      droppedBySeatId: seat.id,
+    });
+  });
+  seat.packages = [];
+  logEvent(
+    state,
+    packet,
+    causeAction,
+    "compromised",
+    `${seat.label} reached 0 Condition, lost Major state, and dropped unsecured Packages`,
+    ["condition", "rescue-window", "package-drop"],
+  );
+}
+
+function resolveResponseAction(state, packet, action) {
+  if (action.baseId === "contest" || action.baseId === "answer-commitment") {
+    const intentId = action.effect.intentId;
+    const enemyAction = state.resolution.actions.find(
+      (candidate) =>
+        candidate.actorEnemyId === action.targetId &&
+        candidate.id === intentId,
+    );
+    if (!enemyAction) {
+      return { begun: false, reason: "Named Commitment no longer exists" };
+    }
+    if (action.baseId === "contest") {
+      enemyAction.effect.force = Math.max(0, (enemyAction.effect.force ?? 0) - 2);
+      if (action.attachedCardId === "brace-through") {
+        enemyAction.effect.force = Math.max(0, enemyAction.effect.force - 1);
+        const seat = findSeat(state, action.actorSeatId);
+        seat.temporaryGuard += 2;
+      }
+      logEvent(
+        state,
+        packet,
+        action,
+        "completed",
+        `Reduced ${enemyAction.name} Force by 2; no Battle Advantage created`,
+        ["response", "minor-foundation"],
+      );
+    } else {
+      enemyAction.effect.answeredBy = action.actorSeatId;
+      const seat = findSeat(state, action.actorSeatId);
+      seat.majorState = {
+        type: "battle-advantage",
+        name: "Battle Advantage",
+        ownerSeatId: seat.id,
+        targetId: action.targetId,
+        createdCycle: state.encounter.cycle,
+        status: "active",
+        surviveFirstShift: action.attachedCardId === "hold-the-edge",
+      };
+      if (action.attachedCardId === "brace-through") {
+        enemyAction.effect.force = Math.max(
+          0,
+          (enemyAction.effect.force ?? 0) - 1,
+        );
+        seat.temporaryGuard += 2;
+      }
+      logEvent(
+        state,
+        packet,
+        action,
+        "completed",
+        `Changed ${enemyAction.name}; created Battle Advantage tied to ${focusLabel(state, action.targetId)}`,
+        ["response", "major-setup", "state-created"],
+      );
+    }
+    return { begun: true, handled: true };
+  }
+  if (action.baseId === "suppress-response") {
+    state.encounter.shutter.resealSuppressedUntilCycle =
+      state.encounter.cycle +
+      (action.attachedCardId === "delay-stack" ? 2 : 1);
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Delayed the visible Reseal Response until after the next Settle; no Control created",
+      ["response", "minor-foundation"],
+    );
+    return { begun: true, handled: true };
+  }
+  if (action.baseId === "protected-access") {
+    const seat = findSeat(state, action.actorSeatId);
+    seat.flags.protectedAccess = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Protected one declared Interface or Hacking action from direct-hit invalidation",
+      ["protection", "equipment"],
+    );
+    return { begun: true, handled: true };
+  }
+  if (action.baseId === "anchor-lock") {
+    const seat = findSeat(state, action.actorSeatId);
+    seat.flags.anchorLock = 2;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Prevent the first 2 Force before Settle; ends on voluntary movement",
+      ["protection", "equipment"],
+    );
+    return { begun: true, handled: true };
+  }
+  return { begun: false, handled: false };
+}
+
+function resolveProtectionAction(state, packet, action) {
+  if (action.baseId !== "guard") return false;
+  const actor = findSeat(state, action.actorSeatId);
+  const target = findSeat(state, action.targetId);
+  if (!target || target.id === actor.id) {
+    const cap = ARMOR[actor.armorId].guardCap;
+    const restored = Math.min(4, cap - actor.guard);
+    actor.guard += restored;
+    actor.flags.braced = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Restored ${restored} Guard to ${actor.guard}/${cap}; Braced against one visible Commitment`,
+      ["protection", "guard"],
+    );
+  } else {
+    target.temporaryGuard += 3;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Granted ${target.label} 3 temporary Guard`,
+      ["protection", "guard", "consent"],
+    );
+  }
+  return true;
+}
+
+function resolveDamageAction(state, packet, action) {
+  if (action.actorEnemyId) {
+    if (action.effect.answeredBy) {
+      logEvent(
+        state,
+        packet,
+        action,
+        "answered",
+        `${action.name} normal result prevented by Answer Commitment`,
+        ["commitment", "answered"],
+      );
+      return true;
+    }
+    if (action.id === "access-clamp" && action.targetActionInstanceId) {
+      const parent = state.resolution.actions.find(
+        (candidate) =>
+          candidate.instanceId === action.targetActionInstanceId,
+      );
+      if (parent?.attachedCardId === "emergency-disconnect") {
+        const target = findSeat(state, parent.actorSeatId);
+        target.flags.emergencyDisconnectTriggeredFor = parent.instanceId;
+        logEvent(
+          state,
+          packet,
+          action,
+          "prevented",
+          `Emergency Disconnect ignored Access Clamp and will abort ${parent.name} before beginning`,
+          ["system-response", "contingency", "access-severed"],
+        );
+        return true;
+      }
+    }
+    if (action.targetId === "frontier-marker") {
+      const marker = state.encounter.marker;
+      const force = Math.max(
+        0,
+        action.effect.force - (marker.locked ? 1 : 0),
+      );
+      if (marker.locked) {
+        marker.integrity = Math.max(0, marker.integrity - action.effect.impact);
+        marker.dislodged = marker.integrity <= 0;
+        marker.surveyAvailable = !marker.dislodged;
+      } else if (force > 0) {
+        marker.dislodged = true;
+        marker.surveyAvailable = false;
+      } else {
+        marker.integrity = Math.max(0, marker.integrity - action.effect.impact);
+      }
+      logEvent(
+        state,
+        packet,
+        action,
+        "completed",
+        marker.dislodged
+          ? "Frontier Marker dislodged; Crossing Survey lost"
+          : `Frontier Marker held at ${marker.integrity} Integrity`,
+        ["enemy", "marker", "force"],
+      );
+      return true;
+    }
+    const target = findSeat(state, action.targetId);
+    if (!target) return false;
+    let force = action.effect.force ?? 0;
+    if (target.flags.anchorLock) {
+      const prevented = Math.min(force, target.flags.anchorLock);
+      force -= prevented;
+      target.flags.anchorLock -= prevented;
+    }
+    if (target.flags.braced) force = Math.max(0, force - 1);
+    force = Math.max(0, force - (target.forceResistance ?? 0));
+    let impact = action.effect.impact ?? 0;
+    if (action.id === "crossing-intercept") {
+      const safeLanding = target.plan.find(
+        (planned) =>
+          planned.instanceId === action.targetActionInstanceId &&
+          planned.attachedCardId === "safe-landing",
+      );
+      const approachReduction = state.encounter.plate.crossingCollisionReduction;
+      if (safeLanding) {
+        impact = Math.max(0, impact - 2);
+        force = Math.max(0, force - 1);
+      }
+      const collision =
+        Math.max(0, (action.effect.edgeCollision ?? 0) - approachReduction) *
+        (force > 0 ? 1 : 0);
+      impact += collision;
+    }
+    if (action.id === "access-clamp" && force > 0) {
+      impact += action.effect.compactCollision ?? 0;
+      force = 0;
+    }
+    const damage = applyGuardBreakAndImpact(target, 0, impact);
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${target.label}: ${damage.temporaryGuardDamage + damage.guardDamage} Guard and ${damage.conditionDamage} Condition lost${force ? `; Force ${force} remains` : ""}`,
+      ["enemy", "impact", ...(force ? ["force"] : [])],
+    );
+    compromiseIfNeeded(state, target, packet, action);
+    return true;
+  }
+
+  if (
+    ["attack", "drive-through", "phase-cut", "ground-lock", "clear-lane"].includes(
+      action.baseId,
+    )
+  ) {
+    const enemy = findEnemy(state, action.targetId);
+    if (!enemy) return false;
+    let guardBreak = action.effect.guardBreak ?? 0;
+    if (WEAPONS[findSeat(state, action.actorSeatId).activeWeaponId].id === "static-driver") {
+      guardBreak = 4;
+    }
+    const broken = Math.min(enemy.guard, guardBreak);
+    enemy.guard -= broken;
+    const guardImpact = Math.min(enemy.guard, action.effect.impact ?? 0);
+    enemy.guard -= guardImpact;
+    const conditionImpact = Math.max(
+      0,
+      (action.effect.impact ?? 0) - guardImpact,
+    );
+    enemy.condition = Math.max(0, enemy.condition - conditionImpact);
+    if (enemy.condition <= 0) {
+      enemy.status = "defeated";
+    }
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${enemy.name}: ${broken} Guard Break, ${guardImpact} Guard damage, ${conditionImpact} Condition damage; ${enemy.status}`,
+      ["attack", "impact", ...(broken ? ["guard-break"] : [])],
+    );
+    return true;
+  }
+  return false;
+}
+
+function resolveMovementAction(state, packet, action) {
+  if (
+    ![
+      "reposition",
+      "additional-movement",
+      "cross-opening",
+      "cross-plate",
+      "follow-route",
+      "exploit-route",
+      "backtrack",
+      "line-move",
+      "emergency-drag",
+    ].includes(action.baseId)
+  ) {
+    return false;
+  }
+  const seat = findSeat(state, action.actorSeatId);
+  if (
+    state.resolution.blockedMovementInstances?.includes(action.instanceId)
+  ) {
+    logEvent(
+      state,
+      packet,
+      action,
+      "failed_after_begin",
+      "Equal-time unlinked moves contested one capacity-one destination; nobody enters",
+      ["movement", "capacity-conflict"],
+    );
+    return true;
+  }
+  const destinationId =
+    action.destinationId ??
+    (action.baseId === "line-move"
+      ? ordinaryNeighbors(seat.position)[0]
+      : null);
+  if (!destinationId) {
+    logEvent(state, packet, action, "failed_after_begin", "No legal destination selected", [
+      "movement",
+    ]);
+    return true;
+  }
+  const capacity = POSITIONS[destinationId]?.capacity ?? 1;
+  const packetMoves = state.resolution.packetMoves ?? {};
+  const competing = packetMoves[destinationId] ?? [];
+  competing.push(action.instanceId);
+  packetMoves[destinationId] = competing;
+  state.resolution.packetMoves = packetMoves;
+  if (
+    competing.length > 1 &&
+    capacity === 1 &&
+    !action.requiresConsentFromSeatId
+  ) {
+    logEvent(
+      state,
+      packet,
+      action,
+      "failed_after_begin",
+      "Equal-time unlinked moves contested one capacity-one destination; nobody enters",
+      ["movement", "capacity-conflict"],
+    );
+    return true;
+  }
+  const initialPositions = state.resolution.packetInitialPositions ?? {};
+  const departingSeatIds = new Set(
+    state.resolution.packetDepartingSeatIds ?? [],
+  );
+  const blockingOccupants = positionOccupants(state, destinationId).filter(
+    (occupant) =>
+      !(
+        initialPositions[occupant.id] === destinationId &&
+        departingSeatIds.has(occupant.id)
+      ),
+  );
+  if (blockingOccupants.length >= capacity) {
+    logEvent(
+      state,
+      packet,
+      action,
+      "failed_after_begin",
+      "Destination became occupied; actor stops at the last legal position",
+      ["movement", "capacity"],
+    );
+    return true;
+  }
+  if (seat.compromised) {
+    logEvent(
+      state,
+      packet,
+      action,
+      "failed_after_begin",
+      "Transit failed because the actor became Compromised",
+      ["movement", "compromised"],
+    );
+    return true;
+  }
+  seat.position = destinationId;
+  if (seat.flags.anchorLock) seat.flags.anchorLock = 0;
+  if (action.attachedCardId === "covering-step") seat.temporaryGuard += 2;
+  if (action.attachedCardId === "backtrack-marker") {
+    seat.flags.backtrack = {
+      originId: state.resolution.packetInitialPositions[seat.id],
+      destinationId,
+      openingId: action.sourceId,
+      createdCycle: state.encounter.cycle,
+    };
+  }
+  if (action.baseId === "backtrack") {
+    seat.flags.backtrack = null;
+    seat.flags.holdLine = null;
+  }
+  if (action.baseId === "exploit-route") {
+    seat.majorState = null;
+  }
+  if (action.baseId === "follow-route") {
+    const owner = state.seats.find(
+      (candidate) =>
+        candidate.majorState?.type === "prepared-route" &&
+        candidate.majorState.followPassages > 0,
+    );
+    if (owner) owner.majorState.followPassages -= 1;
+  }
+  logEvent(
+    state,
+    packet,
+    action,
+    "completed",
+    `${seat.label} moved to ${focusLabel(state, destinationId)}`,
+    ["movement", action.tag.toLowerCase()],
+  );
+  if (action.includedActionId === "complete-release") {
+    state.encounter.release.work = 1;
+    state.encounter.release.pendingValidation = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "included_action_completed",
+      "Exploit destination action added 1 Release Work",
+      ["work", "objective"],
+    );
+  }
+  return true;
+}
+
+function resolveCompletionAction(state, packet, action) {
+  const seat = action.actorSeatId ? findSeat(state, action.actorSeatId) : null;
+  if (action.baseId === "hold-line") {
+    seat.flags.holdLine = {
+      targetEnemyId: action.targetId,
+      lineEndPosition: findEnemy(state, action.targetId)?.position,
+      impact: 3,
+      remainingTriggers: 1,
+      createdCycle: state.encounter.cycle,
+    };
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Prepared one range-four line; its first visible hostile crossing before Settle will receive 3 Impact",
+      ["equipment", "preparation", "line"],
+    );
+    return true;
+  }
+  if (action.baseId === "lock-frontier-marker") {
+    state.encounter.marker.locked = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Frontier Marker locked: +1 Force resistance; direct damage still applies",
+      ["work", "anchor"],
+    );
+    return true;
+  }
+  if (action.baseId === "stabilize-plate") {
+    state.encounter.plate.stabilized = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Maintenance Plate stabilized; Cross Plate is now source-bound and legal",
+      ["work", "opening"],
+    );
+    return true;
+  }
+  if (
+    action.baseId === "manual-shutter-release" ||
+    action.baseId === "basic-interface"
+  ) {
+    state.encounter.shutter.state = "open-until-settle";
+    if (
+      action.baseId === "basic-interface" &&
+      action.attachedCardId === "delay-stack"
+    ) {
+      state.encounter.shutter.resealSuppressedUntilCycle =
+        state.encounter.cycle + 1;
+    }
+    if (
+      action.baseId === "basic-interface" &&
+      seat.flags.traceEcho?.componentId === "shutter-console"
+    ) {
+      seat.flags.traceEcho = null;
+    }
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Shutter opened for this resolution; Reseal Response remains visible",
+      ["infrastructure", "reseal"],
+    );
+    return true;
+  }
+  if (action.baseId === "jam-shutter-track") {
+    state.encounter.shutter.state = "jammed-open";
+    state.encounter.shutter.intact = false;
+    state.encounter.shutter.hackingOutputsAvailable = false;
+    state.encounter.cache.destroyed = true;
+    state.encounter.cache.exposed = false;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Shutter jammed open; cache destroyed; Hacking Outputs removed",
+      ["infrastructure", "work", "sacrifice"],
+    );
+    return true;
+  }
+  if (action.baseId === "complete-release") {
+    state.encounter.release.work = 1;
+    state.encounter.release.pendingValidation = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Release Work complete; validation waits for Settle, open shutter, and entered-threat clear",
+      ["objective", "work", "pending"],
+    );
+    return true;
+  }
+  if (action.baseId === "recover-relay-cache") {
+    const used = seat.packages.reduce((sum, item) => sum + item.slots, 0);
+    if (used + 1 > CORE_RULES.exposedPackageSlots) {
+      logEvent(
+        state,
+        packet,
+        action,
+        "failed_after_begin",
+        "Package capacity exceeded; no automatic replacement occurred",
+        ["package", "capacity"],
+      );
+      return true;
+    }
+    seat.packages.push({
+      id: "relay-needle",
+      name: "Relay Needle",
+      slots: 1,
+      ownerSeatId: seat.id,
+      exposed: true,
+    });
+    state.encounter.cache.recovered = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${seat.label} recovered Relay Needle; ownership remains personal`,
+      ["package", "exclusive-claim"],
+    );
+    return true;
+  }
+  if (action.baseId === "prepare-route") {
+    const destinationId =
+      seat.position === "far-platform" ? "broken-lane-lip" : "far-platform";
+    seat.majorState = {
+      type: "prepared-route",
+      name: "Prepared Route",
+      ownerSeatId: seat.id,
+      openingId: SPECIAL_EDGE.id,
+      originId: seat.position,
+      destinationId,
+      exploitPassages: 1,
+      followPassages: action.attachedCardId === "route-capacity" ? 2 : 1,
+      createdCycle: state.encounter.cycle,
+      status: "active",
+      destinationClaim:
+        action.attachedCardId === "destination-claim",
+    };
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Prepared Route ${seat.position} → ${destinationId}; one Exploit and ${seat.majorState.followPassages} Follow passage(s)`,
+      ["major-setup", "route", "state-created"],
+    );
+    return true;
+  }
+  if (action.baseId === "establish-control") {
+    if (!state.encounter.shutter.hackingOutputsAvailable) {
+      logEvent(
+        state,
+        packet,
+        action,
+        "failed_after_begin",
+        "Shutter track damage removed the bounded Output set",
+        ["control", "infrastructure"],
+      );
+      return true;
+    }
+    seat.majorState = {
+      type: "temporary-control",
+      name: "Temporary Control",
+      ownerSeatId: seat.id,
+      dependencyId: "shutter-dependency",
+      accessPosition: seat.position,
+      createdCycle: state.encounter.cycle,
+      status: "active",
+    };
+    state.encounter.shutter.controlledBySeatId = seat.id;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      "Established character-owned Temporary Control over the Shutter Dependency",
+      ["major-setup", "control", "state-created"],
+    );
+    return true;
+  }
+  if (action.baseId === "execute-output") {
+    if (action.outputId === "hold-open") {
+      state.encounter.shutter.state = "controlled-open";
+    }
+    if (action.outputId === "expose-cache") {
+      state.encounter.shutter.state = "controlled-open";
+      state.encounter.cache.exposed = true;
+      seat.flags.pendingOutputDisruption = action.attachedCardId === "clean-buffer" ? 0 : 1;
+    }
+    if (action.outputId === "blind-repeater") {
+      state.encounter.reinforcementPrevented = true;
+      state.encounter.shutter.state = "output-window";
+      state.encounter.shutter.outputWindowEndsAfterCycle =
+        state.encounter.cycle + 1;
+      const c = state.encounter.enemies["skimmer-c"];
+      if (c.status === "pending") c.status = "prevented";
+    }
+    if (action.attachedCardId === "trace-echo") {
+      seat.flags.traceEcho = {
+        componentId: "shutter-console",
+        responseConfirmed: true,
+        commandReduction: 2,
+      };
+    }
+    seat.majorState = null;
+    state.encounter.shutter.controlledBySeatId = null;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Executed bounded Output: ${action.outputId}; Temporary Control spent`,
+      ["major-payoff", "control", "state-spent"],
+    );
+    return true;
+  }
+  if (action.baseId === "convert-advantage") {
+    const enemy = findEnemy(state, action.targetId);
+    if (action.payoffId === "drive") {
+      enemy.status = "driven";
+      enemy.intactActuator = false;
+    } else if (action.payoffId === "pin") {
+      enemy.status = "pinned";
+      enemy.pinnedUntilSettle = state.encounter.cycle + 1;
+    } else if (action.payoffId === "disarm") {
+      if (enemy.guard > 0) {
+        logEvent(
+          state,
+          packet,
+          action,
+          "failed_after_begin",
+          "Controlled Disarm lacked zero Guard or authored exposure",
+          ["major-payoff", "requirement"],
+        );
+        return true;
+      }
+      enemy.status = "disabled";
+      enemy.intactActuator = true;
+    }
+    seat.majorState = null;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${action.name} resolved; Battle Advantage spent`,
+      ["major-payoff", "state-spent"],
+    );
+    return true;
+  }
+  if (action.baseId === "field-patch") {
+    const target = findSeat(state, action.targetId) ?? seat;
+    let restored = 3;
+    if (target.armorId === "recovery-mesh" && !target.recoveryMeshUsed) {
+      restored += 1;
+      target.recoveryMeshUsed = true;
+    }
+    const actual = Math.min(restored, CORE_RULES.condition - target.condition);
+    target.condition += actual;
+    seat.fieldPatchUsed = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${target.label} restored ${actual} Condition`,
+      ["prepared-card", "condition"],
+    );
+    return true;
+  }
+  if (action.baseId === "refocus") {
+    const cardId = action.refocusCardIds[0];
+    const index = seat.hand.indexOf(cardId);
+    if (index >= 0) {
+      seat.hand.splice(index, 1);
+      seat.discard.push(cardId);
+      if (seat.drawIndex < seat.deck.length) {
+        seat.hand.push(seat.deck[seat.drawIndex]);
+        seat.drawIndex += 1;
+      }
+    }
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Refocused ${CARDS[cardId]?.name ?? cardId}; drew one replacement`,
+      ["prepared-card", "refocus"],
+    );
+    return true;
+  }
+  if (action.baseId === "swap-weapon") {
+    const prior = seat.activeWeaponId;
+    seat.activeWeaponId = seat.reserveWeaponId;
+    seat.reserveWeaponId = prior;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${WEAPONS[seat.activeWeaponId].name} is now active; no Attack included`,
+      ["equipment", "swap"],
+    );
+    return true;
+  }
+  if (action.baseId === "assist") {
+    const supportedSeat = findSeat(state, action.targetId);
+    const supported = supportedSeat?.plan.find(
+      (candidate) => candidate.instanceId === action.supportedActionInstanceId,
+    );
+    if (!supported) {
+      logEvent(
+        state,
+        packet,
+        action,
+        "invalidated_before_begin",
+        "Supported action no longer exists",
+        ["assist"],
+      );
+      return true;
+    }
+    supported.effect.assistWork = ["work-objective", "complete-release", "stabilize-plate"].includes(
+      supported.baseId,
+    )
+      ? 1
+      : 0;
+    supportedSeat.temporaryGuard +=
+      action.attachedCardId === "linked-effort" ? 2 : 0;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `Assist attached to ${supportedSeat.label}'s ${supported.name}`,
+      ["assist", "consent"],
+    );
+    return true;
+  }
+  if (action.baseId === "stabilize") {
+    const target = findSeat(state, action.targetId);
+    if (!target?.compromised) return false;
+    target.compromised = false;
+    target.condition =
+      target.armorId === "recovery-mesh" ? 5 : 4;
+    target.guard = 0;
+    target.disruption += 1;
+    target.rescueSettlesRemaining = null;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${target.label} will return next planning phase at ${target.condition} Condition, 0 Guard, +1 Disruption`,
+      ["rescue", "stabilize"],
+    );
+    return true;
+  }
+  if (action.baseId === "standard-extract") {
+    if (
+      seat.position !== "threshold" ||
+      !state.encounter.release.thresholdOpen ||
+      seat.compromised
+    ) {
+      logEvent(
+        state,
+        packet,
+        action,
+        "failed_after_begin",
+        "Sustained Extract lost its legal exit or actor requirement",
+        ["extract", "sustained"],
+      );
+      return true;
+    }
+    if (action.attachedCardId === "last-exit") {
+      const secured = seat.packages.find(
+        (item) => item.slots === 1 && item.exposed,
+      );
+      if (secured) secured.securedByLastExit = true;
+    }
+    seat.flags.extracted = true;
+    logEvent(
+      state,
+      packet,
+      action,
+      "completed",
+      `${seat.label} extracted with owned carried Packages`,
+      ["extract", "package"],
+    );
+    return true;
+  }
+  return false;
+}
+
+export function resolvePlans(state) {
+  if (!canResolvePlans(state)) {
+    return withWarning(
+      state,
+      validatePartyPlans(state)[0] ??
+        "Every seat must lock its own valid plan before resolution.",
+    );
+  }
+  const next = clone(state);
+  next.stageLabel = `Loose Signal Crossing · Cycle ${next.encounter.cycle} resolution`;
+  next.encounter.resolutionComplete = false;
+  next.resolution = {
+    actions: [],
+    results: {},
+    claimWinners: {},
+    packetMoves: {},
+  };
+  spendPlannedCommand(next);
+  const playerActions = next.seats.flatMap((seat) => seat.plan);
+  const enemyActions = enemyActionsForPlan(next);
+  const actions = [...playerActions, ...enemyActions].sort(compareTiming);
+  next.resolution.actions = actions;
+
+  const packets = [];
+  for (const action of actions) {
+    const key = `${action.lane}/${action.tempo}`;
+    let packet = packets.find((candidate) => candidate.key === key);
+    if (!packet) {
+      packet = {
+        key,
+        lane: action.lane,
+        tempo: action.tempo,
+        actions: [],
+      };
+      packets.push(packet);
+    }
+    packet.actions.push(action);
+  }
+  packets.sort((left, right) =>
+    compareTiming(
+      { lane: left.lane, tempo: left.tempo, instanceId: left.key },
+      { lane: right.lane, tempo: right.tempo, instanceId: right.key },
+    ),
+  );
+
+  for (const packet of packets) {
+    next.resolution.packetMoves = {};
+    next.resolution.packetInitialPositions = Object.fromEntries(
+      next.seats.map((seat) => [seat.id, seat.position]),
+    );
+    const begun = [];
+    const conditional = packet.actions.filter(
+      (action) => action.dependsOnActionInstanceId,
+    );
+    for (const action of packet.actions.filter(
+      (candidate) => !candidate.dependsOnActionInstanceId,
+    )) {
+      const legality = actionStartLegal(next, action);
+      if (!legality.ok) {
+        invalidateBeforeBegin(next, packet, action, legality.reason);
+        continue;
+      }
+      markPrimaryClaim(next, action);
+      begun.push(action);
+      next.resolution.results[action.instanceId] = { status: "begun" };
+    }
+
+    const movementActions = begun.filter((action) =>
+        [
+          "reposition",
+          "additional-movement",
+          "cross-opening",
+          "cross-plate",
+          "follow-route",
+          "exploit-route",
+          "backtrack",
+          "line-move",
+          "emergency-drag",
+        ].includes(action.baseId),
+      );
+    next.resolution.packetDepartingSeatIds = movementActions
+      .filter((action) => action.destinationId)
+      .map((action) => action.actorSeatId);
+    const destinationClaims = new Map();
+    movementActions.forEach((action) => {
+        if (!action.destinationId) return;
+        if (!destinationClaims.has(action.destinationId)) {
+          destinationClaims.set(action.destinationId, []);
+        }
+        destinationClaims.get(action.destinationId).push(action.instanceId);
+      });
+    next.resolution.blockedMovementInstances = [];
+    destinationClaims.forEach((instances, destinationId) => {
+      if (
+        positionOccupants(next, destinationId).filter(
+          (occupant) =>
+            !(
+              next.resolution.packetInitialPositions[occupant.id] ===
+                destinationId &&
+              next.resolution.packetDepartingSeatIds.includes(occupant.id)
+            ),
+        ).length +
+          instances.length >
+        (POSITIONS[destinationId]?.capacity ?? 1)
+      ) {
+        instances.forEach((instanceId) =>
+          next.resolution.blockedMovementInstances.push(instanceId),
+        );
+      }
+    });
+
+    const handled = new Set();
+    begun.forEach((action) => {
+      const result = resolveResponseAction(next, packet, action);
+      if (result.handled) handled.add(action.instanceId);
+    });
+    begun.forEach((action) => {
+      if (!handled.has(action.instanceId) && resolveProtectionAction(next, packet, action)) {
+        handled.add(action.instanceId);
+      }
+    });
+    begun.forEach((action) => {
+      if (!handled.has(action.instanceId) && resolveDamageAction(next, packet, action)) {
+        handled.add(action.instanceId);
+      }
+    });
+    begun.forEach((action) => {
+      if (!handled.has(action.instanceId) && resolveMovementAction(next, packet, action)) {
+        handled.add(action.instanceId);
+      }
+    });
+    begun.forEach((action) => {
+      if (!handled.has(action.instanceId) && resolveCompletionAction(next, packet, action)) {
+        handled.add(action.instanceId);
+      }
+    });
+    begun.forEach((action) => {
+      if (!handled.has(action.instanceId)) {
+        logEvent(
+          next,
+          packet,
+          action,
+          "completed",
+          "Action completed with no additional LS-01 state change",
+          ["no-op"],
+        );
+      }
+      next.resolution.results[action.instanceId] = {
+        status: "completed",
+      };
+    });
+
+    const pendingConditional = [...conditional];
+    while (pendingConditional.length > 0) {
+      let progressed = false;
+      for (
+        let index = pendingConditional.length - 1;
+        index >= 0;
+        index -= 1
+      ) {
+        const action = pendingConditional[index];
+        const dependency =
+          next.resolution.results[action.dependsOnActionInstanceId];
+        if (!dependency) continue;
+        pendingConditional.splice(index, 1);
+        progressed = true;
+        const legality = actionStartLegal(next, action);
+        if (!legality.ok) {
+          invalidateBeforeBegin(next, packet, action, legality.reason);
+          continue;
+        }
+        markPrimaryClaim(next, action);
+        let handled = false;
+        const response = resolveResponseAction(next, packet, action);
+        handled = response.handled;
+        if (!handled) handled = resolveProtectionAction(next, packet, action);
+        if (!handled) handled = resolveDamageAction(next, packet, action);
+        if (!handled) handled = resolveMovementAction(next, packet, action);
+        if (!handled) handled = resolveCompletionAction(next, packet, action);
+        if (!handled) {
+          logEvent(
+            next,
+            packet,
+            action,
+            "completed",
+            "Conditional action completed with no additional LS-01 state change",
+            ["causal-conditional"],
+          );
+        }
+        next.resolution.results[action.instanceId] = { status: "completed" };
+      }
+      if (!progressed) {
+        pendingConditional.forEach((action) =>
+          invalidateBeforeBegin(
+            next,
+            packet,
+            action,
+            "Projected causal prerequisite could not complete before this packet",
+          ),
+        );
+        pendingConditional.length = 0;
+      }
+    }
+  }
+
+  next.encounter.resolutionComplete = true;
+  next.stageLabel = `Loose Signal Crossing · Cycle ${next.encounter.cycle} resolved`;
+  pushEvidence(next, "resolution_completed", {
+    cycle: next.encounter.cycle,
+    packetCount: packets.length,
+    actionCount: actions.length,
+  });
+  return next;
+}
+
+function allEnteredThreatsClear(encounter) {
+  return encounter.enteredEnemyIds.every((enemyId) =>
+    ENTERED_CLEAR_STATUSES.has(encounter.enemies[enemyId].status),
+  );
+}
+
+function addRazorActuatorIfEligible(state) {
+  const intact = state.encounter.enteredEnemyIds
+    .map((enemyId) => state.encounter.enemies[enemyId])
+    .find(
+      (enemy) =>
+        ENTERED_CLEAR_STATUSES.has(enemy.status) && enemy.intactActuator,
+    );
+  if (!intact) return;
+  const recipient = state.seats.find(
+    (seat) =>
+      seat.packages.reduce((sum, item) => sum + item.slots, 0) <
+      CORE_RULES.exposedPackageSlots,
+  );
+  if (!recipient) {
+    state.encounter.packagesOnMap.push({
+      id: "razor-actuator",
+      name: "Razor Actuator",
+      slots: 1,
+      position: "far-platform",
+      ownerSeatId: null,
+    });
+    return;
+  }
+  if (!recipient.packages.some((item) => item.id === "razor-actuator")) {
+    recipient.packages.push({
+      id: "razor-actuator",
+      name: "Razor Actuator",
+      slots: 1,
+      ownerSeatId: recipient.id,
+      exposed: true,
+    });
+  }
+}
+
+function discardCommittedCards(seat) {
+  for (const cardId of seat.committedCards) {
+    const index = seat.hand.indexOf(cardId);
+    if (index >= 0) {
+      seat.hand.splice(index, 1);
+      seat.discard.push(cardId);
+    }
+  }
+  seat.committedCards = [];
+}
+
+function drawAtSettle(seat) {
+  const drawn = [];
+  for (
+    let index = 0;
+    index < CORE_RULES.drawPerSettle && seat.drawIndex < seat.deck.length;
+    index += 1
+  ) {
+    const cardId = seat.deck[seat.drawIndex];
+    seat.drawIndex += 1;
+    seat.hand.push(cardId);
+    drawn.push(cardId);
+  }
+  return drawn;
+}
+
+function settleReinforcement(state) {
+  const c = state.encounter.enemies["skimmer-c"];
+  if (
+    state.encounter.release.validated ||
+    state.encounter.reinforcementPrevented ||
+    c.status !== "pending"
+  ) {
+    return null;
+  }
+  const arrivalAfterSettle = state.seats.length === 1 ? 2 : 1;
+  if (state.encounter.cycle === arrivalAfterSettle) {
+    c.status = "active";
+    c.entered = true;
+    state.encounter.enteredEnemyIds.push(c.id);
+    return c.id;
+  }
+  return null;
+}
+
+export function settleCycle(state) {
+  if (
+    state.stage !== "loose-signal" ||
+    !state.encounter?.resolutionComplete
+  ) {
+    return state;
+  }
+  const next = clone(state);
+  const cycle = next.encounter.cycle;
+
+  next.seats.forEach((seat) => {
+    const refund = next.encounter.refundsPending[seat.id] ?? 0;
+    const returnedReserve = seat.plan.reduce((sum, action) => {
+      if (!action.contingencyReserve) return sum;
+      const result = next.resolution.results[action.instanceId];
+      const triggered =
+        result?.status === "invalidated_before_begin" &&
+        [
+          "fallback-guard",
+          "controlled-withdrawal",
+          "emergency-disconnect",
+        ].includes(action.attachedCardId);
+      return sum + (triggered ? 0 : action.contingencyReserve);
+    }, 0);
+    seat.command += refund + returnedReserve;
+    discardCommittedCards(seat);
+    seat.temporaryGuard = 0;
+    seat.flags.braced = false;
+    seat.flags.anchorLock = 0;
+    seat.flags.backtrack = null;
+    seat.flags.accessSevered = false;
+    seat.flags.emergencyDisconnectTriggeredFor = null;
+    if (seat.flags.pendingOutputDisruption) {
+      const amount = seat.flags.pendingOutputDisruption;
+      if (seat.armorId === "insulated-shell" && !seat.insulatedShellUsed) {
+        seat.insulatedShellUsed = true;
+      } else {
+        seat.disruption += amount;
+      }
+      seat.flags.pendingOutputDisruption = 0;
+    }
+  });
+
+  const resealSuppressed =
+    next.encounter.shutter.resealSuppressedUntilCycle !== null &&
+    next.encounter.shutter.resealSuppressedUntilCycle > cycle;
+  if (
+    next.encounter.shutter.state === "open-until-settle" &&
+    !resealSuppressed
+  ) {
+    next.encounter.shutter.state = "closed";
+    logEvent(
+      next,
+      { lane: "Settle", tempo: 0 },
+      {
+        baseId: "reseal-response",
+        actorEnemyId: "shutter-dependency",
+        targetId: "shutter-console",
+      },
+      "completed",
+      "Reseal Response closed the shutter before Release validation",
+      ["settle", "system-response"],
+    );
+  }
+
+  if (next.encounter.release.pendingValidation) {
+    const shutterOpen = next.encounter.shutter.state !== "closed";
+    const threatsClear = allEnteredThreatsClear(next.encounter);
+    if (shutterOpen && threatsClear) {
+      next.encounter.release.validated = true;
+      next.encounter.release.thresholdOpen = true;
+      next.encounter.release.blockedReason = "";
+      addRazorActuatorIfEligible(next);
+      logEvent(
+        next,
+        { lane: "Settle", tempo: 0 },
+        {
+          baseId: "release-validation",
+          actorEnemyId: "world",
+          targetId: "threshold",
+        },
+        "completed",
+        "Release validated; Threshold opened after the current resolution",
+        ["settle", "objective", "segment-complete"],
+      );
+    } else {
+      next.encounter.release.blockedReason = !shutterOpen
+        ? "Shutter resealed before validation"
+        : "Entered hostile pressure remains active";
+      logEvent(
+        next,
+        { lane: "Settle", tempo: 0 },
+        {
+          baseId: "release-validation",
+          actorEnemyId: "world",
+          targetId: "threshold",
+        },
+        "blocked",
+        next.encounter.release.blockedReason,
+        ["settle", "objective", "source-rule"],
+      );
+    }
+  }
+
+  const reinforcementId = settleReinforcement(next);
+  if (reinforcementId) {
+    logEvent(
+      next,
+      { lane: "Settle", tempo: 0 },
+      {
+        baseId: "reinforcement-arrival",
+        actorEnemyId: reinforcementId,
+        targetId: "upper-trace-rail",
+      },
+      "completed",
+      `${next.encounter.enemies[reinforcementId].name} entered and acts next cycle`,
+      ["settle", "visible-concurrency"],
+    );
+  }
+
+  next.seats.forEach((seat) => {
+    if (seat.compromised && seat.rescueSettlesRemaining !== null) {
+      seat.rescueSettlesRemaining -= 1;
+      if (seat.rescueSettlesRemaining <= 0) {
+        seat.flags.evacuated = true;
+        seat.disruption += 2;
+      }
+    }
+  });
+
+  if (next.encounter.release.thresholdOpen) {
+    next.stage = "segment-settle";
+    next.stageLabel = "Loose Signal complete · Segment Settle";
+    next.seats.forEach((seat) => {
+      seat.plan = [];
+      seat.locked = false;
+    });
+    pushEvidence(next, "segment_complete", {
+      cycle,
+      survey: next.encounter.marker.surveyAvailable,
+      shutter: next.encounter.shutter.intact ? "Intact" : "Damaged",
+      packages: next.seats.flatMap((seat) =>
+        seat.packages.map((item) => ({ ownerSeatId: seat.id, packageId: item.id })),
+      ),
+    });
+    return next;
+  }
+
+  next.encounter.cycle += 1;
+  next.encounter.resolutionComplete = false;
+  next.encounter.refundsPending = Object.fromEntries(
+    next.seats.map((seat) => [seat.id, 0]),
+  );
+  next.resolution = null;
+  next.seats.forEach((seat) => {
+    const before = seat.command;
+    const uncapped = before + CORE_RULES.commandIncome;
+    seat.command = Math.min(CORE_RULES.commandCap, uncapped);
+    const overflow = Math.max(0, uncapped - CORE_RULES.commandCap);
+    const drawn = drawAtSettle(seat);
+    seat.plan = [];
+    seat.locked = false;
+    seat.lockError = "";
+    if (overflow) {
+      next.warnings.push(`${seat.label} lost ${overflow} Command to the 32 cap.`);
+    }
+    if (seat.hand.length > CORE_RULES.retainLimit) {
+      next.warnings.push(
+        `${seat.label} must discard to ${CORE_RULES.retainLimit} before locking the next plan.`,
+      );
+    }
+    pushEvidence(next, "settle_income_draw", {
+      seatId: seat.id,
+      commandBefore: before,
+      income: CORE_RULES.commandIncome,
+      commandAfter: seat.command,
+      overflow,
+      drawn,
+    });
+  });
+  next.stageLabel = `Loose Signal Crossing · Cycle ${next.encounter.cycle} planning`;
+  pushEvidence(next, "settle_completed", {
+    cycle,
+    nextCycle: next.encounter.cycle,
+  });
+  return next;
+}
+
+export function discardCard(state, seatId, cardId) {
+  const next = clone(state);
+  const seat = next.seats.find((candidate) => candidate.id === seatId);
+  if (!seat || seat.locked || seat.hand.length <= CORE_RULES.retainLimit) {
+    return state;
+  }
+  const index = seat.hand.indexOf(cardId);
+  if (index < 0) return state;
+  seat.hand.splice(index, 1);
+  seat.discard.push(cardId);
+  pushEvidence(next, "card_discarded_to_limit", { seatId, cardId });
+  return next;
+}
+
+export function chooseSegmentDecision(state, decision) {
+  if (state.stage !== "segment-settle") return state;
+  const allowed = ["continue", "retreat", "extract-record"];
+  if (!allowed.includes(decision)) return state;
+  const next = clone(state);
+  next.segmentDecision = decision;
+  next.stage = "complete";
+  next.stageLabel =
+    decision === "continue"
+      ? "Evidence boundary reached · Quiet Shift is outside this PR"
+      : decision === "retreat"
+        ? "Private resettable profile · retreat recorded"
+        : "Private resettable profile · extraction evidence recorded";
+  pushEvidence(next, "segment_decision", {
+    decision,
+    protectionAvailable:
+      "No protected Safe Node claims exist in this segment; carried Packages remain exposed.",
+  });
+  return next;
+}
+
+export function getFocuses(state) {
+  if (!state.encounter) return [];
+  const positionFocuses = Object.values(POSITIONS).map((position) => ({
+    id: position.id,
+    name: position.name,
+    kind: position.kind,
+    x: position.x,
+    y: position.y,
+    status:
+      position.id === "frontier-marker"
+        ? state.encounter.marker.dislodged
+          ? "lost"
+          : `${state.encounter.marker.integrity} Integrity`
+        : position.id === "shutter-console"
+          ? state.encounter.shutter.state
+          : position.id === "relay-cache"
+            ? state.encounter.cache.destroyed
+              ? "destroyed"
+              : state.encounter.cache.recovered
+                ? "recovered"
+                : state.encounter.cache.exposed
+                  ? "exposed"
+                  : "sealed"
+            : position.id === "threshold"
+              ? state.encounter.release.thresholdOpen
+                ? "open"
+                : "closed"
+              : "available",
+  }));
+  const enemyFocuses = Object.values(state.encounter.enemies).map((enemy) => ({
+    id: enemy.id,
+    name: enemy.name,
+    kind: "Enemy",
+    x:
+      enemy.id === "skimmer-a"
+        ? 59
+        : enemy.id === "skimmer-b"
+          ? 23
+          : 39,
+    y: enemy.id === "skimmer-a" ? 53 : 14,
+    status: enemy.status,
+    guard: enemy.guard,
+    condition: enemy.condition,
+  }));
+  const seatFocuses = state.seats.map((seat, index) => ({
+    id: seat.id,
+    name: seat.label,
+    kind: "Character",
+    x: (POSITIONS[seat.position]?.x ?? 25) + index * 4,
+    y: (POSITIONS[seat.position]?.y ?? 40) + index * 4,
+    status: seat.compromised ? "Compromised" : focusLabel(state, seat.position),
+    guard: seat.guard + seat.temporaryGuard,
+    condition: seat.condition,
+  }));
+  return [...positionFocuses, ...enemyFocuses, ...seatFocuses];
+}
+
+export function getLayeredIntents(state) {
+  if (!state.encounter) return [];
+  return Object.values(state.encounter.enemies)
+    .filter((enemy) => enemy.status === "active")
+    .map((enemy) => {
+      const preview = currentEnemyIntentPreview(state, enemy.id);
+      if (enemy.id === "skimmer-a") {
+        return preview
+          ? {
+              enemyId: enemy.id,
+              enemy: enemy.name,
+              layer: "Conditional",
+              intent: preview.name,
+              trigger: "Earliest projected crossing to Far Platform",
+              target: preview.targetSeatId
+                ? findSeat(state, preview.targetSeatId)?.label
+                : "Crossing actor",
+              consequence:
+                "3 Impact, Force 1; unresolved edge Force may become 1 collision Impact",
+              timing: `${preview.lane} / ${preview.tempo}`,
+              certainty:
+                "Confirmed response relationship; standalone timing is modeled inside the crossing packet because the source omits it",
+            }
+          : {
+              enemyId: enemy.id,
+              enemy: enemy.name,
+              layer: "Conditional",
+              intent: "Crossing Intercept held",
+              trigger: "A Far Platform crossing is projected",
+              target: "Earliest crossing actor",
+              consequence: "3 Impact, Force 1, edge collision pressure",
+              timing: "Matches crossing packet",
+              certainty: "Confirmed trigger; no target exists yet",
+            };
+      }
+      if (enemy.id === "skimmer-b") {
+        const access = earliestAccessAction(state);
+        return {
+          enemyId: enemy.id,
+          enemy: enemy.name,
+          layer: "Conditional",
+          intent: access ? "Access Clamp" : "Marker Clamp",
+          trigger: access
+            ? "A shutter, release, or cache action is declared"
+            : "No shutter, release, or cache action is declared",
+          target: access
+            ? findSeat(state, access.actorSeatId)?.label
+            : "Frontier Marker",
+          consequence: access
+            ? "2 Impact, Force 1; compact Far Platform may convert Force to collision Impact"
+            : "2 Impact, Force 1; an unlocked Marker is dislodged",
+          timing: "Standard / 5",
+          certainty: "Confirmed conditional rule",
+        };
+      }
+      return {
+        enemyId: enemy.id,
+        enemy: enemy.name,
+        layer: "Locked by visible selector",
+        intent: "Razor Pass",
+        trigger: "Active this cycle",
+        target:
+          findSeat(state, preview?.targetSeatId)?.label ??
+          "Major Package carrier → nearest exposed character → Tie Order",
+        consequence: "3 Impact",
+        timing: "Fast / 7",
+        certainty: "Confirmed selector and visible Tie Order",
+      };
+    });
+}
+
+export function resultSummary(state) {
+  if (!state.encounter) return null;
+  return {
+    cycle: state.encounter.cycle,
+    releaseValidated: state.encounter.release.validated,
+    releaseBlockedReason: state.encounter.release.blockedReason,
+    survey: state.encounter.marker.surveyAvailable ? "Preserved" : "Lost",
+    markerIntegrity: state.encounter.marker.integrity,
+    shutter: state.encounter.shutter.intact ? "Intact" : "Damaged",
+    shutterState: state.encounter.shutter.state,
+    fullEnteredThreatClear: allEnteredThreatsClear(state.encounter),
+    enemies: Object.values(state.encounter.enemies).map((enemy) => ({
+      id: enemy.id,
+      status: enemy.status,
+      guard: enemy.guard,
+      condition: enemy.condition,
+    })),
+    seats: state.seats.map((seat) => ({
+      id: seat.id,
+      build: getBuild(seat.buildId).name,
+      command: seat.command,
+      condition: seat.condition,
+      guard: seat.guard,
+      disruption: seat.disruption,
+      position: focusLabel(state, seat.position),
+      majorState: seat.majorState?.name ?? "None",
+      packages: seat.packages.map((item) => item.name),
+      compromised: seat.compromised,
+    })),
+    packagesOnMap: state.encounter.packagesOnMap,
+    protectedPackages:
+      "None — protected Safe Node claims begin after Quiet Shift and are outside this PR.",
+  };
+}
+
+export function compareToPaperExpectation(state) {
+  const expected = state.expectedPaperResult;
+  if (!expected || !state.encounter) return [];
+  const summary = resultSummary(state);
+  const primarySeat = summary.seats[0];
+  const comparisons = [];
+  if (expected.cycles !== undefined) {
+    comparisons.push({
+      field: "Cycles",
+      expected: expected.cycles,
+      observed: summary.cycle,
+      match: expected.cycles === summary.cycle,
+    });
+  }
+  if (expected.condition !== undefined) {
+    comparisons.push({
+      field: "Final Condition",
+      expected: expected.condition,
+      observed: primarySeat.condition,
+      match: expected.condition === primarySeat.condition,
+    });
+  }
+  if (expected.command !== undefined) {
+    comparisons.push({
+      field: "Command carried",
+      expected: expected.command,
+      observed: primarySeat.command,
+      match: expected.command === primarySeat.command,
+    });
+  }
+  if (expected.survey !== undefined) {
+    comparisons.push({
+      field: "Survey",
+      expected: expected.survey,
+      observed: summary.survey,
+      match: expected.survey === summary.survey,
+    });
+  }
+  if (expected.shutter !== undefined) {
+    comparisons.push({
+      field: "Shutter",
+      expected: expected.shutter,
+      observed: summary.shutter,
+      match: expected.shutter === summary.shutter,
+    });
+  }
+  return comparisons;
+}
+
+export {
+  APPROACHES,
+  ARMOR,
+  BUILDS,
+  CARDS,
+  CORE_RULES,
+  LOADOUTS,
+  POSITIONS,
+  PROFILES,
+  RIGS,
+  WEAPONS,
+};

--- a/tests/barcode-world-boundary.test.mjs
+++ b/tests/barcode-world-boundary.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const gameFiles = [
+  "src/app/world/playtest/page.tsx",
+  "src/components/BarcodeWorldGreybox.tsx",
+  "src/lib/barcode-world/constants.mjs",
+  "src/lib/barcode-world/engine.mjs",
+];
+
+test("greybox is production-gated, unlinked, local-only, and has no live-system dependency", async () => {
+  const contents = await Promise.all(
+    gameFiles.map(async (path) => [path, await readFile(path, "utf8")]),
+  );
+  const combined = contents.map(([, source]) => source).join("\n");
+  assert.match(
+    contents.find(([path]) => path.endsWith("page.tsx"))[1],
+    /process\.env\.NODE_ENV === "production"/,
+  );
+  assert.match(
+    contents.find(([path]) => path.endsWith("page.tsx"))[1],
+    /notFound\(\)/,
+  );
+  assert.doesNotMatch(
+    combined,
+    /\b(fetch|XMLHttpRequest|WebSocket|EventSource)\s*\(/,
+  );
+  assert.doesNotMatch(
+    combined,
+    /\b(localStorage|sessionStorage|indexedDB)\b/,
+  );
+  assert.doesNotMatch(
+    combined,
+    /(?:from|import)\s+["'][^"']*(?:bnl|queue|relay|journal|supabase|redis)/i,
+  );
+
+  const publicShell = (
+    await Promise.all(
+      [
+        "src/components/Header.tsx",
+        "src/app/layout.tsx",
+        "src/app/sitemap.ts",
+      ].map((path) => readFile(path, "utf8")),
+    )
+  ).join("\n");
+  assert.doesNotMatch(publicShell, /\/world\/playtest/);
+});

--- a/tests/barcode-world-engine.test.mjs
+++ b/tests/barcode-world-engine.test.mjs
@@ -1,0 +1,602 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BUILDS,
+  CARDS,
+  CORE_RULES,
+  PROFILES,
+  attachCard,
+  beginOutskirts,
+  canResolvePlans,
+  commitApproach,
+  createGreyboxState,
+  discardCard,
+  getImmediateActionGroups,
+  inspectApproach,
+  lockSeatPlan,
+  queueAction,
+  resetGreybox,
+  resolvePlans,
+  selectApproachResult,
+  setApproachConfirmation,
+  setClaimMode,
+  setConsent,
+  settleCycle,
+} from "../src/lib/barcode-world/engine.mjs";
+
+function enterApproach(
+  profileId,
+  approachId = "impact-scar",
+  resultId = "ordinary",
+) {
+  let state = createGreyboxState(profileId);
+  state = beginOutskirts(state);
+  state = inspectApproach(state, approachId);
+  state = selectApproachResult(
+    state,
+    approachId,
+    resultId,
+    state.seats[0].id,
+  );
+  for (const seat of state.seats) {
+    state = setApproachConfirmation(state, seat.id, true);
+  }
+  state = commitApproach(state);
+  assert.equal(state.stage, "loose-signal");
+  return state;
+}
+
+function actionsFor(state, seatId, focusId) {
+  return getImmediateActionGroups(state, seatId, focusId).flatMap(
+    (group) => group.variants,
+  );
+}
+
+function findAction(state, seatId, focusId, match, label = String(match)) {
+  const candidate = actionsFor(state, seatId, focusId).find((action) =>
+    typeof match === "function"
+      ? match(action)
+      : action.id === match || action.baseId === match,
+  );
+  assert.ok(candidate, `Expected action ${label} for ${seatId} at ${focusId}`);
+  return candidate;
+}
+
+function queueBy(state, seatId, focusId, match, label) {
+  const before = state.seats.find((seat) => seat.id === seatId).plan.length;
+  const candidate = findAction(state, seatId, focusId, match, label);
+  const next = queueAction(state, seatId, candidate);
+  const after = next.seats.find((seat) => seat.id === seatId).plan.length;
+  assert.equal(after, before + 1, `Queued ${label ?? candidate.name}`);
+  return next;
+}
+
+function discardToRetainLimit(state) {
+  let next = state;
+  for (const seat of next.seats) {
+    while (
+      next.seats.find((candidate) => candidate.id === seat.id).hand.length >
+      CORE_RULES.retainLimit
+    ) {
+      const current = next.seats.find((candidate) => candidate.id === seat.id);
+      next = discardCard(next, seat.id, current.hand[0]);
+    }
+  }
+  return next;
+}
+
+function lockResolve(state) {
+  let next = discardToRetainLimit(state);
+  for (const seat of next.seats) {
+    next = lockSeatPlan(next, seat.id);
+  }
+  assert.equal(canResolvePlans(next), true, next.warnings.at(-1));
+  next = resolvePlans(next);
+  assert.equal(next.encounter.resolutionComplete, true);
+  return next;
+}
+
+function runAndSettle(state) {
+  const resolved = lockResolve(state);
+  return settleCycle(resolved);
+}
+
+test("locked source constants expose six ordered solo-safe builds and fixed decks", () => {
+  assert.equal(BUILDS.length, 6);
+  assert.deepEqual(
+    BUILDS.map((build) => build.id),
+    [
+      "battle-exploration",
+      "exploration-battle",
+      "battle-hacking",
+      "hacking-battle",
+      "exploration-hacking",
+      "hacking-exploration",
+    ],
+  );
+  for (const build of BUILDS) {
+    assert.equal(build.deck.length, 12, `${build.id} deck size`);
+    assert.equal(new Set(build.deck).size, 12, `${build.id} deck uniqueness`);
+    assert.deepEqual(build.deck.slice(0, 5), [
+      "fallback-guard",
+      "objective-brace",
+      ...build.deck.slice(2, 5),
+    ]);
+    assert.equal(
+      build.deck.some((cardId) => CARDS[cardId]?.partyOnly),
+      false,
+      `${build.id} solo deck has no party-only card`,
+    );
+  }
+  assert.equal(CORE_RULES.commandStart, 16);
+  assert.equal(CORE_RULES.commandIncome, 16);
+  assert.equal(CORE_RULES.commandCap, 32);
+  assert.equal(CORE_RULES.paidActionCap, 4);
+  assert.equal(CORE_RULES.condition, 12);
+});
+
+test("Outskirts exact-result gates require the matching Major and unanimous consent", () => {
+  let state = createGreyboxState("LS-SOLO-2");
+  state = beginOutskirts(state);
+  state = inspectApproach(state, "impact-scar");
+  const rejected = selectApproachResult(
+    state,
+    "impact-scar",
+    "exact",
+    "seat-1",
+  );
+  assert.equal(rejected.approach.selectedId, null);
+  assert.match(rejected.warnings.at(-1), /Battle Major/);
+
+  state = createGreyboxState("LS-SOLO-1");
+  state = beginOutskirts(state);
+  state = inspectApproach(state, "impact-scar");
+  state = selectApproachResult(state, "impact-scar", "exact", "seat-1");
+  const blocked = commitApproach(state);
+  assert.equal(blocked.stage, "outskirts");
+  assert.match(blocked.warnings.at(-1), /must confirm/);
+  state = setApproachConfirmation(state, "seat-1", true);
+  state = commitApproach(state);
+  assert.equal(state.stage, "loose-signal");
+  assert.equal(state.encounter.enemies["skimmer-b"].status, "absent");
+  assert.equal(state.seats[0].packages[0].id, "counterweight-breaker");
+});
+
+test("all six solo builds complete the same conservative core baseline deterministically", () => {
+  const observations = [];
+  for (const profile of PROFILES.filter((candidate) =>
+    candidate.id.startsWith("LS-SOLO-"),
+  )) {
+    let state = enterApproach(profile.id);
+    const seatId = state.seats[0].id;
+
+    state = queueBy(state, seatId, "skimmer-a", "attack");
+    state = queueBy(state, seatId, "skimmer-a", "attack");
+    state = runAndSettle(state);
+    assert.equal(state.encounter.enemies["skimmer-a"].status, "defeated");
+
+    state = queueBy(
+      state,
+      seatId,
+      "entry-shelf",
+      (action) =>
+        action.baseId === "reposition" &&
+        action.destinationId === "broken-lane-lip",
+      "Reposition to Broken-Lane Lip",
+    );
+    state = queueBy(state, seatId, "broken-lane-lip", "stabilize-plate");
+    state = runAndSettle(state);
+    assert.equal(state.encounter.plate.stabilized, true);
+    assert.equal(state.encounter.enemies["skimmer-c"].status, "active");
+
+    state = queueBy(state, seatId, "skimmer-c", "attack");
+    state = queueBy(state, seatId, "skimmer-c", "attack");
+    state = queueBy(state, seatId, "broken-lane-lip", "cross-plate");
+    state = runAndSettle(state);
+    assert.equal(state.encounter.enemies["skimmer-c"].status, "defeated");
+    assert.equal(state.seats[0].position, "far-platform");
+
+    state = queueBy(state, seatId, "far-platform", "jam-shutter-track");
+    state = queueBy(state, seatId, "release-socket", "complete-release");
+    state = lockResolve(state);
+    state = settleCycle(state);
+
+    assert.equal(state.stage, "segment-settle", profile.id);
+    assert.equal(state.encounter.release.validated, true, profile.id);
+    assert.equal(
+      state.encounter.enteredEnemyIds.every((enemyId) =>
+        ["defeated", "disabled", "driven", "bound"].includes(
+          state.encounter.enemies[enemyId].status,
+        ),
+      ),
+      true,
+      profile.id,
+    );
+    observations.push({
+      profileId: profile.id,
+      cycles: state.encounter.cycle,
+      condition: state.seats[0].condition,
+      command: state.seats[0].command,
+    });
+  }
+  assert.equal(observations.length, 6);
+  assert.equal(new Set(observations.map((item) => item.cycles)).size, 1);
+});
+
+test("Battle Major can answer a projected Commitment and conditionally spend its Advantage", () => {
+  let state = enterApproach(
+    "LS-SOLO-1",
+    "folded-service-walk",
+    "folded",
+  );
+  state = runAndSettle(state);
+  const seatId = "seat-1";
+  state = queueBy(state, seatId, "broken-lane-lip", "cross-opening");
+  state = queueBy(state, seatId, "skimmer-a", "answer-commitment");
+  state = queueBy(state, seatId, "skimmer-a", "convert-drive");
+  state = lockResolve(state);
+  assert.equal(state.encounter.enemies["skimmer-a"].status, "driven");
+  assert.equal(state.seats[0].position, "far-platform");
+  assert.equal(state.seats[0].majorState, null);
+  assert.ok(
+    state.encounter.causalLog.some(
+      (event) =>
+        event.actionId === "answer-commitment" &&
+        event.tags.includes("state-created"),
+    ),
+  );
+});
+
+test("Exploration and Hacking Major state persists across cycles and is owner-spent", () => {
+  let exploration = enterApproach(
+    "LS-SOLO-2",
+    "folded-service-walk",
+    "folded",
+  );
+  exploration = queueBy(
+    exploration,
+    "seat-1",
+    "broken-lane-lip",
+    "prepare-route",
+  );
+  exploration = lockResolve(exploration);
+  assert.equal(exploration.seats[0].majorState.type, "prepared-route");
+  exploration = settleCycle(exploration);
+  exploration = queueBy(
+    exploration,
+    "seat-1",
+    "broken-lane-lip",
+    "exploit-route",
+  );
+  exploration = lockResolve(exploration);
+  assert.equal(exploration.seats[0].position, "far-platform");
+  assert.equal(exploration.seats[0].majorState, null);
+
+  let hacking = enterApproach("LS-SOLO-4");
+  hacking = queueBy(
+    hacking,
+    "seat-1",
+    "entry-shelf",
+    (action) =>
+      action.baseId === "reposition" &&
+      action.destinationId === "shutter-console",
+    "Reposition to Shutter Console",
+  );
+  hacking = runAndSettle(hacking);
+  hacking = queueBy(
+    hacking,
+    "seat-1",
+    "shutter-console",
+    "establish-control",
+  );
+  hacking = lockResolve(hacking);
+  assert.equal(hacking.seats[0].majorState.type, "temporary-control");
+  hacking = settleCycle(hacking);
+  hacking = queueBy(
+    hacking,
+    "seat-1",
+    "shutter-console",
+    "execute-hold-open",
+  );
+  hacking = lockResolve(hacking);
+  assert.equal(hacking.encounter.shutter.state, "controlled-open");
+  assert.equal(hacking.seats[0].majorState, null);
+});
+
+test("contextual browser keeps every legal variant under at most four immediate roots", () => {
+  const state = enterApproach(
+    "LS-SOLO-1",
+    "folded-service-walk",
+    "folded",
+  );
+  for (const focusId of [
+    "skimmer-a",
+    "frontier-marker",
+    "broken-lane-lip",
+    "far-platform",
+    "release-socket",
+    "relay-cache",
+    "seat-1",
+  ]) {
+    const groups = getImmediateActionGroups(state, "seat-1", focusId);
+    assert.ok(groups.length <= CORE_RULES.normalImmediateChoices, focusId);
+    assert.equal(
+      groups.every((group) => group.variants.length > 0),
+      true,
+      focusId,
+    );
+  }
+});
+
+test("all supported local duo, trio, duplicate, and rescue fixtures start and resolve deterministic concurrency", () => {
+  const localProfiles = PROFILES.filter((profile) =>
+    profile.mode.startsWith("local-"),
+  );
+  assert.deepEqual(
+    localProfiles.map((profile) => profile.id),
+    [
+      "LS-DUO-MIXED",
+      "LS-TRIO-MIXED",
+      "LS-TRIO-DUP-EB",
+      "LS-DUO-DUP-HB",
+      "LS-RESCUE-GREEDY",
+    ],
+  );
+  for (const profile of localProfiles) {
+    let state = enterApproach(profile.id);
+    state = lockResolve(state);
+    assert.equal(state.encounter.resolutionComplete, true, profile.id);
+    assert.equal(
+      state.encounter.causalLog.some((event) => event.actor === "skimmer-c"),
+      profile.mode === "local-trio",
+      `${profile.id} immediate reinforcement concurrency`,
+    );
+    state = settleCycle(state);
+    assert.equal(state.encounter.cycle, 2, profile.id);
+  }
+});
+
+test("Command banks to 32, retain limit blocks lock, and four paid slots remain personal", () => {
+  let state = enterApproach(
+    "LS-SOLO-1",
+    "folded-service-walk",
+    "folded",
+  );
+  state = runAndSettle(state);
+  assert.equal(state.seats[0].command, 32);
+
+  state = queueBy(state, "seat-1", "broken-lane-lip", "cross-opening");
+  state = queueBy(state, "seat-1", "skimmer-a", "answer-commitment");
+  state = queueBy(state, "seat-1", "skimmer-a", "convert-drive");
+  state = queueBy(state, "seat-1", "seat-1", "guard");
+  const before = state.seats[0].plan.length;
+  const fifth = findAction(state, "seat-1", "skimmer-a", "scan");
+  const rejected = queueAction(state, "seat-1", fifth);
+  assert.equal(rejected.seats[0].plan.length, before);
+  assert.match(rejected.warnings.at(-1), /four paid action slots/);
+
+  state = lockResolve(state);
+  state = settleCycle(state);
+  assert.ok(state.seats[0].hand.length > CORE_RULES.retainLimit);
+  const blockedLock = lockSeatPlan(state, "seat-1");
+  assert.equal(blockedLock.seats[0].locked, false);
+  assert.match(blockedLock.warnings.at(-1), /discard to 7/);
+});
+
+test("equal-time unlinked movement that exceeds capacity fails for every mover", () => {
+  let state = enterApproach("LS-DUO-MIXED");
+  for (const seat of state.seats) {
+    state = queueBy(
+      state,
+      seat.id,
+      "entry-shelf",
+      (action) =>
+        action.baseId === "reposition" &&
+        action.destinationId === "shutter-console",
+      `${seat.id} to Shutter Console`,
+    );
+  }
+  state = lockResolve(state);
+  assert.deepEqual(
+    state.seats.map((seat) => seat.position),
+    ["entry-shelf", "entry-shelf"],
+  );
+  assert.equal(
+    state.encounter.causalLog.filter((event) =>
+      event.tags.includes("capacity-conflict"),
+    ).length,
+    2,
+  );
+});
+
+test("exclusive claim conflicts block resolution until one owner yields priority", () => {
+  let state = enterApproach("LS-DUO-DUP-HB");
+  state.seats.forEach((seat) => {
+    seat.position = "far-platform";
+  });
+  state = queueBy(
+    state,
+    "seat-1",
+    "far-platform",
+    "establish-control",
+  );
+  state = queueBy(
+    state,
+    "seat-2",
+    "far-platform",
+    "establish-control",
+  );
+  state = lockSeatPlan(state, "seat-1");
+  state = lockSeatPlan(state, "seat-2");
+  assert.equal(canResolvePlans(state), false);
+
+  state.seats.forEach((seat) => {
+    seat.locked = false;
+  });
+  const secondAction = state.seats[1].plan[0];
+  state = setClaimMode(
+    state,
+    "seat-2",
+    secondAction.instanceId,
+    "If Available",
+  );
+  state = lockSeatPlan(state, "seat-1");
+  state = lockSeatPlan(state, "seat-2");
+  assert.equal(canResolvePlans(state), true);
+  state = resolvePlans(state);
+  assert.equal(state.seats[0].majorState?.type, "temporary-control");
+  assert.equal(state.seats[1].majorState, null);
+});
+
+test("ally effects require the recipient's explicit consent", () => {
+  let state = enterApproach("LS-DUO-MIXED");
+  state = queueBy(state, "seat-1", "seat-2", "guard");
+  const action = state.seats[0].plan[0];
+  let blocked = lockSeatPlan(state, "seat-1");
+  assert.equal(blocked.seats[0].locked, false);
+  assert.match(blocked.warnings.at(-1), /needs consent/);
+
+  state = setConsent(state, "seat-2", action.instanceId, true);
+  state = lockSeatPlan(state, "seat-1");
+  state = lockSeatPlan(state, "seat-2");
+  assert.equal(canResolvePlans(state), true);
+});
+
+test("Fallback Guard distinguishes invalidation before begin from ordinary failure", () => {
+  let state = enterApproach(
+    "LS-SOLO-1",
+    "folded-service-walk",
+    "folded",
+  );
+  state.seats[0].command = 32;
+  state.seats[0].activeWeaponId = "breaker";
+  state.seats[0].majorState = {
+    type: "battle-advantage",
+    name: "Battle Advantage",
+    ownerSeatId: "seat-1",
+    targetId: "skimmer-a",
+    status: "active",
+  };
+  state = queueBy(state, "seat-1", "skimmer-a", "convert-drive");
+  state = queueBy(state, "seat-1", "skimmer-a", "attack");
+  const attack = state.seats[0].plan.find(
+    (action) => action.baseId === "attack",
+  );
+  state = attachCard(state, "seat-1", attack.instanceId, "fallback-guard");
+  state = lockResolve(state);
+  assert.equal(
+    state.resolution.results[attack.instanceId].status,
+    "invalidated_before_begin",
+  );
+  assert.equal(state.encounter.refundsPending["seat-1"], 3);
+  assert.equal(state.seats[0].temporaryGuard, 3);
+  assert.equal(state.seats[0].flags.braced, true);
+});
+
+test("release Work remains blocked while any entered threat is active", () => {
+  let state = enterApproach("LS-SOLO-1");
+  state.seats[0].position = "far-platform";
+  state.encounter.shutter.state = "jammed-open";
+  state = queueBy(
+    state,
+    "seat-1",
+    "release-socket",
+    "complete-release",
+  );
+  state = runAndSettle(state);
+  assert.equal(state.stage, "loose-signal");
+  assert.equal(state.encounter.release.validated, false);
+  assert.match(
+    state.encounter.release.blockedReason,
+    /hostile pressure remains active/,
+  );
+  assert.equal(
+    state.sourceMismatches.some(
+      (item) => item.id === "LS-FULL-CLEAR-VS-DUO-EXPECTED",
+    ),
+    true,
+  );
+});
+
+test("Expose Cache can causally unlock same-cycle Relay Needle recovery", () => {
+  let state = enterApproach("LS-DUO-MIXED");
+  state.seats.forEach((seat) => {
+    seat.position = "far-platform";
+  });
+  state.seats[1].majorState = {
+    type: "temporary-control",
+    name: "Temporary Control",
+    ownerSeatId: "seat-2",
+    dependencyId: "shutter-dependency",
+    status: "active",
+  };
+  state.encounter.shutter.controlledBySeatId = "seat-2";
+  state = queueBy(
+    state,
+    "seat-2",
+    "relay-cache",
+    "execute-expose-cache",
+  );
+  state = queueBy(
+    state,
+    "seat-1",
+    "relay-cache",
+    "recover-relay-cache",
+  );
+  state = lockResolve(state);
+  assert.equal(state.encounter.cache.exposed, true);
+  assert.equal(state.encounter.cache.recovered, true);
+  assert.equal(
+    state.seats[0].packages.some((item) => item.id === "relay-needle"),
+    true,
+  );
+});
+
+test("Compromised rescue and opened-Threshold extraction preserve personal ownership", () => {
+  let rescue = enterApproach("LS-DUO-MIXED");
+  rescue.seats[1].condition = 0;
+  rescue.seats[1].guard = 0;
+  rescue.seats[1].compromised = true;
+  rescue.seats[1].rescueSettlesRemaining = 2;
+  rescue = queueBy(rescue, "seat-1", "seat-2", "stabilize");
+  const rescueAction = rescue.seats[0].plan[0];
+  rescue = setConsent(rescue, "seat-2", rescueAction.instanceId, true);
+  rescue = lockResolve(rescue);
+  assert.equal(rescue.seats[1].compromised, false);
+  assert.equal(rescue.seats[1].condition, 4);
+  assert.equal(rescue.seats[1].disruption, 1);
+
+  let extraction = enterApproach("LS-SOLO-1");
+  extraction.seats[0].position = "threshold";
+  extraction.encounter.release.thresholdOpen = true;
+  extraction.encounter.release.validated = true;
+  extraction = queueBy(
+    extraction,
+    "seat-1",
+    "threshold",
+    "standard-extract",
+  );
+  extraction = lockResolve(extraction);
+  assert.equal(extraction.seats[0].flags.extracted, true);
+  assert.equal(extraction.seats[0].packages[0].ownerSeatId, "seat-1");
+});
+
+test("reset restores the selected deterministic profile without persistence", () => {
+  let state = enterApproach("LS-TRIO-MIXED");
+  state.seats[0].command = 1;
+  state.seats[0].condition = 2;
+  state = resetGreybox(state);
+  assert.equal(state.stage, "preparation");
+  assert.equal(state.encounter, null);
+  assert.equal(state.profileId, "LS-TRIO-MIXED");
+  assert.deepEqual(
+    state.seats.map((seat) => [seat.command, seat.condition, seat.plan.length]),
+    [
+      [16, 12, 0],
+      [16, 12, 0],
+      [16, 12, 0],
+    ],
+  );
+  assert.equal(state.evidence.at(-1).type, "reset");
+});


### PR DESCRIPTION
## Summary

- Adds the bounded first-playable BARCODE World browser greybox for Outskirts → Loose Signal at the private development route `/world/playtest`.
- Implements the deterministic Option A engine and UI: preparation, six builds, fixed decks/loadouts, Outskirts consent, physical LS-01 map, contextual actions, personal plans, claims/consent, Tempo packets, Major engines, Packages, rescue, extraction, Settle, evidence export, and reset.
- Keeps the website repository as owner. BNL was inspected only as an integration boundary and has no runtime dependency or modification.

## Safety boundary

- Development-only route; production calls `notFound()`.
- `noindex`, `noarchive`, and `nocache`; no Header or sitemap entry.
- Pure in-memory state: no API, database, local storage, account, economy, queue, BNL, Relay, Journal, or live-system writes.
- No deployment, merge, protected-gate change, canonical write, or live mutation is part of this PR.

## Architecture

- `constants.mjs`: ordered builds, exact costs, fixed decks/opening hands, loadouts, LS-01 relationships, profiles, and paper expectations.
- `engine.mjs`: pure deterministic transitions, planning, ownership, claims, consent, packet resolution, Settle, evidence, and reset.
- `BarcodeWorldGreybox.tsx` + CSS: playable preparation, expedition, map, actions, projection, personal plans, logs, Settle, comparison, and evidence UI.
- `page.tsx`: private route boundary.
- Node tests: mechanical, profile, concurrency, ownership, failure, isolation, and production-boundary evidence.

## Source decisions and unresolved items

- **Full clear vs. mixed-duo paper result:** LS-01 §12's detailed full-entered-threat-clear rule controls; contradictory paper totals remain labeled paper findings.
- **Discipline timing omission:** REV7 provisional timings are a temporary implementation assumption where the controlling pack is silent; Battle responses inherit the Commitment packet; Opening transit is Standard / 5.
- **Profile scripts:** paper totals lack complete lock-ready scripts. Automated six-build evidence uses a declared conservative baseline and does not claim canonical reproduction.
- **Outskirts layout:** neutral relationship diagram only; no final camera choice.
- **Optional Hanging Panel and unexercised weapon-technique geometry:** excluded from balance evidence.

## Validation

- `node --test tests/barcode-world-engine.test.mjs tests/barcode-world-boundary.test.mjs`: **17 passed**.
- `npm run check`: TypeScript passed; lint reported **0 errors** and 36 pre-existing warnings elsewhere; **610 tests passed**.
- `npm run build`: passed with Next.js 16.1.6.
- Production runtime check: `/world/playtest` returned **HTTP 404**.
- Remote verification: branch is exactly one commit ahead of base; all 9 file blob SHAs and the complete tree SHA match the locally tested commit.
- Screenshots are not attached: the authorized cloud browser blocked the local/private preview address. No substitute or fabricated browser evidence was used.

## Manual playtest

Follow the focused Preparation → Outskirts → LS-01 → Settle → evidence/reset sequence in `docs/barcode-world-loose-signal-greybox.md`. It includes explicit checks for the four action roots, projection, character-owned plans/state, consent/claims, packet layers, objectives, rescue/extraction, release validation, and reset.

## Post-merge deployment

Do not expose `/world/playtest` in production. If this is merged and deployed later under separate owner approval:

1. Request production `/world/playtest` and capture the 404 response.
2. Verify the public Header and sitemap do not list `/world/playtest`.
3. Verify homepage, queue, BNL, Journal, and admin health remain unchanged.
4. Run the greybox only in an approved nonproduction development environment.
5. Re-run the focused tests and the documented manual evidence path; attach the 404, command output, and nonproduction browser captures to the deployment record.