### PR TITLE
Implement revised private Fractured Gate proof

### DIFF
--- a/docs/barcode-world-fractured-gate-prototype.md
+++ b/docs/barcode-world-fractured-gate-prototype.md
@@ -3,83 +3,156 @@
 Status: **IMPLEMENTED — PRIVATE OWNER-REVIEW PROTOTYPE**
 
 Controlling checkpoint:
-`BARCODE_WORLD_BATTLE_MODE_FRACTURED_GATE_PREIMPLEMENTATION_CHECKPOINT_2026-07-26`
+`BARCODE_WORLD_BATTLE_MODE_FRACTURED_GATE_REVISED_ENCOUNTER_CHECKPOINT_2026-07-27`
 
-Route: `/world/playtest` in a local development environment only.
+Private development route: `/world/playtest`
 
-This is a bounded Battle Mode workstream inside the larger BARCODE World
-persistent shared-world MMORPG / sandbox RPG. It is not a standalone game,
-canon encounter, public preview, or connection to persistent world systems.
+This is the bounded Battle Mode proof inside the larger BARCODE World
+persistent shared-world MMORPG / sandbox RPG. It is not a standalone game, a
+canonical encounter, a public preview, or a connection to persistent world
+systems.
 
-## Boundary
+## Hard boundary
 
-- Solo only, deterministic, resettable, noncanonical, and in memory.
-- No route link in the public shell or sitemap.
-- The private route suppresses the normal public navigation, relay shell, data
-  stream, and footer so they cannot obscure or pollute the tactical surface;
-  all other routes retain the normal site chrome.
-- `noindex`, `nofollow`, `noarchive`, and `nocache` metadata.
-- A production build returns `notFound()` before rendering the prototype.
+- Solo, deterministic, resettable, noncanonical, and in memory.
+- Production middleware returns an empty, no-store 404 before page metadata or
+  client-chunk references are emitted; the page also retains a `notFound()`
+  fallback.
+- The route is absent from public navigation and the sitemap.
+- `noindex`, `nofollow`, `noarchive`, and `nocache` metadata remain set.
+- Normal public navigation, relay UI, data streams, and footer are suppressed
+  on the exact private route only.
+- Shared live and BNL providers remain inert on the exact private route.
 - No API, account, profile, database, inventory, reward, economy, progression,
   queue, BNL, Relay, Journal, Memory, moderation, multiplayer, or shared-world
   dependency.
-- Shared live and BNL status providers are inert on this exact route and expose
-  fallback-only context, preventing background protected-system requests.
-- No merge or deployment is part of this prototype review.
+- No prototype state survives Reset, reload, or navigation.
+- Merge is authorized for this bounded proof. Manual deployment and public
+  exposure are not.
 
-The prior Loose Signal implementation remains in the repository only as a
-deterministic-mechanics reference. The Fractured Gate engine and interface do
-not extend that old harness or treat it as player evidence.
+The prior Loose Signal and original one-enemy Fractured Gate implementations
+remain historical deterministic-mechanics references only. They are not player
+evidence and no longer control this encounter.
 
-## Implemented proof
+## Implemented encounter
 
-The board presents Entry and West Exit, Lower Yard, Upper Walk, Gate Platform,
-Cracked Divider, Gate Actuator, the three-pip Gate objective, Service Gap,
-optional Field Cache, one Assault, and its confirmed Impact Rush directly in a
-physical tactical location.
+The board uses the checkpointed hidden `13 × 9` tactical scale and exposes 62
+real walkable tiles. The visible location contains the Lower Yard, Upper Walk,
+Gate Platform, West Exit, Cracked Divider, powered service track, Gate
+Actuator, defensive bollard, service gap and shutter, service lift, optional
+Field Cache, and the three-pip Gate objective.
+
+The formation has four independently positioned opponents:
+
+| Enemy | Battlefield responsibility |
+| --- | --- |
+| Breacher | Physical Gate pressure and major contact |
+| Guard | Protection, interception, and lane control |
+| Controller | Machinery, closure, reset, and objective delay |
+| Pressure | Flanks, Cache denial, and West Exit pressure |
+
+Each enemy owns a fixed 12-card deck, five-card opening hand, position, state,
+and legal actions. The solo formation distributes one visible 16-Command squad
+allotment among those four actors. It never receives four hidden full pools.
+
+## Revised battle loop
 
 The interaction is:
 
-`Select → choose → target → preview → plan → lock → watch → settle`
+`Select → choose → target → preview → plan → contest → pass/lock → reveal → watch → settle`
 
-Board selections expose at most four contextual parents from Attack, Defend,
-Discipline, Inspect, Move, Use, and Leave. Movement and targeting happen on the
-board. Preview and resolution call the same deterministic simulator, so paths,
-ghost positions, projected collision, consequences, risk, and the final
-Fast → Standard → Slow packets share one result.
+The player and enemy squad alternate legal commitments. The newest action is
+Open. Adding a new action makes the previous one Solid. Each allotment permits
+one Pivot of the newest Open action; its replacement locks immediately. Two
+consecutive passes Lock both plans. Saved Command cannot become an undeclared
+post-reveal reaction.
 
-The foundation preserves 16 starting Command, +16 on later planning cycles,
-the 32 cap, one free ordinary short Reposition, a four-paid-action hard cap,
-two paid actions as normal and four as exceptional, fixed 12-card Prepared
-decks, validated five-card openings, draw two, retain seven, and once-per-phase
-Refocus for 4 Command replacing up to two cards. Compatible cards are lifted
-visually while the full hand remains visible.
+The foundation preserves:
 
-Invalidation is checked at action start, declared targets never silently
-change, refundable primary costs return at half value during Settle, and a
-triggered Contingency spends its reserve. Same seed, initial state, and
-submitted plan produce the same signature, packets, and legal final state.
+- 16 starting Command, +16 after Settle, and the 32 cap;
+- four paid actions at most and one free ordinary Reposition;
+- fixed 12-card Prepared decks and validated five-card opening hands;
+- draw two, retain seven, and once-per-cycle Refocus for 4 Command;
+- half-primary-cost Settle refunds for invalidation before begin;
+- no silent retargeting;
+- the same deterministic simulator for Preview and resolution;
+- Fast → Standard → Slow global presentation;
+- prerequisite order inside an actor's linked plan.
 
-## Six ordered causal opportunities
+### Command and Tempo
 
-| Build | Distinct player-caused opportunity |
+Command controls action capacity and banking. Tempo controls when materially
+opposed plans develop and intersect. Tempo never becomes Command and never
+creates another action.
+
+Normal presentation uses Fast, Standard, and Slow. A linked transition is
+shown as Preserved, Broken, or Accelerated. Details expose the bounded
+deterministic comparison.
+
+The controlled route proof is:
+
+| Route | Player contact | Enemy contact | Forecast |
+| --- | ---: | ---: | --- |
+| Clear + Follow Through | 6 | 6 | Likely even |
+| Rubble | 4 | 6 | Enemy likely first |
+| Powered toward Divider | 7 | 6 | Player likely first |
+
+The preview exposes contact risk, likely timing, location, and the count of
+concealed factors. It does not reveal exact enemy cards. The `CLASH`
+presentation appears only after reveal produces meaningful opposed contact.
+
+### Skill attribution
+
+Specialized information and actions name their sources:
+
+- `Revealed by` identifies the discipline that noticed the opportunity.
+- `Enabled by` identifies the discipline that makes the action legal.
+- `Modified by` identifies a card or equipment change.
+- `Opposed by` identifies the visible enemy posture or revealed response.
+
+The six ordered builds produce different causal state changes:
+
+| Build | Major condition → Minor payoff |
 | --- | --- |
-| Battle / Exploration | Answer Impact Rush at the Cracked Divider; the collision breaches it; cross the created Opening. |
-| Exploration / Battle | Prepare the Upper Walk relationship; physically contest the threatened landing; exploit the preserved Route. |
-| Battle / Hacking | Answer the Rush to expose the protected Impact Regulator; suppress its real automatic reset. |
-| Hacking / Battle | Establish defensive-bollard Control at the Actuator; physically hold access; execute the pinning Output. |
-| Exploration / Hacking | Prepare the natural Service Gap Route; suppress the real closure mechanism; exploit the preserved relationship. |
-| Hacking / Exploration | Establish lift Control; execute machinery that creates temporary geometry; cross before the lift resets at Settle. |
+| Battle / Exploration | Physical contact breaks the Divider → its safe opening becomes a route |
+| Exploration / Battle | A natural upper relationship is prepared → its landing can be physically protected |
+| Battle / Hacking | Force exposes a regulator → its automatic reset can be suppressed |
+| Hacking / Battle | Local bollard Control is established → physical access can preserve and weaponize it |
+| Exploration / Hacking | A service relationship is prepared → its connected shutter can be suppressed |
+| Hacking / Exploration | Lift Control is established → temporary traversable geometry can be created |
 
-These are different causal interactions and state transitions, not renamed
-copies or numerical normalization.
+These are permissions, positions, Dependencies, and authored state changes—not
+six renamed percentage bonuses. Enemy cards can contest the actual source.
 
-## Results
+## Complete representative encounter
 
-Fast Secure, Clean Secure, Recovery Secure, Gate Lost, and Controlled Retreat
-are all reachable. Each Results view explains objective outcome, enemy state,
-player state, Field Cache status, location consequences, principal turning
-point, and meaningful tradeoff.
+The Battle / Exploration proof has three exchanges:
+
+1. A clear Reposition and Advance enable source-bound **Follow Through**.
+   **Answer Commitment** meets the Breacher's Rush at the Divider. Shield Link
+   protects against full displacement, the emergent Clash breaches the
+   Divider, the Breacher staggers, and Gate Stability remains `3/3`.
+2. **Cross Opening** draws **Charge Debris** and a Gate body block. The player
+   uses their single Pivot to replace Slow Stabilize with **Angle the
+   Contact**; the Guard Pivots to **Brace Line**. Pressure threatens the West
+   Exit. Their revealed Gate-access Clash jams the bollard and places the
+   player at `(10,5)` without stabilizing the objective.
+3. **Guard Gate** establishes before the final Rush. **Objective Brace**
+   protects Slow **Stabilize Gate** from Static Tax. The defended Clash stops
+   the Breacher, the defensive seal completes, and Results assign **Fast
+   Secure** with the damaged Divider, jammed bollard, pressured exit, and
+   unrecovered Cache reported as tradeoffs.
+
+All five owner-facing result families are reachable:
+
+- Fast Secure;
+- Clean Secure;
+- Recovery Secure;
+- Gate Lost;
+- Controlled Retreat.
+
+The diagnostic `Gate Secure` fallback remains internal for a slow damaged
+secure that matches none of the five named cases.
 
 ## Exact private owner review
 
@@ -94,70 +167,73 @@ Open `http://127.0.0.1:3000/world/playtest`.
 
 ### Primary Battle / Exploration path
 
-1. Confirm the header says private, solo, noncanonical, and in-memory; Command
-   is 16; the Gate has three filled pips; the opening hand is Fallback Guard,
-   Objective Brace, Brace Through, Hold the Edge, and Safe Landing.
-2. Select **YOU** on the board, choose **MOVE**, then **Reposition**. Select the
-   dashed **Lower Yard Cover** target on the board. Confirm the ghost/path
-   Preview and add it to the plan.
-3. Select **Impact Rush**, choose **DISCIPLINE**, then
-   **Answer Rush at Divider**. Select **Cracked Divider** on the board, attach
-   the highlighted **Brace Through** card, inspect the projected collision and
-   one important risk, then add it.
-4. Select the newly projected **Projected Breach**, choose **MOVE**, then
-   **Cross Created Opening**. Select **Gate Platform** on the board and add it.
-5. Confirm the plan is one readable chain, contains two paid actions plus the
-   free Reposition, and leaves 1 Command. Lock it.
-6. Watch Fast, Standard, and Slow become visible in order. Do not infer
-   skipped work from an empty lane. At Settle, open Review and verify the
-   causal log and signature, then select **SETTLE**.
-7. In round 2, select the Gate, choose **USE**, then **Stabilize Gate**. Target
-   the Gate, optionally attach Objective Brace, add, lock, watch, and settle.
-   Verify the complete **Fast Secure** Results explanation.
-8. Select **RESET SAME INITIAL STATE**. Confirm the same build, seed-derived
-   signature for the repeated opening plan, starting Command, Gate pips,
-   positions, intent, and opening hand return.
+1. Confirm the header says private, solo, noncanonical, and in-memory. Confirm
+   Player Command `16`, Enemy Squad Command `4` after its opening commitment,
+   Gate Stability `3/3`, four enemy pieces, and five Prepared cards.
+2. On the clear Lower Yard lane, select tile `(3,6)`, choose **Move →
+   Reposition**, select the highlighted tile again, confirm the textual
+   `CONFIRMED` cue, inspect Preview, and add it.
+3. Select clear tile `(5,6)`, choose **Move → Advance**, select the tile again,
+   and add it. Confirm the earlier Reposition is now a Solid commitment.
+4. Select **Cracked Divider**, choose **Discipline → Answer Commitment**, and
+   select the Divider as the target. Attach the source-bound **Follow Through**
+   card. Confirm the forecast says high contact risk, likely even, Cracked
+   Divider, one concealed factor, and `Player 6 · Enemy 6`; it must not name
+   the enemy's exact cards.
+5. Add the action and confirm 4 Player Command remains. Select **Pass / Lock**.
+   After reveal, verify Fast Shield Link precedes movement and the actual
+   `CLASH · Divider contact`. Settle and verify Gate Stability is still `3/3`.
+6. Select the projected breach, choose **Move → Cross Opening**, and target
+   tile `(10,5)`. Then select the Gate, choose **Use → Stabilize Gate**, target
+   the Gate, and add it.
+7. In Plan, choose **Change Newest**. Select **Defensive Bollard**, choose
+   **Discipline → Angle the Contact**, retarget the bollard, and confirm. Verify
+   the earlier Cross is still Solid, both Pivot labels read spent, and the
+   enemy's broad posture changes without revealing its card.
+8. Pass once to let Pressure commit, then pass again to Lock. Verify Charge
+   Debris and West Exit pressure resolve Fast; Cross Opening then
+   `CLASH · Gate access` resolve Standard. Settle and confirm charged conduit,
+   jammed bollard, threatened West Exit, player at `(10,5)`, and Gate `3/3`.
+9. Discard to retain seven. Select the Gate, plan **Defend → Guard Gate**, then
+   **Use → Stabilize Gate** with **Objective Brace**. Pass to Lock. Verify Fast
+   Guard and Static Tax, the Standard defended Gate Clash, and Slow Gate
+   stabilization.
+10. Confirm **Fast Secure** explains the objective, all four enemies, player
+    state, Cache, location consequences, principal turning point, tradeoff, and
+    title reason.
+11. Select **Reset Same Initial State**. Rebuild the opening plan and confirm
+    the starting state and deterministic plan signature return exactly.
 
-### Six-build differentiation
+### Connected owner checks
 
-Changing the ordered build resets the same encounter. Exercise these opening
-proofs:
-
-1. **Battle / Exploration:** Lower Yard Cover Reposition → Answer Rush at
-   Divider + Brace Through → Cross Created Opening.
-2. **Exploration / Battle:** Upper Walk Reposition → Prepare Upper Route +
-   Destination Claim → Contest Threatened Landing. On a later cycle, exploit
-   the preserved Upper Route.
-3. **Battle / Hacking:** Lower Yard Cover Reposition → Expose Impact Regulator
-   + Brace Through → Suppress Regulator Reset.
-4. **Hacking / Battle:** Actuator Reposition → Control Defensive Bollard +
-   Quiet Rewrite → Hold Actuator Access. On a later cycle, execute the Bollard
-   Output.
-5. **Exploration / Hacking:** Prepare Service Route + Destination Claim →
-   Suppress Automatic Closure. On a later cycle, exploit the preserved Service
-   Route.
-6. **Hacking / Exploration:** Actuator Reposition → Control Service Lift +
-   Quiet Rewrite. On the next cycle, execute the Lift Output, then select the
-   projected Service Lift and cross it with Safe Landing. Verify the lift
-   resets after Settle while the player remains at Gate Platform.
+1. Compare the clear lane with rubble `(3–5,5)` and the powered lane
+   `(3–7,7)`. Confirm the forecast changes timing without changing available
+   Command.
+2. Change each ordered build and confirm specialized text names `Revealed by`
+   and `Enabled by`; builds without that opportunity do not receive a gray
+   class-locked substitute.
+3. Let three unopposed Gate impacts complete and verify **Gate Lost** at `0/3`.
+4. Use **Leave** beside the West Exit and verify **Controlled Retreat** does not
+   pretend the Gate or formation was solved.
+5. Exercise Hacking / Exploration's lift. Confirm Output creates a capacity-one
+   bridge, crossing moves to the legal landing, and the lift returns at Settle
+   even if that exchange ends the battle.
+6. Repeat the same submitted plan and initial seed. Confirm Preview signature,
+   resolution packets, and material final state match.
 
 ### Input and presentation checks
 
-1. Pointer: complete the primary path using only visible board and panel
-   controls.
-2. Keyboard: reload, press Tab from the first control through board objects,
-   context parents, targets, plan, and hand; confirm every focused control has
-   a visible amber outline; activate representative controls with Enter and
-   Space.
-3. Touch equivalent: test at 390 × 844 CSS pixels; tap the player, Impact Rush,
-   Cracked Divider target, Gate target, parent actions, cards, Lock, resolution,
-   Settle, Review, and Reset without hover. Confirm controls remain at least
-   44 × 44 CSS pixels and the board remains the dominant interaction surface.
-4. Motion: enable **Reduce motion** and confirm path/target/collision/card
-   animations stop while resolution remains readable and manually advanceable.
-5. Readability: inspect desktop and narrow layouts at 100% zoom. Confirm labels
-   do not depend on color alone: TARGET, CONFIRMED, COMPATIBLE, lane names,
-   pips, focus outlines, text, borders, and shapes carry the state.
+1. Complete the primary path with pointer controls only.
+2. Reload and complete representative selection, targeting, card, Pivot,
+   Pass/Lock, manual resolution, Settle, Review, and Reset interactions using
+   Tab, Enter, and Space. Confirm every focused control has a visible outline.
+3. At `390 × 844` CSS pixels, confirm tile, focus, card, and action controls
+   remain at least `44 × 44` CSS pixels and the board remains usable.
+4. Enable **Reduce motion**. Confirm target, path, Clash, and card animations
+   stop and resolution becomes manually advanceable without hiding state.
+5. Confirm state never depends on color alone: `TARGET`, `CONFIRMED`,
+   `COMPATIBLE`, `NEWEST`, `SOLID COMMITMENT`, Pivot state, lane names, pips,
+   borders, shapes, and text all carry meaning.
 
 ## Automated validation
 
@@ -168,28 +244,40 @@ npm run check
 npm run build
 ```
 
-The focused tests cover deterministic repeatability, all six legal and distinct
-causal opportunities, Preview/resolution parity, Fast → Standard → Slow order,
-Command and action limits, Refocus, exact opening hands, compatible cards,
-invalidation/refunds/no-retargeting, all five Results, reset, production
-gating, absence of persistence/live-system imports, non-color cues, focus
-styles, touch target rules, reduced motion, and core text contrast.
+The focused suite covers the revised source identity, 62 tactical tiles, six
+player decks, four enemy decks, shared squad action economy, spatial legality,
+controlled Tempo routes, source-bound context cards, concealed-information
+boundaries, Preview/lock signature parity, deterministic resolution,
+opposed planning and both Pivots, the complete three-cycle battle, Command
+banking and caps, Refocus, invalidation/refunds/no-retargeting, all six ordered
+build state changes, all five Results, lift reset, reset/replay, production
+gating, isolation from persistent systems, input semantics, non-color cues,
+touch targets, reduced motion, and core text contrast.
 
-These are implementation checks, not player evidence. Passing them does not
-establish comprehension, balance, fun, accessibility, or replay value.
+These are implementation checks—not player evidence. They do not establish
+comprehension, balance, fun, accessibility, or replay value.
 
-## Post-merge deployment and focused verification
+## Post-merge deployment and focused evidence
 
-This draft must not be merged or deployed as part of this work gate. If the
-owner later authorizes a merge and a separate deployment:
+No manual deployment is authorized or initiated for this proof. If normal
+`main` automation produces a deployment after the authorized merge, the
+prototype must remain inaccessible:
 
-1. Keep `/world/playtest` production-inaccessible unless another explicit
-   owner decision changes the gate.
-2. Verify production returns 404 for `/world/playtest`, the route is absent
-   from global navigation and sitemap, and no Fractured Gate client bundle or
-   metadata is publicly discoverable.
-3. Run the exact private owner-review path above in the authorized development
-   environment.
-4. Capture implementation evidence separately from any later moderated player
-   evidence; do not promote automated or owner-review observations into claims
-   of comprehension, balance, fun, accessibility, or replay value.
+1. Request `<production-origin>/world/playtest` and verify an HTTP 404.
+2. Inspect the production global navigation and `/sitemap.xml`; verify neither
+   contains `/world/playtest`.
+3. Inspect returned production HTML and discoverable route metadata; verify no
+   Fractured Gate title, description, board content, or public link is exposed.
+4. Confirm normal public routes still render their existing site chrome and
+   providers.
+5. In an authorized local development environment, run the exact primary path
+   above and record:
+   - the cycle-one Preview and locked signatures;
+   - the three resolution logs;
+   - Gate Stability after each Settle;
+   - the final Results explanation;
+   - Reset producing the same initial state.
+6. Label these captures **implementation evidence**. Keep any future moderated
+   comprehension, balance, fun, accessibility, or replay observations separate
+   and do not promote this private prototype publicly without a new owner
+   decision.

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,22 @@ import { verifyAdminToken, COOKIE_NAME } from "@/lib/auth";
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
+  // The bounded BARCODE World proof is development-only. Stop at the request
+  // boundary in production so no page metadata or client-chunk reference is
+  // returned with the 404 response.
+  if (
+    pathname === "/world/playtest" &&
+    process.env.NODE_ENV === "production"
+  ) {
+    return new NextResponse(null, {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+        "X-Robots-Tag": "noindex, nofollow, noarchive, noimageindex",
+      },
+    });
+  }
+
   // ---- Rate limit: /api/queue/free ----
   if (pathname === "/api/queue/free" && req.method === "POST") {
     // Simple sliding-window rate limit via Upstash (handled in the route itself
@@ -53,5 +69,6 @@ export const config = {
   matcher: [
     "/admin/:path*",
     "/api/queue/free",
+    "/world/playtest",
   ],
 };

--- a/src/app/world/playtest/page.tsx
+++ b/src/app/world/playtest/page.tsx
@@ -4,17 +4,30 @@ import { FracturedGatePrototype } from "@/components/FracturedGatePrototype";
 
 export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "The Fractured Gate · Private BARCODE World Battle Mode Proof",
-  description:
-    "Private, deterministic, resettable, noncanonical BARCODE World Battle Mode prototype.",
-  robots: {
-    index: false,
-    follow: false,
-    noarchive: true,
-    nocache: true,
-  },
-};
+export function generateMetadata(): Metadata {
+  if (process.env.NODE_ENV === "production") {
+    return {
+      title: "Not Found",
+      robots: {
+        index: false,
+        follow: false,
+        noarchive: true,
+        nocache: true,
+      },
+    };
+  }
+  return {
+    title: "The Fractured Gate · Private BARCODE World Battle Mode Proof",
+    description:
+      "Private, deterministic, resettable, noncanonical BARCODE World Battle Mode prototype.",
+    robots: {
+      index: false,
+      follow: false,
+      noarchive: true,
+      nocache: true,
+    },
+  };
+}
 
 export default function BarcodeWorldPlaytestPage() {
   if (process.env.NODE_ENV === "production") {

--- a/src/components/FracturedGatePrototype.module.css
+++ b/src/components/FracturedGatePrototype.module.css
@@ -199,7 +199,7 @@
 
 .hud {
   display: grid;
-  grid-template-columns: 1.2fr repeat(5, minmax(8rem, 1fr));
+  grid-template-columns: 1.2fr repeat(7, minmax(8rem, 1fr));
   border-inline: 1px solid var(--fg-line);
   border-bottom: 1px solid var(--fg-line);
   background: rgba(7, 12, 17, 0.96);
@@ -320,6 +320,52 @@
 
 .collisionMark {
   animation: collisionPulse 1.25s ease-in-out infinite;
+}
+
+.tileLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+}
+
+.boardTile {
+  position: absolute;
+  left: var(--x);
+  top: var(--y);
+  display: grid;
+  place-items: center;
+  width: max(2.75rem, 44px);
+  height: max(2.75rem, 44px);
+  padding: 0;
+  transform: translate(-50%, -50%);
+  border: 1px solid transparent;
+  border-radius: 50%;
+  color: transparent;
+  background: transparent;
+  cursor: pointer;
+}
+
+.boardTile:hover,
+.boardTile:focus-visible,
+.selectedTile {
+  border-color: rgba(97, 220, 255, 0.55);
+  color: var(--fg-cyan);
+  background: rgba(7, 18, 26, 0.56);
+}
+
+.legalTile {
+  z-index: 5;
+  border: 2px dashed var(--fg-amber);
+  color: #171000;
+  background: rgba(255, 209, 102, 0.18);
+  box-shadow: 0 0 18px rgba(255, 209, 102, 0.22);
+  animation: targetPulse 1.15s ease-in-out infinite;
+}
+
+.boardTile span {
+  font-size: 0.44rem;
+  font-weight: 1000;
+  letter-spacing: 0.05em;
 }
 
 @keyframes dashFlow {
@@ -851,6 +897,42 @@
   line-height: 1.4;
 }
 
+.contactForecast,
+.skillAttribution {
+  display: grid;
+  gap: 0.24rem;
+  padding: 0.7rem;
+  border-left: 3px solid var(--fg-orange);
+  background: rgba(255, 155, 106, 0.055);
+  font-size: 0.68rem;
+}
+
+.contactForecast strong,
+.skillAttribution strong {
+  color: var(--fg-orange);
+}
+
+.contactForecast span,
+.skillAttribution span {
+  color: var(--fg-text);
+}
+
+.contactForecast p,
+.contactForecast details {
+  margin: 0.2rem 0 0;
+  color: var(--fg-muted);
+  line-height: 1.35;
+}
+
+.skillAttribution {
+  border-left-color: var(--fg-violet);
+  background: rgba(201, 166, 255, 0.055);
+}
+
+.skillAttribution strong {
+  color: var(--fg-violet);
+}
+
 .emptyPreview,
 .emptyPlan {
   margin: 0.7rem 0 0;
@@ -998,6 +1080,105 @@
   text-transform: uppercase;
 }
 
+.openCommitment,
+.solidCommitment {
+  width: fit-content;
+  margin-top: auto;
+  padding: 0.18rem 0.34rem;
+  border: 1px solid var(--fg-amber);
+  color: var(--fg-amber);
+  font-size: 0.48rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+}
+
+.solidCommitment {
+  border-color: var(--fg-line-bright);
+  color: var(--fg-muted);
+}
+
+.enemyPlan {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(0, 2fr);
+  gap: 1rem;
+  margin-top: 0.8rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(255, 155, 106, 0.4);
+  background: rgba(255, 155, 106, 0.045);
+}
+
+.enemyPlan > div {
+  display: grid;
+  align-content: start;
+  gap: 0.25rem;
+}
+
+.enemyPlan > div span,
+.pivotBar span {
+  color: var(--fg-orange);
+  font-size: 0.54rem;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+}
+
+.enemyPlan > div strong {
+  font-size: 0.7rem;
+}
+
+.enemyPlan ul {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(8rem, 1fr));
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.enemyPlan li {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.5rem;
+  border: 1px solid rgba(255, 155, 106, 0.28);
+}
+
+.enemyPlan li strong,
+.enemyPlan li span,
+.enemyPlan li small {
+  font-size: 0.58rem;
+}
+
+.enemyPlan li span,
+.enemyPlan li small {
+  color: var(--fg-muted);
+}
+
+.pivotBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.65rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(255, 209, 102, 0.35);
+  background: rgba(255, 209, 102, 0.04);
+}
+
+.pivotBar button {
+  min-height: max(2.75rem, 44px);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--fg-amber);
+  color: var(--fg-amber);
+  background: transparent;
+  font-size: 0.62rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.pivotBar button:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
 .planEdit {
   display: flex;
   gap: 0.28rem;
@@ -1141,7 +1322,8 @@
 
 .compatibleCue,
 .plannedCue,
-.discardCue {
+.discardCue,
+.contextCue {
   position: absolute;
   right: 0.45rem;
   bottom: 0.45rem;
@@ -1152,6 +1334,13 @@
   font-size: 0.47rem;
   font-weight: 1000;
   letter-spacing: 0.08em;
+}
+
+.contextCue {
+  right: auto;
+  left: 0.45rem;
+  color: #120d21;
+  background: var(--fg-violet);
 }
 
 .plannedCue {
@@ -1414,14 +1603,14 @@
 
 @media (max-width: 1180px) {
   .hud {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
-  .hud > div:nth-child(3) {
+  .hud > div:nth-child(4) {
     border-right: 0;
   }
 
-  .hud > div:nth-child(-n + 3) {
+  .hud > div:nth-child(-n + 4) {
     border-bottom: 1px solid var(--fg-line);
   }
 
@@ -1435,6 +1624,10 @@
 
   .cards {
     grid-template-columns: repeat(7, minmax(8.5rem, 1fr));
+  }
+
+  .enemyPlan {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1510,6 +1703,10 @@
 
   .resultGrid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .enemyPlan ul {
+    grid-template-columns: repeat(2, minmax(8rem, 1fr));
   }
 }
 
@@ -1638,15 +1835,21 @@
   }
 
   .addBar,
-  .lockBar {
+  .lockBar,
+  .pivotBar {
     align-items: stretch;
     flex-direction: column;
   }
 
   .addBar button,
   .lockBar button,
+  .pivotBar button,
   .primaryButton {
     width: 100%;
+  }
+
+  .enemyPlan ul {
+    grid-template-columns: 1fr;
   }
 
   .lanes strong {

--- a/src/components/FracturedGatePrototype.tsx
+++ b/src/components/FracturedGatePrototype.tsx
@@ -8,26 +8,28 @@ import {
 } from "react";
 import {
   BOARD_FOCUSES,
+  BOARD_TILES,
   BUILDS,
   CARDS,
   CORE_RULES,
   advanceResolution,
   availableCommand,
+  availableEnemyCommand,
   changeFracturedGateBuild,
   createFracturedGateState,
   discardToRetain,
   displaySnapshot,
+  getAvailableContextCards,
   getCompatibleCards,
   getContextActionGroups,
   getPositionCoordinates,
-  lockPlan,
+  passPriority,
   paidActionCount,
+  pivotOpenAction,
   previewAction,
   projectPlan,
   queueAction,
   refocusCards,
-  removePlanAction,
-  reorderPlanAction,
   resetFracturedGate,
   settleRound,
   type FracturedGateChoice,
@@ -43,18 +45,19 @@ type PositionedStyle = CSSProperties & {
 
 const CORE_FOCUS_ORDER = [
   "west-exit",
-  "entry",
-  "lower-cover",
-  "lower-yard",
-  "assault",
-  "impact-rush",
   "cracked-divider",
-  "upper-walk",
-  "field-cache",
-  "service-gap",
   "gate-actuator",
-  "gate-platform",
+  "defensive-bollard",
+  "service-gap",
+  "upper-crossing",
+  "lift-relay",
+  "field-cache",
   "gate",
+  "breacher",
+  "guard",
+  "controller",
+  "pressure",
+  "breacher-intent",
 ];
 
 const LANE_NAMES = ["Fast", "Standard", "Slow"];
@@ -79,22 +82,28 @@ function focusStatus(
   focusId: string,
   snapshot: FracturedGateRecord,
 ) {
+  if (BOARD_TILES[focusId]) {
+    const tile = BOARD_TILES[focusId];
+    return `${titleCase(tile.terrain)} · ${tile.x},${tile.y}`;
+  }
+  if (snapshot.enemies?.[focusId]) {
+    const enemy = snapshot.enemies[focusId];
+    return `${titleCase(enemy.status)} · ${enemy.condition} Condition · ${enemy.guard} Guard`;
+  }
   switch (focusId) {
     case "player":
       return `${snapshot.condition} Condition · ${snapshot.guard} Guard`;
-    case "assault":
-      return `${titleCase(snapshot.enemy.status)} · ${snapshot.enemy.condition} Condition`;
-    case "impact-rush":
-      return snapshot.flags.rushBlocked
-        ? "Confirmed · projected blocked"
-        : "Confirmed · Gate −1 Stability";
+    case "breacher-intent":
+      return "Primary pressure · Gate impact if unopposed";
     case "cracked-divider":
     case "breach":
-      return titleCase(snapshot.divider.status);
+      return `${titleCase(snapshot.divider.status)} · conduit ${titleCase(snapshot.divider.conduit)}`;
     case "gate-actuator":
       return snapshot.actuator.controlled
         ? `${titleCase(snapshot.actuator.mode)} Control active`
         : "Idle · local access";
+    case "defensive-bollard":
+      return titleCase(snapshot.bollard.status);
     case "gate":
       return `${snapshot.gate.stability}/3 Stability · ${titleCase(snapshot.gate.status)}`;
     case "field-cache":
@@ -110,7 +119,7 @@ function focusStatus(
     case "service-lift":
       return snapshot.lift.deployed ? "Deployed until Settle" : "Projected";
     case "regulator":
-      return titleCase(snapshot.enemy.regulator);
+      return snapshot.flags.regulatorExposed ? "Exposed" : "Shielded";
     default:
       return BOARD_FOCUSES[focusId]?.kind ?? "";
   }
@@ -123,7 +132,7 @@ function phaseLabel(game: FracturedGateState) {
   }
   if (game.phase === "settle") return "Settle";
   if (game.phase === "result") return "Results";
-  return "Planning";
+  return game.priority === "player" ? "Planning · your priority" : "Planning · enemy priority";
 }
 
 function GatePips({
@@ -154,12 +163,14 @@ function GatePips({
 function BattleBoard({
   game,
   selectedFocus,
+  confirmedTarget,
   targetingChoice,
   projection,
   onFocus,
 }: {
   game: FracturedGateState;
   selectedFocus: string;
+  confirmedTarget: string | null;
   targetingChoice: FracturedGateChoice | null;
   projection: FracturedGateRecord | null;
   onFocus: (focusId: string) => void;
@@ -193,8 +204,8 @@ function BattleBoard({
     visible.add("service-lift");
   }
   if (
-    projectedSnapshot.enemy.regulator === "exposed" ||
-    snapshot.enemy.regulator === "exposed"
+    projectedSnapshot.flags.regulatorExposed ||
+    snapshot.flags.regulatorExposed
   ) {
     visible.add("regulator");
   }
@@ -312,9 +323,9 @@ function BattleBoard({
           strokeDasharray="20 13"
           markerEnd="url(#intent-arrow)"
           opacity={
-            snapshot.enemy.status === "active" ||
-            snapshot.enemy.status === "staggered" ||
-            snapshot.enemy.status === "pinned"
+            ["active", "staggered", "off-balance", "pinned"].includes(
+              snapshot.enemies.breacher.status,
+            )
               ? 0.9
               : 0.22
           }
@@ -348,12 +359,14 @@ function BattleBoard({
             className={styles.projectionPath}
           />
         ) : null}
-        {projection?.collision ? (
+        {projection?.contact ? (
           <g
             transform={
-              projection.collision === "cracked-divider"
+              projection.contact.location === "Cracked Divider"
                 ? "translate(590 395)"
-                : "translate(510 345)"
+                : projection.contact.location === "Defensive Bollard"
+                  ? "translate(720 390)"
+                  : "translate(820 330)"
             }
             className={styles.collisionMark}
           >
@@ -374,6 +387,44 @@ function BattleBoard({
           GATE PLATFORM
         </text>
       </svg>
+
+      <div className={styles.tileLayer} aria-label="Direct tactical tile selection">
+        {Object.values(BOARD_TILES).map((tile: FracturedGateRecord) => {
+          const target = legalTargets.has(tile.id);
+          const confirmed = confirmedTarget === tile.id;
+          const selected = selectedFocus === tile.id;
+          return (
+            <button
+              type="button"
+              key={tile.id}
+              className={`${styles.boardTile} ${
+                target ? styles.legalTile : ""
+              } ${selected ? styles.selectedTile : ""}`}
+              style={
+                {
+                  "--x": `${tile.boardX}%`,
+                  "--y": `${tile.boardY}%`,
+                } as PositionedStyle
+              }
+              onClick={() => onFocus(tile.id)}
+              aria-label={`${tile.name}. ${
+                confirmed
+                  ? "Confirmed target."
+                  : target
+                    ? "Legal target."
+                    : "Inspect or select."
+              }`}
+              data-tile-id={tile.id}
+            >
+              {target ? (
+                <span>{confirmed ? "CONFIRMED" : "TARGET"}</span>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+            </button>
+          );
+        })}
+      </div>
 
       <button
         type="button"
@@ -418,9 +469,16 @@ function BattleBoard({
         const focus = BOARD_FOCUSES[focusId];
         const selected = selectedFocus === focusId;
         const target = legalTargets.has(focusId);
+        const confirmed = confirmedTarget === focusId;
+        const actor = focus.actorId
+          ? projectedSnapshot.enemies?.[focus.actorId]
+          : null;
+        const actorPoint = actor
+          ? getPositionCoordinates(actor.position)
+          : null;
         const enemyInactive =
-          focusId === "assault" &&
-          !["active", "staggered", "pinned"].includes(snapshot.enemy.status);
+          Boolean(actor) &&
+          !["active", "staggered", "off-balance", "pinned"].includes(actor.status);
         const classNames = [
           styles.boardFocus,
           styles[`focus_${focus.kind}`],
@@ -442,8 +500,8 @@ function BattleBoard({
             className={classNames}
             style={
               {
-                "--x": `${focus.x}%`,
-                "--y": `${focus.y}%`,
+                "--x": `${actorPoint?.x ?? focus.x}%`,
+                "--y": `${actorPoint?.y ?? focus.y}%`,
               } as PositionedStyle
             }
             onClick={() => onFocus(focusId)}
@@ -451,7 +509,11 @@ function BattleBoard({
             aria-label={`${focus.name}. ${focusStatus(focusId, projectedSnapshot)}`}
             data-focus-id={focusId}
           >
-            {target ? <span className={styles.targetCue}>TARGET</span> : null}
+            {target ? (
+              <span className={styles.targetCue}>
+                {confirmed ? "CONFIRMED" : "TARGET"}
+              </span>
+            ) : null}
             <strong>{focus.name}</strong>
             <small>{focusStatus(focusId, projectedSnapshot)}</small>
           </button>
@@ -459,8 +521,8 @@ function BattleBoard({
       })}
 
       <div className={styles.intentLegend} aria-hidden="true">
-        <span>CONFIRMED</span>
-        Impact Rush → Gate
+        <span>PRIMARY PRESSURE</span>
+        Breacher → Gate · Guard protecting · Controller and Pressure adaptive
       </div>
 
       {game.phase === "resolution" ? (
@@ -495,7 +557,16 @@ function ContextPanel({
   onCancelTarget: () => void;
 }) {
   const groups = getContextActionGroups(game, focusId);
-  const focus = BOARD_FOCUSES[focusId] ?? BOARD_FOCUSES.player;
+  const focus =
+    BOARD_FOCUSES[focusId] ??
+    (BOARD_TILES[focusId]
+      ? {
+          ...BOARD_TILES[focusId],
+          kind: "tile",
+          description:
+            "A real tactical tile. Movement cost, occupancy, terrain, and contact are resolved on the hidden 13 × 9 scale.",
+        }
+      : BOARD_FOCUSES.player);
   const activeGroup =
     groups.find((group: FracturedGateRecord) => group.parent === selectedParent) ??
     null;
@@ -591,6 +662,7 @@ function PreviewPanel({
   attachedCard,
   preview,
   planProjection,
+  pivotMode,
   onAdd,
 }: {
   game: FracturedGateState;
@@ -599,6 +671,7 @@ function PreviewPanel({
   attachedCard: string | null;
   preview: FracturedGateRecord | null;
   planProjection: FracturedGateRecord | null;
+  pivotMode: boolean;
   onAdd: () => void;
 }) {
   const shown = preview?.legal ? preview.projection : planProjection;
@@ -637,6 +710,37 @@ function PreviewPanel({
             <strong>Important risk</strong>
             <p>{shown.risk}</p>
           </div>
+          {shown.contact ? (
+            <div className={styles.contactForecast}>
+              <strong>Contact risk · {shown.contact.risk}</strong>
+              <span>{shown.contact.timing}</span>
+              <span>Location · {shown.contact.location}</span>
+              <span>
+                Unknown · {shown.contact.unknown} concealed factor
+                {shown.contact.unknown === 1 ? "" : "s"}
+              </span>
+              <p>{shown.contact.reason}</p>
+              <details>
+                <summary>Tempo details</summary>
+                {shown.contact.details}
+              </details>
+            </div>
+          ) : null}
+          {shown.attribution ? (
+            <div className={styles.skillAttribution}>
+              <strong>
+                {shown.attribution.action} · {shown.attribution.build}
+              </strong>
+              <span>Revealed by · {shown.attribution.revealed}</span>
+              <span>Enabled by · {shown.attribution.enabled}</span>
+              {shown.attribution.modified ? (
+                <span>Modified by · {shown.attribution.modified}</span>
+              ) : null}
+              {shown.attribution.opposed ? (
+                <span>Opposed by · {shown.attribution.opposed}</span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ) : (
         <p className={styles.emptyPreview}>
@@ -653,7 +757,7 @@ function PreviewPanel({
             {attachedCard ? ` · ${cardName(attachedCard)}` : ""}
           </span>
           <button type="button" data-testid="add-to-plan" onClick={onAdd}>
-            ADD TO PLAN
+            {pivotMode ? "LOCK PIVOT" : "ADD TO PLAN"}
           </button>
         </div>
       ) : null}
@@ -667,24 +771,31 @@ function PreviewPanel({
 function PlanChain({
   game,
   projection,
-  onRemove,
-  onReorder,
-  onLock,
+  pivotMode,
+  onBeginPivot,
+  onCancelPivot,
+  onPass,
 }: {
   game: FracturedGateState;
   projection: FracturedGateRecord | null;
-  onRemove: (instanceId: string) => void;
-  onReorder: (instanceId: string, direction: number) => void;
-  onLock: () => void;
+  pivotMode: boolean;
+  onBeginPivot: () => void;
+  onCancelPivot: () => void;
+  onPass: () => void;
 }) {
   const count = paidActionCount(game);
   const density =
     count <= 2 ? "Normal" : count === 3 ? "Pressured" : "Exceptional";
+  const openAction = game.plan.find(
+    (action: FracturedGateRecord) => action.status === "open",
+  );
   return (
     <section className={styles.planPanel} aria-label="Current plan">
       <div className={styles.planTopline}>
         <div>
-          <p className={styles.eyebrow}>Readable plan chain</p>
+          <p className={styles.eyebrow}>
+            Opposed planning · {game.priority === "player" ? "your priority" : "enemy priority"}
+          </p>
           <h2>
             PLAN · {count}/{CORE_RULES.paidActionCap} PAID
           </h2>
@@ -705,39 +816,27 @@ function PlanChain({
 
       {game.plan.length ? (
         <ol className={styles.planChain}>
-          {game.plan.map((action: FracturedGateRecord, index: number) => (
+          {game.plan.map((action: FracturedGateRecord) => (
             <li key={action.instanceId}>
               <span className={styles.planTiming}>{action.lane}</span>
               <strong>{action.label}</strong>
               <small>
                 {action.targetName} · {action.totalCost} Command
-                {action.cardName ? ` · ${action.cardName}` : ""}
+                {action.cardName
+                  ? ` · ${action.concealed ? "concealed modifier" : action.cardName}`
+                  : ""}
               </small>
-              <div className={styles.planEdit}>
-                <button
-                  type="button"
-                  disabled={index === 0}
-                  onClick={() => onReorder(action.instanceId, -1)}
-                  aria-label={`Move ${action.label} earlier`}
-                >
-                  ↑
-                </button>
-                <button
-                  type="button"
-                  disabled={index === game.plan.length - 1}
-                  onClick={() => onReorder(action.instanceId, 1)}
-                  aria-label={`Move ${action.label} later`}
-                >
-                  ↓
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onRemove(action.instanceId)}
-                  aria-label={`Remove ${action.label}`}
-                >
-                  ×
-                </button>
-              </div>
+              <span
+                className={
+                  action.status === "open"
+                    ? styles.openCommitment
+                    : styles.solidCommitment
+                }
+              >
+                {action.status === "open"
+                  ? "NEWEST · MAY CHANGE ONCE"
+                  : "SOLID COMMITMENT"}
+              </span>
             </li>
           ))}
         </ol>
@@ -747,19 +846,64 @@ function PlanChain({
         </p>
       )}
 
+      <div className={styles.enemyPlan}>
+        <div>
+          <span>ENEMY SQUAD PLAN</span>
+          <strong>
+            {game.enemyPlan.length} commitment
+            {game.enemyPlan.length === 1 ? "" : "s"} ·{" "}
+            {availableEnemyCommand(game)} Command saved
+          </strong>
+        </div>
+        <ul>
+          {game.enemyPlan.map((action: FracturedGateRecord) => (
+            <li key={action.instanceId}>
+              <strong>{action.actorName}</strong>
+              <span>{action.posture ?? action.label}</span>
+              <small>
+                {action.totalCost} Command
+                {action.concealed || action.modifierCardId
+                  ? " · concealed factor"
+                  : ""}
+              </small>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className={styles.pivotBar}>
+        <span>
+          Pivot · {game.playerPivotUsed ? "SPENT" : "AVAILABLE"} · newest action
+          only
+        </span>
+        {pivotMode ? (
+          <button type="button" onClick={onCancelPivot}>
+            CANCEL PIVOT
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onBeginPivot}
+            disabled={!openAction || game.playerPivotUsed}
+          >
+            CHANGE NEWEST
+          </button>
+        )}
+      </div>
+
       <div className={styles.lockBar}>
         <span>
           {projection
-            ? `Preview #${projection.signature}`
-            : "Preview updates before Lock"}
+            ? `Preview #${projection.signature} · ${game.consecutivePasses}/2 passes`
+            : "Two consecutive passes Lock both plans"}
         </span>
         <button
           type="button"
           data-testid="lock-plan"
-          onClick={onLock}
+          onClick={onPass}
           disabled={!game.plan.length && !game.refocusRecord}
         >
-          LOCK PLAN
+          PASS / LOCK
         </button>
       </div>
     </section>
@@ -769,6 +913,7 @@ function PlanChain({
 function Hand({
   game,
   compatibleCards,
+  contextCards,
   attachedCard,
   refocusMode,
   refocusSelection,
@@ -780,6 +925,7 @@ function Hand({
 }: {
   game: FracturedGateState;
   compatibleCards: Set<string>;
+  contextCards: string[];
   attachedCard: string | null;
   refocusMode: boolean;
   refocusSelection: string[];
@@ -793,6 +939,7 @@ function Hand({
     game.plan.map((action: FracturedGateRecord) => action.cardId).filter(Boolean),
   );
   const overRetain = game.hand.length > CORE_RULES.retainLimit;
+  const displayedCards = [...game.hand, ...contextCards];
   return (
     <section className={styles.handPanel} aria-label="Prepared card hand">
       <div className={styles.handHeading}>
@@ -838,12 +985,13 @@ function Hand({
       </div>
 
       <div className={styles.cards}>
-        {game.hand.map((cardId: string) => {
+        {displayedCards.map((cardId: string) => {
           const card = CARDS[cardId];
           const compatible = compatibleCards.has(cardId);
           const planned = plannedCards.has(cardId);
           const selected = attachedCard === cardId;
           const refocusSelected = refocusSelection.includes(cardId);
+          const context = contextCards.includes(cardId);
           const classes = [
             styles.card,
             compatible ? styles.compatibleCard : "",
@@ -860,7 +1008,9 @@ function Hand({
               key={cardId}
               data-card-id={cardId}
               className={classes}
-              onClick={() => (overRetain ? onDiscard(cardId) : onCard(cardId))}
+              onClick={() =>
+                overRetain && !context ? onDiscard(cardId) : onCard(cardId)
+              }
               disabled={planned && !overRetain}
               aria-pressed={selected || refocusSelected}
             >
@@ -870,6 +1020,11 @@ function Hand({
               </span>
               <span className={styles.cardKind}>{card.kind}</span>
               <p>{card.text}</p>
+              {context ? (
+                <span className={styles.contextCue}>
+                  SOURCE-BOUND · EXPIRES WITH CHAIN
+                </span>
+              ) : null}
               {compatible && !refocusMode ? (
                 <span className={styles.compatibleCue}>COMPATIBLE</span>
               ) : null}
@@ -1000,8 +1155,8 @@ function SettlePanel({
           <dd>{summary.playerPosition}</dd>
         </div>
         <div>
-          <dt>Assault</dt>
-          <dd>{titleCase(summary.enemyStatus)}</dd>
+          <dt>Enemy formation</dt>
+          <dd>{summary.enemyStates.join(" · ")}</dd>
         </div>
         <div>
           <dt>Divider</dt>
@@ -1014,6 +1169,14 @@ function SettlePanel({
         <div>
           <dt>Command carried</dt>
           <dd>{summary.commandCarried}</dd>
+        </div>
+        <div>
+          <dt>Squad Command carried</dt>
+          <dd>{summary.enemyCommandCarried}</dd>
+        </div>
+        <div>
+          <dt>West Exit</dt>
+          <dd>{titleCase(summary.exitStatus)}</dd>
         </div>
         <div>
           <dt>Refund at Settle</dt>
@@ -1051,8 +1214,8 @@ function ResultsPanel({
           <strong>{result.objective}</strong>
         </div>
         <div>
-          <span>Enemy state</span>
-          <strong>{result.enemy}</strong>
+          <span>Enemy formation</span>
+          <strong>{result.enemies.join(" · ")}</strong>
         </div>
         <div>
           <span>Player state</span>
@@ -1073,6 +1236,10 @@ function ResultsPanel({
         <div className={styles.wideResult}>
           <span>Meaningful tradeoff</span>
           <strong>{result.tradeoff}</strong>
+        </div>
+        <div className={styles.wideResult}>
+          <span>Why this title</span>
+          <strong>{result.reason}</strong>
         </div>
       </div>
       <ReviewLog game={game} />
@@ -1098,6 +1265,7 @@ export function FracturedGatePrototype() {
   const [attachedCard, setAttachedCard] = useState<string | null>(null);
   const [refocusMode, setRefocusMode] = useState(false);
   const [refocusSelection, setRefocusSelection] = useState<string[]>([]);
+  const [pivotMode, setPivotMode] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
@@ -1128,9 +1296,15 @@ export function FracturedGatePrototype() {
   const preview = useMemo(
     () =>
       targetingChoice && targetId
-        ? previewAction(game, targetingChoice.id, targetId, attachedCard)
+        ? previewAction(
+            game,
+            targetingChoice.id,
+            targetId,
+            attachedCard,
+            pivotMode,
+          )
         : null,
-    [game, targetingChoice, targetId, attachedCard],
+    [game, targetingChoice, targetId, attachedCard, pivotMode],
   );
   const activeProjection =
     preview?.legal ? preview.projection : planProjection;
@@ -1141,6 +1315,13 @@ export function FracturedGatePrototype() {
           ? getCompatibleCards(game, targetingChoice.id)
           : [],
       ),
+    [game, targetingChoice],
+  );
+  const contextCards = useMemo(
+    () =>
+      targetingChoice
+        ? getAvailableContextCards(game, targetingChoice.id)
+        : [],
     [game, targetingChoice],
   );
   const build = buildFor(game.buildId);
@@ -1157,6 +1338,7 @@ export function FracturedGatePrototype() {
     clearDraft();
     setRefocusMode(false);
     setRefocusSelection([]);
+    setPivotMode(false);
   }
 
   function handleFocus(focusId: string) {
@@ -1186,16 +1368,24 @@ export function FracturedGatePrototype() {
 
   function addDraft() {
     if (!targetingChoice || !targetId || !preview?.legal) return;
-    const next = queueAction(
-      game,
-      targetingChoice.id,
-      targetId,
-      attachedCard,
-    );
+    const next = pivotMode
+      ? pivotOpenAction(
+          game,
+          targetingChoice.id,
+          targetId,
+          attachedCard,
+        )
+      : queueAction(
+          game,
+          targetingChoice.id,
+          targetId,
+          attachedCard,
+        );
     setGame(next);
-    if (next.plan.length > game.plan.length) {
+    if (next !== game && !next.warning) {
       clearDraft();
       setSelectedParent(null);
+      setPivotMode(false);
     }
   }
 
@@ -1248,7 +1438,8 @@ export function FracturedGatePrototype() {
           </p>
           <h1>THE FRACTURED GATE</h1>
           <p>
-            Select → choose → target → preview → plan → lock → watch → settle
+            Select → choose → target → preview → plan → contest → lock → reveal
+            → watch → settle
           </p>
         </div>
         <div className={styles.boundaryBadges} aria-label="Prototype boundary">
@@ -1310,9 +1501,15 @@ export function FracturedGatePrototype() {
           </strong>
         </div>
         <div>
-          <span>Command</span>
+          <span>Player Command</span>
           <strong>
             {availableCommand(game)} / {CORE_RULES.commandCap}
+          </strong>
+        </div>
+        <div>
+          <span>Enemy Squad Command</span>
+          <strong>
+            {availableEnemyCommand(game)} / {CORE_RULES.commandCap}
           </strong>
         </div>
         <div>
@@ -1334,6 +1531,12 @@ export function FracturedGatePrototype() {
             status={display.gate.status}
           />
         </div>
+        <div>
+          <span>Primary pressure</span>
+          <strong>
+            {game.enemyPlan[0]?.posture ?? "Formation is reading the board"}
+          </strong>
+        </div>
       </section>
 
       {game.warning ? (
@@ -1346,6 +1549,7 @@ export function FracturedGatePrototype() {
         <BattleBoard
           game={game}
           selectedFocus={selectedFocus}
+          confirmedTarget={targetId}
           targetingChoice={targetingChoice}
           projection={activeProjection}
           onFocus={handleFocus}
@@ -1370,27 +1574,32 @@ export function FracturedGatePrototype() {
             attachedCard={attachedCard}
             preview={preview}
             planProjection={planProjection}
+            pivotMode={pivotMode}
             onAdd={addDraft}
           />
           <PlanChain
             game={game}
             projection={planProjection}
-            onRemove={(instanceId) =>
-              setGame((current) => removePlanAction(current, instanceId))
-            }
-            onReorder={(instanceId, direction) =>
-              setGame((current) =>
-                reorderPlanAction(current, instanceId, direction),
-              )
-            }
-            onLock={() => {
+            pivotMode={pivotMode}
+            onBeginPivot={() => {
               clearDraft();
-              setGame((current) => lockPlan(current));
+              setSelectedParent(null);
+              setPivotMode(true);
+            }}
+            onCancelPivot={() => {
+              clearDraft();
+              setPivotMode(false);
+            }}
+            onPass={() => {
+              clearDraft();
+              setPivotMode(false);
+              setGame((current) => passPriority(current));
             }}
           />
           <Hand
             game={game}
             compatibleCards={compatibleCards}
+            contextCards={contextCards}
             attachedCard={attachedCard}
             refocusMode={refocusMode}
             refocusSelection={refocusSelection}

--- a/src/lib/barcode-world/fractured-gate-engine.d.mts
+++ b/src/lib/barcode-world/fractured-gate-engine.d.mts
@@ -7,11 +7,12 @@ export type FracturedGateChoice = FracturedGateRecord;
 export const FRACTURED_GATE_SOURCE: string;
 export const RESULT_TYPES: string[];
 export const BOARD_FOCUSES: Record<string, any>;
+export const BOARD_TILES: Record<string, any>;
 export const FRACTURED_GATE_ACTIONS: Record<string, any>;
 export const BUILDS: any[];
 export const CARDS: Record<string, any>;
+export const ENEMY_CARDS: Record<string, any>;
 export const CORE_RULES: Record<string, any>;
-export const POSITION_NAMES: Record<string, string>;
 
 export function createFracturedGateState(
   buildId?: string,
@@ -24,6 +25,7 @@ export function changeFracturedGateBuild(
   buildId: string,
 ): FracturedGateState;
 export function availableCommand(state: FracturedGateState): number;
+export function availableEnemyCommand(state: FracturedGateState): number;
 export function paidActionCount(state: FracturedGateState): number;
 export function getContextActionGroups(
   state: FracturedGateState,
@@ -33,13 +35,24 @@ export function getCompatibleCards(
   state: FracturedGateState,
   actionId: string,
 ): string[];
+export function getAvailableContextCards(
+  state: FracturedGateState,
+  actionId?: string | null,
+): string[];
 export function previewAction(
   state: FracturedGateState,
   actionId: string,
   targetId: string,
   cardId?: string | null,
+  replacing?: boolean,
 ): FracturedGateRecord;
 export function queueAction(
+  state: FracturedGateState,
+  actionId: string,
+  targetId: string,
+  cardId?: string | null,
+): FracturedGateState;
+export function pivotOpenAction(
   state: FracturedGateState,
   actionId: string,
   targetId: string,
@@ -65,6 +78,9 @@ export function discardToRetain(
 export function projectPlan(
   state: FracturedGateState,
 ): FracturedGateRecord;
+export function passPriority(
+  state: FracturedGateState,
+): FracturedGateState;
 export function lockPlan(
   state: FracturedGateState,
 ): FracturedGateState;
@@ -83,3 +99,7 @@ export function getPositionCoordinates(
 export function getActionDefinition(
   actionId: string,
 ): FracturedGateRecord | null;
+export function tempoComparisonForRoute(
+  route: string,
+  poweredFeed?: string,
+): FracturedGateRecord;

--- a/src/lib/barcode-world/fractured-gate-engine.mjs
+++ b/src/lib/barcode-world/fractured-gate-engine.mjs
@@ -1,11 +1,11 @@
 import {
   BUILDS,
-  CARDS,
+  CARDS as PREPARED_CARDS,
   CORE_RULES,
 } from "./constants.mjs";
 
 export const FRACTURED_GATE_SOURCE =
-  "BARCODE_WORLD_BATTLE_MODE_FRACTURED_GATE_PREIMPLEMENTATION_CHECKPOINT_2026-07-26";
+  "BARCODE_WORLD_BATTLE_MODE_FRACTURED_GATE_REVISED_ENCOUNTER_CHECKPOINT_2026-07-27";
 
 export const RESULT_TYPES = Object.freeze([
   "Fast Secure",
@@ -15,382 +15,708 @@ export const RESULT_TYPES = Object.freeze([
   "Controlled Retreat",
 ]);
 
-export const BOARD_FOCUSES = Object.freeze({
-  "west-exit": {
-    id: "west-exit",
-    name: "West Exit",
-    kind: "exit",
-    x: 6,
-    y: 62,
-    description:
-      "The physical retreat route. Leaving records a Controlled Retreat and abandons unresolved priorities.",
-  },
-  entry: {
-    id: "entry",
-    name: "Entry",
-    kind: "position",
-    x: 18,
-    y: 78,
-    description:
-      "Your insertion point. It connects to the Lower Yard, Upper Walk stairs, Actuator trench, and West Exit.",
-  },
-  player: {
-    id: "player",
-    name: "Player",
-    kind: "player",
-    x: 18,
-    y: 65,
-    description:
-      "Your one directly controlled character. Solo play has no hidden helper or missing-role penalty.",
-  },
-  "lower-cover": {
-    id: "lower-cover",
-    name: "Lower Yard Cover",
-    kind: "terrain",
-    positionId: "lower-cover",
-    x: 28,
-    y: 79,
-    description:
-      "Low fractured plating beside the Assault line. It is one ordinary step from Entry.",
-  },
-  "lower-yard": {
-    id: "lower-yard",
-    name: "Lower Yard",
-    kind: "terrain",
-    positionId: "lower-yard",
-    x: 41,
-    y: 68,
-    description:
-      "The universal confrontation space and the longer ordinary approach to Gate Platform.",
-  },
-  assault: {
-    id: "assault",
-    name: "Assault",
-    kind: "enemy",
-    x: 48,
-    y: 53,
-    description:
-      "A single hostile unit committed to an Impact Rush against the unstable Gate.",
-  },
-  "impact-rush": {
-    id: "impact-rush",
-    name: "Impact Rush",
-    kind: "intent",
-    x: 62,
-    y: 50,
-    description:
-      "Confirmed · Standard. If it is not stopped, the Gate loses one Stability pip.",
-  },
-  "cracked-divider": {
-    id: "cracked-divider",
-    name: "Cracked Divider",
-    kind: "terrain",
-    x: 58,
-    y: 69,
-    description:
-      "A visibly damaged barrier. A Battle answer can turn the Assault's own Force into an Opening.",
-  },
-  "upper-walk": {
-    id: "upper-walk",
-    name: "Upper Walk",
-    kind: "terrain",
-    positionId: "upper-walk",
-    x: 38,
-    y: 17,
-    description:
-      "An elevated optional approach. Its missing eastern span must be prepared, preserved, or replaced.",
-  },
-  "field-cache": {
-    id: "field-cache",
-    name: "Field Cache",
-    kind: "cache",
-    x: 58,
-    y: 19,
-    description:
-      "Optional prototype recovery. Taking it delays the primary objective and creates a different result.",
-  },
-  "service-gap": {
-    id: "service-gap",
-    name: "Service Gap",
-    kind: "terrain",
-    x: 60,
-    y: 36,
-    description:
-      "A narrow relationship beneath the Upper Walk. It can become a Route if its closure mechanism is handled.",
-  },
-  "gate-actuator": {
-    id: "gate-actuator",
-    name: "Gate Actuator",
-    kind: "machinery",
-    positionId: "actuator",
-    x: 68,
-    y: 87,
-    description:
-      "Local machinery with bounded authored Outputs: a defensive bollard or a service lift.",
-  },
-  "gate-platform": {
-    id: "gate-platform",
-    name: "Gate Platform",
-    kind: "position",
-    positionId: "gate-platform",
-    x: 82,
-    y: 64,
-    description:
-      "The objective space. Begin a planning cycle here to complete Stabilize Gate.",
-  },
-  gate: {
-    id: "gate",
-    name: "Fractured Gate",
-    kind: "objective",
-    x: 92,
-    y: 47,
-    description:
-      "The primary objective. Three Stability pips track how many unopposed Impact Rushes it can survive.",
-  },
-  breach: {
-    id: "breach",
-    name: "Projected Breach",
-    kind: "opening",
-    x: 67,
-    y: 59,
-    description:
-      "A causal Opening created by driving the Assault into the Cracked Divider.",
-  },
-  "upper-route": {
-    id: "upper-route",
-    name: "Prepared Upper Route",
-    kind: "opening",
-    x: 68,
-    y: 30,
-    description:
-      "A prepared relationship from the Upper Walk to Gate Platform.",
-  },
-  "service-route": {
-    id: "service-route",
-    name: "Prepared Service Route",
-    kind: "opening",
-    x: 70,
-    y: 40,
-    description:
-      "A protected rear approach created from the service gap.",
-  },
-  "service-lift": {
-    id: "service-lift",
-    name: "Service Lift",
-    kind: "opening",
-    x: 70,
-    y: 27,
-    description:
-      "Temporary machine-created geometry. It resets after Settle and may isolate the player.",
-  },
-  regulator: {
-    id: "regulator",
-    name: "Impact Regulator",
-    kind: "component",
-    x: 52,
-    y: 50,
-    description:
-      "Protected hardware exposed only after a physical answer to the Assault's Rush.",
+const CONTEXT_CARDS = Object.freeze({
+  "follow-through": {
+    id: "follow-through",
+    name: "Follow Through",
+    kind: "Context Extension",
+    cost: 1,
+    compatibility: ["answer-commitment"],
+    text:
+      "Attach after an uninterrupted approach. The linked contact gains +1 Tempo once, then this source-bound card expires.",
+    context: true,
   },
 });
 
-const POSITION_COORDS = Object.freeze({
-  "west-exit": { x: 6, y: 62 },
-  entry: { x: 18, y: 65 },
-  "lower-cover": { x: 33, y: 70 },
-  "lower-yard": { x: 45, y: 61 },
-  "upper-walk": { x: 45, y: 24 },
-  actuator: { x: 63, y: 79 },
-  "gate-platform": { x: 79, y: 53 },
+export const CARDS = Object.freeze({
+  ...PREPARED_CARDS,
+  ...CONTEXT_CARDS,
 });
 
-const POSITION_NAMES = Object.freeze({
-  "west-exit": "West Exit",
-  entry: "Entry",
-  "lower-cover": "Lower Yard Cover",
-  "lower-yard": "Lower Yard",
-  "upper-walk": "Upper Walk",
-  actuator: "Gate Actuator",
-  "gate-platform": "Gate Platform",
+export const ENEMY_CARDS = Object.freeze({
+  "set-guard": {
+    id: "set-guard",
+    name: "Set Guard",
+    cost: 4,
+    lane: "Fast",
+    tempo: 7,
+    text: "Establish physical protection.",
+  },
+  "impact-counter": {
+    id: "impact-counter",
+    name: "Impact Counter",
+    cost: 4,
+    lane: "Standard",
+    tempo: 5,
+    text: "Declared contact contingency.",
+  },
+  "driving-ram": {
+    id: "driving-ram",
+    name: "Driving Ram",
+    cost: 8,
+    lane: "Standard",
+    tempo: 6,
+    text: "Advance with Force toward the Gate.",
+  },
+  "slip-angle": {
+    id: "slip-angle",
+    name: "Slip Angle",
+    cost: 4,
+    lane: "Fast",
+    tempo: 8,
+    text: "Evade laterally while conceding a lane.",
+  },
+  "anchor-down": {
+    id: "anchor-down",
+    name: "Anchor Down",
+    cost: 5,
+    lane: "Fast",
+    tempo: 7,
+    text: "Prevent displacement without preventing damage.",
+  },
+  "follow-pressure": {
+    id: "follow-pressure",
+    name: "Follow Pressure",
+    cost: 5,
+    lane: "Standard",
+    tempo: 5,
+    text: "Advance behind an established threat.",
+  },
+  "breaker-coil": {
+    id: "breaker-coil",
+    name: "Breaker Coil",
+    cost: 2,
+    lane: "Standard",
+    tempo: 5,
+    text: "Increase the force of an Impact Rush.",
+  },
+  "seize-breach": { id: "seize-breach", name: "Seize Breach", cost: 6, lane: "Standard", tempo: 5 },
+  "recover-stance": { id: "recover-stance", name: "Recover Stance", cost: 4, lane: "Slow", tempo: 3 },
+  "crushing-return": { id: "crushing-return", name: "Crushing Return", cost: 8, lane: "Slow", tempo: 3 },
+  "last-push": { id: "last-push", name: "Last Push", cost: 8, lane: "Standard", tempo: 5 },
+  "breacher-withdrawal": { id: "breacher-withdrawal", name: "Controlled Withdrawal", cost: 4, lane: "Fast", tempo: 8 },
+
+  "shield-link": {
+    id: "shield-link",
+    name: "Shield Link",
+    cost: 4,
+    lane: "Fast",
+    tempo: 7,
+    text: "Protect an adjacent or linked ally.",
+  },
+  "body-block": {
+    id: "body-block",
+    name: "Body Block",
+    cost: 6,
+    lane: "Standard",
+    tempo: 5,
+    text: "Occupy and deny a contact lane.",
+  },
+  "vault-intercept": {
+    id: "vault-intercept",
+    name: "Vault Intercept",
+    cost: 6,
+    lane: "Fast",
+    tempo: 7,
+    text: "Contest a reachable landing.",
+  },
+  "brace-line": {
+    id: "brace-line",
+    name: "Brace Line",
+    cost: 5,
+    lane: "Standard",
+    tempo: 6,
+    text: "Hold one line against displacement.",
+  },
+  "cover-advance": { id: "cover-advance", name: "Cover Advance", cost: 4, lane: "Standard", tempo: 5 },
+  "anchor-swap": { id: "anchor-swap", name: "Anchor Swap", cost: 5, lane: "Fast", tempo: 7 },
+  "guard-relay": { id: "guard-relay", name: "Guard Relay", cost: 4, lane: "Fast", tempo: 7 },
+  "pushback-screen": { id: "pushback-screen", name: "Pushback Screen", cost: 6, lane: "Standard", tempo: 5 },
+  "hold-platform": { id: "hold-platform", name: "Hold Platform", cost: 6, lane: "Standard", tempo: 5 },
+  "intercept-route": { id: "intercept-route", name: "Intercept Route", cost: 6, lane: "Fast", tempo: 7 },
+  "recover-link": { id: "recover-link", name: "Recover Link", cost: 4, lane: "Slow", tempo: 3 },
+  "guard-withdrawal": { id: "guard-withdrawal", name: "Controlled Withdrawal", cost: 4, lane: "Fast", tempo: 8 },
+
+  "emergency-reset": {
+    id: "emergency-reset",
+    name: "Emergency Reset",
+    cost: 4,
+    lane: "Fast",
+    tempo: 6,
+    text: "Declared response to exposed hardware.",
+  },
+  "purge-control": {
+    id: "purge-control",
+    name: "Purge Control",
+    cost: 6,
+    lane: "Standard",
+    tempo: 5,
+    text: "Contest Control at a connected Dependency.",
+  },
+  "charge-debris": {
+    id: "charge-debris",
+    name: "Charge Debris",
+    cost: 5,
+    lane: "Fast",
+    tempo: 7,
+    text: "Energize the breached Divider conduit.",
+  },
+  "seal-gap": {
+    id: "seal-gap",
+    name: "Seal Gap",
+    cost: 5,
+    lane: "Standard",
+    tempo: 5,
+    text: "Trigger the service shutter.",
+  },
+  "lift-recall": {
+    id: "lift-recall",
+    name: "Lift Recall",
+    cost: 5,
+    lane: "Fast",
+    tempo: 6,
+    text: "Begin a legal service-lift return.",
+  },
+  "static-tax": {
+    id: "static-tax",
+    name: "Static Tax",
+    cost: 4,
+    lane: "Fast",
+    tempo: 6,
+    text: "Delay Gate stabilization.",
+  },
+  "bollard-override": { id: "bollard-override", name: "Bollard Override", cost: 5, lane: "Fast", tempo: 6 },
+  "cut-power": { id: "cut-power", name: "Cut Power", cost: 6, lane: "Standard", tempo: 5 },
+  "reconnect-line": { id: "reconnect-line", name: "Reconnect Line", cost: 5, lane: "Slow", tempo: 3 },
+  "false-read": { id: "false-read", name: "False Read", cost: 4, lane: "Fast", tempo: 7 },
+  "gate-desync": { id: "gate-desync", name: "Gate Desync", cost: 8, lane: "Slow", tempo: 3 },
+  "emergency-shutdown": { id: "emergency-shutdown", name: "Emergency Shutdown", cost: 7, lane: "Slow", tempo: 3 },
+
+  cutoff: {
+    id: "cutoff",
+    name: "Cutoff",
+    cost: 5,
+    lane: "Fast",
+    tempo: 7,
+    text: "Occupy a likely destination or route.",
+  },
+  "needle-volley": { id: "needle-volley", name: "Needle Volley", cost: 6, lane: "Fast", tempo: 7 },
+  "feint-route": { id: "feint-route", name: "Feint Route", cost: 4, lane: "Fast", tempo: 8 },
+  "pressure-vault-intercept": { id: "pressure-vault-intercept", name: "Vault Intercept", cost: 6, lane: "Fast", tempo: 7 },
+  pursuit: { id: "pursuit", name: "Pursuit", cost: 6, lane: "Standard", tempo: 5 },
+  "exit-pressure": {
+    id: "exit-pressure",
+    name: "Exit Pressure",
+    cost: 6,
+    lane: "Fast",
+    tempo: 7,
+    text: "Threaten the physical retreat route.",
+  },
+  "mark-target": { id: "mark-target", name: "Mark Target", cost: 4, lane: "Fast", tempo: 7 },
+  "deny-cache": { id: "deny-cache", name: "Deny Cache", cost: 5, lane: "Fast", tempo: 7 },
+  "harrier-step": { id: "harrier-step", name: "Harrier Step", cost: 4, lane: "Fast", tempo: 8 },
+  "pinning-shot": { id: "pinning-shot", name: "Pinning Shot", cost: 6, lane: "Fast", tempo: 7 },
+  "flank-run": { id: "flank-run", name: "Flank Run", cost: 6, lane: "Standard", tempo: 5 },
+  withdraw: { id: "withdraw", name: "Withdraw", cost: 4, lane: "Fast", tempo: 8 },
 });
 
-const ORDINARY_EDGES = Object.freeze([
-  ["west-exit", "entry"],
-  ["entry", "lower-cover"],
-  ["entry", "upper-walk"],
-  ["entry", "actuator"],
-  ["lower-cover", "lower-yard"],
-  ["lower-yard", "actuator"],
-  ["lower-yard", "gate-platform"],
+const ENEMY_DECKS = Object.freeze({
+  breacher: [
+    "set-guard",
+    "impact-counter",
+    "driving-ram",
+    "slip-angle",
+    "anchor-down",
+    "follow-pressure",
+    "breaker-coil",
+    "seize-breach",
+    "recover-stance",
+    "crushing-return",
+    "last-push",
+    "breacher-withdrawal",
+  ],
+  guard: [
+    "shield-link",
+    "body-block",
+    "vault-intercept",
+    "brace-line",
+    "cover-advance",
+    "anchor-swap",
+    "guard-relay",
+    "pushback-screen",
+    "hold-platform",
+    "intercept-route",
+    "recover-link",
+    "guard-withdrawal",
+  ],
+  controller: [
+    "emergency-reset",
+    "purge-control",
+    "charge-debris",
+    "seal-gap",
+    "lift-recall",
+    "static-tax",
+    "bollard-override",
+    "cut-power",
+    "reconnect-line",
+    "false-read",
+    "gate-desync",
+    "emergency-shutdown",
+  ],
+  pressure: [
+    "cutoff",
+    "needle-volley",
+    "feint-route",
+    "pressure-vault-intercept",
+    "pursuit",
+    "exit-pressure",
+    "mark-target",
+    "deny-cache",
+    "harrier-step",
+    "pinning-shot",
+    "flank-run",
+    "withdraw",
+  ],
+});
+
+const WALKABLE_COORDS = Object.freeze([
+  [4, 2], [5, 2], [6, 2], [7, 2],
+  [9, 2], [10, 2], [11, 2], [12, 2],
+  [4, 3], [5, 3], [6, 3], [7, 3],
+  [9, 3], [10, 3], [11, 3], [12, 3],
+  [3, 4], [4, 4], [9, 4], [10, 4], [11, 4], [12, 4], [13, 4],
+  [3, 5], [4, 5], [5, 5], [6, 5], [7, 5],
+  [9, 5], [10, 5], [11, 5], [12, 5], [13, 5],
+  [1, 6], [2, 6], [3, 6], [4, 6], [5, 6], [6, 6], [7, 6],
+  [9, 6], [10, 6], [11, 6], [12, 6], [13, 6],
+  [3, 7], [4, 7], [5, 7], [6, 7], [7, 7], [8, 7],
+  [9, 7], [10, 7], [11, 7], [12, 7], [13, 7],
+  [3, 8], [4, 8], [5, 8], [6, 8], [7, 8], [8, 8],
 ]);
+
+const coordKey = (x, y) => `${x},${y}`;
+const tileId = (x, y) => `tile-${x}-${y}`;
+const coordFromTile = (id) => {
+  const match = /^tile-(\d+)-(\d+)$/.exec(id ?? "");
+  return match ? [Number(match[1]), Number(match[2])] : null;
+};
+const WALKABLE = new Set(WALKABLE_COORDS.map(([x, y]) => coordKey(x, y)));
+
+const TERRAIN_BY_COORD = new Map();
+for (const [x, y] of [[3, 6], [4, 6], [5, 6]]) {
+  TERRAIN_BY_COORD.set(coordKey(x, y), "clear");
+}
+for (const [x, y] of [[3, 5], [4, 5], [5, 5]]) {
+  TERRAIN_BY_COORD.set(coordKey(x, y), "rubble");
+}
+for (const [x, y] of [[3, 7], [4, 7], [5, 7], [6, 7], [7, 7]]) {
+  TERRAIN_BY_COORD.set(coordKey(x, y), "powered");
+}
+
+function pointToPercent(x, y) {
+  return {
+    x: 4 + ((x - 1) / 12) * 92,
+    y: 7 + ((y - 1) / 8) * 86,
+  };
+}
+
+export const BOARD_TILES = Object.freeze(
+  Object.fromEntries(
+    WALKABLE_COORDS.map(([x, y]) => {
+      const id = tileId(x, y);
+      const point = pointToPercent(x, y);
+      const terrain = TERRAIN_BY_COORD.get(coordKey(x, y)) ?? "ordinary";
+      return [
+        id,
+        {
+          id,
+          x,
+          y,
+          boardX: point.x,
+          boardY: point.y,
+          terrain,
+          name: `${terrain === "ordinary" ? "Tactical" : titleCase(terrain)} tile ${x},${y}`,
+        },
+      ];
+    }),
+  ),
+);
+
+function focusAt(id, name, kind, x, y, description, extra = {}) {
+  const point = pointToPercent(x, y);
+  return {
+    id,
+    name,
+    kind,
+    tileId: tileId(x, y),
+    x: point.x,
+    y: point.y,
+    description,
+    ...extra,
+  };
+}
+
+export const BOARD_FOCUSES = Object.freeze({
+  player: focusAt(
+    "player",
+    "Player",
+    "player",
+    2,
+    6,
+    "Your one directly controlled character. Solo play has no hidden helper.",
+  ),
+  "west-exit": focusAt(
+    "west-exit",
+    "West Exit",
+    "exit",
+    1,
+    6,
+    "The physical retreat route. Leaving records every abandoned priority.",
+  ),
+  "cracked-divider": focusAt(
+    "cracked-divider",
+    "Cracked Divider",
+    "terrain",
+    8,
+    5,
+    "Brittle, load-bearing cover with a powered conduit and an upper lip.",
+  ),
+  "gate-actuator": focusAt(
+    "gate-actuator",
+    "Gate Actuator",
+    "machinery",
+    7,
+    7,
+    "Physical access controls the defensive bollard and powered track.",
+  ),
+  "defensive-bollard": focusAt(
+    "defensive-bollard",
+    "Defensive Bollard",
+    "machinery",
+    9,
+    6,
+    "A retractable force redirector connected to the Gate Actuator.",
+  ),
+  "service-gap": focusAt(
+    "service-gap",
+    "Service Gap",
+    "terrain",
+    6,
+    7,
+    "A narrow obscured relationship with a Controller-linked shutter.",
+  ),
+  "upper-crossing": focusAt(
+    "upper-crossing",
+    "Upper Natural Crossing",
+    "terrain",
+    7,
+    3,
+    "A broken span with natural handholds and a capacity-one landing.",
+  ),
+  "lift-relay": focusAt(
+    "lift-relay",
+    "Lift Relay",
+    "machinery",
+    5,
+    8,
+    "A local powered relay that can align a temporary upper bridge.",
+  ),
+  "field-cache": focusAt(
+    "field-cache",
+    "Field Cache",
+    "cache",
+    6,
+    2,
+    "An optional one-slot Package. It never becomes a persistent reward.",
+  ),
+  gate: focusAt(
+    "gate",
+    "Fractured Gate",
+    "objective",
+    12,
+    5,
+    "The location objective. Stabilize it before three real impacts complete.",
+  ),
+  breacher: focusAt(
+    "breacher",
+    "Breacher",
+    "enemy",
+    6,
+    5,
+    "Physical Gate pressure and forceful contact.",
+    { actorId: "breacher" },
+  ),
+  guard: focusAt(
+    "guard",
+    "Guard",
+    "enemy",
+    9,
+    5,
+    "Protection, interception, and Gate-lane denial.",
+    { actorId: "guard" },
+  ),
+  controller: focusAt(
+    "controller",
+    "Controller",
+    "enemy",
+    10,
+    7,
+    "Machinery, closure, reset, and powered-terrain opposition.",
+    { actorId: "controller" },
+  ),
+  pressure: focusAt(
+    "pressure",
+    "Pressure",
+    "enemy",
+    9,
+    3,
+    "Flank, Cache, route, and retreat pressure.",
+    { actorId: "pressure" },
+  ),
+  "breacher-intent": focusAt(
+    "breacher-intent",
+    "Breacher Intent",
+    "intent",
+    7,
+    5,
+    "Driving toward the Gate. Contact and one concealed response may alter the line.",
+  ),
+  breach: focusAt(
+    "breach",
+    "Divider Breach",
+    "opening",
+    8,
+    5,
+    "Two-way geometry created by breaking the Cracked Divider.",
+  ),
+  "upper-route": focusAt(
+    "upper-route",
+    "Prepared Upper Route",
+    "opening",
+    8,
+    3,
+    "A prepared natural crossing with a contestable east landing.",
+  ),
+  "service-route": focusAt(
+    "service-route",
+    "Prepared Service Route",
+    "opening",
+    8,
+    6,
+    "A narrow rear approach whose real shutter can still close.",
+  ),
+  "service-lift": focusAt(
+    "service-lift",
+    "Service Lift Bridge",
+    "opening",
+    8,
+    2,
+    "Temporary machine-created geometry that returns at Settle.",
+  ),
+  regulator: focusAt(
+    "regulator",
+    "Impact Regulator",
+    "component",
+    6,
+    5,
+    "Hardware exposed by physical contact and protected by an automatic reset.",
+  ),
+});
 
 const LANE_ORDER = Object.freeze(["Fast", "Standard", "Slow"]);
 const LANE_RANK = Object.freeze({ Fast: 0, Standard: 1, Slow: 2 });
-const ACTIVE_ENEMY_STATUSES = new Set(["active", "staggered", "pinned"]);
+const ACTIVE_ENEMY_STATUSES = new Set(["active", "staggered", "off-balance", "pinned"]);
 
 const ACTIONS = Object.freeze({
   reposition: {
     id: "reposition",
     parent: "Move",
     label: "Reposition",
-    description: "Take one free ordinary adjacent step.",
+    description: "Take the one free adjacent ordinary step in this allotment.",
     cost: 0,
     paid: false,
     lane: "Standard",
-    tempo: 9,
+    tempo: 6,
+    range: 1,
     compatibilityKey: "reposition",
   },
   advance: {
     id: "advance",
     parent: "Move",
     label: "Advance",
-    description: "Take one additional ordinary adjacent step.",
+    description: "Move up to three ordinary tiles. Rubble costs two movement.",
     cost: 4,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 5,
+    range: 3,
     compatibilityKey: "additional-movement",
   },
   attack: {
     id: "attack",
     parent: "Attack",
     label: "Weapon Attack",
-    description: "Break 2 Guard, then deliver 6 Impact to the Assault.",
+    description: "Attack one enemy in legal range without silently retargeting.",
     cost: 6,
     paid: true,
     lane: "Standard",
-    tempo: 6,
+    tempo: 5,
     compatibilityKey: "attack",
   },
   guard: {
     id: "guard",
     parent: "Defend",
     label: "Guard",
-    description: "Gain 4 Guard against the next visible pressure.",
+    description: "Establish 4 Guard before later pressure.",
     cost: 6,
     paid: true,
     lane: "Fast",
-    tempo: 5,
+    tempo: 7,
     compatibilityKey: "guard",
   },
-  "guard-impact": {
-    id: "guard-impact",
+  "guard-gate": {
+    id: "guard-gate",
     parent: "Defend",
-    label: "Brace the Rush",
-    description: "Protect the Gate line from this Impact Rush.",
+    label: "Guard Gate",
+    description: "Brace the Gate lane before completing slow objective Work.",
     cost: 6,
     paid: true,
     lane: "Fast",
-    tempo: 6,
+    tempo: 7,
     compatibilityKey: "guard",
   },
   "stabilize-gate": {
     id: "stabilize-gate",
     parent: "Use",
     label: "Stabilize Gate",
-    description: "Complete the objective and activate the defensive seal.",
+    description: "Complete one Slow Gate Work and activate the defensive seal.",
     cost: 6,
     paid: true,
-    lane: "Standard",
-    tempo: 7,
+    lane: "Slow",
+    tempo: 3,
     compatibilityKey: "work-objective",
   },
   "recover-cache": {
     id: "recover-cache",
     parent: "Use",
     label: "Recover Field Cache",
-    description: "Take the prototype Package before leaving the Upper Walk.",
+    description: "Take the optional one-slot prototype Package.",
     cost: 4,
     paid: true,
-    lane: "Slow",
+    lane: "Standard",
     tempo: 5,
     compatibilityKey: "recover-package",
   },
   leave: {
     id: "leave",
     parent: "Leave",
-    label: "Controlled Retreat",
-    description: "Exit safely and record everything left unresolved.",
-    cost: 8,
-    paid: true,
+    label: "Leave",
+    description: "Use the West Exit and record a Controlled Retreat.",
+    cost: 0,
+    paid: false,
     lane: "Standard",
-    tempo: 10,
+    tempo: 6,
     compatibilityKey: "standard-extract",
   },
   "answer-divider": {
     id: "answer-divider",
     parent: "Discipline",
-    label: "Answer Rush at Divider",
-    description:
-      "Meet the hostile Commitment and turn its Force into a physical breach.",
-    cost: CORE_RULES.majorSetupCost,
+    label: "Answer Commitment",
+    description: "Meet the Rush and turn opposed Force into a Divider breach.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 9,
+    tempo: 5,
     compatibilityKey: "answer-commitment",
+    attribution: {
+      revealed: "Battle reads the opposing collision vector.",
+      enabled: "Exploration identifies the safe line created if the Divider breaks.",
+    },
   },
   "cross-breach": {
     id: "cross-breach",
     parent: "Move",
-    label: "Cross Created Opening",
-    description: "Use the confrontation-created breach to reach Gate Platform.",
-    cost: CORE_RULES.minorFoundationCost,
+    label: "Cross Opening",
+    description: "Use the public Divider breach and its safe upper lip.",
+    cost: 6,
     paid: true,
     lane: "Standard",
-    tempo: 4,
+    tempo: 5,
     compatibilityKey: "cross-opening",
+  },
+  "angle-clash": {
+    id: "angle-clash",
+    parent: "Discipline",
+    label: "Angle the Contact",
+    description: "Redirect the Gate-lane collision into the defensive bollard.",
+    cost: 6,
+    paid: true,
+    lane: "Standard",
+    tempo: 6,
+    compatibilityKey: "contest",
+    attribution: {
+      revealed: "Battle reads the Guard's contact vector.",
+      enabled: "Exploration recognizes the safe upper lip beside charged debris.",
+    },
   },
   "prepare-upper-route": {
     id: "prepare-upper-route",
     parent: "Discipline",
     label: "Prepare Upper Route",
-    description: "Establish a dependable physical relationship to Gate Platform.",
-    cost: CORE_RULES.majorSetupCost,
+    description: "Establish the natural capacity-one crossing.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 5,
     compatibilityKey: "prepare-route",
+    attribution: {
+      revealed: "Exploration identifies the stable handholds and true landing.",
+      enabled: "Battle can protect the landing when an interception arrives.",
+    },
   },
   "contest-upper-landing": {
     id: "contest-upper-landing",
     parent: "Discipline",
-    label: "Contest Threatened Landing",
-    description: "Physically protect the prepared landing from the Rush.",
-    cost: CORE_RULES.minorFoundationCost,
+    label: "Contest Upper Landing",
+    description: "Physically protect the prepared landing.",
+    cost: 6,
     paid: true,
-    lane: "Standard",
+    lane: "Fast",
     tempo: 7,
     compatibilityKey: "contest",
   },
   "cross-upper-route": {
     id: "cross-upper-route",
     parent: "Move",
-    label: "Exploit Upper Route",
-    description: "Spend the prepared Route to reach Gate Platform.",
-    cost: CORE_RULES.majorPayoffCost,
+    label: "Cross Upper Route",
+    description: "Cross the prepared natural relationship.",
+    cost: 8,
     paid: true,
     lane: "Standard",
-    tempo: 4,
+    tempo: 5,
     compatibilityKey: "exploit-route",
   },
   "answer-regulator": {
     id: "answer-regulator",
     parent: "Discipline",
     label: "Expose Impact Regulator",
-    description:
-      "Answer the Rush physically so the Assault's protected regulator becomes reachable.",
-    cost: CORE_RULES.majorSetupCost,
+    description: "Use contact to expose protected Breacher hardware.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 9,
+    tempo: 5,
     compatibilityKey: "answer-commitment",
+    attribution: {
+      revealed: "Battle creates a physical vulnerability at contact.",
+      enabled: "Hacking identifies the automatic reset that follows.",
+    },
   },
   "suppress-regulator": {
     id: "suppress-regulator",
     parent: "Discipline",
-    label: "Suppress Regulator Reset",
-    description: "Delay the actual automatic response that would reseal the hardware.",
-    cost: CORE_RULES.minorFoundationCost,
+    label: "Suppress Reset",
+    description: "Delay the Breacher regulator's real automatic reset.",
+    cost: 6,
     paid: true,
     lane: "Fast",
     tempo: 6,
@@ -399,22 +725,26 @@ const ACTIONS = Object.freeze({
   "establish-bollard-control": {
     id: "establish-bollard-control",
     parent: "Discipline",
-    label: "Control Defensive Bollard",
-    description: "Establish local Control at the exposed Actuator face.",
-    cost: CORE_RULES.majorSetupCost,
+    label: "Establish Actuator Control",
+    description: "Take bounded local Control of the defensive bollard.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 5,
     compatibilityKey: "establish-control",
+    attribution: {
+      revealed: "Hacking finds the Actuator-linked bollard output.",
+      enabled: "Battle identifies the access tile that must be held.",
+    },
   },
-  "contest-actuator": {
-    id: "contest-actuator",
+  "hold-actuator": {
+    id: "hold-actuator",
     parent: "Discipline",
     label: "Hold Actuator Access",
-    description: "Contest the Rush so physical access survives Settle.",
-    cost: CORE_RULES.minorFoundationCost,
+    description: "Physically contest the access tile so Control survives.",
+    cost: 6,
     paid: true,
-    lane: "Standard",
+    lane: "Fast",
     tempo: 7,
     compatibilityKey: "contest",
   },
@@ -422,30 +752,34 @@ const ACTIONS = Object.freeze({
     id: "execute-bollard",
     parent: "Discipline",
     label: "Execute Bollard Output",
-    description: "Spend Control to redirect and pin the Assault.",
-    cost: CORE_RULES.majorPayoffCost,
+    description: "Spend Control to redirect one legal physical commitment.",
+    cost: 8,
     paid: true,
     lane: "Standard",
-    tempo: 9,
+    tempo: 6,
     compatibilityKey: "execute-output",
   },
   "prepare-service-route": {
     id: "prepare-service-route",
     parent: "Discipline",
     label: "Prepare Service Route",
-    description: "Turn the service gap into a protected rear relationship.",
-    cost: CORE_RULES.majorSetupCost,
+    description: "Establish the obscured relationship to the rear Gate lane.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 5,
     compatibilityKey: "prepare-route",
+    attribution: {
+      revealed: "Exploration finds the real under-walk relationship.",
+      enabled: "Hacking identifies the Controller-linked shutter.",
+    },
   },
   "suppress-service-closure": {
     id: "suppress-service-closure",
     parent: "Discipline",
-    label: "Suppress Automatic Closure",
-    description: "Delay the real mechanism that would close the prepared gap.",
-    cost: CORE_RULES.minorFoundationCost,
+    label: "Suppress Closure",
+    description: "Delay the real service shutter response.",
+    cost: 6,
     paid: true,
     lane: "Fast",
     tempo: 6,
@@ -454,51 +788,73 @@ const ACTIONS = Object.freeze({
   "cross-service-route": {
     id: "cross-service-route",
     parent: "Move",
-    label: "Exploit Service Route",
-    description: "Use the preserved rear Route to reach Gate Platform.",
-    cost: CORE_RULES.majorPayoffCost,
+    label: "Cross Service Route",
+    description: "Use the preserved rear relationship.",
+    cost: 8,
     paid: true,
     lane: "Standard",
-    tempo: 4,
+    tempo: 5,
     compatibilityKey: "exploit-route",
   },
   "establish-lift-control": {
     id: "establish-lift-control",
     parent: "Discipline",
-    label: "Control Service Lift",
-    description: "Establish local Control over the lift mechanism.",
-    cost: CORE_RULES.majorSetupCost,
+    label: "Establish Lift Control",
+    description: "Take bounded local Control of the service lift.",
+    cost: 7,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 5,
     compatibilityKey: "establish-control",
+    attribution: {
+      revealed: "Hacking identifies the lift Output and return response.",
+      enabled: "Exploration reads the safe crossing and reset window.",
+    },
   },
   "execute-lift": {
     id: "execute-lift",
     parent: "Discipline",
-    label: "Execute Lift Output",
-    description: "Spend Control to move machinery into the missing upper span.",
-    cost: CORE_RULES.majorPayoffCost,
+    label: "Align Service Lift",
+    description: "Spend Control to create temporary upper geometry.",
+    cost: 8,
     paid: true,
     lane: "Standard",
-    tempo: 8,
+    tempo: 6,
     compatibilityKey: "execute-output",
   },
   "cross-lift": {
     id: "cross-lift",
     parent: "Move",
-    label: "Cross Service Lift",
-    description: "Cross the temporary geometry before it resets.",
-    cost: CORE_RULES.minorFoundationCost,
+    label: "Cross Lift Bridge",
+    description: "Cross before the service lift returns at Settle.",
+    cost: 6,
     paid: true,
     lane: "Standard",
-    tempo: 4,
+    tempo: 5,
     compatibilityKey: "cross-opening",
+  },
+  "redirect-track": {
+    id: "redirect-track",
+    parent: "Discipline",
+    label: "Redirect Service Track",
+    description: "Change the powered track feed toward the Divider.",
+    cost: 6,
+    paid: true,
+    lane: "Standard",
+    tempo: 5,
+    compatibilityKey: "basic-interface",
   },
 });
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function titleCase(value) {
+  return String(value)
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function getBuild(buildId) {
@@ -515,24 +871,557 @@ function stableHash(value) {
   return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
-function neighbors(positionId) {
-  return ORDINARY_EDGES.flatMap(([left, right]) => {
-    if (left === positionId) return [right];
-    if (right === positionId) return [left];
-    return [];
+function enemyActor(id, name, role, x, y) {
+  const deck = ENEMY_DECKS[id];
+  return {
+    id,
+    name,
+    role,
+    position: tileId(x, y),
+    condition: id === "breacher" ? 10 : 8,
+    guard: id === "guard" ? 6 : 4,
+    status: "active",
+    deck: [...deck],
+    hand: deck.slice(0, 5),
+    drawIndex: 5,
+    discard: [],
+    knownCards: [],
+  };
+}
+
+function majorLabel(buildId) {
+  const build = getBuild(buildId);
+  if (build.major === "battle") return "Battle Ready";
+  if (build.major === "exploration") return "Route Sense Ready";
+  return "Local Control Ready";
+}
+
+function makeInitialState(buildId) {
+  const build = getBuild(buildId);
+  return {
+    sourceRevision: FRACTURED_GATE_SOURCE,
+    seed: "FG-R1-BE-CLEAR",
+    buildId: build.id,
+    round: 1,
+    phase: "planning",
+    priority: "enemy",
+    consecutivePasses: 0,
+    command: CORE_RULES.commandStart,
+    enemyCommand: CORE_RULES.commandStart,
+    condition: 12,
+    guard: 4,
+    position: tileId(2, 6),
+    freeRepositionUsed: false,
+    planningActionCount: 0,
+    playerPivotUsed: false,
+    enemyPivotUsed: false,
+    refocusUsed: false,
+    refocusRecord: null,
+    majorState: {
+      type: build.major,
+      name: majorLabel(build.id),
+      status: "ready",
+    },
+    gate: {
+      stability: 3,
+      status: "unstable",
+      workDelayed: false,
+    },
+    enemies: {
+      breacher: enemyActor("breacher", "Breacher", "Physical Gate pressure", 6, 5),
+      guard: enemyActor("guard", "Guard", "Protection and interception", 9, 5),
+      controller: enemyActor("controller", "Controller", "Machinery and closure", 10, 7),
+      pressure: enemyActor("pressure", "Pressure", "Flank, Cache, and exit pressure", 9, 3),
+    },
+    divider: {
+      integrity: 2,
+      status: "cracked",
+      conduit: "neutral",
+    },
+    actuator: {
+      controlled: false,
+      mode: null,
+      accessHeld: false,
+      quietRewrite: false,
+    },
+    bollard: {
+      status: "retracted",
+    },
+    upperRoute: {
+      prepared: false,
+      protected: false,
+      contested: false,
+    },
+    serviceRoute: {
+      prepared: false,
+      closureSuppressed: false,
+      closing: false,
+    },
+    lift: {
+      deployed: false,
+      returning: false,
+      resetAfterSettle: false,
+    },
+    poweredTrack: {
+      feed: "neutral",
+    },
+    cache: {
+      status: "available",
+    },
+    westExit: {
+      status: "open",
+    },
+    deck: [...build.deck],
+    hand: build.deck.slice(0, CORE_RULES.openingHand),
+    drawIndex: CORE_RULES.openingHand,
+    discard: [],
+    plan: [],
+    enemyPlan: [],
+    nextActionSequence: 1,
+    nextEnemySequence: 1,
+    warning: "",
+    planningHistory: [],
+    resolution: null,
+    settleSummary: null,
+    review: [],
+    result: null,
+    retreated: false,
+    flags: {
+      turningPoint: null,
+      playerGuardedGate: false,
+      objectiveBraceUsed: false,
+      contextCardUsed: false,
+      regulatorExposed: false,
+      regulatorResetSuppressed: false,
+      sourceAttribution: [],
+    },
+  };
+}
+
+function cardInEnemyHand(state, actorId, cardId) {
+  return state.enemies[actorId]?.hand.includes(cardId);
+}
+
+function enemyActionDefinition(actionId, actorId, cardId, targetId, extra = {}) {
+  const card = cardId ? ENEMY_CARDS[cardId] : null;
+  const basics = {
+    "impact-rush": {
+      label: "Impact Rush",
+      cost: 8,
+      lane: "Standard",
+      tempo: 6,
+    },
+  };
+  const base = basics[actionId] ?? {
+    label: card?.name ?? titleCase(actionId),
+    cost: card?.cost ?? 0,
+    lane: card?.lane ?? "Standard",
+    tempo: card?.tempo ?? 5,
+  };
+  return {
+    id: actionId,
+    actorId,
+    actorName: titleCase(actorId),
+    label: base.label,
+    cardId,
+    cardName: card?.name ?? null,
+    targetId,
+    cost: base.cost,
+    totalCost: base.cost,
+    lane: base.lane,
+    tempo: base.tempo,
+    paid: true,
+    concealed: Boolean(extra.concealed),
+    modifierCardId: extra.modifierCardId ?? null,
+    modifierCardName: extra.modifierCardId
+      ? ENEMY_CARDS[extra.modifierCardId]?.name
+      : null,
+    modifierCost: extra.modifierCardId
+      ? ENEMY_CARDS[extra.modifierCardId]?.cost ?? 0
+      : 0,
+    status: "open",
+    ...extra,
+  };
+}
+
+function enemyAvailableCommand(state) {
+  if (state.phase !== "planning") return Math.max(0, state.enemyCommand);
+  return Math.max(
+    0,
+    state.enemyCommand -
+      state.enemyPlan.reduce((sum, action) => sum + action.totalCost, 0),
+  );
+}
+
+function enemyPaidActionCount(state) {
+  return state.enemyPlan.length;
+}
+
+function solidifyNewest(plan) {
+  for (const action of plan) {
+    if (action.status === "open") action.status = "solid";
+  }
+}
+
+function commitEnemyAction(state, action) {
+  const next = clone(state);
+  if (action.cardId && !cardInEnemyHand(next, action.actorId, action.cardId)) {
+    return { state, acted: false };
+  }
+  if (
+    action.modifierCardId &&
+    !cardInEnemyHand(next, action.actorId, action.modifierCardId)
+  ) {
+    return { state, acted: false };
+  }
+  action.totalCost =
+    action.cost +
+    (action.modifierCardId
+      ? ENEMY_CARDS[action.modifierCardId]?.cost ?? 0
+      : 0);
+  if (
+    action.totalCost > enemyAvailableCommand(next) ||
+    enemyPaidActionCount(next) >= CORE_RULES.paidActionCap
+  ) {
+    return { state, acted: false };
+  }
+  solidifyNewest(next.enemyPlan);
+  action.instanceId = `enemy-${next.nextEnemySequence}`;
+  action.sequence = next.nextEnemySequence;
+  action.status = "open";
+  next.nextEnemySequence += 1;
+  next.enemyPlan.push(action);
+  next.planningHistory.push({
+    side: "enemy",
+    type: "commit",
+    actorId: action.actorId,
+    actionId: action.id,
+    targetId: action.targetId,
+  });
+  next.consecutivePasses = 0;
+  next.priority = "player";
+  return { state: next, acted: true };
+}
+
+function pivotEnemyAction(state, action) {
+  const next = clone(state);
+  if (next.enemyPivotUsed) return { state, acted: false };
+  const index = next.enemyPlan.findIndex((item) => item.status === "open");
+  if (index < 0) return { state, acted: false };
+  const old = next.enemyPlan[index];
+  const oldCost = old.totalCost;
+  const availableWithReplacement = enemyAvailableCommand(next) + oldCost;
+  action.totalCost =
+    action.cost +
+    (action.modifierCardId
+      ? ENEMY_CARDS[action.modifierCardId]?.cost ?? 0
+      : 0);
+  if (
+    action.totalCost > availableWithReplacement ||
+    (action.cardId && !cardInEnemyHand(next, action.actorId, action.cardId))
+  ) {
+    return { state, acted: false };
+  }
+  action.instanceId = old.instanceId;
+  action.sequence = old.sequence;
+  action.status = "solid";
+  next.enemyPlan[index] = action;
+  next.enemyPivotUsed = true;
+  next.planningHistory.push({
+    side: "enemy",
+    type: "pivot",
+    from: old.id,
+    actionId: action.id,
+    targetId: action.targetId,
+  });
+  next.consecutivePasses = 0;
+  next.priority = "player";
+  return { state: next, acted: true };
+}
+
+function playerHas(state, actionId) {
+  return state.plan.some((action) => action.id === actionId);
+}
+
+function enemyHas(state, actionId) {
+  return state.enemyPlan.some((action) => action.id === actionId);
+}
+
+function hiddenPlayerPlan(state) {
+  return state.plan.map((action) => {
+    const publicAction = { ...action };
+    delete publicAction.cardId;
+    delete publicAction.cardName;
+    return {
+      ...publicAction,
+      concealedModifierCount: publicAction.concealed ? 1 : 0,
+    };
   });
 }
 
-function cardReserved(state, cardId) {
-  return state.plan.some((action) => action.cardId === cardId);
+function takeEnemyPriority(state, reason = "response") {
+  let next = clone(state);
+  next.priority = "enemy";
+
+  const publicPlayerPlan = hiddenPlayerPlan(next);
+  const hasPublic = (id) => publicPlayerPlan.some((action) => action.id === id);
+
+  if (next.round === 1 && !enemyHas(next, "impact-rush")) {
+    const rush = enemyActionDefinition(
+      "impact-rush",
+      "breacher",
+      "driving-ram",
+      "gate",
+      {
+        concealed: true,
+        modifierCardId: "impact-counter",
+        posture: "Driving toward Gate",
+      },
+    );
+    return commitEnemyAction(next, rush);
+  }
+
+  if (
+    next.round === 1 &&
+    enemyHas(next, "impact-rush") &&
+    !enemyHas(next, "shield-link") &&
+    enemyAvailableCommand(next) >= 4
+  ) {
+    return commitEnemyAction(
+      next,
+      enemyActionDefinition(
+        "shield-link",
+        "guard",
+        "shield-link",
+        "breacher",
+        { posture: "Protecting Breacher" },
+      ),
+    );
+  }
+
+  if (next.round === 2) {
+    if (hasPublic("cross-breach") && !enemyHas(next, "charge-debris")) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "charge-debris",
+          "controller",
+          "charge-debris",
+          "cracked-divider",
+          { posture: "Charging the breached conduit" },
+        ),
+      );
+    }
+    if (hasPublic("stabilize-gate") && !enemyHas(next, "body-block")) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "body-block",
+          "guard",
+          "body-block",
+          "gate",
+          { posture: "Occupying Gate access" },
+        ),
+      );
+    }
+    if (
+      hasPublic("angle-clash") &&
+      enemyHas(next, "body-block") &&
+      !enemyHas(next, "brace-line")
+    ) {
+      return pivotEnemyAction(
+        next,
+        enemyActionDefinition(
+          "brace-line",
+          "guard",
+          "brace-line",
+          "defensive-bollard",
+          { posture: "Establishing a faster hold" },
+        ),
+      );
+    }
+    if (
+      reason === "player-pass" &&
+      !enemyHas(next, "exit-pressure") &&
+      enemyAvailableCommand(next) >= 6
+    ) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "exit-pressure",
+          "pressure",
+          "exit-pressure",
+          "west-exit",
+          { posture: "Threatening retreat" },
+        ),
+      );
+    }
+    if (
+      !enemyHas(next, "impact-rush") &&
+      enemyAvailableCommand(next) >= 8 &&
+      cardInEnemyHand(next, "breacher", "follow-pressure")
+    ) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "impact-rush",
+          "breacher",
+          "follow-pressure",
+          "gate",
+          {
+            concealed: true,
+            posture: "Following pressure toward the Gate",
+          },
+        ),
+      );
+    }
+  }
+
+  if (next.round === 3) {
+    if (!enemyHas(next, "static-tax")) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "static-tax",
+          "controller",
+          "static-tax",
+          "gate",
+          { posture: "Delaying Gate Work" },
+        ),
+      );
+    }
+    if (
+      !enemyHas(next, "impact-rush") &&
+      enemyAvailableCommand(next) >= 10
+    ) {
+      return commitEnemyAction(
+        next,
+        enemyActionDefinition(
+          "impact-rush",
+          "breacher",
+          null,
+          "gate",
+          {
+            modifierCardId: "breaker-coil",
+            posture: "Driving through the defended Gate lane",
+          },
+        ),
+      );
+    }
+  }
+
+  if (
+    next.round > 3 &&
+    !enemyHas(next, "impact-rush") &&
+    enemyAvailableCommand(next) >= 8 &&
+    ACTIVE_ENEMY_STATUSES.has(next.enemies.breacher.status)
+  ) {
+    const cardId = cardInEnemyHand(next, "breacher", "last-push")
+      ? "last-push"
+      : cardInEnemyHand(next, "breacher", "follow-pressure")
+        ? "follow-pressure"
+        : null;
+    return commitEnemyAction(
+      next,
+      enemyActionDefinition("impact-rush", "breacher", cardId, "gate", {
+        concealed: Boolean(cardId),
+        posture: "Maintaining visible Gate pressure",
+      }),
+    );
+  }
+
+  const adaptiveResponses = [
+    {
+      player: "prepare-upper-route",
+      enemy: "vault-intercept",
+      actor: "guard",
+      card: "vault-intercept",
+      target: "upper-route",
+      posture: "Contesting the east landing",
+    },
+    {
+      player: "answer-regulator",
+      enemy: "emergency-reset",
+      actor: "controller",
+      card: "emergency-reset",
+      target: "regulator",
+      posture: "Preparing an automatic reset",
+    },
+    {
+      player: "establish-bollard-control",
+      enemy: "purge-control",
+      actor: "controller",
+      card: "purge-control",
+      target: "gate-actuator",
+      posture: "Contesting Actuator Control",
+    },
+    {
+      player: "prepare-service-route",
+      enemy: "seal-gap",
+      actor: "controller",
+      card: "seal-gap",
+      target: "service-gap",
+      posture: "Closing the service shutter",
+    },
+    {
+      player: "establish-lift-control",
+      enemy: "lift-recall",
+      actor: "controller",
+      card: "lift-recall",
+      target: "service-lift",
+      posture: "Preparing lift recall",
+    },
+  ];
+  for (const response of adaptiveResponses) {
+    if (
+      hasPublic(response.player) &&
+      !enemyHas(next, response.enemy) &&
+      cardInEnemyHand(next, response.actor, response.card)
+    ) {
+      const candidate = enemyActionDefinition(
+        response.enemy,
+        response.actor,
+        response.card,
+        response.target,
+        { posture: response.posture },
+      );
+      if (candidate.totalCost <= enemyAvailableCommand(next)) {
+        return commitEnemyAction(next, candidate);
+      }
+    }
+  }
+
+  next.consecutivePasses += 1;
+  next.planningHistory.push({ side: "enemy", type: "pass" });
+  next.priority = "player";
+  return { state: next, acted: false };
+}
+
+export function createFracturedGateState(buildId = "battle-exploration") {
+  const initial = makeInitialState(buildId);
+  return takeEnemyPriority(initial, "opening").state;
+}
+
+export function resetFracturedGate(state) {
+  return createFracturedGateState(state.buildId);
+}
+
+export function changeFracturedGateBuild(state, buildId) {
+  if (!BUILDS.some((build) => build.id === buildId)) return state;
+  return createFracturedGateState(buildId);
 }
 
 export function availableCommand(state) {
+  if (state.phase !== "planning") return Math.max(0, state.command);
   return Math.max(
     0,
     state.command -
       state.plan.reduce((sum, action) => sum + action.totalCost, 0),
   );
+}
+
+export function availableEnemyCommand(state) {
+  return enemyAvailableCommand(state);
 }
 
 export function paidActionCount(state) {
@@ -548,104 +1437,86 @@ function withWarning(state, warning) {
   return next;
 }
 
-function majorLabel(buildId) {
-  const build = getBuild(buildId);
-  if (build.major === "battle") return "Battle Ready";
-  if (build.major === "exploration") return "Route Sense Ready";
-  return "Local Control Ready";
+function activeEnemyPositions(state) {
+  return new Set(
+    Object.values(state.enemies)
+      .filter((enemy) => ACTIVE_ENEMY_STATUSES.has(enemy.status))
+      .map((enemy) => enemy.position),
+  );
 }
 
-export function createFracturedGateState(
-  buildId = "battle-exploration",
-) {
-  const build = getBuild(buildId);
-  return {
-    sourceRevision: FRACTURED_GATE_SOURCE,
-    seed: "FRACTURED-GATE-001",
-    buildId: build.id,
-    round: 1,
-    phase: "planning",
-    command: CORE_RULES.commandStart,
-    condition: 12,
-    guard: 4,
-    position: "entry",
-    freeRepositionUsed: false,
-    planningActionCount: 0,
-    refocusUsed: false,
-    refocusRecord: null,
-    majorState: {
-      type: build.major,
-      name: majorLabel(build.id),
-      status: "ready",
-    },
-    gate: {
-      stability: 3,
-      status: "unstable",
-    },
-    enemy: {
-      id: "assault",
-      status: "active",
-      condition: 8,
-      guard: 4,
-      position: "lower-yard",
-      regulator: "shielded",
-      regulatorResetSuppressed: false,
-      staggered: false,
-    },
-    divider: {
-      status: "cracked",
-    },
-    actuator: {
-      mode: null,
-      controlled: false,
-      accessHeld: false,
-      quietRewrite: false,
-    },
-    upperRoute: {
-      prepared: false,
-      protected: false,
-      destinationClaim: false,
-    },
-    serviceRoute: {
-      prepared: false,
-      closureSuppressed: false,
-      destinationClaim: false,
-    },
-    lift: {
-      deployed: false,
-      resetAfterSettle: false,
-    },
-    cache: {
-      status: "available",
-    },
-    deck: [...build.deck],
-    hand: build.deck.slice(0, CORE_RULES.openingHand),
-    drawIndex: CORE_RULES.openingHand,
-    discard: [],
-    plan: [],
-    nextActionSequence: 1,
-    warning: "",
-    resolution: null,
-    settleSummary: null,
-    review: [],
-    result: null,
-    retreated: false,
-    flags: {
-      rushBlocked: false,
-      regulatorSuppressionArmed: false,
-      serviceSuppressionArmed: false,
-      turningPoint: null,
-    },
-  };
+function isBlocked(state, id, view = null) {
+  if (!BOARD_TILES[id]) return true;
+  if (
+    state.divider.status !== "breached" &&
+    [tileId(8, 5), tileId(8, 6)].includes(id)
+  ) {
+    return true;
+  }
+  const occupants = activeEnemyPositions(state);
+  if (view?.position === id) return false;
+  return occupants.has(id);
 }
 
-export function resetFracturedGate(state) {
-  return createFracturedGateState(state.buildId);
+function ordinaryNeighbors(state, id, view = null) {
+  const point = coordFromTile(id);
+  if (!point) return [];
+  const [x, y] = point;
+  const results = [];
+  for (const [dx, dy] of [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1],
+  ]) {
+    const nx = x + dx;
+    const ny = y + dy;
+    const nextId = tileId(nx, ny);
+    if (!WALKABLE.has(coordKey(nx, ny)) || isBlocked(state, nextId, view)) {
+      continue;
+    }
+    if (dx !== 0 && dy !== 0) {
+      const sideA = tileId(x + dx, y);
+      const sideB = tileId(x, y + dy);
+      if (isBlocked(state, sideA, view) || isBlocked(state, sideB, view)) {
+        continue;
+      }
+    }
+    results.push(nextId);
+  }
+  return results;
 }
 
-export function changeFracturedGateBuild(state, buildId) {
-  if (!BUILDS.some((build) => build.id === buildId)) return state;
-  return createFracturedGateState(buildId);
+function terrainCost(id) {
+  const point = coordFromTile(id);
+  if (!point) return 99;
+  return TERRAIN_BY_COORD.get(coordKey(point[0], point[1])) === "rubble"
+    ? 2
+    : 1;
+}
+
+function reachablePaths(state, from, budget, view = null) {
+  const best = new Map([[from, { cost: 0, path: [from] }]]);
+  const queue = [from];
+  while (queue.length) {
+    queue.sort((left, right) => best.get(left).cost - best.get(right).cost);
+    const current = queue.shift();
+    const currentData = best.get(current);
+    for (const next of ordinaryNeighbors(state, current, view)) {
+      const cost = currentData.cost + terrainCost(next);
+      if (cost > budget || (best.has(next) && best.get(next).cost <= cost)) {
+        continue;
+      }
+      best.set(next, { cost, path: [...currentData.path, next] });
+      queue.push(next);
+    }
+  }
+  best.delete(from);
+  return best;
 }
 
 function planningView(state) {
@@ -656,18 +1527,36 @@ function planningView(state) {
     upperPrepared: state.upperRoute.prepared,
     servicePrepared: state.serviceRoute.prepared,
     liftDeployed: state.lift.deployed,
-    regulatorExposed: state.enemy.regulator === "exposed",
+    regulatorExposed: state.flags.regulatorExposed,
     controlMode: state.actuator.controlled ? state.actuator.mode : null,
+    pathHistory: [],
   };
   for (const action of state.plan) {
+    if (action.path?.length) {
+      view.pathHistory.push(...action.path.slice(1));
+      view.position = action.path.at(-1);
+    }
     switch (action.id) {
       case "reposition":
-      case "advance":
-        view.position = action.targetId;
-        if (action.id === "reposition") view.freeRepositionUsed = true;
+        view.freeRepositionUsed = true;
         break;
       case "answer-divider":
         view.dividerOpen = true;
+        break;
+      case "cross-breach":
+        view.position = tileId(10, 5);
+        break;
+      case "cross-upper-route":
+        view.position = tileId(9, 3);
+        break;
+      case "cross-service-route":
+        view.position = tileId(10, 6);
+        break;
+      case "cross-lift":
+        view.position = tileId(9, 2);
+        break;
+      case "leave":
+        view.position = tileId(1, 6);
         break;
       case "answer-regulator":
         view.regulatorExposed = true;
@@ -687,12 +1576,6 @@ function planningView(state) {
       case "execute-lift":
         view.liftDeployed = true;
         break;
-      case "cross-breach":
-      case "cross-upper-route":
-      case "cross-service-route":
-      case "cross-lift":
-        view.position = "gate-platform";
-        break;
       default:
         break;
     }
@@ -700,21 +1583,93 @@ function planningView(state) {
   return view;
 }
 
-function legalTargetsForAction(state, actionId) {
+function routeKind(path) {
+  const terrain = new Set(
+    (path ?? [])
+      .map(coordFromTile)
+      .filter(Boolean)
+      .map(([x, y]) => TERRAIN_BY_COORD.get(coordKey(x, y)) ?? "ordinary"),
+  );
+  if (terrain.has("rubble")) return "rubble";
+  if (terrain.has("powered")) return "powered";
+  if (terrain.has("clear")) return "clear";
+  return "ordinary";
+}
+
+export function tempoComparisonForRoute(route, poweredFeed = "toward-divider") {
+  const enemy = 6;
+  if (route === "rubble") {
+    return {
+      route,
+      player: 4,
+      enemy,
+      outcome: "enemy_first",
+      link: "Broken",
+      reason: "Rubble breaks the movement-to-contact link.",
+    };
+  }
+  if (route === "powered" && poweredFeed === "toward-divider") {
+    return {
+      route,
+      player: 7,
+      enemy,
+      outcome: "player_first",
+      link: "Accelerated",
+      reason: "The powered service track carries momentum toward contact.",
+    };
+  }
+  return {
+    route,
+    player: 6,
+    enemy,
+    outcome: "simultaneous",
+    link: "Preserved",
+    reason: "The clear approach preserves Follow Through.",
+  };
+}
+
+function latestApproach(state) {
+  const paths = state.plan
+    .filter((action) => ["reposition", "advance"].includes(action.id))
+    .flatMap((action) => action.path ?? []);
+  return routeKind(paths);
+}
+
+function contextCardsForAction(state, actionId) {
+  if (
+    actionId === "answer-divider" &&
+    latestApproach(state) === "clear" &&
+    !state.flags.contextCardUsed &&
+    !state.plan.some((action) => action.cardId === "follow-through")
+  ) {
+    return ["follow-through"];
+  }
+  return [];
+}
+
+export function getAvailableContextCards(state, actionId = null) {
+  return actionId ? contextCardsForAction(state, actionId) : [];
+}
+
+function legalMovementTargets(state, actionId) {
   const view = planningView(state);
+  const range = actionId === "reposition" ? 1 : ACTIONS[actionId].range;
+  return [...reachablePaths(state, view.position, range, view).keys()];
+}
+
+function legalTargetsForAction(state, actionId) {
+  if (["reposition", "advance"].includes(actionId)) {
+    return legalMovementTargets(state, actionId);
+  }
   switch (actionId) {
-    case "reposition":
-    case "advance":
-      return neighbors(view.position);
     case "attack":
-    case "answer-regulator":
-    case "suppress-regulator":
-    case "execute-bollard":
-      return ["assault"];
+      return Object.values(state.enemies)
+        .filter((enemy) => ACTIVE_ENEMY_STATUSES.has(enemy.status))
+        .map((enemy) => enemy.id);
     case "guard":
       return ["player"];
-    case "guard-impact":
-      return ["impact-rush"];
+    case "guard-gate":
+      return ["gate"];
     case "stabilize-gate":
       return ["gate"];
     case "recover-cache":
@@ -724,97 +1679,151 @@ function legalTargetsForAction(state, actionId) {
     case "answer-divider":
       return ["cracked-divider"];
     case "cross-breach":
-      return ["gate-platform"];
+      return [tileId(10, 5)];
+    case "angle-clash":
+      return ["defensive-bollard"];
     case "prepare-upper-route":
-      return ["gate-platform"];
     case "contest-upper-landing":
-      return ["upper-walk"];
+      return ["upper-crossing"];
     case "cross-upper-route":
-      return ["gate-platform"];
+      return [tileId(9, 3)];
+    case "answer-regulator":
+    case "suppress-regulator":
+      return ["breacher"];
     case "establish-bollard-control":
-    case "establish-lift-control":
+    case "hold-actuator":
+    case "redirect-track":
       return ["gate-actuator"];
-    case "contest-actuator":
-      return ["gate-actuator"];
+    case "execute-bollard":
+      return ["defensive-bollard"];
     case "prepare-service-route":
     case "suppress-service-closure":
       return ["service-gap"];
     case "cross-service-route":
-      return ["gate-platform"];
+      return [tileId(10, 6)];
+    case "establish-lift-control":
+      return ["lift-relay"];
     case "execute-lift":
       return ["service-lift"];
     case "cross-lift":
-      return ["gate-platform"];
+      return [tileId(9, 2)];
     default:
       return [];
   }
 }
 
-function validateAction(state, actionId, targetId, cardId = null) {
+function actionPath(state, actionId, targetId) {
+  if (!["reposition", "advance"].includes(actionId)) return null;
+  const view = planningView(state);
+  const range = actionId === "reposition" ? 1 : ACTIONS[actionId].range;
+  return reachablePaths(state, view.position, range, view).get(targetId)?.path ?? null;
+}
+
+function cardReserved(state, cardId) {
+  return state.plan.some((action) => action.cardId === cardId);
+}
+
+function validateAction(state, actionId, targetId, cardId = null, replacing = false) {
   const action = ACTIONS[actionId];
   if (!action) return "Unknown action.";
   if (state.phase !== "planning") return "Actions are available only during Planning.";
+  if (state.priority !== "player") return "The enemy squad currently has priority.";
   if (state.hand.length > CORE_RULES.retainLimit) {
     return `Retain ${CORE_RULES.retainLimit} cards before planning.`;
   }
   const build = getBuild(state.buildId);
   const view = planningView(state);
-  const legalTargets = legalTargetsForAction(state, actionId);
-  if (!targetId || !legalTargets.includes(targetId)) {
-    return "Choose a highlighted target on the board.";
+  if (!targetId || !legalTargetsForAction(state, actionId).includes(targetId)) {
+    return "Choose a highlighted legal target directly on the board.";
   }
-  if (action.paid && paidActionCount(state) >= CORE_RULES.paidActionCap) {
-    return "Four paid actions is the hard cap; four should remain exceptional.";
+  const replaced = replacing
+    ? state.plan.find((candidate) => candidate.status === "open")
+    : null;
+  const effectivePaid = paidActionCount(state) - (replaced?.paid ? 1 : 0);
+  if (action.paid && effectivePaid >= CORE_RULES.paidActionCap) {
+    return "Four paid actions is the hard cap.";
   }
   if (actionId === "reposition" && view.freeRepositionUsed) {
     return "The one free ordinary Reposition is already committed.";
   }
+  if (actionId === "stabilize-gate") {
+    const [x, y] = coordFromTile(view.position) ?? [];
+    if (!x || Math.abs(x - 12) + Math.abs(y - 5) > 2) {
+      return "Reach Gate Platform before stabilizing the Gate.";
+    }
+    if (state.gate.status === "failed") return "The Gate has already failed.";
+  }
+  if (actionId === "recover-cache" && view.position !== tileId(6, 2)) {
+    return "Reach the Upper Walk Field Cache before recovering it.";
+  }
+  if (actionId === "leave" && view.position !== tileId(2, 6)) {
+    return "Return adjacent to West Exit before leaving.";
+  }
+  if (actionId === "attack") {
+    const enemy = state.enemies[targetId];
+    const [playerX, playerY] = coordFromTile(view.position) ?? [];
+    const [enemyX, enemyY] = coordFromTile(enemy?.position) ?? [];
+    if (
+      playerX == null ||
+      enemyX == null ||
+      Math.max(Math.abs(playerX - enemyX), Math.abs(playerY - enemyY)) > 2
+    ) {
+      return "Move within two tactical tiles before declaring this attack.";
+    }
+  }
+  const buildRules = {
+    "answer-divider": "battle-exploration",
+    "angle-clash": "battle-exploration",
+    "prepare-upper-route": "exploration-battle",
+    "contest-upper-landing": "exploration-battle",
+    "answer-regulator": "battle-hacking",
+    "suppress-regulator": "battle-hacking",
+    "establish-bollard-control": "hacking-battle",
+    "hold-actuator": "hacking-battle",
+    "execute-bollard": "hacking-battle",
+    "prepare-service-route": "exploration-hacking",
+    "suppress-service-closure": "exploration-hacking",
+    "establish-lift-control": "hacking-exploration",
+    "execute-lift": "hacking-exploration",
+  };
+  if (buildRules[actionId] && build.id !== buildRules[actionId]) {
+    return `${ACTIONS[actionId].label} is not enabled by this ordered build.`;
+  }
   if (
-    ["attack", "answer-divider", "answer-regulator", "guard-impact"].includes(
-      actionId,
-    ) &&
-    !ACTIVE_ENEMY_STATUSES.has(state.enemy.status)
+    ["answer-divider", "answer-regulator"].includes(actionId) &&
+    !ACTIVE_ENEMY_STATUSES.has(state.enemies.breacher.status)
   ) {
-    return "The Assault no longer presents this hostile Commitment.";
+    return "The Breacher no longer presents this hostile Commitment.";
   }
-  if (actionId === "stabilize-gate" && state.position !== "gate-platform") {
-    return "Begin a planning cycle on Gate Platform to stabilize the Gate.";
+  if (["answer-divider", "answer-regulator"].includes(actionId)) {
+    const [playerX, playerY] = coordFromTile(view.position) ?? [];
+    const [breacherX, breacherY] =
+      coordFromTile(state.enemies.breacher.position) ?? [];
+    if (
+      playerX == null ||
+      breacherX == null ||
+      Math.max(
+        Math.abs(playerX - breacherX),
+        Math.abs(playerY - breacherY),
+      ) > 2
+    ) {
+      return "Approach within two tactical tiles before answering the Commitment.";
+    }
   }
-  if (actionId === "stabilize-gate" && state.gate.status === "failed") {
-    return "The Gate has already failed.";
+  if (actionId === "cross-breach" && !view.dividerOpen) {
+    return "The Divider breach does not exist.";
   }
-  if (actionId === "recover-cache" && state.position !== "upper-walk") {
-    return "Begin a planning cycle on Upper Walk to recover the Cache.";
+  if (actionId === "angle-clash" && !view.dividerOpen) {
+    return "The safe collision line requires the Divider breach.";
   }
-  if (actionId === "recover-cache" && state.cache.status !== "available") {
-    return "The Field Cache is no longer available.";
-  }
-  if (actionId === "leave" && state.position !== "entry") {
-    return "Return to Entry before leaving through West Exit.";
-  }
-  if (actionId === "answer-divider" && build.id !== "battle-exploration") {
-    return "This causal answer belongs to Battle / Exploration.";
-  }
-  if (actionId === "answer-regulator" && build.id !== "battle-hacking") {
-    return "This causal answer belongs to Battle / Hacking.";
+  if (actionId === "angle-clash" && view.position !== tileId(10, 5)) {
+    return "Cross the Divider opening before angling contact at Gate access.";
   }
   if (
     actionId === "prepare-upper-route" &&
-    build.id !== "exploration-battle"
+    ![tileId(6, 3), tileId(7, 3)].includes(view.position)
   ) {
-    return "This Route preparation belongs to Exploration / Battle.";
-  }
-  if (
-    actionId === "prepare-upper-route" &&
-    view.position !== "upper-walk"
-  ) {
-    return "Reach Upper Walk before preparing its missing span.";
-  }
-  if (
-    actionId === "contest-upper-landing" &&
-    build.id !== "exploration-battle"
-  ) {
-    return "This physical protection belongs to Exploration / Battle.";
+    return "Reach the west Upper Walk before preparing its crossing.";
   }
   if (actionId === "contest-upper-landing" && !view.upperPrepared) {
     return "Prepare the Upper Route before protecting its landing.";
@@ -822,86 +1831,54 @@ function validateAction(state, actionId, targetId, cardId = null) {
   if (actionId === "cross-upper-route" && !view.upperPrepared) {
     return "No prepared Upper Route exists.";
   }
-  if (actionId === "cross-upper-route" && view.position !== "upper-walk") {
-    return "Reach Upper Walk before exploiting its Route.";
-  }
-  if (actionId === "suppress-regulator") {
-    if (build.id !== "battle-hacking") {
-      return "This response suppression belongs to Battle / Hacking.";
-    }
-    if (!view.regulatorExposed) {
-      return "Expose the regulator through confrontation before suppressing its reset.";
-    }
+  if (actionId === "suppress-regulator" && !view.regulatorExposed) {
+    return "Expose the regulator before suppressing its reset.";
   }
   if (
-    actionId === "establish-bollard-control" &&
-    build.id !== "hacking-battle"
+    ["establish-bollard-control", "hold-actuator", "redirect-track"].includes(actionId) &&
+    view.position !== tileId(7, 7)
   ) {
-    return "This bounded Output belongs to Hacking / Battle.";
+    return "Physical Gate Actuator access is required.";
+  }
+  if (actionId === "hold-actuator" && view.controlMode !== "bollard") {
+    return "Establish Bollard Control before holding access.";
   }
   if (
-    actionId === "establish-lift-control" &&
-    build.id !== "hacking-exploration"
+    actionId === "execute-bollard" &&
+    (!state.actuator.controlled || state.actuator.mode !== "bollard")
   ) {
-    return "This bounded Output belongs to Hacking / Exploration.";
+    return "Persistent Bollard Control is required.";
   }
-  if (
-    ["establish-bollard-control", "establish-lift-control"].includes(
-      actionId,
-    ) &&
-    view.position !== "actuator"
-  ) {
-    return "Reach the Gate Actuator before establishing local Control.";
-  }
-  if (actionId === "contest-actuator") {
-    if (build.id !== "hacking-battle") {
-      return "This access protection belongs to Hacking / Battle.";
-    }
-    if (view.controlMode !== "bollard") {
-      return "Establish Bollard Control before holding its access.";
-    }
-  }
-  if (actionId === "execute-bollard") {
-    if (
-      !state.actuator.controlled ||
-      state.actuator.mode !== "bollard" ||
-      state.position !== "actuator"
-    ) {
-      return "Persistent Bollard Control and physical Actuator access are required.";
-    }
-  }
-  if (
-    actionId === "prepare-service-route" &&
-    build.id !== "exploration-hacking"
-  ) {
-    return "This natural Route belongs to Exploration / Hacking.";
-  }
-  if (actionId === "suppress-service-closure") {
-    if (build.id !== "exploration-hacking") {
-      return "This closure suppression belongs to Exploration / Hacking.";
-    }
-    if (!view.servicePrepared) {
-      return "Prepare the service relationship before suppressing its closure.";
-    }
+  if (actionId === "suppress-service-closure" && !view.servicePrepared) {
+    return "Prepare the Service Route before suppressing closure.";
   }
   if (actionId === "cross-service-route" && !view.servicePrepared) {
     return "No prepared Service Route exists.";
   }
   if (
-    actionId === "execute-lift" &&
-    (!state.actuator.controlled ||
-      state.actuator.mode !== "lift" ||
-      state.position !== "actuator")
+    actionId === "establish-lift-control" &&
+    view.position !== tileId(5, 8)
   ) {
-    return "Persistent Lift Control and physical Actuator access are required.";
+    return "Physical Lift Relay access is required.";
+  }
+  if (
+    actionId === "execute-lift" &&
+    (!state.actuator.controlled || state.actuator.mode !== "lift")
+  ) {
+    return "Persistent Lift Control is required.";
   }
   if (actionId === "cross-lift" && !view.liftDeployed) {
-    return "Execute the Lift Output before crossing its temporary geometry.";
+    return "Align the Service Lift before crossing.";
   }
   if (cardId) {
     const card = CARDS[cardId];
-    if (!card || !state.hand.includes(cardId) || cardReserved(state, cardId)) {
-      return "That Prepared Card is not available.";
+    const contextAvailable = contextCardsForAction(state, actionId).includes(cardId);
+    if (
+      !card ||
+      ((!state.hand.includes(cardId) || cardReserved(state, cardId)) &&
+        !contextAvailable)
+    ) {
+      return "That card is not available.";
     }
     const compatible =
       card.compatibility.includes(action.compatibilityKey) ||
@@ -909,50 +1886,17 @@ function validateAction(state, actionId, targetId, cardId = null) {
     if (!compatible) return "That card is not compatible with this action.";
   }
   const cardCost = cardId ? CARDS[cardId].cost : 0;
-  if (availableCommand(state) < action.cost + cardCost) {
-    return "Not enough Command remains for this plan.";
+  const availableWithReplacement =
+    availableCommand(state) + (replaced?.totalCost ?? 0);
+  if (availableWithReplacement < action.cost + cardCost) {
+    return "Not enough Command remains for this commitment.";
   }
   return null;
 }
 
 function targetPositionForFocus(focusId) {
-  if (POSITION_COORDS[focusId]) return focusId;
-  if (focusId === "gate-actuator") return "actuator";
-  if (focusId === "gate" || focusId === "field-cache") {
-    return focusId === "gate" ? "gate-platform" : "upper-walk";
-  }
-  return BOARD_FOCUSES[focusId]?.positionId ?? null;
-}
-
-function movementChoices(state, focusId) {
-  const view = planningView(state);
-  if (focusId === "breach") {
-    return [makeChoice(state, "cross-breach")];
-  }
-  if (focusId === "upper-route") {
-    return [makeChoice(state, "cross-upper-route")];
-  }
-  if (focusId === "service-route") {
-    return [makeChoice(state, "cross-service-route")];
-  }
-  if (focusId === "service-lift") {
-    return [makeChoice(state, "cross-lift")];
-  }
-  const selectedPosition = targetPositionForFocus(focusId);
-  const targets = selectedPosition
-    ? [selectedPosition]
-    : focusId === "player"
-      ? neighbors(view.position)
-      : [];
-  if (!targets.length || targets.every((target) => target === view.position)) {
-    return [];
-  }
-  const choices = [];
-  if (!view.freeRepositionUsed) {
-    choices.push(makeChoice(state, "reposition", targets));
-  }
-  choices.push(makeChoice(state, "advance", targets));
-  return choices;
+  if (BOARD_TILES[focusId]) return focusId;
+  return BOARD_FOCUSES[focusId]?.tileId ?? null;
 }
 
 function makeChoice(state, actionId, targets = legalTargetsForAction(state, actionId)) {
@@ -974,12 +1918,11 @@ function inspectChoice() {
     id: "inspect",
     parent: "Inspect",
     label: "Inspect",
-    description: "Open the selected board element's concise details.",
+    description: "Open concise visible details for this board element.",
     cost: 0,
     paid: false,
     lane: "Now",
     tempo: null,
-    compatibilityKey: null,
     legalTargets: [],
     legal: true,
     reason: null,
@@ -987,42 +1930,81 @@ function inspectChoice() {
   };
 }
 
+function movementChoices(state, focusId) {
+  const target = targetPositionForFocus(focusId);
+  if (!target) return [];
+  const choices = [];
+  for (const actionId of ["reposition", "advance"]) {
+    const legalTargets = legalMovementTargets(state, actionId);
+    if (legalTargets.includes(target)) {
+      choices.push(makeChoice(state, actionId, [target]));
+    }
+  }
+  if (focusId === "breach" && planningView(state).dividerOpen) {
+    choices.push(makeChoice(state, "cross-breach"));
+  }
+  if (focusId === "upper-route" && planningView(state).upperPrepared) {
+    choices.push(makeChoice(state, "cross-upper-route"));
+  }
+  if (focusId === "service-route" && planningView(state).servicePrepared) {
+    choices.push(makeChoice(state, "cross-service-route"));
+  }
+  if (focusId === "service-lift" && planningView(state).liftDeployed) {
+    choices.push(makeChoice(state, "cross-lift"));
+  }
+  return choices;
+}
+
 function disciplineChoices(state, focusId) {
-  const buildId = state.buildId;
   const view = planningView(state);
   const ids = [];
-  if (focusId === "impact-rush" || focusId === "cracked-divider") {
-    if (buildId === "battle-exploration") ids.push("answer-divider");
-    if (buildId === "battle-hacking") ids.push("answer-regulator");
-    if (buildId === "exploration-battle") ids.push("contest-upper-landing");
-    if (buildId === "hacking-battle") ids.push("contest-actuator");
+  if (["breacher-intent", "cracked-divider"].includes(focusId)) {
+    if (state.buildId === "battle-exploration") ids.push("answer-divider");
+    if (state.buildId === "battle-hacking") ids.push("answer-regulator");
   }
-  if (focusId === "assault" || focusId === "regulator") {
-    if (buildId === "battle-hacking") ids.push("suppress-regulator");
-    if (buildId === "hacking-battle" && state.actuator.mode === "bollard") {
+  if (["defensive-bollard", "guard"].includes(focusId)) {
+    if (state.buildId === "battle-exploration" && view.dividerOpen) {
+      ids.push("angle-clash");
+    }
+    if (state.buildId === "hacking-battle" && state.actuator.controlled) {
       ids.push("execute-bollard");
     }
   }
-  if (focusId === "upper-walk" || focusId === "upper-route") {
-    if (buildId === "exploration-battle") {
-      if (!view.upperPrepared) ids.push("prepare-upper-route");
+  if (["upper-crossing", "upper-route"].includes(focusId)) {
+    if (state.buildId === "exploration-battle") {
+      ids.push(view.upperPrepared ? "contest-upper-landing" : "prepare-upper-route");
     }
   }
-  if (focusId === "service-gap" || focusId === "service-route") {
-    if (buildId === "exploration-hacking") {
-      if (!view.servicePrepared) ids.push("prepare-service-route");
-      else ids.push("suppress-service-closure");
+  if (["breacher", "regulator"].includes(focusId)) {
+    if (state.buildId === "battle-hacking") {
+      ids.push(view.regulatorExposed ? "suppress-regulator" : "answer-regulator");
     }
   }
-  if (focusId === "gate-actuator" || focusId === "service-lift") {
-    if (buildId === "hacking-battle") {
+  if (focusId === "gate-actuator") {
+    if (state.buildId === "hacking-battle") {
       ids.push(
-        state.actuator.controlled ? "execute-bollard" : "establish-bollard-control",
+        view.controlMode === "bollard"
+          ? "hold-actuator"
+          : "establish-bollard-control",
       );
     }
-    if (buildId === "hacking-exploration") {
+    if (getBuild(state.buildId).major === "hacking") ids.push("redirect-track");
+  }
+  if (["service-gap", "service-route"].includes(focusId)) {
+    if (state.buildId === "exploration-hacking") {
       ids.push(
-        state.actuator.controlled ? "execute-lift" : "establish-lift-control",
+        view.servicePrepared
+          ? "suppress-service-closure"
+          : "prepare-service-route",
+      );
+    }
+  }
+  if (["lift-relay", "service-lift"].includes(focusId)) {
+    if (state.buildId === "hacking-exploration") {
+      ids.push(
+        view.controlMode === "lift"
+          ? "execute-lift"
+          : "establish-lift-control",
       );
     }
   }
@@ -1034,14 +2016,17 @@ export function getContextActionGroups(state, focusId) {
   const movement = movementChoices(state, focusId);
   if (movement.length) groups.push({ parent: "Move", choices: movement });
 
-  if (["assault", "impact-rush"].includes(focusId)) {
-    groups.push({ parent: "Attack", choices: [makeChoice(state, "attack")] });
-    groups.push({
-      parent: "Defend",
-      choices: [makeChoice(state, "guard-impact")],
-    });
-  } else if (focusId === "player") {
+  if (Object.keys(state.enemies).includes(focusId)) {
+    groups.push({ parent: "Attack", choices: [makeChoice(state, "attack", [focusId])] });
+  }
+  if (focusId === "player") {
     groups.push({ parent: "Defend", choices: [makeChoice(state, "guard")] });
+  }
+  if (
+    ["gate", "breacher-intent"].includes(focusId) &&
+    planningView(state).position === tileId(10, 5)
+  ) {
+    groups.push({ parent: "Defend", choices: [makeChoice(state, "guard-gate")] });
   }
 
   const disciplines = disciplineChoices(state, focusId);
@@ -1050,16 +2035,10 @@ export function getContextActionGroups(state, focusId) {
   }
 
   if (focusId === "gate") {
-    groups.push({
-      parent: "Use",
-      choices: [makeChoice(state, "stabilize-gate")],
-    });
+    groups.push({ parent: "Use", choices: [makeChoice(state, "stabilize-gate")] });
   }
   if (focusId === "field-cache") {
-    groups.push({
-      parent: "Use",
-      choices: [makeChoice(state, "recover-cache")],
-    });
+    groups.push({ parent: "Use", choices: [makeChoice(state, "recover-cache")] });
   }
   if (focusId === "west-exit") {
     groups.push({ parent: "Leave", choices: [makeChoice(state, "leave")] });
@@ -1072,7 +2051,7 @@ export function getContextActionGroups(state, focusId) {
 export function getCompatibleCards(state, actionId) {
   const action = ACTIONS[actionId];
   if (!action) return [];
-  return state.hand
+  const prepared = state.hand
     .filter((cardId) => !cardReserved(state, cardId))
     .filter((cardId) => {
       const card = CARDS[cardId];
@@ -1081,81 +2060,149 @@ export function getCompatibleCards(state, actionId) {
         (cardId === "fallback-guard" && action.paid)
       );
     });
+  return [...prepared, ...contextCardsForAction(state, actionId)];
 }
 
 function makePlannedAction(state, actionId, targetId, cardId = null) {
   const definition = ACTIONS[actionId];
   const card = cardId ? CARDS[cardId] : null;
+  const path = actionPath(state, actionId, targetId);
+  const concealed =
+    Boolean(cardId) &&
+    ["Modifier", "Contingency", "Context Extension", "Preparation"].includes(
+      card?.kind,
+    );
   return {
     ...definition,
     targetId,
-    targetName: BOARD_FOCUSES[targetId]?.name ?? POSITION_NAMES[targetId] ?? targetId,
+    targetName:
+      BOARD_FOCUSES[targetId]?.name ??
+      BOARD_TILES[targetId]?.name ??
+      titleCase(targetId),
+    path,
+    route: path ? routeKind(path) : null,
     cardId,
     cardName: card?.name ?? null,
     cardCost: card?.cost ?? 0,
+    contextCard: Boolean(card?.context),
+    concealed,
     totalCost: definition.cost + (card?.cost ?? 0),
     instanceId: `plan-${state.nextActionSequence}`,
     sequence: state.nextActionSequence,
+    status: "open",
   };
 }
 
-export function previewAction(state, actionId, targetId, cardId = null) {
-  const error = validateAction(state, actionId, targetId, cardId);
+export function previewAction(
+  state,
+  actionId,
+  targetId,
+  cardId = null,
+  replacing = false,
+) {
+  const error = validateAction(state, actionId, targetId, cardId, replacing);
   if (error) return { legal: false, error };
   const next = clone(state);
-  next.plan.push(makePlannedAction(next, actionId, targetId, cardId));
-  const projection = projectPlan(next);
+  const action = makePlannedAction(next, actionId, targetId, cardId);
+  if (replacing) {
+    const index = next.plan.findIndex((item) => item.status === "open");
+    if (index < 0) return { legal: false, error: "No Open action can be changed." };
+    action.instanceId = next.plan[index].instanceId;
+    action.sequence = next.plan[index].sequence;
+    action.status = "solid";
+    next.plan[index] = action;
+  } else {
+    solidifyNewest(next.plan);
+    next.plan.push(action);
+  }
   return {
     legal: true,
-    action: next.plan.at(-1),
-    projection,
+    action,
+    projection: projectPlan(next),
   };
 }
 
 export function queueAction(state, actionId, targetId, cardId = null) {
   const error = validateAction(state, actionId, targetId, cardId);
   if (error) return withWarning(state, error);
-  const next = clone(state);
+  let next = clone(state);
   const action = makePlannedAction(next, actionId, targetId, cardId);
+  solidifyNewest(next.plan);
   next.plan.push(action);
   next.nextActionSequence += 1;
   if (actionId === "reposition") next.freeRepositionUsed = true;
+  next.consecutivePasses = 0;
+  next.planningHistory.push({
+    side: "player",
+    type: "commit",
+    actionId,
+    targetId,
+    concealedModifier: Boolean(action.concealed),
+  });
   next.warning = "";
-  return next;
+  next = takeEnemyPriority(next, "player-commit").state;
+  return maybeLockAfterPasses(next);
+}
+
+export function pivotOpenAction(state, actionId, targetId, cardId = null) {
+  if (state.playerPivotUsed) {
+    return withWarning(state, "This allotment's one Pivot is already spent.");
+  }
+  const index = state.plan.findIndex((action) => action.status === "open");
+  if (index < 0) {
+    return withWarning(state, "No newest Open action can be changed.");
+  }
+  const error = validateAction(state, actionId, targetId, cardId, true);
+  if (error) return withWarning(state, error);
+  let next = clone(state);
+  const prior = next.plan[index];
+  const replacement = makePlannedAction(next, actionId, targetId, cardId);
+  replacement.instanceId = prior.instanceId;
+  replacement.sequence = prior.sequence;
+  replacement.status = "solid";
+  next.plan[index] = replacement;
+  next.playerPivotUsed = true;
+  next.consecutivePasses = 0;
+  next.planningHistory.push({
+    side: "player",
+    type: "pivot",
+    from: prior.id,
+    actionId,
+    targetId,
+    concealedModifier: Boolean(replacement.concealed),
+  });
+  next.warning = "";
+  next = takeEnemyPriority(next, "player-pivot").state;
+  return maybeLockAfterPasses(next);
 }
 
 export function removePlanAction(state, instanceId) {
   if (state.phase !== "planning") return state;
-  const next = clone(state);
-  const index = next.plan.findIndex((action) => action.instanceId === instanceId);
-  if (index < 0) return state;
-  next.plan.splice(index, 1);
-  next.freeRepositionUsed = next.plan.some((action) => action.id === "reposition");
-  next.warning = "";
-  return next;
+  const action = state.plan.find((candidate) => candidate.instanceId === instanceId);
+  if (!action || action.status !== "open") {
+    return withWarning(
+      state,
+      "Earlier solid commitments cannot be erased. Change only the newest Open action.",
+    );
+  }
+  return withWarning(
+    state,
+    "Use Change Newest so the replacement spends the bounded Pivot immediately.",
+  );
 }
 
-export function reorderPlanAction(state, instanceId, direction) {
-  if (state.phase !== "planning") return state;
-  const next = clone(state);
-  const index = next.plan.findIndex((action) => action.instanceId === instanceId);
-  const destination = index + direction;
-  if (index < 0 || destination < 0 || destination >= next.plan.length) {
-    return state;
-  }
-  const [action] = next.plan.splice(index, 1);
-  next.plan.splice(destination, 0, action);
-  next.plan.forEach((item, itemIndex) => {
-    item.sequence = itemIndex + 1;
-  });
-  return next;
+export function reorderPlanAction(state) {
+  return withWarning(
+    state,
+    "Committed actions keep their causal order; earlier commitments cannot be reordered.",
+  );
 }
 
 export function refocusCards(state, cardIds) {
-  if (state.phase !== "planning") return state;
+  if (state.phase !== "planning" || state.priority !== "player") return state;
   const unique = [...new Set(cardIds)];
   if (state.refocusUsed) {
-    return withWarning(state, "Refocus is available once per planning phase.");
+    return withWarning(state, "Refocus is available once per planning cycle.");
   }
   if (unique.length < 1 || unique.length > 2) {
     return withWarning(state, "Choose one or two cards to Refocus.");
@@ -1172,9 +2219,9 @@ export function refocusCards(state, cardIds) {
         !state.hand.includes(cardId) || cardReserved(state, cardId),
     )
   ) {
-    return withWarning(state, "Only uncommitted cards in hand can be Refocused.");
+    return withWarning(state, "Only uncommitted Prepared Cards can be Refocused.");
   }
-  const next = clone(state);
+  let next = clone(state);
   const drawn = [];
   for (const cardId of unique) {
     next.hand.splice(next.hand.indexOf(cardId), 1);
@@ -1189,13 +2236,11 @@ export function refocusCards(state, cardIds) {
   next.command -= 4;
   next.planningActionCount += 1;
   next.refocusUsed = true;
-  next.refocusRecord = {
-    discarded: unique,
-    drawn,
-    cost: 4,
-  };
-  next.warning = "";
-  return next;
+  next.refocusRecord = { discarded: unique, drawn, cost: 4 };
+  next.planningHistory.push({ side: "player", type: "refocus", count: unique.length });
+  next.consecutivePasses = 0;
+  next = takeEnemyPriority(next, "player-refocus").state;
+  return maybeLockAfterPasses(next);
 }
 
 export function discardToRetain(state, cardId) {
@@ -1217,13 +2262,16 @@ function dynamicSnapshot(state) {
     guard: state.guard,
     majorState: state.majorState,
     gate: state.gate,
-    enemy: state.enemy,
+    enemies: state.enemies,
     divider: state.divider,
     actuator: state.actuator,
+    bollard: state.bollard,
     upperRoute: state.upperRoute,
     serviceRoute: state.serviceRoute,
     lift: state.lift,
+    poweredTrack: state.poweredTrack,
     cache: state.cache,
+    westExit: state.westExit,
     retreated: state.retreated,
     flags: state.flags,
   });
@@ -1237,640 +2285,8 @@ function applySnapshot(state, snapshot) {
   return next;
 }
 
-function logEvent(packets, lane, action, title, detail, outcome = "resolved") {
-  packets[lane].events.push({
-    actionId: action?.id ?? "enemy-impact-rush",
-    instanceId: action?.instanceId ?? "enemy-impact-rush",
-    title,
-    detail,
-    outcome,
-  });
-}
-
-function invalidate(sim, packets, lane, action, reason) {
-  const card = action.cardId ? CARDS[action.cardId] : null;
-  const contingency = card?.kind === "Contingency";
-  const refundablePrimary = contingency
-    ? action.cost
-    : action.cost + action.cardCost;
-  sim.refunds += Math.floor(refundablePrimary / 2);
-  if (action.cardId === "fallback-guard") {
-    sim.guard += 3;
-    sim.flags.braced = true;
-    logEvent(
-      packets,
-      "Fast",
-      action,
-      "Fallback Guard triggered",
-      "The primary invalidated before beginning; gain 3 Guard. Its 4 Command reserve is spent.",
-    );
-  }
-  logEvent(packets, lane, action, `${action.label} invalidated`, reason, "invalidated_before_begin");
-}
-
-function applyImpactToPlayer(sim, impact) {
-  const absorbed = Math.min(sim.guard, impact);
-  sim.guard -= absorbed;
-  sim.condition = Math.max(0, sim.condition - (impact - absorbed));
-}
-
-function applyPlayerAction(sim, packets, lane, action, fullPlan) {
-  const hasCard = (cardId) => action.cardId === cardId;
-  switch (action.id) {
-    case "reposition":
-    case "advance": {
-      if (!neighbors(sim.position).includes(action.targetId)) {
-        invalidate(
-          sim,
-          packets,
-          lane,
-          action,
-          `The path from ${POSITION_NAMES[sim.position]} to ${POSITION_NAMES[action.targetId]} is no longer ordinary and adjacent.`,
-        );
-        return;
-      }
-      sim.position = action.targetId;
-      sim.movementPath.push(action.targetId);
-      if (hasCard("covering-step")) sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        action.label,
-        `Player moved to ${POSITION_NAMES[action.targetId]}.`,
-      );
-      return;
-    }
-    case "guard":
-      sim.guard += 4;
-      logEvent(packets, lane, action, "Guard raised", "Player gained 4 Guard.");
-      return;
-    case "guard-impact":
-      sim.flags.rushBlocked = true;
-      sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Impact line braced",
-        "The confirmed Rush will not remove Gate Stability this cycle.",
-      );
-      return;
-    case "attack": {
-      if (!ACTIVE_ENEMY_STATUSES.has(sim.enemy.status)) {
-        invalidate(
-          sim,
-          packets,
-          lane,
-          action,
-          "The declared Assault target was no longer active. No retarget occurred.",
-        );
-        return;
-      }
-      const guardBreak = Math.min(2, sim.enemy.guard);
-      sim.enemy.guard -= guardBreak;
-      const absorbed = Math.min(sim.enemy.guard, 6);
-      sim.enemy.guard -= absorbed;
-      sim.enemy.condition = Math.max(
-        0,
-        sim.enemy.condition - (6 - absorbed),
-      );
-      if (sim.enemy.condition === 0) {
-        sim.enemy.status = "disabled";
-        sim.flags.rushBlocked = true;
-      }
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Weapon Attack",
-        sim.enemy.status === "disabled"
-          ? "The Assault was disabled before its Rush."
-          : `Assault now has ${sim.enemy.guard} Guard and ${sim.enemy.condition} Condition.`,
-      );
-      return;
-    }
-    case "answer-divider":
-      if (!ACTIVE_ENEMY_STATUSES.has(sim.enemy.status)) {
-        invalidate(sim, packets, lane, action, "The hostile Commitment no longer existed.");
-        return;
-      }
-      sim.flags.rushBlocked = true;
-      sim.divider.status = "breached";
-      sim.enemy.status = "staggered";
-      sim.enemy.staggered = true;
-      sim.majorState = {
-        type: "battle",
-        name: "Battle Advantage",
-        status: "active",
-      };
-      sim.flags.turningPoint = "divider";
-      if (hasCard("brace-through")) sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Cracked Divider breached",
-        "The Assault's own Rush created a physical Opening usable by either side.",
-      );
-      return;
-    case "cross-breach":
-      if (sim.divider.status !== "breached") {
-        invalidate(sim, packets, lane, action, "The causal breach was never created.");
-        return;
-      }
-      sim.position = "gate-platform";
-      sim.movementPath.push("gate-platform");
-      sim.majorState = {
-        type: "battle",
-        name: "Battle Advantage",
-        status: "spent",
-      };
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Breach crossed",
-        "Player reached Gate Platform through confrontation-created geometry.",
-      );
-      return;
-    case "prepare-upper-route":
-      if (sim.position !== "upper-walk") {
-        invalidate(sim, packets, lane, action, "Upper Walk access was lost before setup.");
-        return;
-      }
-      sim.upperRoute.prepared = true;
-      sim.upperRoute.destinationClaim = hasCard("destination-claim");
-      sim.majorState = {
-        type: "exploration",
-        name: "Prepared Upper Route",
-        status: "active",
-      };
-      sim.flags.turningPoint = "upper-route";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Upper Route prepared",
-        "A physical relationship to Gate Platform now exists.",
-      );
-      return;
-    case "contest-upper-landing":
-      if (!sim.upperRoute.prepared) {
-        invalidate(sim, packets, lane, action, "No Upper Route landing existed to protect.");
-        return;
-      }
-      sim.upperRoute.protected = true;
-      sim.flags.rushBlocked = true;
-      if (hasCard("brace-through")) sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Upper landing held",
-        "The prepared Route survived physical pressure and the Rush was turned aside.",
-      );
-      return;
-    case "cross-upper-route":
-      if (!sim.upperRoute.prepared || sim.position !== "upper-walk") {
-        invalidate(sim, packets, lane, action, "The prepared Upper Route was unavailable.");
-        return;
-      }
-      sim.position = "gate-platform";
-      sim.movementPath.push("gate-platform");
-      sim.upperRoute.prepared = false;
-      sim.majorState = {
-        type: "exploration",
-        name: "Prepared Upper Route",
-        status: "spent",
-      };
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Upper Route crossed",
-        "Player spent the prepared relationship and reached Gate Platform.",
-      );
-      return;
-    case "answer-regulator":
-      if (!ACTIVE_ENEMY_STATUSES.has(sim.enemy.status)) {
-        invalidate(sim, packets, lane, action, "The hostile Commitment no longer existed.");
-        return;
-      }
-      sim.flags.rushBlocked = true;
-      sim.enemy.status = "staggered";
-      sim.enemy.staggered = true;
-      sim.enemy.regulator = "exposed";
-      sim.majorState = {
-        type: "battle",
-        name: "Battle Advantage",
-        status: "active",
-      };
-      sim.flags.turningPoint = "regulator";
-      if (hasCard("brace-through")) sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Impact regulator exposed",
-        "Physical confrontation opened access to protected hardware.",
-      );
-      return;
-    case "suppress-regulator":
-      if (
-        !fullPlan.some((candidate) => candidate.id === "answer-regulator") &&
-        sim.enemy.regulator !== "exposed"
-      ) {
-        invalidate(sim, packets, lane, action, "The regulator was never exposed.");
-        return;
-      }
-      sim.flags.regulatorSuppressionArmed = true;
-      sim.enemy.regulatorResetSuppressed = true;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Regulator reset suppressed",
-        "The automatic reseal response is delayed beyond Settle.",
-      );
-      return;
-    case "establish-bollard-control":
-      if (sim.position !== "actuator") {
-        invalidate(sim, packets, lane, action, "Physical Actuator access was lost.");
-        return;
-      }
-      sim.actuator.mode = "bollard";
-      sim.actuator.controlled = true;
-      sim.actuator.quietRewrite = hasCard("quiet-rewrite");
-      sim.majorState = {
-        type: "hacking",
-        name: "Temporary Bollard Control",
-        status: "active",
-      };
-      sim.flags.turningPoint = "bollard";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Bollard Control established",
-        "A next-cycle defensive Output is available if physical access survives.",
-      );
-      return;
-    case "contest-actuator":
-      if (!sim.actuator.controlled || sim.actuator.mode !== "bollard") {
-        invalidate(sim, packets, lane, action, "No Bollard Control existed to protect.");
-        return;
-      }
-      sim.actuator.accessHeld = true;
-      sim.flags.rushBlocked = true;
-      if (hasCard("brace-through")) sim.guard += 2;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Actuator access held",
-        "Physical protection preserved local Control against ejection.",
-      );
-      return;
-    case "execute-bollard":
-      if (
-        !sim.actuator.controlled ||
-        sim.actuator.mode !== "bollard" ||
-        sim.position !== "actuator"
-      ) {
-        invalidate(sim, packets, lane, action, "Bollard Control or physical access was unavailable.");
-        return;
-      }
-      sim.actuator.controlled = false;
-      sim.enemy.status = "pinned";
-      sim.flags.rushBlocked = true;
-      sim.majorState = {
-        type: "hacking",
-        name: "Temporary Bollard Control",
-        status: "spent",
-      };
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Bollard Output executed",
-        "The Assault was redirected and pinned by authored machinery.",
-      );
-      return;
-    case "prepare-service-route":
-      sim.serviceRoute.prepared = true;
-      sim.serviceRoute.destinationClaim = hasCard("destination-claim");
-      sim.majorState = {
-        type: "exploration",
-        name: "Prepared Service Route",
-        status: "active",
-      };
-      sim.flags.turningPoint = "service-route";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Service Route prepared",
-        "The natural relationship now reaches toward Gate Platform.",
-      );
-      return;
-    case "suppress-service-closure":
-      if (
-        !fullPlan.some((candidate) => candidate.id === "prepare-service-route") &&
-        !sim.serviceRoute.prepared
-      ) {
-        invalidate(sim, packets, lane, action, "No prepared service relationship existed.");
-        return;
-      }
-      sim.flags.serviceSuppressionArmed = true;
-      sim.serviceRoute.closureSuppressed = true;
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Service closure suppressed",
-        "The actual automatic closure mechanism is delayed.",
-      );
-      return;
-    case "cross-service-route":
-      if (!sim.serviceRoute.prepared) {
-        invalidate(sim, packets, lane, action, "The Service Route was unavailable.");
-        return;
-      }
-      sim.position = "gate-platform";
-      sim.movementPath.push("gate-platform");
-      sim.serviceRoute.prepared = false;
-      sim.majorState = {
-        type: "exploration",
-        name: "Prepared Service Route",
-        status: "spent",
-      };
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Service Route crossed",
-        "Player reached Gate Platform through the protected rear relationship.",
-      );
-      return;
-    case "establish-lift-control":
-      if (sim.position !== "actuator") {
-        invalidate(sim, packets, lane, action, "Physical Actuator access was lost.");
-        return;
-      }
-      sim.actuator.mode = "lift";
-      sim.actuator.controlled = true;
-      sim.actuator.quietRewrite = hasCard("quiet-rewrite");
-      sim.majorState = {
-        type: "hacking",
-        name: "Temporary Lift Control",
-        status: "active",
-      };
-      sim.flags.turningPoint = "lift";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Lift Control established",
-        "A next-cycle geometry Output is available.",
-      );
-      return;
-    case "execute-lift":
-      if (
-        !sim.actuator.controlled ||
-        sim.actuator.mode !== "lift" ||
-        sim.position !== "actuator"
-      ) {
-        invalidate(sim, packets, lane, action, "Lift Control or physical access was unavailable.");
-        return;
-      }
-      sim.actuator.controlled = false;
-      sim.lift.deployed = true;
-      sim.lift.resetAfterSettle = true;
-      sim.majorState = {
-        type: "hacking",
-        name: "Temporary Lift Control",
-        status: "spent",
-      };
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Service Lift deployed",
-        "Machinery created temporary geometry across the missing upper span.",
-      );
-      return;
-    case "cross-lift":
-      if (!sim.lift.deployed) {
-        invalidate(sim, packets, lane, action, "The Lift Output never created the crossing.");
-        return;
-      }
-      sim.position = "gate-platform";
-      sim.movementPath.push("gate-platform");
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Service Lift crossed",
-        "Player reached Gate Platform before the machinery reset.",
-      );
-      return;
-    case "stabilize-gate":
-      if (sim.position !== "gate-platform" || sim.gate.status === "failed") {
-        invalidate(sim, packets, lane, action, "Gate Platform access or Gate integrity was lost.");
-        return;
-      }
-      sim.gate.status = "stabilized";
-      sim.flags.rushBlocked = true;
-      if (ACTIVE_ENEMY_STATUSES.has(sim.enemy.status)) {
-        sim.enemy.status = "driven";
-      }
-      sim.flags.turningPoint ??= "stabilize";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Gate stabilized",
-        "The defensive seal activated and forced the remaining Assault out.",
-      );
-      return;
-    case "recover-cache":
-      if (sim.position !== "upper-walk" || sim.cache.status !== "available") {
-        invalidate(sim, packets, lane, action, "Upper Walk access to the Cache was lost.");
-        return;
-      }
-      sim.cache.status = "recovered";
-      sim.flags.turningPoint = "cache";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Field Cache recovered",
-        "The prototype Package is carried locally; no persistent reward is created.",
-      );
-      return;
-    case "leave":
-      if (sim.position !== "entry") {
-        invalidate(sim, packets, lane, action, "The West Exit was no longer adjacent.");
-        return;
-      }
-      sim.position = "west-exit";
-      sim.movementPath.push("west-exit");
-      sim.retreated = true;
-      sim.flags.turningPoint = "retreat";
-      logEvent(
-        packets,
-        lane,
-        action,
-        "Controlled Retreat",
-        "Player left through West Exit before becoming Compromised.",
-      );
-      return;
-    default:
-      invalidate(sim, packets, lane, action, "This action has no deterministic resolver.");
-  }
-}
-
-function resolveEnemyRush(sim, packets) {
-  const action = { id: "enemy-impact-rush", instanceId: "enemy-impact-rush" };
-  if (!ACTIVE_ENEMY_STATUSES.has(sim.enemy.status)) {
-    logEvent(
-      packets,
-      "Standard",
-      action,
-      "Impact Rush canceled",
-      "The Assault was no longer able to execute its Commitment.",
-      "canceled",
-    );
-    return;
-  }
-  if (sim.gate.status === "stabilized") {
-    sim.enemy.status = "driven";
-    logEvent(
-      packets,
-      "Standard",
-      action,
-      "Impact Rush denied",
-      "The stabilized defensive seal drove the Assault out.",
-      "canceled",
-    );
-    return;
-  }
-  if (sim.flags.rushBlocked) {
-    logEvent(
-      packets,
-      "Standard",
-      action,
-      "Impact Rush stopped",
-      "A visible player action prevented Gate Stability loss.",
-      "blocked",
-    );
-    return;
-  }
-  sim.gate.stability = Math.max(0, sim.gate.stability - 1);
-  if (
-    ["lower-cover", "lower-yard", "gate-platform"].includes(sim.position)
-  ) {
-    applyImpactToPlayer(sim, 3);
-    if (sim.position !== "gate-platform") sim.position = "entry";
-  }
-  if (
-    sim.position === "actuator" &&
-    sim.buildId === "hacking-battle" &&
-    sim.actuator.controlled &&
-    !sim.actuator.accessHeld
-  ) {
-    applyImpactToPlayer(sim, 3);
-    sim.position = "lower-yard";
-    sim.actuator.controlled = false;
-    sim.majorState = {
-      type: "hacking",
-      name: "Temporary Bollard Control",
-      status: "lost",
-    };
-  }
-  if (sim.gate.stability === 0) sim.gate.status = "failed";
-  logEvent(
-    packets,
-    "Standard",
-    action,
-    "Impact Rush connected",
-    sim.gate.status === "failed"
-      ? "The third unopposed Rush removed the final Stability pip. The Gate failed."
-      : `Gate Stability fell to ${sim.gate.stability} of 3.`,
-  );
-}
-
-function finishAutomaticResponses(sim, packets) {
-  if (
-    sim.enemy.regulator === "exposed" &&
-    !sim.enemy.regulatorResetSuppressed
-  ) {
-    sim.enemy.regulator = "shielded";
-    sim.enemy.staggered = false;
-    if (sim.enemy.status === "staggered") sim.enemy.status = "active";
-    logEvent(
-      packets,
-      "Slow",
-      null,
-      "Regulator automatically reset",
-      "The exposed component resealed because its response was not suppressed.",
-    );
-  }
-  if (
-    sim.serviceRoute.prepared &&
-    !sim.serviceRoute.closureSuppressed
-  ) {
-    if (sim.serviceRoute.destinationClaim) {
-      sim.serviceRoute.destinationClaim = false;
-      logEvent(
-        packets,
-        "Slow",
-        null,
-        "Destination Claim absorbed closure",
-        "The observed relationship survives this environmental shift once.",
-      );
-    } else {
-      sim.serviceRoute.prepared = false;
-      sim.majorState = {
-        type: "exploration",
-        name: "Prepared Service Route",
-        status: "lost",
-      };
-      logEvent(
-        packets,
-        "Slow",
-        null,
-        "Service Route closed",
-        "The unsuppressed mechanism removed the prepared relationship.",
-      );
-    }
-  }
-  if (sim.actuator.controlled && !sim.actuator.quietRewrite) {
-    sim.actuator.controlled = false;
-    sim.majorState = {
-      type: "hacking",
-      name:
-        sim.actuator.mode === "bollard"
-          ? "Temporary Bollard Control"
-          : "Temporary Lift Control",
-      status: "lost",
-    };
-    logEvent(
-      packets,
-      "Slow",
-      null,
-      "Actuator lockout responded",
-      "Local Control was lost because its automatic response was not delayed.",
-    );
-  }
-}
-
-function simulateCycle(state) {
-  const sim = dynamicSnapshot(state);
-  sim.movementPath = [state.position];
-  sim.refunds = 0;
-  const packets = Object.fromEntries(
+function createPackets() {
+  return Object.fromEntries(
     LANE_ORDER.map((lane) => [
       lane,
       {
@@ -1880,55 +2296,730 @@ function simulateCycle(state) {
       },
     ]),
   );
+}
 
-  for (const action of state.plan) {
-    if (action.cardId) {
+function logEvent(
+  packets,
+  lane,
+  action,
+  title,
+  detail,
+  outcome = "resolved",
+  extra = {},
+) {
+  packets[lane].events.push({
+    actionId: action?.id ?? "system",
+    instanceId: action?.instanceId ?? `system-${packets[lane].events.length}`,
+    actorId: action?.actorId ?? "system",
+    title,
+    detail,
+    outcome,
+    ...extra,
+  });
+}
+
+function invalidate(sim, packets, lane, action, reason) {
+  const refundable = action.contextCard
+    ? action.cost
+    : action.totalCost;
+  sim.refunds += Math.floor(refundable / 2);
+  logEvent(
+    packets,
+    lane,
+    action,
+    `${action.label} invalidated`,
+    `${reason} No retarget occurred.`,
+    "invalidated_before_begin",
+  );
+}
+
+function impactActor(actor, impact) {
+  const absorbed = Math.min(actor.guard, impact);
+  actor.guard -= absorbed;
+  actor.condition = Math.max(0, actor.condition - (impact - absorbed));
+  if (actor.condition === 0) actor.status = "disabled";
+}
+
+function applyPlayerMovement(sim, packets, action) {
+  const destination = action.path?.at(-1);
+  if (!destination) {
+    invalidate(sim, packets, "Standard", action, "The declared path was unavailable.");
+    return;
+  }
+  sim.position = destination;
+  sim.movementPath.push(...action.path.slice(1));
+  if (action.cardId === "covering-step") sim.guard += 2;
+  logEvent(
+    packets,
+    "Standard",
+    action,
+    action.label,
+    `Player moved to tile ${coordFromTile(destination).join(",")}. ${titleCase(action.route)} route.`,
+  );
+}
+
+function applyCycleOneClash(sim, packets, playerAction, enemyAction) {
+  const route = latestApproach(sim._state);
+  const comparison = tempoComparisonForRoute(
+    route,
+    sim.poweredTrack.feed,
+  );
+  const hasFollow = playerAction.cardId === "follow-through";
+  const effective =
+    hasFollow || route !== "clear"
+      ? comparison
+      : {
+          ...comparison,
+          player: 5,
+          outcome: "enemy_first",
+          link: "Unlinked",
+          reason: "No Follow Through modifier was attached.",
+        };
+  if (effective.outcome === "enemy_first") {
+    sim.enemies.breacher.guard += 3;
+  }
+  sim.divider.integrity = 0;
+  sim.divider.status = "breached";
+  sim.enemies.breacher.guard = 0;
+  sim.enemies.breacher.condition = Math.max(1, sim.enemies.breacher.condition - 4);
+  sim.enemies.breacher.status = "staggered";
+  sim.guard = 0;
+  sim.condition = Math.max(1, sim.condition - 1);
+  sim.flags.turningPoint = "divider";
+  sim.flags.contextCardUsed ||= hasFollow;
+  sim.majorState = {
+    type: "battle",
+    name: "Battle Advantage",
+    status: "active",
+  };
+  logEvent(
+    packets,
+    "Standard",
+    playerAction,
+    "CLASH · Divider contact",
+    `The plans met ${effective.outcome === "simultaneous" ? "simultaneously" : effective.outcome === "player_first" ? "with the player ahead" : "with the Breacher ahead"}. Opposed Force broke the Divider; Shield Link prevented full displacement; Impact Counter damaged the player.`,
+    "simultaneous_contact",
+    {
+      clash: true,
+      contact: {
+        risk: "high",
+        timing: effective.outcome,
+        location: "Cracked Divider",
+        playerTempo: effective.player,
+        enemyTempo: effective.enemy,
+        link: effective.link,
+        reason: effective.reason,
+      },
+    },
+  );
+  sim.handled.add(playerAction.instanceId);
+  sim.handled.add(enemyAction.instanceId);
+}
+
+function applyGateLaneClash(sim, packets, playerAction, enemyAction) {
+  sim.position = tileId(10, 5);
+  sim.bollard.status = "jammed";
+  sim.enemies.guard.condition = Math.max(1, sim.enemies.guard.condition - 3);
+  sim.enemies.guard.guard = Math.max(0, sim.enemies.guard.guard - 3);
+  sim.flags.turningPoint = "bollard";
+  logEvent(
+    packets,
+    "Standard",
+    playerAction,
+    "CLASH · Gate access",
+    "Angle the Contact and Brace Line reached the bollard together. The Guard held its edge, the bollard jammed open, and the player gained the Gate-adjacent tile.",
+    "simultaneous_contact",
+    {
+      clash: true,
+      contact: {
+        risk: "high",
+        timing: "simultaneous",
+        location: "Defensive Bollard",
+        playerTempo: 6,
+        enemyTempo: 6,
+        link: "Preserved",
+      },
+    },
+  );
+  sim.handled.add(playerAction.instanceId);
+  sim.handled.add(enemyAction.instanceId);
+}
+
+function applyDefendedGateClash(sim, packets, enemyAction) {
+  const absorbed = Math.min(sim.guard, 5);
+  sim.guard -= absorbed;
+  sim.condition = Math.max(1, sim.condition - Math.max(0, 5 - absorbed));
+  sim.enemies.breacher.condition = Math.max(1, sim.enemies.breacher.condition - 2);
+  sim.enemies.breacher.status = "off-balance";
+  logEvent(
+    packets,
+    "Standard",
+    enemyAction,
+    "CLASH · Defended Gate lane",
+    "Guard Gate and Objective Brace held the player in place. The Breacher spent its Force against the defense and never reached the Gate.",
+    "simultaneous_contact",
+    {
+      clash: true,
+      contact: {
+        risk: "high",
+        timing: "player_guard_first",
+        location: "Gate lane",
+        playerTempo: 7,
+        enemyTempo: 5,
+        link: "Guard established",
+      },
+    },
+  );
+  sim.handled.add(enemyAction.instanceId);
+}
+
+function applyPlayerAction(sim, packets, action) {
+  if (sim.handled.has(action.instanceId)) return;
+  switch (action.id) {
+    case "reposition":
+    case "advance":
+      applyPlayerMovement(sim, packets, action);
+      return;
+    case "guard":
+      sim.guard += 4;
+      logEvent(packets, "Fast", action, "Guard established", "Player gained 4 Guard.");
+      return;
+    case "guard-gate":
+      sim.guard += 4;
+      sim.flags.playerGuardedGate = true;
       logEvent(
         packets,
         "Fast",
         action,
-        `${action.cardName} prepared`,
-        `Compatible card attached to ${action.label}.`,
+        "Gate lane guarded",
+        "The player's defense will establish before Standard contact.",
       );
+      return;
+    case "attack": {
+      const enemy = sim.enemies[action.targetId];
+      if (!enemy || !ACTIVE_ENEMY_STATUSES.has(enemy.status)) {
+        invalidate(sim, packets, action.lane, action, "The declared enemy was no longer legal.");
+        return;
+      }
+      impactActor(enemy, 5);
+      logEvent(
+        packets,
+        action.lane,
+        action,
+        "Weapon Attack",
+        `${enemy.name} now has ${enemy.condition} Condition and ${enemy.guard} Guard.`,
+      );
+      return;
     }
+    case "answer-divider":
+      return;
+    case "cross-breach":
+      if (sim.divider.status !== "breached") {
+        invalidate(sim, packets, action.lane, action, "The Divider breach never opened.");
+        return;
+      }
+      sim.position = tileId(10, 5);
+      sim.movementPath.push(tileId(7, 5), tileId(9, 5), tileId(10, 5));
+      logEvent(
+        packets,
+        "Standard",
+        action,
+        "Divider opening crossed",
+        sim.divider.conduit === "charged"
+          ? "The skill-revealed upper lip avoided the charged center and reached Gate access."
+          : "The player used the public breach to reach Gate access.",
+      );
+      return;
+    case "angle-clash":
+      return;
+    case "prepare-upper-route":
+      sim.upperRoute.prepared = true;
+      sim.majorState = { type: "exploration", name: "Prepared Upper Route", status: "active" };
+      sim.flags.turningPoint = "upper-route";
+      logEvent(packets, action.lane, action, "Upper Route prepared", "The capacity-one natural crossing is now public and contestable.");
+      return;
+    case "contest-upper-landing":
+      if (!sim.upperRoute.prepared) {
+        invalidate(sim, packets, action.lane, action, "No Upper Route landing existed.");
+        return;
+      }
+      sim.upperRoute.protected = true;
+      logEvent(packets, action.lane, action, "Upper landing contested", "The player protected the landing without erasing the interceptor.");
+      return;
+    case "cross-upper-route":
+      if (!sim.upperRoute.prepared) {
+        invalidate(sim, packets, action.lane, action, "The Upper Route was unavailable.");
+        return;
+      }
+      sim.position = tileId(9, 3);
+      sim.upperRoute.prepared = false;
+      logEvent(packets, action.lane, action, "Upper Route crossed", "The player reached the east Upper Walk.");
+      return;
+    case "answer-regulator":
+      sim.flags.regulatorExposed = true;
+      sim.enemies.breacher.status = "staggered";
+      sim.enemies.breacher.guard = 0;
+      sim.majorState = { type: "battle", name: "Exposed Regulator", status: "active" };
+      sim.flags.turningPoint = "regulator";
+      logEvent(packets, action.lane, action, "Impact regulator exposed", "Physical contact created a real Hacking opportunity.");
+      return;
+    case "suppress-regulator":
+      if (!sim.flags.regulatorExposed) {
+        invalidate(sim, packets, action.lane, action, "The regulator was never exposed.");
+        return;
+      }
+      sim.flags.regulatorResetSuppressed = true;
+      logEvent(packets, action.lane, action, "Regulator reset suppressed", "The Breacher's automatic recovery was delayed.");
+      return;
+    case "establish-bollard-control":
+      sim.actuator.controlled = true;
+      sim.actuator.mode = "bollard";
+      sim.actuator.quietRewrite = action.cardId === "quiet-rewrite";
+      sim.majorState = { type: "hacking", name: "Bollard Control", status: "active" };
+      sim.flags.turningPoint = "actuator";
+      logEvent(packets, action.lane, action, "Actuator Control established", "The bollard Output is available, but physical access remains exposed.");
+      return;
+    case "hold-actuator":
+      if (!sim.actuator.controlled) {
+        invalidate(sim, packets, action.lane, action, "Actuator Control was already lost.");
+        return;
+      }
+      sim.actuator.accessHeld = true;
+      logEvent(packets, action.lane, action, "Actuator access held", "Battle converted local Control into a defended physical position.");
+      return;
+    case "execute-bollard":
+      if (!sim.actuator.controlled || sim.actuator.mode !== "bollard") {
+        invalidate(sim, packets, action.lane, action, "Bollard Control was unavailable.");
+        return;
+      }
+      sim.bollard.status = "extended";
+      sim.enemies.breacher.status = "pinned";
+      sim.actuator.controlled = false;
+      sim.majorState.status = "spent";
+      logEvent(packets, action.lane, action, "Bollard Output executed", "The authored machinery pinned the Breacher's physical line.");
+      return;
+    case "prepare-service-route":
+      sim.serviceRoute.prepared = true;
+      sim.majorState = { type: "exploration", name: "Prepared Service Route", status: "active" };
+      sim.flags.turningPoint = "service-route";
+      logEvent(packets, action.lane, action, "Service Route prepared", "The obscured relationship is real; its shutter remains connected.");
+      return;
+    case "suppress-service-closure":
+      if (!sim.serviceRoute.prepared) {
+        invalidate(sim, packets, action.lane, action, "No service relationship existed.");
+        return;
+      }
+      sim.serviceRoute.closureSuppressed = true;
+      sim.serviceRoute.closing = false;
+      logEvent(packets, action.lane, action, "Service shutter suppressed", "The route remains open beyond its first closure response.");
+      return;
+    case "cross-service-route":
+      if (!sim.serviceRoute.prepared) {
+        invalidate(sim, packets, action.lane, action, "The Service Route was unavailable.");
+        return;
+      }
+      sim.position = tileId(10, 6);
+      logEvent(packets, action.lane, action, "Service Route crossed", "The player reached the rear Gate lane.");
+      return;
+    case "establish-lift-control":
+      sim.actuator.controlled = true;
+      sim.actuator.mode = "lift";
+      sim.actuator.quietRewrite = action.cardId === "quiet-rewrite";
+      sim.majorState = { type: "hacking", name: "Lift Control", status: "active" };
+      sim.flags.turningPoint = "lift";
+      logEvent(packets, action.lane, action, "Lift Control established", "A later Output can create temporary upper geometry.");
+      return;
+    case "execute-lift":
+      if (!sim.actuator.controlled || sim.actuator.mode !== "lift") {
+        invalidate(sim, packets, action.lane, action, "Lift Control was unavailable.");
+        return;
+      }
+      sim.lift.deployed = true;
+      sim.lift.resetAfterSettle = true;
+      sim.actuator.controlled = false;
+      sim.majorState.status = "spent";
+      logEvent(packets, action.lane, action, "Service Lift aligned", "A temporary capacity-one bridge now spans the Upper Walk gap.");
+      return;
+    case "cross-lift":
+      if (!sim.lift.deployed) {
+        invalidate(sim, packets, action.lane, action, "The lift never aligned.");
+        return;
+      }
+      sim.position = tileId(9, 2);
+      logEvent(packets, action.lane, action, "Lift bridge crossed", "The player crossed before the authored Settle reset.");
+      return;
+    case "redirect-track":
+      sim.poweredTrack.feed = "toward-divider";
+      logEvent(packets, action.lane, action, "Service track redirected", "The physical feed now accelerates one compatible approach toward the Divider.");
+      return;
+    case "recover-cache":
+      if (sim.position !== tileId(6, 2) || sim.cache.status !== "available") {
+        invalidate(sim, packets, action.lane, action, "The Field Cache was no longer reachable.");
+        return;
+      }
+      sim.cache.status = "carried";
+      sim.flags.turningPoint = "cache";
+      logEvent(packets, action.lane, action, "Field Cache recovered", "The Package is carried only inside this resettable proof.");
+      return;
+    case "leave":
+      if (sim.position !== tileId(2, 6) || sim.westExit.status === "blocked") {
+        invalidate(sim, packets, action.lane, action, "The physical West Exit was unavailable.");
+        return;
+      }
+      sim.position = tileId(1, 6);
+      sim.retreated = true;
+      sim.flags.turningPoint = "retreat";
+      logEvent(packets, action.lane, action, "Controlled Retreat", "The player left before becoming unable to withdraw.");
+      return;
+    case "stabilize-gate":
+      if (
+        ![tileId(10, 5), tileId(11, 5), tileId(10, 6)].includes(sim.position) ||
+        sim.gate.status === "failed"
+      ) {
+        invalidate(sim, packets, action.lane, action, "Gate access was lost before Work began.");
+        return;
+      }
+      if (sim.gate.workDelayed && action.cardId !== "objective-brace") {
+        invalidate(sim, packets, action.lane, action, "Static Tax interrupted unprotected Gate Work.");
+        return;
+      }
+      sim.gate.status = "stabilized";
+      sim.flags.objectiveBraceUsed = action.cardId === "objective-brace";
+      for (const enemy of Object.values(sim.enemies)) {
+        if (ACTIVE_ENEMY_STATUSES.has(enemy.status)) {
+          enemy.status = enemy.id === "breacher" ? "driven" : "withdrew";
+        }
+      }
+      sim.flags.turningPoint ??= "stabilize";
+      logEvent(packets, "Slow", action, "Gate stabilized", "The defensive seal activated after faster commitments resolved.");
+      return;
+    default:
+      invalidate(sim, packets, action.lane, action, "No deterministic resolver exists.");
   }
+}
 
-  const entries = state.plan.map((action) => ({ type: "player", action }));
-  entries.push({
-    type: "enemy",
-    action: {
-      id: "enemy-impact-rush",
-      instanceId: "enemy-impact-rush",
-      lane: "Standard",
-      tempo: 5,
-      sequence: Number.MAX_SAFE_INTEGER,
-    },
-  });
-  entries.sort((left, right) => {
-    const laneDelta =
-      LANE_RANK[left.action.lane] - LANE_RANK[right.action.lane];
-    if (laneDelta !== 0) return laneDelta;
-    const tempoDelta = right.action.tempo - left.action.tempo;
-    if (tempoDelta !== 0) return tempoDelta;
-    return left.action.sequence - right.action.sequence;
-  });
+function applyEnemyAction(sim, packets, action) {
+  if (sim.handled.has(action.instanceId)) return;
+  switch (action.id) {
+    case "shield-link":
+      sim.enemies.breacher.guard += 3;
+      logEvent(packets, "Fast", action, "Guard linked to Breacher", "Shield Link established before contact.");
+      return;
+    case "charge-debris":
+      if (sim.divider.status !== "breached") {
+        logEvent(packets, "Fast", action, "Charge Debris invalidated", "No breached conduit existed.", "invalidated_before_begin");
+        return;
+      }
+      sim.divider.conduit = "charged";
+      logEvent(packets, "Fast", action, "Divider conduit charged", "The lower breach became dangerous and slower.");
+      return;
+    case "body-block":
+      sim.enemies.guard.position = tileId(10, 5);
+      logEvent(packets, "Standard", action, "Guard occupied Gate access", "The broad body block threatened to invalidate Gate Work.");
+      return;
+    case "brace-line":
+      return;
+    case "exit-pressure":
+      sim.westExit.status = "threatened";
+      sim.enemies.pressure.position = tileId(4, 3);
+      logEvent(packets, "Fast", action, "West Exit threatened", "Pressure committed away from the Gate lane to endanger retreat.");
+      return;
+    case "static-tax":
+      sim.gate.workDelayed = true;
+      logEvent(packets, "Fast", action, "Static Tax attached", "Gate stabilization will resolve slower and needs protection.");
+      return;
+    case "impact-rush":
+      if (!ACTIVE_ENEMY_STATUSES.has(sim.enemies.breacher.status)) {
+        logEvent(packets, "Standard", action, "Impact Rush canceled", "The Breacher was no longer able to commit.", "canceled");
+        return;
+      }
+      if (sim.flags.playerGuardedGate && sim.position === tileId(10, 5)) {
+        applyDefendedGateClash(sim, packets, action);
+        return;
+      }
+      sim.gate.stability = Math.max(0, sim.gate.stability - 1);
+      if (sim.gate.stability === 0) sim.gate.status = "failed";
+      logEvent(
+        packets,
+        "Standard",
+        action,
+        "Impact Rush connected",
+        sim.gate.status === "failed"
+          ? "The final Stability pip was removed. The Gate is lost."
+          : `Gate Stability fell to ${sim.gate.stability} of 3.`,
+      );
+      return;
+    case "emergency-reset":
+      if (sim.flags.regulatorExposed && !sim.flags.regulatorResetSuppressed) {
+        sim.flags.regulatorExposed = false;
+        sim.enemies.breacher.status = "active";
+        logEvent(packets, "Fast", action, "Regulator reset", "The exposed hardware resealed.");
+      } else {
+        logEvent(packets, "Fast", action, "Emergency Reset held", "The declared trigger did not remain legal.", "not_triggered");
+      }
+      return;
+    case "purge-control":
+      if (sim.actuator.controlled && !sim.actuator.accessHeld) {
+        sim.actuator.controlled = false;
+        sim.majorState.status = "lost";
+        logEvent(packets, action.lane, action, "Actuator Control purged", "The player did not physically hold access.");
+      } else {
+        logEvent(packets, action.lane, action, "Purge contested", "Physical access prevented the immediate purge.", "blocked");
+      }
+      return;
+    case "seal-gap":
+      if (sim.serviceRoute.prepared && !sim.serviceRoute.closureSuppressed) {
+        sim.serviceRoute.closing = true;
+        logEvent(packets, action.lane, action, "Service shutter closing", "The prepared relationship will close unless suppressed.");
+      } else {
+        logEvent(packets, action.lane, action, "Seal Gap held", "No legal unsuppressed Route existed.", "not_triggered");
+      }
+      return;
+    case "lift-recall":
+      if (sim.lift.deployed) {
+        sim.lift.returning = true;
+        logEvent(packets, action.lane, action, "Lift recall started", "The bridge will return at Settle.");
+      } else {
+        logEvent(packets, action.lane, action, "Lift Recall reserved", "The lift Output has not yet occurred.", "not_triggered");
+      }
+      return;
+    case "vault-intercept":
+      sim.upperRoute.contested = true;
+      logEvent(packets, action.lane, action, "Upper landing intercepted", "The route remains real, but its east landing is contested.");
+      return;
+    default:
+      logEvent(packets, action.lane, action, action.label, `${action.actorName} completed its legal commitment.`);
+  }
+}
+
+function revealCommittedCards(state, packets, revealSecrets) {
+  for (const action of state.plan) {
+    if (!action.cardId) continue;
+    logEvent(
+      packets,
+      "Fast",
+      action,
+      revealSecrets ? `${action.cardName} revealed` : "Player modifier committed",
+      revealSecrets
+        ? `${action.cardName} modifies ${action.label}.`
+        : "One concealed player modifier may change the commitment.",
+      "revealed",
+    );
+  }
+  for (const action of state.enemyPlan) {
+    if (!action.cardId && !action.modifierCardId) continue;
+    const names = [action.cardName, action.modifierCardName].filter(Boolean);
+    logEvent(
+      packets,
+      "Fast",
+      action,
+      revealSecrets ? `${names.join(" + ")} revealed` : "Enemy commitment prepared",
+      revealSecrets
+        ? `${action.actorName} committed ${names.join(" and ")} before Lock.`
+        : `${action.actorName} has ${names.length} concealed factor${names.length === 1 ? "" : "s"}.`,
+      "revealed",
+    );
+  }
+}
+
+function compareEntries(left, right) {
+  const laneDelta = LANE_RANK[left.lane] - LANE_RANK[right.lane];
+  if (laneDelta !== 0) return laneDelta;
+  const tempoDelta = right.tempo - left.tempo;
+  if (tempoDelta !== 0) return tempoDelta;
+  if (left.side !== right.side) return left.side === "player" ? -1 : 1;
+  return left.sequence - right.sequence;
+}
+
+function resolutionChainKey(entry) {
+  return entry.side === "player" ? "player" : `enemy:${entry.actorId}`;
+}
+
+function withEffectiveResolutionLanes(entries) {
+  const previousRank = new Map();
+  return [...entries]
+    .sort((left, right) => left.sequence - right.sequence)
+    .map((entry) => {
+      const chain = resolutionChainKey(entry);
+      const effectiveRank = Math.max(
+        LANE_RANK[entry.lane],
+        previousRank.get(chain) ?? LANE_RANK.Fast,
+      );
+      previousRank.set(chain, effectiveRank);
+      return {
+        ...entry,
+        baseLane: entry.lane,
+        lane: LANE_ORDER[effectiveRank],
+      };
+    });
+}
+
+function nextRunnableEntries(pending) {
+  return pending.filter(
+    (candidate) =>
+      !pending.some(
+        (other) =>
+          resolutionChainKey(other) === resolutionChainKey(candidate) &&
+          other.sequence < candidate.sequence,
+      ),
+  );
+}
+
+function simulateCycle(state, revealSecrets = false) {
+  const sim = dynamicSnapshot(state);
+  sim._state = state;
+  sim.movementPath = [state.position];
+  sim.refunds = 0;
+  sim.handled = new Set();
+  const packets = createPackets();
+  revealCommittedCards(state, packets, revealSecrets);
+
+  const playerDivider = state.plan.find((action) => action.id === "answer-divider");
+  const enemyRush = state.enemyPlan.find((action) => action.id === "impact-rush");
+  const playerAngle = state.plan.find((action) => action.id === "angle-clash");
+  const enemyBrace = state.enemyPlan.find((action) => action.id === "brace-line");
+
+  const entries = withEffectiveResolutionLanes([
+    ...state.plan.map((action) => ({ ...action, side: "player" })),
+    ...state.enemyPlan.map((action) => ({ ...action, side: "enemy" })),
+  ]);
 
   for (const lane of LANE_ORDER) {
-    for (const entry of entries.filter((candidate) => candidate.action.lane === lane)) {
-      if (entry.type === "enemy") resolveEnemyRush(sim, packets);
-      else applyPlayerAction(sim, packets, lane, entry.action, state.plan);
+    const pending = entries.filter((candidate) => candidate.lane === lane);
+    while (pending.length) {
+      const runnable = nextRunnableEntries(pending);
+      const paired = [];
+      const dividerPlayer = pending.find(
+        (entry) => entry.instanceId === playerDivider?.instanceId,
+      );
+      const dividerEnemy = pending.find(
+        (entry) => entry.instanceId === enemyRush?.instanceId,
+      );
+      if (
+        dividerPlayer &&
+        dividerEnemy &&
+        runnable.includes(dividerPlayer) &&
+        runnable.includes(dividerEnemy)
+      ) {
+        paired.push({
+          type: "divider",
+          entries: [dividerPlayer, dividerEnemy],
+          lane,
+          tempo: Math.max(dividerPlayer.tempo, dividerEnemy.tempo),
+          side: "player",
+          sequence: Math.min(dividerPlayer.sequence, dividerEnemy.sequence),
+        });
+      }
+      const gatePlayer = pending.find(
+        (entry) => entry.instanceId === playerAngle?.instanceId,
+      );
+      const gateEnemy = pending.find(
+        (entry) => entry.instanceId === enemyBrace?.instanceId,
+      );
+      if (
+        gatePlayer &&
+        gateEnemy &&
+        runnable.includes(gatePlayer) &&
+        runnable.includes(gateEnemy)
+      ) {
+        paired.push({
+          type: "gate",
+          entries: [gatePlayer, gateEnemy],
+          lane,
+          tempo: Math.max(gatePlayer.tempo, gateEnemy.tempo),
+          side: "player",
+          sequence: Math.min(gatePlayer.sequence, gateEnemy.sequence),
+        });
+      }
+
+      const waitingForPair = new Set(
+        [
+          dividerPlayer && dividerEnemy ? dividerPlayer.instanceId : null,
+          dividerPlayer && dividerEnemy ? dividerEnemy.instanceId : null,
+          gatePlayer && gateEnemy ? gatePlayer.instanceId : null,
+          gatePlayer && gateEnemy ? gateEnemy.instanceId : null,
+        ].filter(Boolean),
+      );
+      const candidates = [
+        ...runnable.filter((entry) => !waitingForPair.has(entry.instanceId)),
+        ...paired,
+      ].sort(compareEntries);
+      const nextEntry = candidates[0];
+      if (!nextEntry) {
+        throw new Error(`Resolution dependency deadlock in ${lane}.`);
+      }
+
+      if (nextEntry.type === "divider") {
+        applyCycleOneClash(
+          sim,
+          packets,
+          nextEntry.entries[0],
+          nextEntry.entries[1],
+        );
+        for (const pairedEntry of nextEntry.entries) {
+          pending.splice(pending.indexOf(pairedEntry), 1);
+        }
+        continue;
+      }
+      if (nextEntry.type === "gate") {
+        applyGateLaneClash(
+          sim,
+          packets,
+          nextEntry.entries[0],
+          nextEntry.entries[1],
+        );
+        for (const pairedEntry of nextEntry.entries) {
+          pending.splice(pending.indexOf(pairedEntry), 1);
+        }
+        continue;
+      }
+
+      if (nextEntry.side === "player") applyPlayerAction(sim, packets, nextEntry);
+      else applyEnemyAction(sim, packets, nextEntry);
+      pending.splice(pending.indexOf(nextEntry), 1);
     }
-    if (lane === "Slow") finishAutomaticResponses(sim, packets);
-    packets[lane].snapshot = clone({
+    if (lane === "Slow") {
+      if (sim.serviceRoute.closing && !sim.serviceRoute.closureSuppressed) {
+        sim.serviceRoute.prepared = false;
+        sim.serviceRoute.closing = false;
+        logEvent(packets, "Slow", null, "Service Route closed", "The unsuppressed shutter removed the prepared relationship.");
+      }
+      if (
+        sim.flags.regulatorExposed &&
+        !sim.flags.regulatorResetSuppressed &&
+        !state.enemyPlan.some((action) => action.id === "emergency-reset")
+      ) {
+        sim.flags.regulatorExposed = false;
+        sim.enemies.breacher.status = "active";
+        logEvent(packets, "Slow", null, "Regulator automatically reset", "The exposed hardware resealed at the end of the cycle.");
+      }
+      if (
+        sim.actuator.controlled &&
+        !sim.actuator.quietRewrite &&
+        !sim.actuator.accessHeld
+      ) {
+        sim.actuator.controlled = false;
+        sim.majorState.status = "lost";
+        logEvent(packets, "Slow", null, "Actuator lockout responded", "Unprotected local Control was lost.");
+      }
+    }
+    const snapshot = clone({
       ...sim,
+      _state: undefined,
+      handled: undefined,
       movementPath: sim.movementPath,
       refunds: sim.refunds,
     });
+    delete snapshot._state;
+    delete snapshot.handled;
+    packets[lane].snapshot = snapshot;
   }
 
   const finalSnapshot = clone(sim);
+  delete finalSnapshot._state;
   delete finalSnapshot.movementPath;
   delete finalSnapshot.refunds;
+  delete finalSnapshot.handled;
   return {
     packets: LANE_ORDER.map((lane) => packets[lane]),
     finalSnapshot,
@@ -1937,58 +3028,186 @@ function simulateCycle(state) {
   };
 }
 
-function importantRisk(state, finalSnapshot) {
-  if (state.plan.some((action) => action.id === "answer-divider")) {
-    return "The breach remains usable by the Assault and the Divider stays destroyed.";
-  }
-  if (state.plan.some((action) => action.id === "prepare-upper-route")) {
-    return "Route setup consumes time while Gate Stability remains under pressure.";
-  }
-  if (state.plan.some((action) => action.id === "answer-regulator")) {
-    return "Technical control delays direct objective access.";
-  }
-  if (state.plan.some((action) => action.id === "establish-bollard-control")) {
-    return "Control is lost if the exposed Actuator access is not physically held.";
-  }
-  if (state.plan.some((action) => action.id === "prepare-service-route")) {
-    return "The Assault remains active while the rear relationship is established.";
-  }
-  if (state.plan.some((action) => action.id === "execute-lift")) {
-    return "The service lift resets at Settle and may isolate you on the far side.";
-  }
-  if (state.plan.some((action) => action.id === "recover-cache")) {
-    return "Recovering the Cache spends a pressure cycle before the Gate is stable.";
-  }
+function contactForecast(state) {
   if (
-    finalSnapshot.gate.stability < state.gate.stability &&
-    finalSnapshot.gate.status !== "stabilized"
+    playerHas(state, "answer-divider") &&
+    enemyHas(state, "impact-rush")
   ) {
-    return "An unopposed Impact Rush removes one Gate Stability pip.";
+    const route = latestApproach(state);
+    const attached = state.plan.find((action) => action.id === "answer-divider")?.cardId;
+    const comparison =
+      attached === "follow-through"
+        ? tempoComparisonForRoute(route, state.poweredTrack.feed)
+        : {
+            ...tempoComparisonForRoute(route, state.poweredTrack.feed),
+            player: route === "rubble" ? 4 : 5,
+            outcome: "enemy_first",
+            link: route === "rubble" ? "Broken" : "Unlinked",
+          };
+    return {
+      risk: "HIGH",
+      timing:
+        comparison.outcome === "simultaneous"
+          ? "Likely even"
+          : comparison.outcome === "player_first"
+            ? "You likely act first"
+            : "Enemy likely acts first",
+      location: "Cracked Divider",
+      unknown: state.enemyPlan.filter((action) => action.concealed).length,
+      link: comparison.link,
+      reason: comparison.reason,
+      details: `Player ${comparison.player} · Enemy ${comparison.enemy}`,
+    };
   }
-  return "No hidden uncertainty: the confirmed projection resolves exactly as shown.";
+  if (playerHas(state, "angle-clash") && enemyHas(state, "brace-line")) {
+    return {
+      risk: "HIGH",
+      timing: "Likely even",
+      location: "Defensive Bollard",
+      unknown: 1,
+      link: "Preserved",
+      reason: "The safe upper lip preserves the redirected contact line.",
+      details: "Player 6 · Enemy 6",
+    };
+  }
+  if (playerHas(state, "guard-gate") && enemyHas(state, "impact-rush")) {
+    return {
+      risk: "HIGH",
+      timing: "Your Guard establishes first",
+      location: "Gate lane",
+      unknown: state.enemyPlan.filter((action) => action.modifierCardId).length,
+      link: "Guard established",
+      reason: "Fast Guard precedes the Standard Rush; Stabilize remains Slow.",
+      details: "Guard 7 · Rush 5 · Work 3",
+    };
+  }
+  if (state.plan.some((action) => action.id.includes("upper"))) {
+    return {
+      risk: "MEDIUM–HIGH",
+      timing: "Interception possible",
+      location: "East Upper Landing",
+      unknown: 1,
+      link: "Route dependent",
+      reason: "Pressure or Guard may contest the capacity-one landing.",
+      details: "Open Details after reveal",
+    };
+  }
+  return null;
+}
+
+function skillAttribution(state) {
+  const lastSpecial = [...state.plan]
+    .reverse()
+    .find((action) => ACTIONS[action.id]?.attribution);
+  if (!lastSpecial) return null;
+  return {
+    action: lastSpecial.label,
+    build: getBuild(state.buildId).name,
+    revealed: ACTIONS[lastSpecial.id].attribution.revealed,
+    enabled: ACTIONS[lastSpecial.id].attribution.enabled,
+    modified: lastSpecial.cardName ?? null,
+    opposed:
+      state.enemyPlan.at(-1)?.posture ??
+      state.enemyPlan.at(-1)?.label ??
+      null,
+  };
 }
 
 function expectedConsequences(state, simulation) {
-  const events = simulation.packets.flatMap((packet) => packet.events);
-  const material = events
-    .filter((event) => event.outcome !== "canceled")
-    .map((event) => event.detail)
-    .filter(Boolean);
+  const material = [];
+  if (simulation.movementPath.length > 1) {
+    const destination = BOARD_TILES[simulation.movementPath.at(-1)];
+    material.push(
+      `Your declared movement reaches ${destination?.name ?? "the selected tile"} if its prerequisites remain legal.`,
+    );
+  }
+  const publicConsequences = {
+    "answer-divider":
+      "Opposed contact may turn the Cracked Divider into a public opening.",
+    "cross-breach":
+      "The selected upper lip can preserve the crossing if the breach remains open.",
+    "angle-clash":
+      "The redirected contact can jam the defensive bollard and contest Gate access.",
+    "prepare-upper-route":
+      "A natural capacity-one Upper Route will become visible and contestable.",
+    "contest-upper-landing":
+      "The prepared landing will gain physical protection.",
+    "answer-regulator":
+      "Physical contact can expose a real regulator and its automatic response.",
+    "suppress-regulator":
+      "A still-exposed regulator will have its reset delayed.",
+    "establish-bollard-control":
+      "Local bollard Control will become available while its access remains exposed.",
+    "hold-actuator":
+      "Physical access can protect existing local Control.",
+    "execute-bollard":
+      "Existing bollard Control can become one authored physical output.",
+    "prepare-service-route":
+      "The obscured rear relationship will become real and its shutter can respond.",
+    "suppress-service-closure":
+      "A prepared service shutter will have its closure delayed.",
+    "establish-lift-control":
+      "Local lift Control will expose a later temporary-geometry output.",
+    "execute-lift":
+      "Existing lift Control can create a capacity-one bridge until Settle.",
+    "guard-gate":
+      "Fast Guard will establish before later Gate pressure.",
+    "stabilize-gate":
+      "Gate Work resolves Slow and succeeds only if access and protection survive.",
+  };
+  for (const action of state.plan) {
+    const consequence = publicConsequences[action.id];
+    if (consequence && !material.includes(consequence)) material.push(consequence);
+  }
+  if (state.enemyPlan.length) {
+    material.push(
+      `${state.enemyPlan.length} enemy commitment${state.enemyPlan.length === 1 ? "" : "s"} may interleave; concealed cards remain unrevealed until Lock.`,
+    );
+  }
   return material.slice(0, 5);
 }
 
+function importantRisk(state, finalSnapshot) {
+  const contact = contactForecast(state);
+  if (contact) {
+    return `${contact.risk} contact risk at ${contact.location}. ${contact.unknown} concealed factor${contact.unknown === 1 ? "" : "s"} may alter exact contact.`;
+  }
+  if (finalSnapshot.gate.stability < state.gate.stability) {
+    return "An unopposed Gate-impact commitment removes one visible Stability pip.";
+  }
+  if (playerHas(state, "prepare-service-route")) {
+    return "The enemy formation remains active while the route is established.";
+  }
+  if (playerHas(state, "execute-lift")) {
+    return "The lift returns at Settle and may isolate the player.";
+  }
+  return "No hidden random roll: material uncertainty comes from labeled concealed commitments.";
+}
+
 export function projectPlan(state) {
-  const simulation = simulateCycle(state);
+  const simulation = simulateCycle(state, false);
   const signature = stableHash({
+    source: state.sourceRevision,
     seed: state.seed,
     round: state.round,
     initial: dynamicSnapshot(state),
-    plan: state.plan.map((action) => ({
+    playerPlan: state.plan.map((action) => ({
       id: action.id,
       targetId: action.targetId,
       cardId: action.cardId,
       totalCost: action.totalCost,
       sequence: action.sequence,
+      status: action.status,
+    })),
+    enemyPlan: state.enemyPlan.map((action) => ({
+      id: action.id,
+      actorId: action.actorId,
+      targetId: action.targetId,
+      cardId: action.cardId,
+      modifierCardId: action.modifierCardId,
+      totalCost: action.totalCost,
+      sequence: action.sequence,
+      status: action.status,
     })),
   });
   return {
@@ -1998,69 +3217,75 @@ export function projectPlan(state) {
     movementPath: simulation.movementPath,
     ghostPosition:
       simulation.movementPath.at(-1) ?? simulation.finalSnapshot.position,
-    collision:
-      state.plan.some((action) => action.id === "answer-divider")
-        ? "cracked-divider"
-        : state.plan.some((action) => action.id === "answer-regulator")
-          ? "assault"
-          : null,
     expected: expectedConsequences(state, simulation),
     risk: importantRisk(state, simulation.finalSnapshot),
     refunds: simulation.refunds,
+    contact: contactForecast(state),
+    attribution: skillAttribution(state),
   };
 }
 
 function planLockError(state) {
   if (state.phase !== "planning") return "The current phase cannot be locked.";
   if (!state.plan.length && !state.refocusRecord) {
-    return "Add at least one action before Lock.";
+    return "Commit at least one player action before passing to Lock.";
   }
   if (state.hand.length > CORE_RULES.retainLimit) {
     return `Discard to retain ${CORE_RULES.retainLimit} cards before Lock.`;
   }
   if (paidActionCount(state) > CORE_RULES.paidActionCap) {
-    return "The plan exceeds four paid actions.";
+    return "The player plan exceeds four paid actions.";
   }
-  if (availableCommand(state) < 0) return "The plan exceeds available Command.";
-  const test = createFracturedGateState(state.buildId);
-  Object.assign(test, clone(state), {
-    plan: [],
-    freeRepositionUsed: false,
-    warning: "",
-  });
-  for (const action of state.plan) {
-    const error = validateAction(
-      { ...test, plan: clone(test.plan) },
-      action.id,
-      action.targetId,
-      action.cardId,
-    );
-    if (error) return `${action.label}: ${error}`;
-    test.plan.push(clone(action));
-    if (action.id === "reposition") test.freeRepositionUsed = true;
+  if (enemyPaidActionCount(state) > CORE_RULES.paidActionCap) {
+    return "The squad plan exceeds four paid actions.";
+  }
+  if (availableCommand(state) < 0 || enemyAvailableCommand(state) < 0) {
+    return "A plan exceeds its visible Command allotment.";
   }
   return null;
 }
 
-export function lockPlan(state) {
+function lockResolvedPlans(state) {
   const error = planLockError(state);
   if (error) return withWarning(state, error);
+  const fullSimulation = simulateCycle(state, true);
   const projection = projectPlan(state);
   const next = clone(state);
   next.command = availableCommand(next);
+  next.enemyCommand = enemyAvailableCommand(next);
   next.phase = "resolution";
+  next.priority = "locked";
   next.warning = "";
   next.resolution = {
     signature: projection.signature,
     visibleLaneIndex: -1,
-    packets: projection.packets,
-    finalSnapshot: projection.finalSnapshot,
-    movementPath: projection.movementPath,
-    refunds: projection.refunds,
+    packets: fullSimulation.packets,
+    finalSnapshot: fullSimulation.finalSnapshot,
+    movementPath: fullSimulation.movementPath,
+    refunds: fullSimulation.refunds,
     expected: projection.expected,
     risk: projection.risk,
+    contact: projection.contact,
   };
   return next;
+}
+
+function maybeLockAfterPasses(state) {
+  return state.consecutivePasses >= 2 ? lockResolvedPlans(state) : state;
+}
+
+export function passPriority(state) {
+  if (state.phase !== "planning" || state.priority !== "player") return state;
+  let next = clone(state);
+  next.consecutivePasses += 1;
+  next.planningHistory.push({ side: "player", type: "pass" });
+  if (next.consecutivePasses >= 2) return lockResolvedPlans(next);
+  next = takeEnemyPriority(next, "player-pass").state;
+  return maybeLockAfterPasses(next);
+}
+
+export function lockPlan(state) {
+  return passPriority(state);
 }
 
 export function advanceResolution(state) {
@@ -2075,21 +3300,37 @@ export function advanceResolution(state) {
   applied.review = next.resolution.packets.flatMap((packet) =>
     packet.events.map((event) => ({ lane: packet.lane, ...event })),
   );
-  const committedCards = next.plan
-    .map((action) => action.cardId)
-    .filter(Boolean);
+
+  const committedPlayerCards = next.plan
+    .filter((action) => action.cardId && !action.contextCard)
+    .map((action) => action.cardId);
   applied.hand = applied.hand.filter(
-    (cardId) => !committedCards.includes(cardId),
+    (cardId) => !committedPlayerCards.includes(cardId),
   );
-  applied.discard.push(...committedCards);
+  applied.discard.push(...committedPlayerCards);
+
+  for (const action of next.enemyPlan) {
+    for (const cardId of [action.cardId, action.modifierCardId].filter(Boolean)) {
+      const actor = applied.enemies[action.actorId];
+      const index = actor.hand.indexOf(cardId);
+      if (index >= 0) actor.hand.splice(index, 1);
+      actor.discard.push(cardId);
+      if (!actor.knownCards.includes(cardId)) actor.knownCards.push(cardId);
+    }
+  }
+
   applied.settleSummary = {
     gateStability: applied.gate.stability,
     gateStatus: applied.gate.status,
-    playerPosition: POSITION_NAMES[applied.position],
-    enemyStatus: applied.enemy.status,
+    playerPosition: BOARD_TILES[applied.position]?.name ?? applied.position,
+    enemyStates: Object.values(applied.enemies).map(
+      (enemy) => `${enemy.name}: ${titleCase(enemy.status)}`,
+    ),
     dividerStatus: applied.divider.status,
     cacheStatus: applied.cache.status,
+    exitStatus: applied.westExit.status,
     commandCarried: applied.command,
+    enemyCommandCarried: applied.enemyCommand,
     refunds: next.resolution.refunds,
     draw: [],
   };
@@ -2100,105 +3341,134 @@ function pendingResultType(state) {
   if (state.retreated) return "Controlled Retreat";
   if (state.gate.status === "failed" || state.condition === 0) return "Gate Lost";
   if (state.gate.status !== "stabilized") return null;
-  if (state.cache.status === "recovered") return "Recovery Secure";
+  if (state.cache.status === "carried") return "Recovery Secure";
+  const platformEnemies = Object.values(state.enemies).filter(
+    (enemy) =>
+      ACTIVE_ENEMY_STATUSES.has(enemy.status) &&
+      [tileId(9, 5), tileId(10, 5), tileId(10, 6), tileId(10, 7)].includes(
+        enemy.position,
+      ),
+  );
   if (
-    state.enemy.status === "disabled" &&
-    state.divider.status === "cracked"
+    state.divider.status !== "breached" &&
+    platformEnemies.length === 0 &&
+    state.condition > 0
   ) {
     return "Clean Secure";
   }
-  return "Fast Secure";
+  if (state.round <= 3) return "Fast Secure";
+  return "Gate Secure";
 }
 
 function turningPointText(state, resultType) {
   if (resultType === "Controlled Retreat") {
-    return "Selecting the physical West Exit preserved the character before the situation collapsed.";
+    return "The player used the physical West Exit before retreat became impossible.";
   }
   if (resultType === "Gate Lost") {
-    return state.enemy.status === "disabled"
-      ? "The Assault was stopped, but combat consumed the cycles needed to stabilize the Gate."
-      : "The final unopposed Impact Rush removed the Gate's last Stability pip.";
+    return "Completed Gate impacts reached zero Stability before Stabilize finished.";
   }
   if (resultType === "Recovery Secure") {
-    return "You accepted another pressure cycle to recover the Field Cache before sealing the Gate.";
+    return "The player accepted optional Cache pressure and still completed the Gate objective.";
   }
-  const turningPoints = {
-    divider:
-      "The enemy's own Impact Rush broke the Cracked Divider and created your path.",
-    "upper-route":
-      "Preparing and physically protecting the Upper Walk created a clean objective approach.",
-    regulator:
-      "Physical confrontation exposed hardware before Hacking suppressed its automatic reset.",
-    bollard:
-      "Local Control survived because you physically held the Actuator access.",
-    "service-route":
-      "A natural service relationship survived because its real closure mechanism was suppressed.",
-    lift:
-      "The Gate Actuator moved machinery into the missing span, creating temporary geometry.",
-    stabilize:
-      "Reaching Gate Platform in time let the defensive seal end the confrontation.",
+  const points = {
+    divider: "The first meaningful Clash broke the Divider and created the route used to reach the Gate.",
+    bollard: "The second contact was redirected into the defensive bollard, winning Gate position.",
+    regulator: "Physical contact exposed hardware before Hacking suppressed its recovery.",
+    actuator: "Local Control became useful only because physical access survived.",
+    "upper-route": "The prepared natural crossing created a different objective approach.",
+    "service-route": "The real service relationship survived its connected shutter response.",
+    lift: "The lift Output created temporary geometry across the Upper Walk gap.",
+    cache: "The optional recovery decision changed the battle's priority order.",
+    stabilize: "Protected Slow Work activated the defensive seal.",
   };
-  return (
-    turningPoints[state.flags.turningPoint] ??
-    "The plan removed the immediate threat and reached the objective in time."
-  );
+  return points[state.flags.turningPoint] ?? "The player protected the objective long enough to complete Stabilize.";
 }
 
 function tradeoffText(state, resultType) {
   if (resultType === "Controlled Retreat") {
-    return "The Gate and Field Cache remain unresolved, but the player survives.";
+    return "The character remains safe, but the Gate, formation, and Cache remain unresolved.";
   }
   if (resultType === "Gate Lost") {
-    return "A combat success cannot replace the failed location objective.";
+    return "Enemy damage or defeat cannot overwrite the failed location objective.";
   }
   if (resultType === "Recovery Secure") {
-    return `The Cache was recovered, but the Gate absorbed ${3 - state.gate.stability} Rush impact${3 - state.gate.stability === 1 ? "" : "s"}.`;
+    return "The Cache was recovered, but optional pressure exposed other priorities.";
   }
-  if (resultType === "Clean Secure") {
-    return "The location stayed intact, but the slower direct approach abandoned the Field Cache.";
-  }
-  if (state.divider.status === "breached") {
-    return "The quickest path destroyed the Divider and left the breach usable from either side.";
-  }
-  return "The Gate was secured quickly, but the Field Cache was left behind.";
+  const costs = [];
+  if (state.divider.status === "breached") costs.push("Divider destroyed");
+  if (state.bollard.status === "jammed") costs.push("bollard jammed");
+  if (state.cache.status !== "carried") costs.push("Field Cache left");
+  if (state.westExit.status !== "open") costs.push("retreat route pressured");
+  return costs.length
+    ? costs.join("; ")
+    : "Infrastructure was preserved, but the optional Field Cache was left behind.";
 }
 
 function buildResult(state, resultType) {
   return {
     type: resultType,
+    diagnostic: resultType === "Gate Secure",
     objective:
       state.gate.status === "stabilized"
-        ? "Gate stabilized"
+        ? `Gate stabilized with ${state.gate.stability}/3 Stability`
         : state.gate.status === "failed"
-          ? "Gate failed"
+          ? "Gate failed at 0/3 Stability"
           : `Gate unresolved · ${state.gate.stability}/3 Stability`,
-    enemy:
-      state.enemy.status === "driven"
-        ? "Driven out"
-        : state.enemy.status[0].toUpperCase() + state.enemy.status.slice(1),
-    player:
-      state.retreated
-        ? "Extracted safely"
-        : state.condition === 0
-          ? "Compromised"
-          : `Safe · ${state.condition} Condition · ${state.guard} Guard`,
+    enemies: Object.values(state.enemies).map(
+      (enemy) =>
+        `${enemy.name}: ${titleCase(enemy.status)} · ${enemy.condition} Condition · ${enemy.guard} Guard`,
+    ),
+    player: state.retreated
+      ? "Extracted safely"
+      : state.condition === 0
+        ? "Compromised"
+        : `Safe · ${state.condition} Condition · ${state.guard} Guard`,
     cache:
-      state.cache.status === "recovered"
+      state.cache.status === "carried"
         ? "Recovered · prototype-only"
-        : "Left at Upper Walk",
+        : "Not recovered",
     location:
-      `Divider ${state.divider.status}; Actuator ${
-        state.actuator.controlled ? "controlled" : "idle"
-      }; Gate ${state.gate.status}.`,
+      `Divider ${state.divider.status}; conduit ${state.divider.conduit}; bollard ${state.bollard.status}; Actuator ${state.actuator.controlled ? "controlled" : "idle"}; lift ${state.lift.deployed ? "aligned" : "parked"}; West Exit ${state.westExit.status}.`,
     turningPoint: turningPointText(state, resultType),
     tradeoff: tradeoffText(state, resultType),
+    reason:
+      resultType === "Gate Secure"
+        ? "Diagnostic fallback: secured after cycle 3 without Clean or Recovery conditions."
+        : `Assigned by result precedence: ${resultType}.`,
   };
+}
+
+function drawCardsForActor(actor) {
+  const drawn = [];
+  while (drawn.length < 2 && actor.drawIndex < actor.deck.length) {
+    const cardId = actor.deck[actor.drawIndex];
+    actor.drawIndex += 1;
+    actor.hand.push(cardId);
+    drawn.push(cardId);
+  }
+  while (actor.hand.length > 7) {
+    actor.discard.push(actor.hand.pop());
+  }
+  return drawn;
 }
 
 export function settleRound(state) {
   if (state.phase !== "settle") return state;
-  const resultType = pendingResultType(state);
   const next = clone(state);
+  if (next.lift.resetAfterSettle) {
+    next.lift.deployed = false;
+    next.lift.returning = false;
+    next.lift.resetAfterSettle = false;
+    next.review.push({
+      lane: "Settle",
+      actionId: "lift-reset",
+      instanceId: "lift-reset",
+      title: "Service Lift returned",
+      detail: "Temporary geometry closed; the player remains at the last legal landing.",
+      outcome: "resolved",
+    });
+  }
+  const resultType = pendingResultType(next);
   if (resultType) {
     next.phase = "result";
     next.result = buildResult(next, resultType);
@@ -2216,44 +3486,44 @@ export function settleRound(state) {
     next.hand.push(cardId);
     drawn.push(cardId);
   }
+  for (const actor of Object.values(next.enemies)) drawCardsForActor(actor);
+
   next.command = Math.min(
     CORE_RULES.commandCap,
     next.command + (next.resolution?.refunds ?? 0) + CORE_RULES.commandIncome,
   );
+  next.enemyCommand = Math.min(
+    CORE_RULES.commandCap,
+    next.enemyCommand + CORE_RULES.commandIncome,
+  );
   next.round += 1;
   next.phase = "planning";
+  next.priority = next.round === 3 ? "enemy" : "player";
+  next.consecutivePasses = 0;
   next.plan = [];
+  next.enemyPlan = [];
   next.resolution = null;
   next.freeRepositionUsed = false;
   next.planningActionCount = 0;
+  next.playerPivotUsed = false;
+  next.enemyPivotUsed = false;
   next.refocusUsed = false;
   next.refocusRecord = null;
   next.warning = "";
-  next.flags.rushBlocked = false;
-  next.flags.regulatorSuppressionArmed = false;
-  next.flags.serviceSuppressionArmed = false;
-  if (next.enemy.status === "pinned") next.enemy.status = "active";
+  next.gate.workDelayed = false;
+  next.flags.playerGuardedGate = false;
+  next.flags.objectiveBraceUsed = false;
+  next.flags.sourceAttribution = [];
   if (
-    next.enemy.status === "staggered" &&
-    !next.enemy.regulatorResetSuppressed
+    next.enemies.breacher.status === "staggered" &&
+    !next.flags.regulatorResetSuppressed
   ) {
-    next.enemy.status = "active";
-    next.enemy.staggered = false;
-  }
-  if (next.lift.resetAfterSettle) {
-    next.lift.deployed = false;
-    next.lift.resetAfterSettle = false;
-    next.review.push({
-      lane: "Settle",
-      actionId: "lift-reset",
-      instanceId: "lift-reset",
-      title: "Service Lift reset",
-      detail:
-        "Temporary geometry closed; the player remains at the last legal landing.",
-      outcome: "resolved",
-    });
+    next.enemies.breacher.status = "active";
   }
   next.settleSummary.draw = drawn;
+  if (next.priority === "enemy") {
+    return takeEnemyPriority(next, "round-opening").state;
+  }
   return next;
 }
 
@@ -2268,7 +3538,9 @@ export function displaySnapshot(state) {
 }
 
 export function getPositionCoordinates(positionId) {
-  return POSITION_COORDS[positionId] ?? POSITION_COORDS.entry;
+  const tile = BOARD_TILES[positionId];
+  if (!tile) return pointToPercent(2, 6);
+  return { x: tile.boardX, y: tile.boardY };
 }
 
 export function getActionDefinition(actionId) {
@@ -2278,7 +3550,6 @@ export function getActionDefinition(actionId) {
 export {
   ACTIONS as FRACTURED_GATE_ACTIONS,
   BUILDS,
-  CARDS,
   CORE_RULES,
-  POSITION_NAMES,
+  ENEMY_DECKS,
 };

--- a/tests/barcode-world-boundary.test.mjs
+++ b/tests/barcode-world-boundary.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const gameFiles = [
+  "middleware.ts",
   "src/app/world/playtest/page.tsx",
   "src/components/FracturedGatePrototype.tsx",
   "src/components/FracturedGatePrototype.module.css",
@@ -31,6 +32,12 @@ test("Fractured Gate is production-gated, unlinked, local-only, and has no live-
     contents.find(([path]) => path.endsWith("page.tsx"))[1],
     /BarcodeWorldGreybox/,
   );
+  const middleware = contents.find(([path]) => path === "middleware.ts")[1];
+  assert.match(middleware, /pathname === "\/world\/playtest"/);
+  assert.match(middleware, /process\.env\.NODE_ENV === "production"/);
+  assert.match(middleware, /status:\s*404/);
+  assert.match(middleware, /Cache-Control/);
+  assert.match(middleware, /X-Robots-Tag/);
   assert.doesNotMatch(
     combined,
     /\b(fetch|XMLHttpRequest|WebSocket|EventSource)\s*\(/,

--- a/tests/barcode-world-fractured-gate.test.mjs
+++ b/tests/barcode-world-fractured-gate.test.mjs
@@ -1,24 +1,33 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  BOARD_TILES,
   BUILDS,
   CARDS,
   CORE_RULES,
+  ENEMY_CARDS,
+  FRACTURED_GATE_ACTIONS,
+  FRACTURED_GATE_SOURCE,
   RESULT_TYPES,
   advanceResolution,
   availableCommand,
+  availableEnemyCommand,
   createFracturedGateState,
   discardToRetain,
   displaySnapshot,
+  getAvailableContextCards,
   getCompatibleCards,
   getContextActionGroups,
-  lockPlan,
   paidActionCount,
+  passPriority,
+  pivotOpenAction,
   projectPlan,
   queueAction,
   refocusCards,
+  removePlanAction,
   resetFracturedGate,
   settleRound,
+  tempoComparisonForRoute,
 } from "../src/lib/barcode-world/fractured-gate-engine.mjs";
 
 const EXPECTED_OPENING_HANDS = {
@@ -77,53 +86,108 @@ function queue(state, actionId, targetId, cardId = null) {
   return next;
 }
 
+function passToLock(state) {
+  let next = state;
+  for (let count = 0; count < 12 && next.phase === "planning"; count += 1) {
+    next = passPriority(next);
+  }
+  assert.equal(next.phase, "resolution", next.warning);
+  return next;
+}
+
 function resolveToSettle(state) {
-  const locked = lockPlan(state);
-  assert.equal(locked.phase, "resolution", locked.warning);
-  let next = locked;
-  let guard = 0;
-  while (next.phase === "resolution" && guard < 8) {
+  let next = state.phase === "planning" ? passToLock(state) : state;
+  for (let count = 0; count < 8 && next.phase === "resolution"; count += 1) {
     next = advanceResolution(next);
-    guard += 1;
   }
   assert.equal(next.phase, "settle");
   return next;
 }
 
-function finishRound(state) {
-  return settleRound(resolveToSettle(state));
-}
-
-function retainSeven(state) {
+function retainSeven(state, preserve = []) {
   let next = state;
   while (next.phase === "planning" && next.hand.length > CORE_RULES.retainLimit) {
-    next = discardToRetain(next, next.hand.at(-1));
+    const discard = [...next.hand]
+      .reverse()
+      .find((cardId) => !preserve.includes(cardId));
+    assert.ok(discard, "a discardable card should remain");
+    next = discardToRetain(next, discard);
   }
   return next;
 }
 
-function battleExplorationOpening() {
+function battleExplorationCycleOne() {
   let state = createFracturedGateState("battle-exploration");
-  state = queue(state, "reposition", "lower-cover");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-5-6");
+  assert.deepEqual(getAvailableContextCards(state, "answer-divider"), [
+    "follow-through",
+  ]);
   state = queue(
     state,
     "answer-divider",
     "cracked-divider",
-    "brace-through",
+    "follow-through",
   );
-  state = queue(state, "cross-breach", "gate-platform");
   return state;
 }
 
-test("locked Battle foundation and all validated opening hands are preserved", () => {
+function settledCycleOne() {
+  return resolveToSettle(battleExplorationCycleOne());
+}
+
+function battleExplorationCycleTwo() {
+  let state = settleRound(settledCycleOne());
+  state = queue(state, "cross-breach", "tile-10-5");
+  state = queue(state, "stabilize-gate", "gate");
+  state = pivotOpenAction(
+    state,
+    "angle-clash",
+    "defensive-bollard",
+  );
+  assert.equal(state.warning, "");
+  return state;
+}
+
+function settledCycleTwo() {
+  return resolveToSettle(battleExplorationCycleTwo());
+}
+
+function fastSecureResult() {
+  let state = settleRound(settledCycleTwo());
+  state = retainSeven(state, ["objective-brace"]);
+  state = queue(state, "guard-gate", "gate");
+  state = queue(
+    state,
+    "stabilize-gate",
+    "gate",
+    "objective-brace",
+  );
+  state = resolveToSettle(state);
+  return settleRound(state);
+}
+
+test("revised checkpoint, 62-tile board, six builds, and shared squad economy are locked", () => {
+  assert.equal(
+    FRACTURED_GATE_SOURCE,
+    "BARCODE_WORLD_BATTLE_MODE_FRACTURED_GATE_REVISED_ENCOUNTER_CHECKPOINT_2026-07-27",
+  );
+  assert.equal(Object.keys(BOARD_TILES).length, 62);
+  assert.equal(
+    new Set(
+      Object.values(BOARD_TILES).map((tile) => `${tile.x},${tile.y}`),
+    ).size,
+    62,
+  );
   assert.deepEqual(
     BUILDS.map((build) => build.id),
     Object.keys(EXPECTED_OPENING_HANDS),
   );
+
   for (const build of BUILDS) {
     const state = createFracturedGateState(build.id);
-    assert.equal(state.deck.length, 12, `${build.id} deck`);
-    assert.equal(new Set(state.deck).size, 12, `${build.id} unique deck`);
+    assert.equal(state.deck.length, 12, `${build.id} player deck`);
+    assert.equal(new Set(state.deck).size, 12, `${build.id} unique player deck`);
     assert.deepEqual(state.hand, EXPECTED_OPENING_HANDS[build.id]);
     assert.equal(
       state.hand.some((cardId) => CARDS[cardId].partyOnly),
@@ -131,6 +195,28 @@ test("locked Battle foundation and all validated opening hands are preserved", (
       `${build.id} opening is solo-safe`,
     );
   }
+
+  const state = createFracturedGateState();
+  assert.deepEqual(Object.keys(state.enemies), [
+    "breacher",
+    "guard",
+    "controller",
+    "pressure",
+  ]);
+  for (const enemy of Object.values(state.enemies)) {
+    assert.equal(enemy.deck.length, 12, `${enemy.name} deck`);
+    assert.equal(new Set(enemy.deck).size, 12, `${enemy.name} unique deck`);
+    assert.equal(enemy.hand.length, 5, `${enemy.name} opening hand`);
+    assert.ok(enemy.hand.every((cardId) => ENEMY_CARDS[cardId]));
+  }
+  assert.equal(state.enemyCommand, 16);
+  assert.equal(availableEnemyCommand(state), 4);
+  assert.deepEqual(
+    state.enemyPlan.map((action) => action.id),
+    ["impact-rush"],
+  );
+  assert.equal(state.enemyPlan[0].totalCost, 12);
+
   assert.equal(CORE_RULES.commandStart, 16);
   assert.equal(CORE_RULES.commandIncome, 16);
   assert.equal(CORE_RULES.commandCap, 32);
@@ -141,212 +227,328 @@ test("locked Battle foundation and all validated opening hands are preserved", (
   assert.equal(CORE_RULES.retainLimit, 7);
 });
 
-test("context selection exposes no more than four parent actions and never uses dropdown movement", () => {
+test("board-first context stays bounded and spatial legality blocks remote attacks and contact", () => {
   const state = createFracturedGateState("battle-exploration");
   for (const focusId of [
     "player",
-    "impact-rush",
-    "assault",
+    "breacher",
     "cracked-divider",
-    "upper-walk",
     "gate-actuator",
     "gate",
     "field-cache",
     "west-exit",
+    "tile-3-6",
   ]) {
     const groups = getContextActionGroups(state, focusId);
     assert.ok(groups.length <= 4, focusId);
     assert.equal(new Set(groups.map((group) => group.parent)).size, groups.length);
   }
-  assert.deepEqual(
-    getContextActionGroups(state, "impact-rush").map((group) => group.parent),
-    ["Attack", "Defend", "Discipline", "Inspect"],
-  );
-  const playerMove = getContextActionGroups(state, "player").find(
-    (group) => group.parent === "Move",
-  );
-  assert.ok(playerMove.choices[0].legalTargets.includes("lower-cover"));
 
-  let projected = createFracturedGateState("battle-exploration");
-  projected = queue(projected, "reposition", "lower-cover");
-  projected = queue(
-    projected,
+  const remoteAttack = getContextActionGroups(state, "breacher")
+    .find((group) => group.parent === "Attack")
+    .choices[0];
+  assert.equal(remoteAttack.legal, false);
+  assert.match(remoteAttack.reason, /within two tactical tiles/);
+
+  const remoteAnswer = getContextActionGroups(state, "cracked-divider")
+    .find((group) => group.parent === "Discipline")
+    .choices[0];
+  assert.equal(remoteAnswer.legal, false);
+  assert.match(remoteAnswer.reason, /Approach within two tactical tiles/);
+
+  const tileMove = getContextActionGroups(state, "tile-3-6")
+    .find((group) => group.parent === "Move");
+  assert.deepEqual(
+    tileMove.choices.map((choice) => choice.id),
+    ["reposition", "advance"],
+  );
+  assert.deepEqual(tileMove.choices[0].legalTargets, ["tile-3-6"]);
+});
+
+test("Tempo distinguishes clear, rubble, and powered routes without changing Command", () => {
+  assert.deepEqual(
+    tempoComparisonForRoute("clear"),
+    {
+      route: "clear",
+      player: 6,
+      enemy: 6,
+      outcome: "simultaneous",
+      link: "Preserved",
+      reason: "The clear approach preserves Follow Through.",
+    },
+  );
+  assert.deepEqual(
+    tempoComparisonForRoute("rubble"),
+    {
+      route: "rubble",
+      player: 4,
+      enemy: 6,
+      outcome: "enemy_first",
+      link: "Broken",
+      reason: "Rubble breaks the movement-to-contact link.",
+    },
+  );
+  assert.deepEqual(
+    tempoComparisonForRoute("powered", "toward-divider"),
+    {
+      route: "powered",
+      player: 7,
+      enemy: 6,
+      outcome: "player_first",
+      link: "Accelerated",
+      reason:
+        "The powered service track carries momentum toward contact.",
+    },
+  );
+  assert.equal(createFracturedGateState().command, 16);
+});
+
+test("Follow Through is source-bound, appears only after a clear approach, and does not leak enemy cards", () => {
+  let state = createFracturedGateState();
+  assert.deepEqual(getAvailableContextCards(state, "answer-divider"), []);
+  assert.equal(state.hand.includes("follow-through"), false);
+
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-5-6");
+  assert.deepEqual(getAvailableContextCards(state, "answer-divider"), [
+    "follow-through",
+  ]);
+  assert.ok(
+    getCompatibleCards(state, "answer-divider").includes("follow-through"),
+  );
+  state = queue(
+    state,
     "answer-divider",
     "cracked-divider",
-    "brace-through",
+    "follow-through",
   );
-  const breachMove = getContextActionGroups(projected, "breach").find(
-    (group) => group.parent === "Move",
-  );
-  assert.equal(breachMove.choices[0].id, "cross-breach");
-  assert.deepEqual(breachMove.choices[0].legalTargets, ["gate-platform"]);
-});
+  assert.equal(availableCommand(state), 4);
 
-test("all six ordered builds have legal, distinct causal openings on the same board", () => {
-  const observations = {};
-
-  let state = battleExplorationOpening();
-  state = resolveToSettle(state);
-  observations["battle-exploration"] = {
-    divider: state.divider.status,
-    position: state.position,
-    gate: state.gate.stability,
-  };
-
-  state = createFracturedGateState("exploration-battle");
-  state = queue(state, "reposition", "upper-walk");
-  state = queue(
-    state,
-    "prepare-upper-route",
-    "gate-platform",
-    "destination-claim",
-  );
-  state = queue(state, "contest-upper-landing", "upper-walk");
-  state = resolveToSettle(state);
-  observations["exploration-battle"] = {
-    prepared: state.upperRoute.prepared,
-    protected: state.upperRoute.protected,
-    gate: state.gate.stability,
-  };
-
-  state = createFracturedGateState("battle-hacking");
-  state = queue(state, "reposition", "lower-cover");
-  state = queue(
-    state,
-    "answer-regulator",
-    "assault",
-    "brace-through",
-  );
-  state = queue(state, "suppress-regulator", "assault");
-  state = resolveToSettle(state);
-  observations["battle-hacking"] = {
-    regulator: state.enemy.regulator,
-    suppressed: state.enemy.regulatorResetSuppressed,
-    gate: state.gate.stability,
-  };
-
-  state = createFracturedGateState("hacking-battle");
-  state = queue(state, "reposition", "actuator");
-  state = queue(
-    state,
-    "establish-bollard-control",
-    "gate-actuator",
-    "quiet-rewrite",
-  );
-  state = queue(state, "contest-actuator", "gate-actuator");
-  state = resolveToSettle(state);
-  observations["hacking-battle"] = {
-    mode: state.actuator.mode,
-    controlled: state.actuator.controlled,
-    held: state.actuator.accessHeld,
-    gate: state.gate.stability,
-  };
-
-  state = createFracturedGateState("exploration-hacking");
-  state = queue(
-    state,
-    "prepare-service-route",
-    "service-gap",
-    "destination-claim",
-  );
-  state = queue(state, "suppress-service-closure", "service-gap");
-  state = resolveToSettle(state);
-  observations["exploration-hacking"] = {
-    prepared: state.serviceRoute.prepared,
-    suppressed: state.serviceRoute.closureSuppressed,
-    gate: state.gate.stability,
-  };
-
-  state = createFracturedGateState("hacking-exploration");
-  state = queue(state, "reposition", "actuator");
-  state = queue(
-    state,
-    "establish-lift-control",
-    "gate-actuator",
-    "quiet-rewrite",
-  );
-  state = resolveToSettle(state);
-  observations["hacking-exploration"] = {
-    mode: state.actuator.mode,
-    controlled: state.actuator.controlled,
-    gate: state.gate.stability,
-  };
-
-  assert.deepEqual(observations, {
-    "battle-exploration": {
-      divider: "breached",
-      position: "gate-platform",
-      gate: 3,
-    },
-    "exploration-battle": {
-      prepared: true,
-      protected: true,
-      gate: 3,
-    },
-    "battle-hacking": {
-      regulator: "exposed",
-      suppressed: true,
-      gate: 3,
-    },
-    "hacking-battle": {
-      mode: "bollard",
-      controlled: true,
-      held: true,
-      gate: 3,
-    },
-    "exploration-hacking": {
-      prepared: true,
-      suppressed: true,
-      gate: 2,
-    },
-    "hacking-exploration": {
-      mode: "lift",
-      controlled: true,
-      gate: 2,
-    },
+  const projection = projectPlan(state);
+  assert.equal(projection.contact.timing, "Likely even");
+  assert.equal(projection.contact.link, "Preserved");
+  const playerFacingPreview = JSON.stringify({
+    expected: projection.expected,
+    risk: projection.risk,
+    contact: projection.contact,
   });
+  assert.doesNotMatch(
+    playerFacingPreview,
+    /Driving Ram|Impact Counter|Shield Link/,
+  );
+  assert.match(playerFacingPreview, /concealed/);
 });
 
-test("Preview and visible Fast → Standard → Slow resolution share the exact deterministic result", () => {
-  const first = battleExplorationOpening();
+test("Preview and resolution share one deterministic simulation while Clash remains a reveal payoff", () => {
+  const first = battleExplorationCycleOne();
+  const second = battleExplorationCycleOne();
   const firstProjection = projectPlan(first);
-  const second = battleExplorationOpening();
   const secondProjection = projectPlan(second);
+
   assert.equal(firstProjection.signature, secondProjection.signature);
   assert.deepEqual(
     firstProjection.packets.map((packet) => packet.lane),
     ["Fast", "Standard", "Slow"],
   );
+  assert.equal(firstProjection.packets[0].snapshot.position, "tile-2-6");
+  assert.equal(firstProjection.packets[0].snapshot.divider.status, "cracked");
+  assert.equal(firstProjection.packets[1].snapshot.position, "tile-5-6");
+  assert.equal(firstProjection.packets[1].snapshot.divider.status, "breached");
 
   const resolved = resolveToSettle(first);
-  assert.deepEqual(displaySnapshot(resolved), firstProjection.finalSnapshot);
+  const resolvedDisplay = displaySnapshot(resolved);
+  for (const key of [
+    "position",
+    "condition",
+    "guard",
+    "majorState",
+    "gate",
+    "divider",
+    "actuator",
+    "bollard",
+    "upperRoute",
+    "serviceRoute",
+    "lift",
+    "poweredTrack",
+    "cache",
+    "westExit",
+    "flags",
+  ]) {
+    assert.deepEqual(
+      resolvedDisplay[key],
+      firstProjection.finalSnapshot[key],
+      key,
+    );
+  }
+  for (const enemyId of Object.keys(resolved.enemies)) {
+    for (const key of ["position", "condition", "guard", "status"]) {
+      assert.deepEqual(
+        resolvedDisplay.enemies[enemyId][key],
+        firstProjection.finalSnapshot.enemies[enemyId][key],
+        `${enemyId}.${key}`,
+      );
+    }
+  }
   assert.equal(resolved.resolution.signature, firstProjection.signature);
+  assert.equal(resolved.divider.status, "breached");
+  assert.equal(resolved.gate.stability, 3);
+  assert.equal(resolved.enemies.breacher.status, "staggered");
   assert.equal(
-    resolved.review.some((event) => event.title === "Cracked Divider breached"),
+    resolved.review.some(
+      (event) => event.title === "CLASH · Divider contact" && event.clash,
+    ),
     true,
+  );
+  assert.deepEqual(
+    resolved.review
+      .filter((event) => !event.title.includes("revealed"))
+      .map((event) => event.title),
+    [
+      "Guard linked to Breacher",
+      "Reposition",
+      "Advance",
+      "CLASH · Divider contact",
+    ],
   );
 });
 
-test("Command, free Reposition, paid-action cap, and Refocus accounting are enforced", () => {
+test("opposed planning protects solid commitments and permits one bounded Pivot per side", () => {
+  let state = settleRound(settledCycleOne());
+  state = queue(state, "cross-breach", "tile-10-5");
+  const committedCross = state.plan[0];
+  state = queue(state, "stabilize-gate", "gate");
+
+  assert.deepEqual(
+    state.plan.map((action) => [action.id, action.status]),
+    [
+      ["cross-breach", "solid"],
+      ["stabilize-gate", "open"],
+    ],
+  );
+  assert.deepEqual(
+    state.enemyPlan.map((action) => [action.id, action.status]),
+    [
+      ["charge-debris", "solid"],
+      ["body-block", "open"],
+    ],
+  );
+
+  state = pivotOpenAction(state, "angle-clash", "defensive-bollard");
+  assert.equal(state.playerPivotUsed, true);
+  assert.equal(state.enemyPivotUsed, true);
+  assert.equal(state.plan[0].instanceId, committedCross.instanceId);
+  assert.equal(state.plan[0].id, "cross-breach");
+  assert.deepEqual(
+    state.plan.map((action) => [action.id, action.status]),
+    [
+      ["cross-breach", "solid"],
+      ["angle-clash", "solid"],
+    ],
+  );
+  assert.deepEqual(
+    state.enemyPlan.map((action) => action.id),
+    ["charge-debris", "brace-line"],
+  );
+
+  const secondPivot = pivotOpenAction(
+    state,
+    "stabilize-gate",
+    "gate",
+  );
+  assert.deepEqual(secondPivot.plan, state.plan);
+  assert.match(secondPivot.warning, /one Pivot is already spent/);
+
+  const erased = removePlanAction(state, committedCross.instanceId);
+  assert.deepEqual(erased.plan, state.plan);
+  assert.match(erased.warning, /Earlier solid commitments cannot be erased/);
+});
+
+test("the revised second cycle reveals fast terrain pressure before linked movement and its Gate Clash", () => {
+  const planned = battleExplorationCycleTwo();
+  const projection = projectPlan(planned);
+  assert.deepEqual(projection.contact, {
+    risk: "HIGH",
+    timing: "Likely even",
+    location: "Defensive Bollard",
+    unknown: 1,
+    link: "Preserved",
+    reason: "The safe upper lip preserves the redirected contact line.",
+    details: "Player 6 · Enemy 6",
+  });
+
+  const resolved = resolveToSettle(planned);
+  const material = resolved.review
+    .filter((event) => !event.title.includes("revealed"))
+    .map((event) => `${event.lane}:${event.title}`);
+  assert.deepEqual(material, [
+    "Fast:Divider conduit charged",
+    "Fast:West Exit threatened",
+    "Standard:Divider opening crossed",
+    "Standard:CLASH · Gate access",
+  ]);
+  assert.equal(resolved.position, "tile-10-5");
+  assert.equal(resolved.divider.conduit, "charged");
+  assert.equal(resolved.bollard.status, "jammed");
+  assert.equal(resolved.westExit.status, "threatened");
+  assert.equal(resolved.gate.stability, 3);
+  assert.equal(resolved.enemies.guard.condition, 5);
+  assert.equal(availableCommand(resolved), 8);
+  assert.equal(availableEnemyCommand(resolved), 0);
+});
+
+test("the complete three-cycle encounter ends in an explained Fast Secure result", () => {
+  const resultState = fastSecureResult();
+  assert.equal(resultState.phase, "result");
+  assert.equal(resultState.result.type, "Fast Secure");
+  assert.equal(resultState.result.diagnostic, false);
+  assert.equal(resultState.result.objective, "Gate stabilized with 3/3 Stability");
+  assert.equal(resultState.result.enemies.length, 4);
+  assert.match(resultState.result.location, /Divider breached/);
+  assert.match(resultState.result.location, /bollard jammed/);
+  assert.match(resultState.result.turningPoint, /second contact/);
+  assert.match(resultState.result.tradeoff, /Field Cache left/);
+
+  const finalReview = resultState.review.map(
+    (event) => `${event.lane}:${event.title}`,
+  );
+  assert.ok(finalReview.includes("Fast:Gate lane guarded"));
+  assert.ok(finalReview.includes("Standard:CLASH · Defended Gate lane"));
+  assert.ok(finalReview.includes("Slow:Gate stabilized"));
+  assert.ok(
+    finalReview.indexOf("Fast:Gate lane guarded") <
+      finalReview.indexOf("Standard:CLASH · Defended Gate lane"),
+  );
+  assert.ok(
+    finalReview.indexOf("Standard:CLASH · Defended Gate lane") <
+      finalReview.indexOf("Slow:Gate stabilized"),
+  );
+
+  assert.deepEqual(
+    resetFracturedGate(resultState),
+    createFracturedGateState("battle-exploration"),
+  );
+});
+
+test("Command banking, free Reposition, paid-action cap, and Refocus are independent from Tempo", () => {
   let state = createFracturedGateState();
-  state = queue(state, "reposition", "lower-cover");
-  const secondFree = queueAction(state, "reposition", "lower-yard");
+  state = queue(state, "reposition", "tile-3-6");
+  const secondFree = queueAction(state, "reposition", "tile-4-6");
   assert.equal(secondFree.plan.length, state.plan.length);
   assert.match(secondFree.warning, /one free ordinary Reposition/);
 
-  state = finishRound(state);
+  state = settleRound(resolveToSettle(state));
   assert.equal(state.command, 32);
   assert.equal(state.round, 2);
 
-  state = queue(state, "guard", "player");
-  state = queue(state, "guard", "player");
-  state = queue(state, "guard", "player");
-  state = queue(state, "guard", "player");
+  for (let count = 0; count < 4; count += 1) {
+    state = queue(state, "guard", "player");
+  }
   assert.equal(paidActionCount(state), 4);
   const fifth = queueAction(state, "guard", "player");
   assert.equal(fifth.plan.length, 4);
   assert.match(fifth.warning, /Four paid actions/);
   assert.equal(availableCommand(state), 8);
+  assert.equal(tempoComparisonForRoute("clear").player, 6);
 
   let refocus = createFracturedGateState("battle-exploration");
   refocus = refocusCards(refocus, [
@@ -362,44 +564,38 @@ test("Command, free Reposition, paid-action cap, and Refocus accounting are enfo
   ]);
   const repeated = refocusCards(refocus, ["brace-through"]);
   assert.deepEqual(repeated.hand, refocus.hand);
-  assert.match(repeated.warning, /once per planning phase/);
+  assert.match(repeated.warning, /once per planning cycle/);
 });
 
-test("compatible cards lift for the current action while the complete hand remains available", () => {
-  let state = createFracturedGateState("battle-exploration");
-  assert.deepEqual(
-    new Set(getCompatibleCards(state, "answer-divider")),
-    new Set(["fallback-guard", "brace-through", "hold-the-edge"]),
-  );
-  assert.ok(
-    getCompatibleCards(state, "stabilize-gate").includes("objective-brace"),
-  );
-
-  state = createFracturedGateState("exploration-battle");
-  assert.ok(
-    getCompatibleCards(state, "prepare-upper-route").includes(
-      "destination-claim",
-    ),
-  );
-
-  state = createFracturedGateState("hacking-battle");
-  assert.ok(
-    getCompatibleCards(state, "establish-bollard-control").includes(
-      "quiet-rewrite",
-    ),
-  );
-});
-
-test("invalidated actions do not retarget and receive deterministic Settle refunds", () => {
+test("invalidated attacks never retarget and refund half the primary cost at Settle", () => {
   let state = createFracturedGateState();
-  state.enemy.guard = 0;
-  state.enemy.condition = 6;
-  state = queue(state, "attack", "assault");
-  state = queue(state, "attack", "assault", "fallback-guard");
+  state.position = "tile-5-6";
+  state.command = 32;
+  state.enemies.breacher.guard = 0;
+  state.enemies.breacher.condition = 5;
+  const untouched = Object.fromEntries(
+    ["guard", "controller", "pressure"].map((id) => [
+      id,
+      state.enemies[id].condition,
+    ]),
+  );
+
+  state = queue(state, "attack", "breacher");
+  state = queue(state, "attack", "breacher");
+  state = queue(state, "attack", "breacher");
   state = resolveToSettle(state);
-  assert.equal(state.enemy.status, "disabled");
+
+  assert.equal(state.enemies.breacher.status, "disabled");
+  assert.deepEqual(
+    Object.fromEntries(
+      ["guard", "controller", "pressure"].map((id) => [
+        id,
+        state.enemies[id].condition,
+      ]),
+    ),
+    untouched,
+  );
   assert.equal(state.settleSummary.refunds, 3);
-  assert.equal(state.guard, 7);
   assert.equal(
     state.review.some(
       (event) =>
@@ -410,55 +606,185 @@ test("invalidated actions do not retarget and receive deterministic Settle refun
   );
 });
 
-test("all five required Results are reachable and explain complete state", () => {
-  const results = [];
+test("all six ordered builds cause distinct, attributed state changes against the same formation", () => {
+  const observations = {};
 
-  let state = finishRound(battleExplorationOpening());
-  state = queue(state, "stabilize-gate", "gate");
-  state = finishRound(state);
-  results.push(state.result);
-
-  state = createFracturedGateState();
-  state = queue(state, "attack", "assault");
-  state = queue(state, "attack", "assault");
-  state = finishRound(state);
-  state = queue(state, "reposition", "lower-cover");
-  state = queue(state, "advance", "lower-yard");
-  state = queue(state, "advance", "gate-platform");
-  state = retainSeven(finishRound(state));
-  state = queue(state, "stabilize-gate", "gate");
-  state = finishRound(state);
-  results.push(state.result);
+  let state = settledCycleOne();
+  observations["battle-exploration"] = {
+    turningPoint: state.flags.turningPoint,
+    divider: state.divider.status,
+  };
 
   state = createFracturedGateState("exploration-battle");
-  state = queue(state, "reposition", "upper-walk");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-4-4");
+  state = queue(state, "advance", "tile-6-3");
+  state = queue(state, "prepare-upper-route", "upper-crossing");
+  state = resolveToSettle(state);
+  observations["exploration-battle"] = {
+    turningPoint: state.flags.turningPoint,
+    prepared: state.upperRoute.prepared,
+  };
+
+  state = createFracturedGateState("battle-hacking");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-5-6");
+  state = queue(state, "answer-regulator", "breacher");
+  state = resolveToSettle(state);
+  observations["battle-hacking"] = {
+    turningPoint: state.flags.turningPoint,
+    exposedThenReset:
+      state.review.some((event) => event.title === "Impact regulator exposed") &&
+      state.review.some(
+        (event) => event.title === "Regulator automatically reset",
+      ),
+  };
+
+  state = createFracturedGateState("hacking-battle");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-5-7");
+  state = queue(state, "advance", "tile-7-7");
+  state = settleRound(resolveToSettle(state));
   state = queue(
     state,
-    "prepare-upper-route",
-    "gate-platform",
-    "destination-claim",
+    "establish-bollard-control",
+    "gate-actuator",
+    "quiet-rewrite",
   );
-  state = queue(state, "contest-upper-landing", "upper-walk");
-  state = retainSeven(finishRound(state));
-  state = queue(state, "recover-cache", "field-cache");
-  state = retainSeven(finishRound(state));
-  state = queue(state, "cross-upper-route", "gate-platform");
-  state = retainSeven(finishRound(state));
-  state = queue(state, "stabilize-gate", "gate");
-  state = finishRound(state);
-  results.push(state.result);
+  state = queue(state, "hold-actuator", "gate-actuator");
+  state = resolveToSettle(state);
+  observations["hacking-battle"] = {
+    turningPoint: state.flags.turningPoint,
+    mode: state.actuator.mode,
+    held: state.actuator.accessHeld,
+  };
 
-  state = createFracturedGateState();
-  for (let round = 0; round < 3; round += 1) {
-    state = queue(state, "guard", "player");
-    state = retainSeven(finishRound(state));
+  state = createFracturedGateState("exploration-hacking");
+  state = queue(state, "prepare-service-route", "service-gap");
+  state = queue(state, "suppress-service-closure", "service-gap");
+  state = resolveToSettle(state);
+  observations["exploration-hacking"] = {
+    turningPoint: state.flags.turningPoint,
+    prepared: state.serviceRoute.prepared,
+    suppressed: state.serviceRoute.closureSuppressed,
+  };
+
+  state = createFracturedGateState("hacking-exploration");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-4-8");
+  state = queue(state, "advance", "tile-5-8");
+  state = settleRound(resolveToSettle(state));
+  state = queue(
+    state,
+    "establish-lift-control",
+    "lift-relay",
+    "quiet-rewrite",
+  );
+  state = resolveToSettle(state);
+  observations["hacking-exploration"] = {
+    turningPoint: state.flags.turningPoint,
+    mode: state.actuator.mode,
+    controlled: state.actuator.controlled,
+  };
+
+  assert.deepEqual(observations, {
+    "battle-exploration": {
+      turningPoint: "divider",
+      divider: "breached",
+    },
+    "exploration-battle": {
+      turningPoint: "upper-route",
+      prepared: true,
+    },
+    "battle-hacking": {
+      turningPoint: "regulator",
+      exposedThenReset: true,
+    },
+    "hacking-battle": {
+      turningPoint: "actuator",
+      mode: "bollard",
+      held: true,
+    },
+    "exploration-hacking": {
+      turningPoint: "service-route",
+      prepared: true,
+      suppressed: true,
+    },
+    "hacking-exploration": {
+      turningPoint: "lift",
+      mode: "lift",
+      controlled: true,
+    },
+  });
+
+  const attributed = [
+    "answer-divider",
+    "prepare-upper-route",
+    "answer-regulator",
+    "establish-bollard-control",
+    "prepare-service-route",
+    "establish-lift-control",
+  ];
+  for (const actionId of attributed) {
+    assert.ok(FRACTURED_GATE_ACTIONS[actionId].attribution.revealed);
+    assert.ok(FRACTURED_GATE_ACTIONS[actionId].attribution.enabled);
   }
-  results.push(state.result);
+});
 
-  state = createFracturedGateState();
-  state = queue(state, "leave", "west-exit");
-  state = finishRound(state);
-  results.push(state.result);
+test("all five owner-facing result families are reachable and explain complete state", () => {
+  const results = [fastSecureResult().result];
+
+  let clean = createFracturedGateState("exploration-battle");
+  clean = queue(clean, "reposition", "tile-3-6");
+  clean = queue(clean, "advance", "tile-4-4");
+  clean = queue(clean, "advance", "tile-6-3");
+  clean = queue(clean, "prepare-upper-route", "upper-crossing");
+  clean = settleRound(resolveToSettle(clean));
+  clean = queue(clean, "cross-upper-route", "tile-9-3");
+  clean = queue(clean, "advance", "tile-10-5");
+  clean = settleRound(resolveToSettle(clean));
+  clean = retainSeven(clean, ["objective-brace"]);
+  clean = queue(clean, "guard-gate", "gate");
+  clean = queue(clean, "stabilize-gate", "gate", "objective-brace");
+  clean = settleRound(resolveToSettle(clean));
+  results.push(clean.result);
+
+  let recovery = createFracturedGateState("exploration-battle");
+  recovery = queue(recovery, "reposition", "tile-3-6");
+  recovery = queue(recovery, "advance", "tile-4-4");
+  recovery = queue(recovery, "advance", "tile-6-3");
+  recovery = queue(recovery, "prepare-upper-route", "upper-crossing");
+  recovery = settleRound(resolveToSettle(recovery));
+  recovery = queue(recovery, "reposition", "tile-6-2");
+  recovery = queue(recovery, "recover-cache", "field-cache");
+  recovery = queue(recovery, "cross-upper-route", "tile-9-3");
+  recovery = queue(recovery, "advance", "tile-10-5");
+  recovery = settleRound(resolveToSettle(recovery));
+  recovery = retainSeven(recovery, ["objective-brace"]);
+  recovery = queue(recovery, "guard-gate", "gate");
+  recovery = queue(
+    recovery,
+    "stabilize-gate",
+    "gate",
+    "objective-brace",
+  );
+  recovery = settleRound(resolveToSettle(recovery));
+  results.push(recovery.result);
+
+  let lost = createFracturedGateState();
+  lost = queue(lost, "guard", "player");
+  lost = settleRound(resolveToSettle(lost));
+  lost = queue(lost, "guard", "player");
+  lost = settleRound(resolveToSettle(lost));
+  lost = retainSeven(lost);
+  lost = queue(lost, "guard", "player");
+  lost = settleRound(resolveToSettle(lost));
+  results.push(lost.result);
+
+  let retreat = createFracturedGateState();
+  retreat = queue(retreat, "leave", "west-exit");
+  retreat = settleRound(resolveToSettle(retreat));
+  results.push(retreat.result);
 
   assert.deepEqual(
     results.map((result) => result.type),
@@ -466,43 +792,44 @@ test("all five required Results are reachable and explain complete state", () =>
   );
   for (const result of results) {
     assert.ok(result.objective);
-    assert.ok(result.enemy);
+    assert.equal(result.enemies.length, 4);
     assert.ok(result.player);
     assert.ok(result.cache);
     assert.ok(result.location);
     assert.ok(result.turningPoint);
     assert.ok(result.tradeoff);
+    assert.ok(result.reason);
   }
 });
 
-test("Hacking / Exploration creates temporary geometry and the lift resets after Settle", () => {
+test("Hacking / Exploration creates temporary geometry and the lift returns at Settle", () => {
   let state = createFracturedGateState("hacking-exploration");
-  state = queue(state, "reposition", "actuator");
+  state = queue(state, "reposition", "tile-3-6");
+  state = queue(state, "advance", "tile-4-8");
+  state = queue(state, "advance", "tile-5-8");
+  state = settleRound(resolveToSettle(state));
   state = queue(
     state,
     "establish-lift-control",
-    "gate-actuator",
+    "lift-relay",
     "quiet-rewrite",
   );
-  state = finishRound(state);
+  state = settleRound(resolveToSettle(state));
+  state = retainSeven(state);
   state = queue(state, "execute-lift", "service-lift");
-  state = queue(state, "cross-lift", "gate-platform", "safe-landing");
+  state = queue(
+    state,
+    "cross-lift",
+    "tile-9-2",
+    state.hand.includes("safe-landing") ? "safe-landing" : null,
+  );
   state = resolveToSettle(state);
-  assert.equal(state.position, "gate-platform");
+  assert.equal(state.position, "tile-9-2");
   assert.equal(state.lift.deployed, true);
   state = settleRound(state);
   assert.equal(state.lift.deployed, false);
   assert.equal(
-    state.review.some((event) => event.title === "Service Lift reset"),
+    state.review.some((event) => event.title === "Service Lift returned"),
     true,
   );
-});
-
-test("reset restores the same seed, opening state, and deterministic plan signature", () => {
-  const planned = battleExplorationOpening();
-  const signature = projectPlan(planned).signature;
-  const reset = resetFracturedGate(resolveToSettle(planned));
-  assert.deepEqual(reset, createFracturedGateState("battle-exploration"));
-  const replay = battleExplorationOpening();
-  assert.equal(projectPlan(replay).signature, signature);
 });


### PR DESCRIPTION
## Summary

- replace the earlier one-enemy demonstration with the checkpointed 62-tile Fractured Gate encounter
- add four independently positioned, card-using enemies sharing one visible 16-Command squad allotment
- implement opposed planning, bounded Pivots, Command/Tempo separation, contact forecasts, emergent Clashes, all six ordered builds, and the three-exchange representative proof
- keep the proof resettable and in memory, with no persistence or live-system integration

## Private prototype boundary

- `/world/playtest` remains development-only and has no public navigation or sitemap entry
- production middleware returns an empty `404` before route rendering, with `no-store` and `noindex, nofollow, noarchive, noimageindex`
- no canonical/public game claims, public launch surface, deployment change, or scope expansion
- the prototype data remains browser-session-only and resettable

## Validation

- `npm run check`: typecheck, lint, and all 626 tests passed
- focused Fractured Gate and boundary suites: 17/17 passed
- `npm run build`: optimized production build passed
- development smoke: private route `200`, full encounter markers present, no public-site link
- production smoke: exact route `404`, 0-byte body, no prototype text or client-chunk reference, required privacy/cache headers present
- remote parent, complete tree, and all nine changed blob hashes match the locally tested state

## Post-merge deployment and focused evidence

No manual deployment is part of this PR. If the repository's normal `main` automation deploys the merge:

1. production: request `/world/playtest` and record `404`, an empty body, `Cache-Control: no-store, max-age=0`, and `X-Robots-Tag: noindex, nofollow, noarchive, noimageindex`
2. production: confirm the body contains neither `Fractured Gate` nor a `_next/static` reference
3. production: confirm the public home page remains `200` and contains no link to `/world/playtest`
4. owner review: run the merged commit locally in development, open `/world/playtest`, reset once, and complete the three-exchange Battle / Exploration proof while checking Command, Tempo preview, concealed response, Pivot, Clash, Settle, and Results review

Expected evidence: exact response status/body/header capture for production isolation, plus the local development commit SHA and a short pass/fail note for the representative encounter.