### PR TITLE
Rebuild Fractured Gate battlefield readability

### DIFF
--- a/docs/barcode-world-fractured-gate-prototype.md
+++ b/docs/barcode-world-fractured-gate-prototype.md
@@ -42,6 +42,28 @@ Gate Platform, West Exit, Cracked Divider, powered service track, Gate
 Actuator, defensive bollard, service gap and shutter, service lift, optional
 Field Cache, and the three-pip Gate objective.
 
+The owner-readability revision preserves that tactical scale while replacing
+the original sparse circular hit areas and oversized map labels:
+
+- all 62 spaces are visible, compact, staggered diamonds with safe board
+  margins;
+- selecting the player exposes **Move** first and marks every legal free
+  Reposition and paid Advance destination before a destination is probed;
+- special terrain is physical and causal: clear lanes carry route chevrons,
+  rubble visibly obstructs movement, and the powered service track is drawn
+  from the Gate Actuator to its connected output;
+- enemies are always-visible pieces with Condition and Guard, and their
+  current control/intent overlay is textual as well as colored;
+- the selected ordered build names and marks its exact battlefield source,
+  required setup, skill attribution, and currently legal action;
+- compact object pieces move aside and yield pointer input when an underlying
+  tile becomes a legal movement destination;
+- Preview and **Add to Plan** share the board's command rail instead of being
+  separated from the target by a full-screen scroll; and
+- a persistent five-stage rail names **Read & Plan**, **Contest & Lock**,
+  **Resolve**, **Settle**, and **Results**, while a live instruction states the
+  exact task the player should perform now.
+
 The formation has four independently positioned opponents:
 
 | Enemy | Battlefield responsibility |
@@ -170,11 +192,13 @@ Open `http://127.0.0.1:3000/world/playtest`.
 1. Confirm the header says private, solo, noncanonical, and in-memory. Confirm
    Player Command `16`, Enemy Squad Command `4` after its opening commitment,
    Gate Stability `3/3`, four enemy pieces, and five Prepared cards.
-2. On the clear Lower Yard lane, select tile `(3,6)`, choose **Move →
-   Reposition**, select the highlighted tile again, confirm the textual
-   `CONFIRMED` cue, inspect Preview, and add it.
-3. Select clear tile `(5,6)`, choose **Move → Advance**, select the tile again,
-   and add it. Confirm the earlier Reposition is now a Solid commitment.
+2. Confirm **Read & Plan** and **Move** are active. Verify the board already
+   distinguishes green `FREE` destinations from cyan `ADV` destinations.
+   Choose **Reposition**, select clear tile `(3,6)`, inspect Preview beside the
+   board, and add it.
+3. The player remains selected. Choose **Move → Advance**, select clear tile
+   `(5,6)`, inspect the projected route, and add it. Confirm the earlier
+   Reposition is now a Solid commitment.
 4. Select **Cracked Divider**, choose **Discipline → Answer Commitment**, and
    select the Divider as the target. Attach the source-bound **Follow Through**
    card. Confirm the forecast says high contact risk, likely even, Cracked
@@ -207,11 +231,13 @@ Open `http://127.0.0.1:3000/world/playtest`.
 ### Connected owner checks
 
 1. Compare the clear lane with rubble `(3–5,5)` and the powered lane
-   `(3–7,7)`. Confirm the forecast changes timing without changing available
-   Command.
+   `(3–7,7)`. Confirm each terrain is identifiable before selection, the
+   powered lane visibly connects to the Gate Actuator, and the forecast
+   changes timing without changing available Command.
 2. Change each ordered build and confirm specialized text names `Revealed by`
-   and `Enabled by`; builds without that opportunity do not receive a gray
-   class-locked substitute.
+   and `Enabled by`, while **Build Line** moves to the exact relevant actor or
+   object; builds without that opportunity do not receive a gray class-locked
+   substitute.
 3. Let three unopposed Gate impacts complete and verify **Gate Lost** at `0/3`.
 4. Use **Leave** beside the West Exit and verify **Controlled Retreat** does not
    pretend the Gate or formation was solved.
@@ -228,12 +254,14 @@ Open `http://127.0.0.1:3000/world/playtest`.
    Pass/Lock, manual resolution, Settle, Review, and Reset interactions using
    Tab, Enter, and Space. Confirm every focused control has a visible outline.
 3. At `390 × 844` CSS pixels, confirm tile, focus, card, and action controls
-   remain at least `44 × 44` CSS pixels and the board remains usable.
+   remain at least `44 × 44` CSS pixels. The compact board may pan
+   horizontally, but no tile may be scaled below its usable hit area or placed
+   outside the battlefield.
 4. Enable **Reduce motion**. Confirm target, path, Clash, and card animations
    stop and resolution becomes manually advanceable without hiding state.
-5. Confirm state never depends on color alone: `TARGET`, `CONFIRMED`,
+5. Confirm state never depends on color alone: `FREE`, `ADV`, `TARGET`, `SET`,
    `COMPATIBLE`, `NEWEST`, `SOLID COMMITMENT`, Pivot state, lane names, pips,
-   borders, shapes, and text all carry meaning.
+   icons, borders, shapes, and text all carry meaning.
 
 ## Automated validation
 
@@ -252,7 +280,9 @@ opposed planning and both Pivots, the complete three-cycle battle, Command
 banking and caps, Refocus, invalidation/refunds/no-retargeting, all six ordered
 build state changes, all five Results, lift reset, reset/replay, production
 gating, isolation from persistent systems, input semantics, non-color cues,
-touch targets, reduced motion, and core text contrast.
+touch targets, reduced motion, core text contrast, staggered board bounds,
+action-first movement, phase guidance, visible terrain causality, and
+non-obstructing movement targets.
 
 These are implementation checks—not player evidence. They do not establish
 comprehension, balance, fun, accessibility, or replay value.

--- a/src/components/FracturedGatePrototype.module.css
+++ b/src/components/FracturedGatePrototype.module.css
@@ -45,6 +45,7 @@
 
 .prototypeHeader,
 .controlStrip,
+.phaseDirector,
 .hud,
 .warning,
 .battleLayout,
@@ -61,10 +62,10 @@
 
 .prototypeHeader {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 2rem;
-  padding: clamp(1.2rem, 3vw, 2.4rem);
+  padding: clamp(1rem, 2vw, 1.45rem);
   border: 1px solid var(--fg-line);
   border-bottom: 2px solid rgba(99, 255, 159, 0.7);
   background: rgba(5, 8, 12, 0.95);
@@ -73,9 +74,10 @@
 
 .prototypeHeader h1 {
   margin: 0.2rem 0 0.45rem;
-  font-size: clamp(2.2rem, 6vw, 5.8rem);
-  line-height: 0.82;
-  letter-spacing: -0.075em;
+  font-size: clamp(2.2rem, 4vw, 4.1rem);
+  line-height: 0.88;
+  letter-spacing: -0.06em;
+  white-space: nowrap;
 }
 
 .prototypeHeader > div:first-child > p:last-child {
@@ -99,7 +101,7 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.45rem;
-  max-width: 34rem;
+  max-width: 29rem;
 }
 
 .boundaryBadges span {
@@ -197,6 +199,191 @@
   color: var(--fg-cyan);
 }
 
+.phaseDirector {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 0.8fr);
+  border-inline: 1px solid var(--fg-line);
+  border-bottom: 1px solid var(--fg-line);
+  background: rgba(7, 12, 17, 0.98);
+}
+
+.phaseTrack {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid var(--fg-line);
+  list-style: none;
+}
+
+.phaseTrack li {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.8rem;
+  padding: 0.55rem 0.75rem;
+  border-right: 1px solid var(--fg-line);
+  color: #73858b;
+  font-size: 0.61rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.phaseTrack li:last-child {
+  border-right: 0;
+}
+
+.phaseTrack li::after {
+  position: absolute;
+  right: -0.31rem;
+  z-index: 2;
+  color: var(--fg-line-bright);
+  content: "›";
+  font-size: 1.2rem;
+}
+
+.phaseTrack li:last-child::after {
+  display: none;
+}
+
+.phaseTrack li span {
+  display: grid;
+  place-items: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.56rem;
+}
+
+.phaseTrack .completedPhase {
+  color: var(--fg-muted);
+}
+
+.phaseTrack .currentPhase {
+  color: var(--fg-green);
+  background:
+    linear-gradient(90deg, rgba(99, 255, 159, 0.12), transparent),
+    var(--fg-panel-2);
+}
+
+.phaseTrack .currentPhase span {
+  color: #04120a;
+  background: var(--fg-green);
+  box-shadow: 0 0 18px rgba(99, 255, 159, 0.32);
+}
+
+.phaseInstruction {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+  min-height: 8.2rem;
+  padding: 0.9rem 1.15rem;
+  border-right: 1px solid var(--fg-line);
+  background:
+    radial-gradient(circle at 12% 50%, rgba(97, 220, 255, 0.09), transparent 15rem),
+    var(--fg-panel);
+}
+
+.phaseNumber {
+  display: grid;
+  gap: 0.25rem;
+  padding-right: 1rem;
+  border-right: 1px solid var(--fg-line-bright);
+}
+
+.phaseNumber span {
+  color: var(--fg-muted);
+  font-size: 0.58rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.phaseNumber strong {
+  color: var(--fg-cyan);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.phaseInstruction h2 {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.2vw, 2rem);
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+
+.phaseInstruction p {
+  margin: 0.48rem 0 0;
+  color: var(--fg-text);
+  font-size: 0.8rem;
+  line-height: 1.42;
+}
+
+.phaseInstruction small {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--fg-muted);
+  font-size: 0.67rem;
+  line-height: 1.35;
+}
+
+.opportunityCard {
+  display: grid;
+  align-content: center;
+  gap: 0.32rem;
+  min-height: 8.2rem;
+  padding: 0.85rem 1.05rem;
+  border: 0;
+  border-left: 3px solid var(--fg-violet);
+  color: var(--fg-text);
+  background:
+    linear-gradient(135deg, rgba(201, 166, 255, 0.13), transparent 72%),
+    var(--fg-panel-2);
+  text-align: left;
+  cursor: pointer;
+}
+
+.opportunityCard:hover {
+  background:
+    linear-gradient(135deg, rgba(201, 166, 255, 0.2), transparent 76%),
+    #17212a;
+}
+
+.opportunityCard > span {
+  color: var(--fg-violet);
+  font-size: 0.55rem;
+  font-weight: 1000;
+  letter-spacing: 0.12em;
+}
+
+.opportunityCard strong {
+  font-size: 0.82rem;
+}
+
+.opportunityCard p {
+  margin: 0;
+  color: #ddd1ef;
+  font-size: 0.66rem;
+  line-height: 1.34;
+}
+
+.opportunityCard small {
+  color: var(--fg-muted);
+  font-size: 0.57rem;
+}
+
+.opportunityCard b {
+  color: var(--fg-amber);
+  font-size: 0.6rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
 .hud {
   display: grid;
   grid-template-columns: 1.2fr repeat(7, minmax(8rem, 1fr));
@@ -260,20 +447,30 @@
 
 .battleLayout {
   display: grid;
-  grid-template-columns: minmax(0, 4fr) minmax(19rem, 1fr);
-  min-height: 42rem;
+  grid-template-columns: minmax(0, 3.6fr) minmax(20rem, 1fr);
+  min-height: 39rem;
   margin-top: 0.8rem;
   border: 1px solid var(--fg-line);
   background: var(--fg-bg);
 }
 
 .board {
-  position: relative;
+  display: grid;
+  grid-template-rows: minmax(36rem, 1fr) auto;
   min-width: 0;
-  min-height: 42rem;
-  overflow: hidden;
+  min-height: 39rem;
+  overflow-x: auto;
   isolation: isolate;
   border-right: 1px solid var(--fg-line);
+  background: #060a0f;
+}
+
+.boardViewport {
+  position: relative;
+  min-width: 800px;
+  min-height: 36rem;
+  overflow: hidden;
+  isolation: isolate;
   background:
     linear-gradient(rgba(97, 220, 255, 0.024) 1px, transparent 1px),
     linear-gradient(90deg, rgba(97, 220, 255, 0.024) 1px, transparent 1px),
@@ -281,10 +478,10 @@
   background-size: 24px 24px;
 }
 
-.board::after {
+.boardViewport::after {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 3;
   pointer-events: none;
   content: "";
   background:
@@ -306,12 +503,78 @@
   height: 100%;
 }
 
-.areaLabel {
-  fill: rgba(220, 235, 238, 0.24);
-  font-family: monospace;
-  font-size: 22px;
+.boardTools {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  top: 0.65rem;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  pointer-events: none;
+}
+
+.boardTools > span {
+  color: var(--fg-muted);
+  font-size: 0.55rem;
   font-weight: 900;
-  letter-spacing: 5px;
+  letter-spacing: 0.13em;
+}
+
+.boardTools > div {
+  display: flex;
+  gap: 0.38rem;
+  pointer-events: auto;
+}
+
+.boardTools button {
+  min-height: max(2.75rem, 44px);
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--fg-line-bright);
+  border-radius: 0.28rem;
+  color: var(--fg-muted);
+  background: rgba(8, 14, 19, 0.92);
+  font-size: 0.55rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  cursor: pointer;
+}
+
+.boardTools button:hover {
+  color: var(--fg-text);
+  border-color: var(--fg-text);
+}
+
+.boardTools .activeBoardTool {
+  border-color: var(--fg-cyan);
+  color: var(--fg-cyan);
+  background: rgba(97, 220, 255, 0.11);
+}
+
+.boardTools .activeThreatTool {
+  border-color: var(--fg-orange);
+  color: var(--fg-orange);
+  background: rgba(255, 155, 106, 0.1);
+}
+
+.boardTools .activeBuildTool {
+  border-color: var(--fg-violet);
+  color: var(--fg-violet);
+  background: rgba(201, 166, 255, 0.1);
+}
+
+.boardPanHint {
+  display: none;
+}
+
+.areaLabel {
+  fill: rgba(220, 235, 238, 0.15);
+  font-family: monospace;
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 4px;
 }
 
 .projectionPath {
@@ -325,7 +588,7 @@
 .tileLayer {
   position: absolute;
   inset: 0;
-  z-index: 4;
+  z-index: 5;
 }
 
 .boardTile {
@@ -334,38 +597,166 @@
   top: var(--y);
   display: grid;
   place-items: center;
-  width: max(2.75rem, 44px);
+  width: 3.9rem;
   height: max(2.75rem, 44px);
   padding: 0;
   transform: translate(-50%, -50%);
-  border: 1px solid transparent;
-  border-radius: 50%;
-  color: transparent;
+  border: 0;
+  color: var(--fg-muted);
   background: transparent;
   cursor: pointer;
+}
+
+.tileDiamond {
+  position: absolute;
+  inset: 0.18rem 0;
+  z-index: 0;
+  display: grid;
+  place-items: center;
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+  border: 1px solid transparent;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.045), transparent 54%),
+    #111b23;
+  box-shadow: inset 0 0 0 1px rgba(121, 149, 159, 0.27);
+  transition:
+    transform 120ms ease,
+    filter 120ms ease;
+}
+
+.tileDiamond i {
+  color: #6f838b;
+  font-size: 0.64rem;
+  font-style: normal;
+  font-weight: 1000;
+  text-shadow: 0 1px 2px #000;
+}
+
+.terrain_clear .tileDiamond {
+  background:
+    linear-gradient(90deg, transparent 15%, rgba(99, 255, 159, 0.1) 50%, transparent 85%),
+    #13211f;
+  box-shadow: inset 0 0 0 1px rgba(99, 255, 159, 0.3);
+}
+
+.terrain_clear .tileDiamond i {
+  color: var(--fg-green);
+  font-size: 1.05rem;
+}
+
+.terrain_rubble .tileDiamond {
+  background:
+    radial-gradient(circle at 35% 42%, #765a49 0 7%, transparent 8%),
+    radial-gradient(circle at 58% 58%, #59463d 0 9%, transparent 10%),
+    radial-gradient(circle at 70% 38%, #8b6b54 0 6%, transparent 7%),
+    #251e1b;
+  box-shadow: inset 0 0 0 1px rgba(255, 155, 106, 0.38);
+}
+
+.terrain_rubble .tileDiamond i {
+  color: var(--fg-orange);
+}
+
+.terrain_powered .tileDiamond {
+  background:
+    linear-gradient(
+      0deg,
+      transparent 37%,
+      rgba(97, 220, 255, 0.55) 39% 44%,
+      transparent 46% 54%,
+      rgba(97, 220, 255, 0.55) 56% 61%,
+      transparent 63%
+    ),
+    #10212a;
+  box-shadow:
+    inset 0 0 0 1px rgba(97, 220, 255, 0.5),
+    0 0 12px rgba(97, 220, 255, 0.12);
+}
+
+.terrain_powered .tileDiamond i {
+  color: var(--fg-cyan);
 }
 
 .boardTile:hover,
 .boardTile:focus-visible,
 .selectedTile {
-  border-color: rgba(97, 220, 255, 0.55);
   color: var(--fg-cyan);
-  background: rgba(7, 18, 26, 0.56);
+}
+
+.boardTile:hover .tileDiamond,
+.boardTile:focus-visible .tileDiamond,
+.selectedTile .tileDiamond {
+  filter: brightness(1.35);
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 0 0 2px var(--fg-cyan),
+    0 0 18px rgba(97, 220, 255, 0.28);
 }
 
 .legalTile {
-  z-index: 5;
-  border: 2px dashed var(--fg-amber);
+  z-index: 8;
   color: #171000;
-  background: rgba(255, 209, 102, 0.18);
-  box-shadow: 0 0 18px rgba(255, 209, 102, 0.22);
   animation: targetPulse 1.15s ease-in-out infinite;
 }
 
-.boardTile span {
+.legalTile .tileDiamond {
+  background: rgba(255, 209, 102, 0.34);
+  box-shadow:
+    inset 0 0 0 3px var(--fg-amber),
+    0 0 20px rgba(255, 209, 102, 0.34);
+}
+
+.freeMoveTile .tileDiamond {
+  background: rgba(99, 255, 159, 0.22);
+  box-shadow:
+    inset 0 0 0 2px var(--fg-green),
+    0 0 15px rgba(99, 255, 159, 0.22);
+}
+
+.advanceMoveTile .tileDiamond {
+  background: rgba(97, 220, 255, 0.19);
+  box-shadow:
+    inset 0 0 0 2px var(--fg-cyan),
+    0 0 15px rgba(97, 220, 255, 0.2);
+}
+
+.threatenedTile .tileDiamond {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 120, 132, 0.78),
+    inset 0 0 18px rgba(255, 120, 132, 0.13);
+}
+
+.buildOpportunityTile .tileDiamond {
+  box-shadow:
+    inset 0 0 0 2px var(--fg-violet),
+    0 0 21px rgba(201, 166, 255, 0.25);
+}
+
+.tileCue {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  min-width: 1.7rem;
+  min-height: 1.15rem;
+  padding: 0.05rem 0.18rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: #07110c;
+  background: var(--fg-green);
   font-size: 0.44rem;
   font-weight: 1000;
   letter-spacing: 0.05em;
+}
+
+.legalTile .tileCue {
+  color: #171000;
+  background: var(--fg-amber);
+}
+
+.advanceMoveTile .tileCue {
+  color: #03151b;
+  background: var(--fg-cyan);
 }
 
 @keyframes dashFlow {
@@ -393,36 +784,81 @@
 
 .boardFocus {
   display: grid;
-  gap: 0.1rem;
-  width: max-content;
-  max-width: 9.5rem;
-  min-width: 5rem;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
   min-height: max(2.75rem, 44px);
-  padding: 0.38rem 0.55rem;
+  padding: 0;
   border: 1px solid rgba(168, 184, 189, 0.4);
-  border-radius: 0.34rem;
+  border-radius: 0.55rem;
   color: var(--fg-text);
-  background: rgba(7, 12, 17, 0.84);
-  text-align: left;
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.38);
+  background: rgba(7, 12, 17, 0.95);
+  text-align: center;
+  box-shadow:
+    0 7px 18px rgba(0, 0, 0, 0.46),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   cursor: pointer;
 }
 
-.boardFocus strong {
-  font-size: clamp(0.58rem, 0.78vw, 0.72rem);
-  line-height: 1.08;
+.markerGlyph {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid currentColor;
+  border-radius: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 1000;
+  line-height: 1;
 }
 
-.boardFocus small {
+.markerLabel {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.18rem);
+  display: grid;
+  gap: 0.05rem;
+  width: max-content;
+  max-width: 8.8rem;
+  padding: 0.18rem 0.3rem;
+  transform: translateX(-50%);
+  border: 1px solid rgba(50, 67, 77, 0.8);
+  border-radius: 0.2rem;
+  color: var(--fg-text);
+  background: rgba(4, 8, 12, 0.9);
+  line-height: 1.05;
+  pointer-events: none;
+}
+
+.markerLabel strong {
+  font-size: 0.5rem;
+  font-weight: 1000;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.markerLabel small {
+  overflow: hidden;
+  max-width: 8.2rem;
   color: var(--fg-muted);
-  font-size: clamp(0.47rem, 0.65vw, 0.58rem);
-  line-height: 1.12;
+  font-size: 0.43rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .boardFocus:hover {
-  z-index: 10;
+  z-index: 18;
   border-color: var(--fg-cyan);
   background: rgba(16, 31, 40, 0.96);
+}
+
+.boardFocus:hover .markerLabel,
+.selectedFocus .markerLabel,
+.legalTarget .markerLabel,
+.buildOpportunityFocus .markerLabel {
+  z-index: 19;
+  border-color: currentColor;
+  background: rgba(4, 8, 12, 0.98);
 }
 
 .focus_terrain,
@@ -433,18 +869,25 @@
 }
 
 .focus_enemy {
+  border-radius: 50%;
   border: 2px solid var(--fg-orange);
   color: #fff1eb;
   background: rgba(74, 31, 22, 0.92);
 }
 
 .focus_intent {
+  width: 2.35rem;
+  height: 2.35rem;
+  min-height: 2.35rem;
+  border-radius: 50%;
   border: 2px solid var(--fg-orange);
   color: var(--fg-orange);
   background: rgba(47, 23, 18, 0.95);
 }
 
 .focus_objective {
+  width: 3.35rem;
+  height: 3.35rem;
   border: 2px solid var(--fg-green);
   color: var(--fg-green);
   background: rgba(10, 43, 31, 0.93);
@@ -476,6 +919,42 @@
 .projectedFocus {
   border-style: dashed;
   box-shadow: 0 0 0 2px rgba(97, 220, 255, 0.13);
+}
+
+.movementPassThrough {
+  z-index: 7;
+  transform: translate(-50%, -112%) scale(0.72);
+  pointer-events: none;
+  opacity: 0.58;
+}
+
+.movementPassThrough .markerLabel,
+.movementPassThrough .buildCue {
+  display: none;
+}
+
+.buildOpportunityFocus {
+  z-index: 13;
+  box-shadow:
+    0 0 0 4px rgba(201, 166, 255, 0.2),
+    0 0 26px rgba(201, 166, 255, 0.36);
+}
+
+.buildCue {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.28rem);
+  width: max-content;
+  padding: 0.14rem 0.28rem;
+  transform: translateX(-50%);
+  border: 1px solid rgba(201, 166, 255, 0.7);
+  border-radius: 0.2rem;
+  color: #13091e;
+  background: var(--fg-violet);
+  font-size: 0.43rem;
+  font-weight: 1000;
+  letter-spacing: 0.07em;
+  pointer-events: none;
 }
 
 .inactiveFocus {
@@ -525,8 +1004,8 @@
 .playerPiece {
   display: grid;
   place-items: center;
-  width: 4.2rem;
-  height: 4.2rem;
+  width: 3.6rem;
+  height: 3.6rem;
   border: 2px solid var(--fg-green);
   border-radius: 50%;
   color: #04130b;
@@ -540,8 +1019,8 @@
 .pieceCore {
   display: grid;
   place-items: center;
-  width: 2.45rem;
-  height: 2.45rem;
+  width: 2.2rem;
+  height: 2.2rem;
   border-radius: 50%;
   color: #06130b;
   background: var(--fg-green);
@@ -569,8 +1048,8 @@
 .ghostPiece {
   display: grid;
   place-items: center;
-  width: 4rem;
-  height: 4rem;
+  width: 3.55rem;
+  height: 3.55rem;
   border: 3px dashed var(--fg-cyan);
   border-radius: 50%;
   color: var(--fg-cyan);
@@ -595,11 +1074,12 @@
 
 .intentLegend {
   position: absolute;
-  right: 3%;
-  top: 4%;
-  z-index: 5;
+  right: 1rem;
+  top: 4.15rem;
+  z-index: 7;
   display: grid;
-  gap: 0.08rem;
+  gap: 0.12rem;
+  max-width: 19rem;
   padding: 0.45rem 0.65rem;
   border: 1px solid rgba(255, 155, 106, 0.54);
   color: #ffd8c5;
@@ -613,6 +1093,60 @@
   font-size: 0.5rem;
   font-weight: 1000;
   letter-spacing: 0.12em;
+}
+
+.intentLegend strong {
+  font-size: 0.67rem;
+}
+
+.intentLegend small {
+  color: #caa99a;
+  font-size: 0.52rem;
+  line-height: 1.25;
+}
+
+.terrainLegend {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 800px;
+  padding: 0.55rem 0.7rem;
+  border-top: 1px solid var(--fg-line);
+  background: var(--fg-panel);
+  overflow-x: auto;
+}
+
+.terrainLegend span {
+  width: max-content;
+  padding: 0.24rem 0.42rem;
+  border: 1px solid var(--fg-line);
+  border-radius: 999px;
+  color: var(--fg-muted);
+  font-size: 0.49rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.terrainLegend .legendClear {
+  border-color: rgba(99, 255, 159, 0.38);
+  color: var(--fg-green);
+}
+
+.terrainLegend .legendRubble,
+.terrainLegend .legendThreat {
+  border-color: rgba(255, 155, 106, 0.4);
+  color: var(--fg-orange);
+}
+
+.terrainLegend .legendPowered {
+  border-color: rgba(97, 220, 255, 0.4);
+  color: var(--fg-cyan);
+}
+
+.terrainLegend .legendBuild {
+  border-color: rgba(201, 166, 255, 0.42);
+  color: var(--fg-violet);
 }
 
 .resolutionVeil {
@@ -642,6 +1176,15 @@
   font-size: 1.25rem;
 }
 
+.commandRail {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  max-height: 39rem;
+  overflow-y: auto;
+  background: var(--fg-panel);
+}
+
 .contextPanel {
   min-width: 0;
   padding: 1.15rem;
@@ -658,11 +1201,40 @@
 }
 
 .contextDescription {
-  min-height: 5.3rem;
+  min-height: 3.4rem;
   margin: 0;
   color: var(--fg-muted);
   font-size: 0.76rem;
   line-height: 1.45;
+}
+
+.commandRail .previewPanel {
+  display: flex;
+  flex-direction: column;
+  width: auto;
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--fg-line);
+}
+
+.commandRail .previewHeading {
+  order: -2;
+}
+
+.commandRail .addBar {
+  order: -1;
+  margin-top: 0.7rem;
+  padding: 0.65rem;
+  border: 1px solid rgba(99, 255, 159, 0.42);
+  background: rgba(99, 255, 159, 0.06);
+}
+
+.commandRail .previewContent {
+  grid-template-columns: 1fr;
+}
+
+.commandRail .previewContent ul {
+  grid-template-columns: 1fr;
 }
 
 .parentActions {
@@ -760,6 +1332,35 @@
   border: 2px dashed var(--fg-amber);
   color: var(--fg-text);
   background: rgba(65, 48, 7, 0.27);
+}
+
+.phaseContextNotice {
+  display: grid;
+  gap: 0.36rem;
+  margin-top: 1rem;
+  padding: 0.8rem;
+  border: 1px solid rgba(97, 220, 255, 0.45);
+  border-left: 3px solid var(--fg-cyan);
+  background: rgba(97, 220, 255, 0.055);
+}
+
+.phaseContextNotice span {
+  color: var(--fg-cyan);
+  font-size: 0.55rem;
+  font-weight: 1000;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.phaseContextNotice strong {
+  font-size: 0.75rem;
+}
+
+.phaseContextNotice p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.67rem;
+  line-height: 1.4;
 }
 
 .targetingNotice span {
@@ -1602,6 +2203,10 @@
 }
 
 @media (max-width: 1180px) {
+  .phaseDirector {
+    grid-template-columns: minmax(0, 1.35fr) minmax(17rem, 0.8fr);
+  }
+
   .hud {
     grid-template-columns: repeat(4, 1fr);
   }
@@ -1658,14 +2263,27 @@
     grid-column: auto;
   }
 
+  .phaseDirector {
+    grid-template-columns: 1fr;
+  }
+
+  .phaseInstruction {
+    border-right: 0;
+    border-bottom: 1px solid var(--fg-line);
+  }
+
   .battleLayout {
     grid-template-columns: 1fr;
   }
 
   .board {
-    min-height: 38rem;
+    min-height: 39rem;
     border-right: 0;
     border-bottom: 1px solid var(--fg-line);
+  }
+
+  .commandRail {
+    max-height: none;
   }
 
   .contextPanel {
@@ -1683,6 +2301,7 @@
   .parentActions,
   .actionVariants,
   .targetingNotice,
+  .phaseContextNotice,
   .contextHint {
     grid-column: 2;
     grid-row: 1 / span 4;
@@ -1713,9 +2332,11 @@
 @media (max-width: 620px) {
   .prototypeHeader h1 {
     font-size: clamp(2.4rem, 16vw, 4.2rem);
+    white-space: normal;
   }
 
   .controlStrip,
+  .phaseDirector,
   .hud,
   .contextPanel,
   .settleGrid,
@@ -1739,29 +2360,71 @@
     border-bottom: 0;
   }
 
+  .phaseTrack {
+    grid-template-columns: repeat(5, minmax(7.5rem, 1fr));
+    overflow-x: auto;
+  }
+
+  .phaseTrack li {
+    min-height: 2.6rem;
+  }
+
+  .phaseInstruction {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .phaseNumber {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 0;
+    padding-bottom: 0.55rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--fg-line-bright);
+  }
+
+  .opportunityCard {
+    min-height: auto;
+  }
+
   .board {
-    min-height: 640px;
+    min-height: 39rem;
   }
 
   .boardFocus {
-    max-width: 6.6rem;
-    min-width: 3.8rem;
+    width: 3rem;
+    height: 3rem;
     min-height: max(2.75rem, 44px);
-    padding: 0.3rem 0.4rem;
+    padding: 0;
   }
 
-  .boardFocus strong {
-    font-size: 0.56rem;
+  .boardTools {
+    align-items: flex-start;
   }
 
-  .boardFocus small {
+  .boardTools > span {
     display: none;
   }
 
-  .selectedFocus small,
-  .legalTarget small {
+  .boardTools > div {
+    margin-left: auto;
+  }
+
+  .boardPanHint {
+    position: absolute;
+    left: 1rem;
+    top: 0.85rem;
+    z-index: 18;
     display: block;
-    font-size: 0.46rem;
+    padding: 0.28rem 0.42rem;
+    border: 1px solid rgba(97, 220, 255, 0.5);
+    color: var(--fg-cyan);
+    background: rgba(4, 10, 14, 0.9);
+    font-size: 0.48rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    pointer-events: none;
   }
 
   .playerPiece {
@@ -1774,29 +2437,13 @@
     height: 2.1rem;
   }
 
-  .boardFocus[data-focus-id="impact-rush"] {
-    top: 46%;
-    left: 70%;
-  }
-
-  .boardFocus[data-focus-id="cracked-divider"] {
-    top: 67%;
-  }
-
-  .boardFocus[data-focus-id="service-gap"] {
-    left: 55%;
-  }
-
-  .intentLegend {
-    display: none;
-  }
-
   .contextPanel > .eyebrow,
   .contextPanel > h2,
   .contextDescription,
   .parentActions,
   .actionVariants,
   .targetingNotice,
+  .phaseContextNotice,
   .contextHint,
   .inspectDetails {
     grid-column: 1;

--- a/src/components/FracturedGatePrototype.tsx
+++ b/src/components/FracturedGatePrototype.tsx
@@ -61,6 +61,113 @@ const CORE_FOCUS_ORDER = [
 ];
 
 const LANE_NAMES = ["Fast", "Standard", "Slow"];
+const BATTLE_PHASES = [
+  "Read & plan",
+  "Contest & lock",
+  "Resolve",
+  "Settle",
+  "Results",
+];
+
+const MARKER_VISUALS: Record<
+  string,
+  { glyph: string; short: string; relationship?: string }
+> = {
+  "west-exit": { glyph: "↤", short: "EXIT", relationship: "Retreat route" },
+  "cracked-divider": {
+    glyph: "╫",
+    short: "DIVIDER",
+    relationship: "Brittle cover + conduit",
+  },
+  "gate-actuator": {
+    glyph: "A",
+    short: "ACTUATOR",
+    relationship: "Powers track + bollard",
+  },
+  "defensive-bollard": {
+    glyph: "B",
+    short: "BOLLARD",
+    relationship: "Redirects physical force",
+  },
+  "service-gap": {
+    glyph: "⇥",
+    short: "SERVICE GAP",
+    relationship: "Shutter-controlled route",
+  },
+  "upper-crossing": {
+    glyph: "⌁",
+    short: "UPPER GAP",
+    relationship: "Natural crossing",
+  },
+  "lift-relay": {
+    glyph: "L",
+    short: "LIFT RELAY",
+    relationship: "Creates temporary bridge",
+  },
+  "field-cache": {
+    glyph: "◇",
+    short: "CACHE",
+    relationship: "Optional package",
+  },
+  gate: { glyph: "G", short: "GATE", relationship: "Protect + stabilize" },
+  breacher: { glyph: "BR", short: "BREACHER", relationship: "Gate pressure" },
+  guard: { glyph: "GD", short: "GUARD", relationship: "Protects + intercepts" },
+  controller: {
+    glyph: "CT",
+    short: "CONTROLLER",
+    relationship: "Opposes machinery",
+  },
+  pressure: {
+    glyph: "PR",
+    short: "PRESSURE",
+    relationship: "Flank + route denial",
+  },
+  "breacher-intent": {
+    glyph: "!",
+    short: "IMPACT LINE",
+    relationship: "Breacher → Gate",
+  },
+  breach: { glyph: "↔", short: "BREACH", relationship: "Two-way opening" },
+  "upper-route": {
+    glyph: "↗",
+    short: "UPPER ROUTE",
+    relationship: "Prepared crossing",
+  },
+  "service-route": {
+    glyph: "⇢",
+    short: "SERVICE ROUTE",
+    relationship: "Prepared rear route",
+  },
+  "service-lift": {
+    glyph: "⇈",
+    short: "LIFT BRIDGE",
+    relationship: "Returns at Settle",
+  },
+  regulator: {
+    glyph: "R",
+    short: "REGULATOR",
+    relationship: "Exposed impact hardware",
+  },
+};
+
+type BuildOpportunity = {
+  focusId: string;
+  title: string;
+  instruction: string;
+  revealed: string;
+  enabled: string;
+  actionLabel: string | null;
+  ready: boolean;
+  reason: string | null;
+};
+
+type PhaseGuide = {
+  phaseIndex: number;
+  kicker: string;
+  title: string;
+  instruction: string;
+  detail: string;
+};
 
 function buildFor(buildId: string) {
   return BUILDS.find((build: FracturedGateRecord) => build.id === buildId) ??
@@ -84,6 +191,17 @@ function focusStatus(
 ) {
   if (BOARD_TILES[focusId]) {
     const tile = BOARD_TILES[focusId];
+    if (tile.terrain === "powered") {
+      return `Powered service track · Gate Actuator feed ${titleCase(
+        snapshot.poweredTrack.feed,
+      )}`;
+    }
+    if (tile.terrain === "rubble") {
+      return `Loose rubble · costs 2 movement · ${tile.x},${tile.y}`;
+    }
+    if (tile.terrain === "clear") {
+      return `Clear approach lane · ${tile.x},${tile.y}`;
+    }
     return `${titleCase(tile.terrain)} · ${tile.x},${tile.y}`;
   }
   if (snapshot.enemies?.[focusId]) {
@@ -135,6 +253,349 @@ function phaseLabel(game: FracturedGateState) {
   return game.priority === "player" ? "Planning · your priority" : "Planning · enemy priority";
 }
 
+function getBuildOpportunity(
+  game: FracturedGateState,
+  snapshot: FracturedGateRecord,
+): BuildOpportunity {
+  const build = buildFor(game.buildId);
+  const major = titleCase(build.major);
+  const minor = titleCase(build.minor);
+  const opportunities: Record<
+    string,
+    { focusId: string; title: string; instruction: string }
+  > = {
+    "battle-exploration":
+      snapshot.divider.status === "breached"
+        ? {
+            focusId: "defensive-bollard",
+            title: "Turn the breach into a contact angle",
+            instruction:
+              "Battle created the opening. Exploration can now carry contact along its safe upper lip.",
+          }
+        : {
+            focusId: "cracked-divider",
+            title: "Break the Divider to create a route",
+            instruction:
+              "Approach on the clear lane, then answer the Breacher at this brittle, load-bearing cover.",
+          },
+    "exploration-battle":
+      snapshot.upperRoute.prepared
+        ? {
+            focusId: "upper-crossing",
+            title: "Protect the prepared landing",
+            instruction:
+              "Exploration established the route. Battle can preserve its capacity-one landing against interception.",
+          }
+        : {
+            focusId: "upper-crossing",
+            title: "Prepare the Upper Natural Crossing",
+            instruction:
+              "Exploration sees the handholds. Battle can later defend the east landing.",
+          },
+    "battle-hacking":
+      snapshot.flags.regulatorExposed
+        ? {
+            focusId: "regulator",
+            title: "Suppress the exposed regulator reset",
+            instruction:
+              "Battle exposed real hardware. Hacking can keep its automatic reset from erasing that advantage.",
+          }
+        : {
+            focusId: "breacher",
+            title: "Expose the Breacher’s impact regulator",
+            instruction:
+              "Meet the Breacher physically, then use Hacking on the hardware the collision reveals.",
+          },
+    "hacking-battle":
+      snapshot.actuator.controlled
+        ? {
+            focusId: "defensive-bollard",
+            title: "Convert Control into physical force",
+            instruction:
+              "Hacking owns the output. Battle must hold the access point and author where that force lands.",
+          }
+        : {
+            focusId: "gate-actuator",
+            title: "Take local control of the Gate Actuator",
+            instruction:
+              "Reach the visible actuator that powers both the service track and defensive bollard.",
+          },
+    "exploration-hacking":
+      snapshot.serviceRoute.prepared
+        ? {
+            focusId: "service-gap",
+            title: "Suppress the service shutter",
+            instruction:
+              "Exploration found the rear route. Hacking can delay the Controller-linked closure.",
+          }
+        : {
+            focusId: "service-gap",
+            title: "Prepare the concealed Service Gap",
+            instruction:
+              "Exploration reads the physical gap. Hacking can later keep its shutter open.",
+          },
+    "hacking-exploration":
+      snapshot.actuator.controlled && snapshot.actuator.mode === "lift"
+        ? {
+            focusId: "service-lift",
+            title: "Align and cross the temporary lift bridge",
+            instruction:
+              "Hacking created a movable output. Exploration reads its safe crossing and reset window.",
+          }
+        : {
+            focusId: "lift-relay",
+            title: "Establish Lift Relay Control",
+            instruction:
+              "Reach the powered relay. Exploration can turn its output into temporary geometry.",
+          },
+  };
+  const opportunity =
+    opportunities[game.buildId] ?? opportunities["battle-exploration"];
+  const discipline = getContextActionGroups(game, opportunity.focusId).find(
+    (group: FracturedGateRecord) => group.parent === "Discipline",
+  );
+  const choice = discipline?.choices[0] ?? null;
+  return {
+    ...opportunity,
+    revealed: `${major} Major`,
+    enabled: `${minor} Minor`,
+    actionLabel: choice?.label ?? null,
+    ready: Boolean(choice?.legal),
+    reason: choice?.legal ? null : choice?.reason ?? null,
+  };
+}
+
+function getPhaseGuide({
+  game,
+  targetingChoice,
+  targetId,
+  selectedParent,
+  pivotMode,
+}: {
+  game: FracturedGateState;
+  targetingChoice: FracturedGateChoice | null;
+  targetId: string | null;
+  selectedParent: string | null;
+  pivotMode: boolean;
+}): PhaseGuide {
+  if (game.phase === "resolution") {
+    const index = game.resolution?.visibleLaneIndex ?? -1;
+    return {
+      phaseIndex: 2,
+      kicker: index < 0 ? "Plans revealed" : `${LANE_NAMES[index]} lane`,
+      title: index < 0 ? "The plans are locked" : `Resolve ${LANE_NAMES[index]}`,
+      instruction:
+        index < 0
+          ? "Compare both plans, then reveal the first timing lane."
+          : "Watch positions, protection, machinery, and contact update on the battlefield.",
+      detail:
+        "Nothing may be added or retargeted after Lock. Invalidated actions are explained in the review.",
+    };
+  }
+  if (game.phase === "settle") {
+    return {
+      phaseIndex: 3,
+      kicker: "Aftermath",
+      title: "Read what changed, then Settle",
+      instruction:
+        "Review damage, Gate pressure, terrain, temporary machinery, cards, and Command before the next exchange.",
+      detail: "Temporary outputs reset here; persistent physical changes remain.",
+    };
+  }
+  if (game.phase === "result") {
+    return {
+      phaseIndex: 4,
+      kicker: "Battle complete",
+      title: "Review the result and tradeoff",
+      instruction:
+        "The result names the objective outcome, principal turning point, location consequence, and cost.",
+      detail: "Reset returns the exact same deterministic opening state.",
+    };
+  }
+  if (game.hand.length > CORE_RULES.retainLimit) {
+    return {
+      phaseIndex: 0,
+      kicker: "Retain limit",
+      title: `Discard ${game.hand.length - CORE_RULES.retainLimit} card${
+        game.hand.length - CORE_RULES.retainLimit === 1 ? "" : "s"
+      } before planning`,
+      instruction:
+        "Use the hand controls below. The battlefield remains readable, but no new action can be committed yet.",
+      detail: `${CORE_RULES.retainLimit} prepared cards may be carried into Lock.`,
+    };
+  }
+  if (pivotMode) {
+    return {
+      phaseIndex: 1,
+      kicker: "One bounded change",
+      title: "Pivot the newest Open action",
+      instruction:
+        "Choose a replacement action and target. Earlier solid commitments cannot be erased.",
+      detail: game.playerPivotUsed
+        ? "The player Pivot has already been used this allotment."
+        : "The replacement locks immediately and returns priority to the enemy squad.",
+    };
+  }
+  if (targetingChoice && !targetId) {
+    return {
+      phaseIndex: game.plan.length ? 1 : 0,
+      kicker: "Targeting",
+      title: `Choose a highlighted target for ${targetingChoice.label}`,
+      instruction:
+        targetingChoice.parent === "Move"
+          ? "Select one glowing diamond. The map shows every legal destination; occupied or blocked spaces are not offered."
+          : "Select the clearly marked actor, object, or battlefield position.",
+      detail:
+        targetingChoice.parent === "Move"
+          ? `${targetingChoice.label}: ${targetingChoice.cost} Command · ${targetingChoice.description}`
+          : "Targeting does not commit the action. You will preview it next.",
+    };
+  }
+  if (targetingChoice && targetId) {
+    return {
+      phaseIndex: game.plan.length ? 1 : 0,
+      kicker: "Preview",
+      title: "Confirm the projected consequence",
+      instruction:
+        "Read the expected movement, important risk, Tempo, contact forecast, and skill attribution in the command rail.",
+      detail:
+        "Attach a compatible card only if it changes the plan you want, then Add to Plan.",
+    };
+  }
+  if (game.priority !== "player") {
+    return {
+      phaseIndex: 1,
+      kicker: "Enemy priority",
+      title: "The enemy squad is committing",
+      instruction:
+        "Read its visible posture and remaining squad Command. Concealed cards stay concealed.",
+      detail: "The squad uses its own real hands and cannot inspect yours.",
+    };
+  }
+  if (selectedParent === "Move") {
+    return {
+      phaseIndex: game.plan.length ? 1 : 0,
+      kicker: game.plan.length ? "Continue or lock" : "Opening selection",
+      title: "Choose how far you want to move",
+      instruction:
+        "Green diamonds are the one free Reposition. Cyan diamonds are reachable with the paid Advance.",
+      detail:
+        game.plan.length
+          ? "You can add another action, inspect another focus, Pivot the newest action, or Pass / Lock."
+          : "Select Reposition or Advance in the command rail, then choose a glowing destination.",
+    };
+  }
+  if (selectedParent) {
+    return {
+      phaseIndex: game.plan.length ? 1 : 0,
+      kicker: "Action selection",
+      title: `Choose a ${selectedParent} action`,
+      instruction:
+        "Only actions relevant to the selected battlefield focus are shown in the command rail.",
+      detail: "Disabled actions name the physical position or setup they still require.",
+    };
+  }
+  return {
+    phaseIndex: game.plan.length ? 1 : 0,
+    kicker: game.plan.length ? "Contest the plan" : "Read the battlefield",
+    title: game.plan.length
+      ? "Add, Pivot, or Pass / Lock"
+      : "Select your piece, an enemy, or a visible object",
+    instruction:
+      "Use the board itself. Enemy pressure, physical terrain, powered relationships, and your build opportunity are already marked.",
+    detail:
+      "Selecting a focus reveals only the actions that make physical and tactical sense there.",
+  };
+}
+
+function PhaseDirector({
+  game,
+  targetingChoice,
+  targetId,
+  selectedParent,
+  pivotMode,
+  opportunity,
+  onOpportunity,
+}: {
+  game: FracturedGateState;
+  targetingChoice: FracturedGateChoice | null;
+  targetId: string | null;
+  selectedParent: string | null;
+  pivotMode: boolean;
+  opportunity: BuildOpportunity;
+  onOpportunity: (focusId: string) => void;
+}) {
+  const guide = getPhaseGuide({
+    game,
+    targetingChoice,
+    targetId,
+    selectedParent,
+    pivotMode,
+  });
+  return (
+    <section className={styles.phaseDirector} aria-label="Current battle phase">
+      <ol className={styles.phaseTrack}>
+        {BATTLE_PHASES.map((phase, index) => (
+          <li
+            key={phase}
+            className={
+              index === guide.phaseIndex
+                ? styles.currentPhase
+                : index < guide.phaseIndex
+                  ? styles.completedPhase
+                  : ""
+            }
+            aria-current={index === guide.phaseIndex ? "step" : undefined}
+          >
+            <span>{index + 1}</span>
+            {phase}
+          </li>
+        ))}
+      </ol>
+      <div className={styles.phaseInstruction} aria-live="polite">
+        <div className={styles.phaseNumber}>
+          <span>ROUND {game.round}</span>
+          <strong>{guide.kicker}</strong>
+        </div>
+        <div>
+          <h2>{guide.title}</h2>
+          <p>{guide.instruction}</p>
+          <small>{guide.detail}</small>
+        </div>
+      </div>
+      <button
+        type="button"
+        className={styles.opportunityCard}
+        onClick={() => onOpportunity(opportunity.focusId)}
+        data-testid="build-opportunity"
+      >
+        <span>
+          CURRENT BUILD LINE ·{" "}
+          {game.phase === "planning"
+            ? opportunity.ready
+              ? "ACTION READY"
+              : "SETUP VISIBLE"
+            : game.phase === "result"
+              ? "RESULTING FIELD STATE"
+              : "SOURCE IN VIEW"}
+        </span>
+        <strong>{opportunity.title}</strong>
+        <p>{opportunity.instruction}</p>
+        <small>
+          Revealed by {opportunity.revealed} · Enabled by {opportunity.enabled}
+        </small>
+        <b>
+          {game.phase !== "planning"
+            ? "Select to inspect this source on the battlefield."
+            : opportunity.ready
+            ? `Select · ${opportunity.actionLabel}`
+            : opportunity.reason ?? "Select to inspect the required setup."}
+        </b>
+      </button>
+    </section>
+  );
+}
+
 function GatePips({
   stability,
   status,
@@ -163,24 +624,55 @@ function GatePips({
 function BattleBoard({
   game,
   selectedFocus,
+  selectedParent,
   confirmedTarget,
   targetingChoice,
   projection,
+  opportunity,
   onFocus,
+  onShowMove,
+  onOpportunity,
 }: {
   game: FracturedGateState;
   selectedFocus: string;
+  selectedParent: string | null;
   confirmedTarget: string | null;
   targetingChoice: FracturedGateChoice | null;
   projection: FracturedGateRecord | null;
+  opportunity: BuildOpportunity;
   onFocus: (focusId: string) => void;
+  onShowMove: () => void;
+  onOpportunity: (focusId: string) => void;
 }) {
+  const [showThreats, setShowThreats] = useState(true);
+  const [showBuildLine, setShowBuildLine] = useState(true);
   const snapshot = displaySnapshot(game);
   const legalTargets = new Set<string>(
     (targetingChoice?.legalTargets ?? []) as string[],
   );
   const visible = new Set(CORE_FOCUS_ORDER);
   const projectedSnapshot = projection?.finalSnapshot ?? snapshot;
+  const movementGroup = getContextActionGroups(game, "player").find(
+    (group: FracturedGateRecord) => group.parent === "Move",
+  );
+  const repositionTargets = new Set<string>(
+    (movementGroup?.choices.find(
+      (choice: FracturedGateChoice) => choice.id === "reposition",
+    )?.legalTargets ?? []) as string[],
+  );
+  const advanceTargets = new Set<string>(
+    (movementGroup?.choices.find(
+      (choice: FracturedGateChoice) => choice.id === "advance",
+    )?.legalTargets ?? []) as string[],
+  );
+  const showMoveGuide =
+    game.phase === "planning" &&
+    game.priority === "player" &&
+    selectedFocus === "player" &&
+    selectedParent === "Move" &&
+    !targetingChoice;
+  const opportunityTileId =
+    BOARD_FOCUSES[opportunity.focusId]?.tileId ?? opportunity.focusId;
 
   if (
     projectedSnapshot.divider.status === "breached" ||
@@ -215,10 +707,55 @@ function BattleBoard({
   const ghostPosition = projection?.ghostPosition
     ? getPositionCoordinates(projection.ghostPosition)
     : null;
+  const svgPoint = (point: { x: number; y: number }) =>
+    `${point.x * 10},${point.y * 6.2}`;
   const pathPoints = (projection?.movementPath ?? [])
     .map((positionId: string) => getPositionCoordinates(positionId))
-    .map((point: { x: number; y: number }) => `${point.x * 10},${point.y * 6.2}`)
+    .map(svgPoint)
     .join(" ");
+  const feedPoints = [
+    "tile-3-7",
+    "tile-4-7",
+    "tile-5-7",
+    "tile-6-7",
+    "tile-7-7",
+  ]
+    .map((positionId) => getPositionCoordinates(positionId))
+    .map(svgPoint)
+    .join(" ");
+  const actuatorPoint = BOARD_FOCUSES["gate-actuator"];
+  const bollardPoint = BOARD_FOCUSES["defensive-bollard"];
+  const dividerPoint = BOARD_FOCUSES["cracked-divider"];
+  const gatePoint = BOARD_FOCUSES.gate;
+  const breacherPoint = getPositionCoordinates(
+    projectedSnapshot.enemies.breacher.position,
+  );
+  const intentPoints = [
+    breacherPoint,
+    getPositionCoordinates("tile-7-5"),
+    dividerPoint,
+    getPositionCoordinates("tile-9-5"),
+    getPositionCoordinates("tile-10-5"),
+    getPositionCoordinates("tile-11-5"),
+    gatePoint,
+  ]
+    .map(svgPoint)
+    .join(" ");
+  const activeEnemyTiles = new Set<string>();
+  for (const enemy of Object.values(projectedSnapshot.enemies) as FracturedGateRecord[]) {
+    if (!["active", "staggered", "off-balance", "pinned"].includes(enemy.status)) {
+      continue;
+    }
+    const origin = BOARD_TILES[enemy.position];
+    if (!origin) continue;
+    for (const tile of Object.values(BOARD_TILES) as FracturedGateRecord[]) {
+      if (
+        Math.max(Math.abs(tile.x - origin.x), Math.abs(tile.y - origin.y)) <= 1
+      ) {
+        activeEnemyTiles.add(tile.id);
+      }
+    }
+  }
 
   const boardFocuses = [...visible]
     .filter((focusId) => BOARD_FOCUSES[focusId])
@@ -230,311 +767,441 @@ function BattleBoard({
       aria-label="The Fractured Gate tactical board"
       data-testid="fractured-gate-board"
     >
-      <svg
-        className={styles.boardArt}
-        viewBox="0 0 1000 620"
-        preserveAspectRatio="none"
-        aria-hidden="true"
-      >
-        <defs>
-          <linearGradient id="yard-fill" x1="0" x2="1">
-            <stop offset="0" stopColor="#101a22" />
-            <stop offset="1" stopColor="#192630" />
-          </linearGradient>
-          <linearGradient id="walk-fill" x1="0" x2="1">
-            <stop offset="0" stopColor="#1a262c" />
-            <stop offset="1" stopColor="#23343b" />
-          </linearGradient>
-          <linearGradient id="gate-fill" x1="0" x2="1">
-            <stop offset="0" stopColor="#17252d" />
-            <stop offset="1" stopColor="#203d42" />
-          </linearGradient>
-          <marker
-            id="intent-arrow"
-            viewBox="0 0 10 10"
-            refX="8"
-            refY="5"
-            markerWidth="8"
-            markerHeight="8"
-            orient="auto-start-reverse"
-          >
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff8a5c" />
-          </marker>
-          <filter id="soft-glow">
-            <feGaussianBlur stdDeviation="5" result="blur" />
-            <feMerge>
-              <feMergeNode in="blur" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
-        </defs>
+      <div className={styles.boardViewport}>
+        <div className={styles.boardTools}>
+          <span>PHYSICAL BATTLEFIELD · DIRECT SELECTION</span>
+          <div>
+            <button
+              type="button"
+              className={showMoveGuide ? styles.activeBoardTool : ""}
+              onClick={onShowMove}
+              aria-pressed={showMoveGuide}
+            >
+              MOVE RANGE
+            </button>
+            <button
+              type="button"
+              className={showThreats ? styles.activeThreatTool : ""}
+              onClick={() => setShowThreats((current) => !current)}
+              aria-pressed={showThreats}
+            >
+              ENEMY PRESSURE
+            </button>
+            <button
+              type="button"
+              className={showBuildLine ? styles.activeBuildTool : ""}
+              onClick={() => {
+                setShowBuildLine((current) => !current);
+                onOpportunity(opportunity.focusId);
+              }}
+              aria-pressed={showBuildLine}
+            >
+              BUILD LINE
+            </button>
+          </div>
+        </div>
+        <div className={styles.boardPanHint} aria-hidden="true">
+          DRAG / SCROLL MAP → ENEMIES + GATE
+        </div>
 
-        <rect width="1000" height="620" fill="#070b10" />
-        <path
-          d="M70 350 L210 335 L510 315 L790 300 L925 275 L930 500 L710 520 L420 500 L130 475 Z"
-          fill="url(#yard-fill)"
-          stroke="#334752"
-          strokeWidth="3"
-        />
-        <path
-          d="M170 175 L430 105 L665 135 L775 215 L650 250 L435 220 L245 260 Z"
-          fill="url(#walk-fill)"
-          stroke="#50636a"
-          strokeWidth="3"
-        />
-        <path
-          d="M720 250 L930 220 L975 430 L760 470 L685 395 Z"
-          fill="url(#gate-fill)"
-          stroke="#3a7774"
-          strokeWidth="4"
-        />
-        <path
-          d="M210 335 L245 260 M250 360 L300 245 M295 380 L350 230"
-          stroke="#56666d"
-          strokeWidth="9"
-          opacity="0.75"
-        />
-        <path
-          d="M505 315 L585 395 L650 360 L585 290 Z"
-          fill="#2c2525"
-          stroke="#9d6759"
-          strokeWidth="4"
-          strokeDasharray="14 8"
-        />
-        <path
-          d="M565 220 L650 250 L690 330"
-          fill="none"
-          stroke="#53656d"
-          strokeWidth="5"
-          strokeDasharray="10 12"
-        />
-        <path
-          d="M585 405 L630 485 L710 470 L680 390 Z"
-          fill="#111a20"
-          stroke="#4edfff"
-          strokeWidth="3"
-          opacity="0.7"
-        />
-        <path
-          d="M515 348 C 610 320, 710 300, 870 285"
-          fill="none"
-          stroke="#ff8a5c"
-          strokeWidth="8"
-          strokeDasharray="20 13"
-          markerEnd="url(#intent-arrow)"
-          opacity={
-            ["active", "staggered", "off-balance", "pinned"].includes(
-              snapshot.enemies.breacher.status,
-            )
-              ? 0.9
-              : 0.22
-          }
-        />
-        <circle
-          cx="875"
-          cy="285"
-          r="38"
-          fill="none"
-          stroke="#ff8a5c"
-          strokeWidth="4"
-          opacity="0.6"
-        />
-        <path
-          d="M930 220 L970 205 L990 420 L975 430"
-          fill="none"
-          stroke={snapshot.gate.status === "failed" ? "#ff6474" : "#52ff9b"}
-          strokeWidth="11"
-          opacity="0.8"
-          filter="url(#soft-glow)"
-        />
-        {pathPoints ? (
+        <svg
+          className={styles.boardArt}
+          viewBox="0 0 1000 620"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient id="yard-fill" x1="0" x2="1">
+              <stop offset="0" stopColor="#0d171f" />
+              <stop offset="1" stopColor="#182832" />
+            </linearGradient>
+            <linearGradient id="walk-fill" x1="0" x2="1">
+              <stop offset="0" stopColor="#17242b" />
+              <stop offset="1" stopColor="#26363c" />
+            </linearGradient>
+            <linearGradient id="gate-fill" x1="0" x2="1">
+              <stop offset="0" stopColor="#14272d" />
+              <stop offset="1" stopColor="#1d3b3d" />
+            </linearGradient>
+            <marker
+              id="intent-arrow"
+              viewBox="0 0 10 10"
+              refX="8"
+              refY="5"
+              markerWidth="8"
+              markerHeight="8"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff8a5c" />
+            </marker>
+            <filter id="soft-glow">
+              <feGaussianBlur stdDeviation="5" result="blur" />
+              <feMerge>
+                <feMergeNode in="blur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+
+          <rect width="1000" height="620" fill="#060a0f" />
+          <path
+            d="M50 205 L670 205 L760 535 L45 535 Z"
+            fill="url(#yard-fill)"
+            stroke="#334752"
+            strokeWidth="3"
+          />
+          <path
+            d="M245 65 L900 65 L935 225 L230 225 Z"
+            fill="url(#walk-fill)"
+            stroke="#50636a"
+            strokeWidth="3"
+          />
+          <path
+            d="M645 190 L965 190 L980 535 L700 535 Z"
+            fill="url(#gate-fill)"
+            stroke="#3a7774"
+            strokeWidth="4"
+          />
           <polyline
-            points={pathPoints}
+            points={feedPoints}
             fill="none"
             stroke="#4edfff"
-            strokeWidth="7"
+            strokeWidth="13"
             strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeDasharray="14 10"
-            className={styles.projectionPath}
+            opacity="0.23"
           />
-        ) : null}
-        {projection?.contact ? (
-          <g
-            transform={
-              projection.contact.location === "Cracked Divider"
-                ? "translate(590 395)"
-                : projection.contact.location === "Defensive Bollard"
-                  ? "translate(720 390)"
-                  : "translate(820 330)"
+          <polyline
+            points={`${svgPoint(actuatorPoint)} ${svgPoint(bollardPoint)}`}
+            fill="none"
+            stroke="#4edfff"
+            strokeWidth="4"
+            strokeDasharray="7 8"
+            opacity="0.7"
+          />
+          <polyline
+            points={intentPoints}
+            fill="none"
+            stroke="#ff8a5c"
+            strokeWidth="8"
+            strokeDasharray="20 13"
+            markerEnd="url(#intent-arrow)"
+            opacity={showThreats ? 0.9 : 0.16}
+          />
+          <circle
+            cx={gatePoint.x * 10}
+            cy={gatePoint.y * 6.2}
+            r="42"
+            fill="none"
+            stroke="#ff8a5c"
+            strokeWidth="4"
+            opacity={showThreats ? 0.65 : 0.14}
+          />
+          <path
+            d={`M${gatePoint.x * 10 + 30} ${gatePoint.y * 6.2 - 75} L${
+              gatePoint.x * 10 + 55
+            } ${gatePoint.y * 6.2 + 75}`}
+            fill="none"
+            stroke={
+              snapshot.gate.status === "failed" ? "#ff6474" : "#52ff9b"
             }
-            className={styles.collisionMark}
-          >
-            <path
-              d="M-24 0 L-7 -7 L0 -27 L8 -8 L28 0 L8 8 L0 28 L-8 8 Z"
-              fill="#ffc857"
+            strokeWidth="12"
+            opacity="0.8"
+            filter="url(#soft-glow)"
+          />
+          {pathPoints ? (
+            <polyline
+              points={pathPoints}
+              fill="none"
+              stroke="#4edfff"
+              strokeWidth="7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeDasharray="14 10"
+              className={styles.projectionPath}
             />
-            <circle r="42" fill="none" stroke="#ffc857" strokeWidth="3" />
-          </g>
-        ) : null}
-        <text x="320" y="450" className={styles.areaLabel}>
-          LOWER YARD
-        </text>
-        <text x="320" y="145" className={styles.areaLabel}>
-          UPPER WALK
-        </text>
-        <text x="760" y="420" className={styles.areaLabel}>
-          GATE PLATFORM
-        </text>
-      </svg>
+          ) : null}
+          {projection?.contact ? (
+            <g
+              transform={`translate(${
+                projection.contact.location === "Cracked Divider"
+                  ? dividerPoint.x * 10
+                  : projection.contact.location === "Defensive Bollard"
+                    ? bollardPoint.x * 10
+                    : gatePoint.x * 10
+              } ${
+                projection.contact.location === "Cracked Divider"
+                  ? dividerPoint.y * 6.2
+                  : projection.contact.location === "Defensive Bollard"
+                    ? bollardPoint.y * 6.2
+                    : gatePoint.y * 6.2
+              })`}
+              className={styles.collisionMark}
+            >
+              <path
+                d="M-24 0 L-7 -7 L0 -27 L8 -8 L28 0 L8 8 L0 28 L-8 8 Z"
+                fill="#ffc857"
+              />
+              <circle r="42" fill="none" stroke="#ffc857" strokeWidth="3" />
+            </g>
+          ) : null}
+          <text x="255" y="185" className={styles.areaLabel}>
+            UPPER WALK
+          </text>
+          <text x="145" y="505" className={styles.areaLabel}>
+            LOWER YARD
+          </text>
+          <text x="750" y="505" className={styles.areaLabel}>
+            GATE PLATFORM
+          </text>
+        </svg>
 
-      <div className={styles.tileLayer} aria-label="Direct tactical tile selection">
-        {Object.values(BOARD_TILES).map((tile: FracturedGateRecord) => {
-          const target = legalTargets.has(tile.id);
-          const confirmed = confirmedTarget === tile.id;
-          const selected = selectedFocus === tile.id;
+        <div className={styles.tileLayer} aria-label="Direct tactical tile selection">
+          {Object.values(BOARD_TILES).map((tile: FracturedGateRecord) => {
+            const target = legalTargets.has(tile.id);
+            const confirmed = confirmedTarget === tile.id;
+            const selected = selectedFocus === tile.id;
+            const freeMove =
+              showMoveGuide && repositionTargets.has(tile.id);
+            const paidMove =
+              showMoveGuide &&
+              advanceTargets.has(tile.id) &&
+              !repositionTargets.has(tile.id);
+            const threatened = showThreats && activeEnemyTiles.has(tile.id);
+            const buildTile =
+              showBuildLine && opportunityTileId === tile.id;
+            const cue = confirmed
+              ? "SET"
+              : target
+                ? targetingChoice?.id === "reposition"
+                  ? "FREE"
+                  : targetingChoice?.parent === "Move"
+                    ? "MOVE"
+                    : "TARGET"
+                : freeMove
+                  ? "FREE"
+                  : paidMove
+                    ? "ADV"
+                    : "";
+            const classNames = [
+              styles.boardTile,
+              styles[`terrain_${tile.terrain}`],
+              target ? styles.legalTile : "",
+              selected ? styles.selectedTile : "",
+              freeMove ? styles.freeMoveTile : "",
+              paidMove ? styles.advanceMoveTile : "",
+              threatened ? styles.threatenedTile : "",
+              buildTile ? styles.buildOpportunityTile : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <button
+                type="button"
+                key={tile.id}
+                className={classNames}
+                style={
+                  {
+                    "--x": `${tile.boardX}%`,
+                    "--y": `${tile.boardY}%`,
+                  } as PositionedStyle
+                }
+                onClick={() => onFocus(tile.id)}
+                aria-label={`${focusStatus(tile.id, projectedSnapshot)}. ${
+                  confirmed
+                    ? "Confirmed target."
+                    : target
+                      ? "Legal target."
+                      : freeMove
+                        ? "Legal free Reposition destination."
+                        : paidMove
+                          ? "Legal paid Advance destination."
+                          : threatened
+                            ? "Inside visible enemy control."
+                            : "Inspect or select."
+                }`}
+                data-tile-id={tile.id}
+                data-terrain={tile.terrain}
+              >
+                <span className={styles.tileDiamond} aria-hidden="true">
+                  <i>
+                    {tile.terrain === "powered"
+                      ? "⚡"
+                      : tile.terrain === "rubble"
+                        ? "▲"
+                        : tile.terrain === "clear"
+                          ? "›"
+                          : ""}
+                  </i>
+                </span>
+                {cue ? (
+                  <span className={styles.tileCue}>{cue}</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          className={`${styles.playerPiece} ${
+            selectedFocus === "player" ? styles.selectedPiece : ""
+          } ${legalTargets.has("player") ? styles.legalTarget : ""}`}
+          style={
+            {
+              "--x": `${playerPosition.x}%`,
+              "--y": `${playerPosition.y}%`,
+            } as PositionedStyle
+          }
+          onClick={() => onFocus("player")}
+          aria-label={`Player at ${focusStatus("player", snapshot)}`}
+          data-focus-id="player"
+        >
+          <span className={styles.pieceCore} aria-hidden="true">
+            6
+          </span>
+          <span className={styles.pieceLabel}>YOU</span>
+        </button>
+
+        {ghostPosition &&
+        (ghostPosition.x !== playerPosition.x ||
+          ghostPosition.y !== playerPosition.y) ? (
+          <div
+            className={styles.ghostPiece}
+            style={
+              {
+                "--x": `${ghostPosition.x}%`,
+                "--y": `${ghostPosition.y}%`,
+              } as PositionedStyle
+            }
+            aria-hidden="true"
+          >
+            <span>6</span>
+            <small>PREVIEW</small>
+          </div>
+        ) : null}
+
+        {boardFocuses.map((focusId) => {
+          const focus = BOARD_FOCUSES[focusId];
+          const marker = MARKER_VISUALS[focusId] ?? {
+            glyph: "•",
+            short: focus.name.toUpperCase(),
+            relationship: focus.kind,
+          };
+          const selected = selectedFocus === focusId;
+          const target = legalTargets.has(focusId);
+          const confirmed = confirmedTarget === focusId;
+          const actor = focus.actorId
+            ? projectedSnapshot.enemies?.[focus.actorId]
+            : null;
+          const actorPoint = actor
+            ? getPositionCoordinates(actor.position)
+            : null;
+          const enemyInactive =
+            Boolean(actor) &&
+            !["active", "staggered", "off-balance", "pinned"].includes(actor.status);
+          const movementPassThrough =
+            targetingChoice?.parent === "Move" &&
+            legalTargets.has(focus.tileId) &&
+            !target;
+          const opportunityFocus =
+            showBuildLine && focusId === opportunity.focusId;
+          const classNames = [
+            styles.boardFocus,
+            styles[`focus_${focus.kind}`],
+            selected ? styles.selectedFocus : "",
+            target ? styles.legalTarget : "",
+            enemyInactive ? styles.inactiveFocus : "",
+            movementPassThrough ? styles.movementPassThrough : "",
+            opportunityFocus ? styles.buildOpportunityFocus : "",
+            ["breach", "upper-route", "service-route", "service-lift", "regulator"].includes(
+              focusId,
+            )
+              ? styles.projectedFocus
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+          const conciseStatus = actor
+            ? `${actor.condition} Condition · ${actor.guard} Guard`
+            : focusId === "gate"
+              ? `${projectedSnapshot.gate.stability}/3 Stability`
+              : focusId === "gate-actuator"
+                ? projectedSnapshot.actuator.controlled
+                  ? `${titleCase(projectedSnapshot.actuator.mode)} Control`
+                  : "Feed neutral"
+                : focusId === "cracked-divider"
+                  ? `${titleCase(projectedSnapshot.divider.status)} · conduit ${titleCase(
+                      projectedSnapshot.divider.conduit,
+                    )}`
+                  : marker.relationship;
           return (
             <button
               type="button"
-              key={tile.id}
-              className={`${styles.boardTile} ${
-                target ? styles.legalTile : ""
-              } ${selected ? styles.selectedTile : ""}`}
+              key={focusId}
+              className={classNames}
               style={
                 {
-                  "--x": `${tile.boardX}%`,
-                  "--y": `${tile.boardY}%`,
+                  "--x": `${actorPoint?.x ?? focus.x}%`,
+                  "--y": `${actorPoint?.y ?? focus.y}%`,
                 } as PositionedStyle
               }
-              onClick={() => onFocus(tile.id)}
-              aria-label={`${tile.name}. ${
-                confirmed
-                  ? "Confirmed target."
-                  : target
-                    ? "Legal target."
-                    : "Inspect or select."
-              }`}
-              data-tile-id={tile.id}
+              onClick={() => onFocus(focusId)}
+              aria-pressed={selected}
+              aria-label={`${focus.name}. ${focusStatus(focusId, projectedSnapshot)}`}
+              data-focus-id={focusId}
             >
               {target ? (
-                <span>{confirmed ? "CONFIRMED" : "TARGET"}</span>
-              ) : (
-                <span aria-hidden="true" />
-              )}
+                <span className={styles.targetCue}>
+                  {confirmed ? "CONFIRMED" : "TARGET"}
+                </span>
+              ) : null}
+              {opportunityFocus ? (
+                <span className={styles.buildCue}>YOUR BUILD</span>
+              ) : null}
+              <span className={styles.markerGlyph} aria-hidden="true">
+                {marker.glyph}
+              </span>
+              <span className={styles.markerLabel}>
+                <strong>{marker.short}</strong>
+                <small>{conciseStatus}</small>
+              </span>
             </button>
           );
         })}
+
+        <div className={styles.intentLegend}>
+          <span>PRIMARY PRESSURE · VISIBLE INTENT</span>
+          <strong>Breacher → Fractured Gate</strong>
+          <small>
+            Guard protects the lane · Controller contests machinery · Pressure
+            contests routes
+          </small>
+        </div>
+
+        {game.phase === "resolution" ? (
+          <div className={styles.resolutionVeil} aria-live="polite">
+            <span>RESOLVING</span>
+            <strong>
+              {game.resolution.visibleLaneIndex >= 0
+                ? LANE_NAMES[game.resolution.visibleLaneIndex]
+                : "Plan locked"}
+            </strong>
+          </div>
+        ) : null}
       </div>
 
-      <button
-        type="button"
-        className={`${styles.playerPiece} ${
-          selectedFocus === "player" ? styles.selectedPiece : ""
-        } ${legalTargets.has("player") ? styles.legalTarget : ""}`}
-        style={
-          {
-            "--x": `${playerPosition.x}%`,
-            "--y": `${playerPosition.y}%`,
-          } as PositionedStyle
-        }
-        onClick={() => onFocus("player")}
-        aria-label={`Player at ${focusStatus("player", snapshot)}`}
-        data-focus-id="player"
-      >
-        <span className={styles.pieceCore} aria-hidden="true">
-          6
+      <div className={styles.terrainLegend} aria-label="Battlefield legend">
+        <span className={styles.legendClear}>› CLEAR · ordinary cost</span>
+        <span className={styles.legendRubble}>▲ RUBBLE · costs 2 movement</span>
+        <span className={styles.legendPowered}>
+          ⚡ SERVICE TRACK · powered by Gate Actuator · feed{" "}
+          {titleCase(projectedSnapshot.poweredTrack.feed)}
         </span>
-        <span className={styles.pieceLabel}>YOU</span>
-      </button>
-
-      {ghostPosition &&
-      (ghostPosition.x !== playerPosition.x ||
-        ghostPosition.y !== playerPosition.y) ? (
-        <div
-          className={styles.ghostPiece}
-          style={
-            {
-              "--x": `${ghostPosition.x}%`,
-              "--y": `${ghostPosition.y}%`,
-            } as PositionedStyle
-          }
-          aria-hidden="true"
-        >
-          <span>6</span>
-          <small>PREVIEW</small>
-        </div>
-      ) : null}
-
-      {boardFocuses.map((focusId) => {
-        const focus = BOARD_FOCUSES[focusId];
-        const selected = selectedFocus === focusId;
-        const target = legalTargets.has(focusId);
-        const confirmed = confirmedTarget === focusId;
-        const actor = focus.actorId
-          ? projectedSnapshot.enemies?.[focus.actorId]
-          : null;
-        const actorPoint = actor
-          ? getPositionCoordinates(actor.position)
-          : null;
-        const enemyInactive =
-          Boolean(actor) &&
-          !["active", "staggered", "off-balance", "pinned"].includes(actor.status);
-        const classNames = [
-          styles.boardFocus,
-          styles[`focus_${focus.kind}`],
-          selected ? styles.selectedFocus : "",
-          target ? styles.legalTarget : "",
-          enemyInactive ? styles.inactiveFocus : "",
-          ["breach", "upper-route", "service-route", "service-lift", "regulator"].includes(
-            focusId,
-          )
-            ? styles.projectedFocus
-            : "",
-        ]
-          .filter(Boolean)
-          .join(" ");
-        return (
-          <button
-            type="button"
-            key={focusId}
-            className={classNames}
-            style={
-              {
-                "--x": `${actorPoint?.x ?? focus.x}%`,
-                "--y": `${actorPoint?.y ?? focus.y}%`,
-              } as PositionedStyle
-            }
-            onClick={() => onFocus(focusId)}
-            aria-pressed={selected}
-            aria-label={`${focus.name}. ${focusStatus(focusId, projectedSnapshot)}`}
-            data-focus-id={focusId}
-          >
-            {target ? (
-              <span className={styles.targetCue}>
-                {confirmed ? "CONFIRMED" : "TARGET"}
-              </span>
-            ) : null}
-            <strong>{focus.name}</strong>
-            <small>{focusStatus(focusId, projectedSnapshot)}</small>
-          </button>
-        );
-      })}
-
-      <div className={styles.intentLegend} aria-hidden="true">
-        <span>PRIMARY PRESSURE</span>
-        Breacher → Gate · Guard protecting · Controller and Pressure adaptive
+        <span className={styles.legendThreat}>RED · enemy control / intent</span>
+        <span className={styles.legendBuild}>
+          VIOLET · {buildFor(game.buildId).name} opportunity
+        </span>
       </div>
-
-      {game.phase === "resolution" ? (
-        <div className={styles.resolutionVeil} aria-live="polite">
-          <span>RESOLVING</span>
-          <strong>
-            {game.resolution.visibleLaneIndex >= 0
-              ? LANE_NAMES[game.resolution.visibleLaneIndex]
-              : "Plan locked"}
-          </strong>
-        </div>
-      ) : null}
     </section>
   );
 }
@@ -577,11 +1244,38 @@ function ContextPanel({
       <h2>{focus.name}</h2>
       <p className={styles.contextDescription}>{focus.description}</p>
 
-      {targetingChoice ? (
+      {game.phase !== "planning" ? (
+        <div className={styles.phaseContextNotice} role="status">
+          <span>
+            {game.phase === "resolution"
+              ? "Resolution · actions locked"
+              : game.phase === "settle"
+                ? "Aftermath · inspect changes"
+                : "Battle complete · review"}
+          </span>
+          <strong>
+            {game.phase === "resolution"
+              ? "Watch the battlefield"
+              : game.phase === "settle"
+                ? "Compare the new state"
+                : "No further battle actions"}
+          </strong>
+          <p>
+            {game.phase === "resolution"
+              ? "Use the timing controls below to advance. Nothing may be added or retargeted."
+              : game.phase === "settle"
+                ? "Select any visible actor or object to inspect it, then use Settle below."
+                : "Read the result and tradeoff below, or reset the same deterministic opening."}
+          </p>
+        </div>
+      ) : targetingChoice ? (
         <div className={styles.targetingNotice} role="status">
-          <span>Choose target</span>
+          <span>Targeting · board is filtered</span>
           <strong>{targetingChoice.label}</strong>
-          <p>Select a dashed TARGET directly on the board.</p>
+          <p>
+            Select one glowing legal destination or target directly on the
+            battlefield.
+          </p>
           <button type="button" onClick={onCancelTarget}>
             Cancel
           </button>
@@ -634,8 +1328,8 @@ function ContextPanel({
             </div>
           ) : (
             <p className={styles.contextHint}>
-              Choose one parent action. Legal mechanics appear only when this
-              selection makes them relevant.
+              Choose an action family. The battlefield will then show every
+              legal target, range, and relevant physical relationship.
             </p>
           )}
         </>
@@ -1258,7 +1952,7 @@ function ResultsPanel({
 export function FracturedGatePrototype() {
   const [game, setGame] = useState(() => createFracturedGateState());
   const [selectedFocus, setSelectedFocus] = useState("player");
-  const [selectedParent, setSelectedParent] = useState<string | null>(null);
+  const [selectedParent, setSelectedParent] = useState<string | null>("Move");
   const [targetingChoice, setTargetingChoice] =
     useState<FracturedGateChoice | null>(null);
   const [targetId, setTargetId] = useState<string | null>(null);
@@ -1325,6 +2019,10 @@ export function FracturedGatePrototype() {
     [game, targetingChoice],
   );
   const build = buildFor(game.buildId);
+  const opportunity = getBuildOpportunity(
+    game,
+    activeProjection?.finalSnapshot ?? displaySnapshot(game),
+  );
 
   function clearDraft() {
     setTargetingChoice(null);
@@ -1334,7 +2032,7 @@ export function FracturedGatePrototype() {
 
   function resetInteraction() {
     setSelectedFocus("player");
-    setSelectedParent(null);
+    setSelectedParent("Move");
     clearDraft();
     setRefocusMode(false);
     setRefocusSelection([]);
@@ -1350,8 +2048,29 @@ export function FracturedGatePrototype() {
       return;
     }
     setSelectedFocus(focusId);
-    setSelectedParent(game.phase === "planning" ? null : "Inspect");
+    setSelectedParent(
+      game.phase === "planning"
+        ? focusId === "player"
+          ? "Move"
+          : null
+        : "Inspect",
+    );
     clearDraft();
+  }
+
+  function handleOpportunity(focusId: string) {
+    clearDraft();
+    setSelectedFocus(focusId);
+    const hasDiscipline = getContextActionGroups(game, focusId).some(
+      (group: FracturedGateRecord) => group.parent === "Discipline",
+    );
+    setSelectedParent(hasDiscipline ? "Discipline" : null);
+  }
+
+  function handleShowMove() {
+    clearDraft();
+    setSelectedFocus("player");
+    setSelectedParent("Move");
   }
 
   function handleChoice(choice: FracturedGateChoice) {
@@ -1368,6 +2087,7 @@ export function FracturedGatePrototype() {
 
   function addDraft() {
     if (!targetingChoice || !targetId || !preview?.legal) return;
+    const wasMovement = targetingChoice.parent === "Move";
     const next = pivotMode
       ? pivotOpenAction(
           game,
@@ -1384,6 +2104,7 @@ export function FracturedGatePrototype() {
     setGame(next);
     if (next !== game && !next.warning) {
       clearDraft();
+      setSelectedFocus(wasMovement ? "player" : targetId);
       setSelectedParent(null);
       setPivotMode(false);
     }
@@ -1489,6 +2210,16 @@ export function FracturedGatePrototype() {
         </button>
       </section>
 
+      <PhaseDirector
+        game={game}
+        targetingChoice={targetingChoice}
+        targetId={targetId}
+        selectedParent={selectedParent}
+        pivotMode={pivotMode}
+        opportunity={opportunity}
+        onOpportunity={handleOpportunity}
+      />
+
       <section className={styles.hud} aria-label="Battle status">
         <div>
           <span>Objective</span>
@@ -1549,34 +2280,42 @@ export function FracturedGatePrototype() {
         <BattleBoard
           game={game}
           selectedFocus={selectedFocus}
+          selectedParent={selectedParent}
           confirmedTarget={targetId}
           targetingChoice={targetingChoice}
           projection={activeProjection}
+          opportunity={opportunity}
           onFocus={handleFocus}
+          onShowMove={handleShowMove}
+          onOpportunity={handleOpportunity}
         />
-        <ContextPanel
-          game={game}
-          focusId={selectedFocus}
-          selectedParent={selectedParent}
-          targetingChoice={targetingChoice}
-          onParent={setSelectedParent}
-          onChoice={handleChoice}
-          onCancelTarget={clearDraft}
-        />
+        <div className={styles.commandRail}>
+          <ContextPanel
+            game={game}
+            focusId={selectedFocus}
+            selectedParent={selectedParent}
+            targetingChoice={targetingChoice}
+            onParent={setSelectedParent}
+            onChoice={handleChoice}
+            onCancelTarget={clearDraft}
+          />
+          {game.phase === "planning" ? (
+            <PreviewPanel
+              game={game}
+              targetingChoice={targetingChoice}
+              targetId={targetId}
+              attachedCard={attachedCard}
+              preview={preview}
+              planProjection={planProjection}
+              pivotMode={pivotMode}
+              onAdd={addDraft}
+            />
+          ) : null}
+        </div>
       </div>
 
       {game.phase === "planning" ? (
         <>
-          <PreviewPanel
-            game={game}
-            targetingChoice={targetingChoice}
-            targetId={targetId}
-            attachedCard={attachedCard}
-            preview={preview}
-            planProjection={planProjection}
-            pivotMode={pivotMode}
-            onAdd={addDraft}
-          />
           <PlanChain
             game={game}
             projection={planProjection}

--- a/src/lib/barcode-world/fractured-gate-engine.mjs
+++ b/src/lib/barcode-world/fractured-gate-engine.mjs
@@ -314,9 +314,10 @@ for (const [x, y] of [[3, 7], [4, 7], [5, 7], [6, 7], [7, 7]]) {
 }
 
 function pointToPercent(x, y) {
+  const row = y - 2;
   return {
-    x: 4 + ((x - 1) / 12) * 92,
-    y: 7 + ((y - 1) / 8) * 86,
+    x: 9 + ((x - 1) / 12) * 80 + (Math.abs(row) % 2) * 2.2,
+    y: 17 + (row / 6) * 65,
   };
 }
 
@@ -2013,7 +2014,10 @@ function disciplineChoices(state, focusId) {
 
 export function getContextActionGroups(state, focusId) {
   const groups = [];
-  const movement = movementChoices(state, focusId);
+  const movement =
+    focusId === "player"
+      ? ["reposition", "advance"].map((actionId) => makeChoice(state, actionId))
+      : movementChoices(state, focusId);
   if (movement.length) groups.push({ parent: "Move", choices: movement });
 
   if (Object.keys(state.enemies).includes(focusId)) {

--- a/tests/barcode-world-boundary.test.mjs
+++ b/tests/barcode-world-boundary.test.mjs
@@ -73,6 +73,12 @@ test("Fractured Gate preserves semantic input, focus, non-color cues, touch targ
     "utf8",
   );
   assert.match(component, /aria-label="The Fractured Gate tactical board"/);
+  assert.match(component, /aria-label="Current battle phase"/);
+  assert.match(component, /MOVE RANGE/);
+  assert.match(component, /ENEMY PRESSURE/);
+  assert.match(component, /CURRENT BUILD LINE/);
+  assert.match(component, /powered by Gate Actuator/);
+  assert.match(component, /data-terrain=/);
   assert.match(component, /type="button"/);
   assert.match(component, /TARGET/);
   assert.match(component, /CONFIRMED/);
@@ -81,6 +87,11 @@ test("Fractured Gate preserves semantic input, focus, non-color cues, touch targ
   assert.match(css, /touch-action:\s*manipulation/);
   assert.match(css, /min-height:\s*max\(2\.75rem,\s*44px\)/);
   assert.match(css, /min-width:\s*44px/);
+  assert.match(
+    css,
+    /clip-path:\s*polygon\(50% 0,\s*100% 50%,\s*50% 100%,\s*0 50%\)/,
+  );
+  assert.match(css, /\.movementPassThrough/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
   assert.match(css, /animation-duration:\s*0\.001ms/);
 });

--- a/tests/barcode-world-fractured-gate.test.mjs
+++ b/tests/barcode-world-fractured-gate.test.mjs
@@ -229,6 +229,22 @@ test("revised checkpoint, 62-tile board, six builds, and shared squad economy ar
 
 test("board-first context stays bounded and spatial legality blocks remote attacks and contact", () => {
   const state = createFracturedGateState("battle-exploration");
+  for (const tile of Object.values(BOARD_TILES)) {
+    assert.ok(
+      tile.boardX >= 9 && tile.boardX <= 92,
+      `${tile.id} horizontal bounds`,
+    );
+    assert.ok(
+      tile.boardY >= 17 && tile.boardY <= 82,
+      `${tile.id} vertical bounds`,
+    );
+  }
+  assert.notEqual(
+    BOARD_TILES["tile-4-2"].boardX,
+    BOARD_TILES["tile-4-3"].boardX,
+    "adjacent rows should be visibly staggered",
+  );
+
   for (const focusId of [
     "player",
     "breacher",
@@ -243,6 +259,26 @@ test("board-first context stays bounded and spatial legality blocks remote attac
     assert.ok(groups.length <= 4, focusId);
     assert.equal(new Set(groups.map((group) => group.parent)).size, groups.length);
   }
+
+  const playerMove = getContextActionGroups(state, "player").find(
+    (group) => group.parent === "Move",
+  );
+  assert.ok(
+    playerMove,
+    "selecting the player should expose action-first movement",
+  );
+  assert.deepEqual(
+    playerMove.choices.map((choice) => choice.id),
+    ["reposition", "advance"],
+  );
+  assert.deepEqual(playerMove.choices[0].legalTargets.sort(), [
+    "tile-1-6",
+    "tile-3-6",
+  ]);
+  assert.ok(
+    playerMove.choices[1].legalTargets.includes("tile-5-6"),
+    "paid Advance should expose every reachable destination before tile probing",
+  );
 
   const remoteAttack = getContextActionGroups(state, "breacher")
     .find((group) => group.parent === "Attack")


### PR DESCRIPTION
## Summary

- add a persistent five-stage battle flow with a live instruction for the player's exact current task
- replace sparse circular hit areas with 62 compact staggered diamond tiles kept inside safe map margins
- expose action-first Move choices and visible free/paid destinations before tile probing
- render enemies, Gate pressure, terrain, machinery, powered relationships, and all six ordered-build opportunities directly on the battlefield
- keep Preview and Add to Plan beside the board and move map objects aside only while their underlying tile is an active movement target
- remove irrelevant action choices during Resolution, Settle, and Results

## Validation

- `npm run check` — 626 tests passed; TypeScript passed; lint has only 36 existing unrelated warnings
- `npm run build` — optimized production build passed
- focused Fractured Gate suite — 17 tests passed
- browser-rendered desktop and 390px checks — all 62 tiles in bounds, 44px minimum tile height, no document overflow, internal map pan
- browser click-through — all three exchanges completed through the UI and reached Fast Secure
- all six builds — exactly one visible physical build source and distinct opportunity per build

## Private boundary

- `/world/playtest` remains development-only, resettable, deterministic, noncanonical, and in-memory
- optimized production returns an empty 404 with `no-store` and full `X-Robots-Tag` protection
- no prototype link appears in the public home page or sitemap
- no accounts, APIs, rewards, progression, BNL, queue, or persistent-world integrations were added
- no manual deployment is requested